### PR TITLE
feat: fix cr sync manifest bug and add cr commit/push commands

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -1,0 +1,117 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import { loadManifest, getAllRepoInfo } from '../lib/manifest.js';
+import { pathExists, getGitInstance, hasUncommittedChanges } from '../lib/git.js';
+import type { RepoInfo } from '../types.js';
+
+interface CommitOptions {
+  message: string;
+  all?: boolean;
+}
+
+interface CommitResult {
+  repo: RepoInfo;
+  success: boolean;
+  committed: boolean;
+  error?: string;
+}
+
+/**
+ * Check if a repo has staged changes
+ */
+async function hasStagedChanges(repoPath: string): Promise<boolean> {
+  const git = getGitInstance(repoPath);
+  const status = await git.status();
+  return status.staged.length > 0;
+}
+
+/**
+ * Stage all changes in a repo
+ */
+async function stageAll(repoPath: string): Promise<void> {
+  const git = getGitInstance(repoPath);
+  await git.add('-A');
+}
+
+/**
+ * Commit staged changes in a repo
+ */
+async function commitChanges(repoPath: string, message: string): Promise<void> {
+  const git = getGitInstance(repoPath);
+  await git.commit(message);
+}
+
+/**
+ * Commit staged changes across all repositories
+ */
+export async function commit(options: CommitOptions): Promise<void> {
+  const { message, all = false } = options;
+
+  if (!message) {
+    console.error(chalk.red('Commit message is required. Use -m "message"'));
+    process.exit(1);
+  }
+
+  const { manifest, rootDir } = await loadManifest();
+  const repos = getAllRepoInfo(manifest, rootDir);
+
+  const results: CommitResult[] = [];
+  let hasChanges = false;
+
+  console.log(chalk.blue('Checking repositories for changes...\n'));
+
+  for (const repo of repos) {
+    const exists = await pathExists(repo.absolutePath);
+
+    if (!exists) {
+      continue;
+    }
+
+    // If --all flag, stage all changes first
+    if (all) {
+      const hasChangesToStage = await hasUncommittedChanges(repo.absolutePath);
+      if (hasChangesToStage) {
+        await stageAll(repo.absolutePath);
+      }
+    }
+
+    // Check if there are staged changes
+    const hasStaged = await hasStagedChanges(repo.absolutePath);
+
+    if (!hasStaged) {
+      continue;
+    }
+
+    hasChanges = true;
+    const spinner = ora(`Committing ${repo.name}...`).start();
+
+    try {
+      await commitChanges(repo.absolutePath, message);
+      spinner.succeed(`${repo.name}: committed`);
+      results.push({ repo, success: true, committed: true });
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      spinner.fail(`${repo.name}: ${errorMsg}`);
+      results.push({ repo, success: false, committed: false, error: errorMsg });
+    }
+  }
+
+  if (!hasChanges) {
+    console.log(chalk.yellow('No staged changes to commit in any repository.'));
+    if (!all) {
+      console.log(chalk.dim('Use --all to stage and commit all changes, or stage changes with git add first.'));
+    }
+    return;
+  }
+
+  // Summary
+  console.log('');
+  const committed = results.filter((r) => r.committed).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  if (failed === 0) {
+    console.log(chalk.green(`Committed in ${committed} repository(s).`));
+  } else {
+    console.log(chalk.yellow(`Committed in ${committed} repository(s). ${failed} failed.`));
+  }
+}

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,0 +1,124 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import { loadManifest, getAllRepoInfo } from '../lib/manifest.js';
+import { pathExists, getCurrentBranch, pushBranch, getGitInstance } from '../lib/git.js';
+import type { RepoInfo } from '../types.js';
+
+interface PushOptions {
+  setUpstream?: boolean;
+  force?: boolean;
+}
+
+interface PushResult {
+  repo: RepoInfo;
+  success: boolean;
+  pushed: boolean;
+  branch?: string;
+  error?: string;
+}
+
+/**
+ * Check if current branch has commits ahead of remote
+ */
+async function hasCommitsAheadOfRemote(repoPath: string): Promise<boolean> {
+  const git = getGitInstance(repoPath);
+  try {
+    const status = await git.status();
+    return status.ahead > 0;
+  } catch {
+    // If we can't determine, assume we might need to push
+    return true;
+  }
+}
+
+/**
+ * Check if branch has an upstream configured
+ */
+async function hasUpstream(repoPath: string): Promise<boolean> {
+  const git = getGitInstance(repoPath);
+  try {
+    const branch = await getCurrentBranch(repoPath);
+    const result = await git.raw(['config', '--get', `branch.${branch}.remote`]);
+    return result.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Push current branch to remote across all repositories
+ */
+export async function push(options: PushOptions = {}): Promise<void> {
+  const { setUpstream = false, force = false } = options;
+
+  const { manifest, rootDir } = await loadManifest();
+  const repos = getAllRepoInfo(manifest, rootDir);
+
+  const results: PushResult[] = [];
+  let hasCommits = false;
+
+  console.log(chalk.blue('Checking repositories for commits to push...\n'));
+
+  for (const repo of repos) {
+    const exists = await pathExists(repo.absolutePath);
+
+    if (!exists) {
+      continue;
+    }
+
+    const branch = await getCurrentBranch(repo.absolutePath);
+    const hasUpstreamConfigured = await hasUpstream(repo.absolutePath);
+
+    // Check if there are commits to push
+    const needsPush = await hasCommitsAheadOfRemote(repo.absolutePath);
+
+    // Also push if no upstream and --set-upstream is specified
+    const needsUpstreamPush = !hasUpstreamConfigured && setUpstream;
+
+    if (!needsPush && !needsUpstreamPush) {
+      continue;
+    }
+
+    hasCommits = true;
+    const spinner = ora(`Pushing ${repo.name} (${branch})...`).start();
+
+    try {
+      const git = getGitInstance(repo.absolutePath);
+      const pushOptions: string[] = [];
+
+      if (setUpstream || !hasUpstreamConfigured) {
+        pushOptions.push('-u', 'origin', branch);
+      } else {
+        pushOptions.push('origin', branch);
+      }
+
+      if (force) {
+        pushOptions.unshift('--force');
+      }
+
+      await git.push(pushOptions);
+      spinner.succeed(`${repo.name} (${chalk.cyan(branch)}): pushed`);
+      results.push({ repo, success: true, pushed: true, branch });
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      spinner.fail(`${repo.name}: ${errorMsg}`);
+      results.push({ repo, success: false, pushed: false, branch, error: errorMsg });
+    }
+  }
+
+  if (!hasCommits) {
+    console.log(chalk.yellow('No commits to push in any repository.'));
+    return;
+  }
+
+  // Summary
+  console.log('');
+  const pushed = results.filter((r) => r.pushed).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  if (failed === 0) {
+    console.log(chalk.green(`Pushed ${pushed} repository(s).`));
+  } else {
+    console.log(chalk.yellow(`Pushed ${pushed} repository(s). ${failed} failed.`));
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { link } from './commands/link.js';
 import { run } from './commands/run.js';
 import { env } from './commands/env.js';
 import { bench } from './commands/bench.js';
+import { commit } from './commands/commit.js';
+import { push } from './commands/push.js';
 import { TimingContext, formatTimingReport, setTimingContext, getTimingContext } from './lib/timing.js';
 
 const program = new Command();
@@ -247,6 +249,42 @@ program
         iterations: parseInt(options.iterations, 10),
         warmup: parseInt(options.warmup, 10),
         json: options.json,
+      });
+    } catch (error) {
+      console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+      process.exit(1);
+    }
+  });
+
+// Commit command
+program
+  .command('commit')
+  .description('Commit staged changes across all repositories')
+  .option('-m, --message <message>', 'Commit message')
+  .option('-a, --all', 'Stage all changes before committing')
+  .action(async (options) => {
+    try {
+      await commit({
+        message: options.message,
+        all: options.all,
+      });
+    } catch (error) {
+      console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+      process.exit(1);
+    }
+  });
+
+// Push command
+program
+  .command('push')
+  .description('Push current branch to remote across all repositories')
+  .option('-u, --set-upstream', 'Set upstream tracking for the branch')
+  .option('-f, --force', 'Force push (use with caution)')
+  .action(async (options) => {
+    try {
+      await push({
+        setUpstream: options.setUpstream,
+        force: options.force,
       });
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));


### PR DESCRIPTION
## Summary

Fixes issue #4 and implements issues #5 and #6.

## Changes

### Issue #4: Fix `cr sync` failing after PR merge
When the manifest repo is on a feature branch and that branch is deleted on remote (after PR merge), `cr sync` would fail. Now it automatically recovers by:
1. Detecting that the upstream branch no longer exists
2. Checking out the default branch
3. Pulling successfully
4. Showing an informative message about the recovery

### Issue #5: Add `cr commit` command
```bash
cr commit -m "feat: my changes"      # Commit staged changes in all repos
cr commit -a -m "feat: my changes"   # Stage and commit all changes
```

### Issue #6: Add `cr push` command
```bash
cr push                # Push repos with commits ahead
cr push -u             # Set upstream tracking
cr push -f             # Force push (use with caution)
```

## New Functions in git.ts
- `getUpstreamBranch()` - Get the tracking branch for a local branch
- `upstreamBranchExists()` - Check if upstream branch still exists on remote
- `safePullLatest()` - Pull with automatic recovery for deleted upstream

## Test Plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [x] New commands appear in `cr --help`
- [ ] Manual test: `cr commit -m "test"`
- [ ] Manual test: `cr push`
- [ ] Manual test: `cr sync` after PR merge with deleted branch

Closes #4, closes #5, closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)