### PR TITLE
chore: reinforce cr-only workflow, add cr forall improvement

### DIFF
--- a/.claude/skills/codi-repo/SKILL.md
+++ b/.claude/skills/codi-repo/SKILL.md
@@ -105,11 +105,12 @@ cr bench manifest-load -n 10 # Run specific benchmark
 
 ## Workflow Rules
 
-1. **Always run `cr sync` before starting new work**
-2. **Always use `cr branch` to create branches** - Creates across all repos simultaneously
-3. **Use `cr add`, `cr commit`, `cr push`** instead of raw git commands
-4. **Always use pull requests** - No direct pushes to main
+1. **NEVER use raw `git` or `gh` commands** - Use `cr` for ALL operations (branch, add, commit, push, PR)
+2. **Always run `cr sync` before starting new work**
+3. **Always use `cr branch` to create branches** - Creates across all repos simultaneously
+4. **Always use pull requests** - `cr pr create`, never push directly to main
 5. **Check `cr status` frequently** - Before and after operations
+6. **`cr` handles the manifest repo automatically** - No need for separate git operations in `.codi-repo/manifests/`
 
 ## Typical Workflow
 

--- a/CODI.md
+++ b/CODI.md
@@ -13,7 +13,7 @@ pnpm lint             # Lint code
 
 ## Git Workflow
 
-**IMPORTANT: Never push directly to main.** Always use feature branches and pull requests.
+**IMPORTANT:** Never push directly to main. Never use raw `git` commands. Always use `cr` for all operations.
 
 ### Branch Strategy
 
@@ -21,45 +21,51 @@ pnpm lint             # Lint code
 - Production-ready code
 - Protected with PR requirements
 - All PRs must target `main`
-- Use `git pull origin main --rebase` to stay current
+- Use `cr sync` to stay current (not `git pull`)
 
 **Feature Branches (`feat/*`, `fix/*`, `chore/*`)**
 - All development happens here
 - Short-lived, deleted after merge
-- Always rebase from `origin/main`, never merge
-
-### Rebase vs Merge
-
-**✅ Use REBASE** (correct):
-```bash
-git rebase origin/main           # Keeps history linear
-git push --force-with-lease      # Safe force-push after rebase
-```
-
-**❌ DO NOT Use MERGE** (incorrect):
-```bash
-git merge origin/main            # Creates unnecessary merge commits
-```
 
 ### Standard Workflow
 
 ```bash
 # Start new work
 cr sync                              # Pull latest from all repos
+cr status                            # Verify clean state
 cr branch feat/my-feature            # Create branch across repos
 
 # Make changes...
+cr diff                              # Review changes
 cr add .                             # Stage changes across repos
 cr commit -m "feat: description"     # Commit across repos
 cr push -u                           # Push with upstream tracking
 
 # Create PR
-cr pr create -t "feat: description"  # Create linked PRs
+cr pr create -t "feat: description" --push
 
 # After PR merged
 cr sync                              # Pull latest and cleanup
 cr checkout main                     # Switch back to main
 ```
+
+### IMPORTANT: Never Use Raw Git
+
+All git operations must go through `cr`. There is no exception.
+
+```
+❌ WRONG:
+   git checkout -b feat/x
+   git add . && git commit -m "msg" && git push
+   gh pr create --title "msg"
+
+✅ CORRECT:
+   cr branch feat/x
+   cr add . && cr commit -m "msg" && cr push -u
+   cr pr create -t "msg" --push
+```
+
+`cr` manages all repos and the manifest together. Using raw `git` or `gh` bypasses multi-repo coordination and will miss the manifest repo.
 
 ### PR Review Process
 

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -7,7 +7,19 @@ Items here should be reviewed before creating GitHub issues.
 
 ## Pending Review
 
-_No items pending review._
+#### `cr forall` command (like AOSP `repo forall`)
+- **Problem**: Some git operations (rebase, cherry-pick, stash, etc.) don't have dedicated `cr` commands yet, forcing users to run raw `git` in each repo manually
+- **Observation**: AOSP's `repo` tool solves this with `repo forall -c "git command"` which runs a shell command in every repo directory
+- **Proposal**: Add `cr forall -c "command"` that runs an arbitrary command in each repo (and optionally the manifest)
+- **Example usage**:
+  ```bash
+  cr forall -c "git rebase origin/main"       # Rebase all repos
+  cr forall -c "git stash"                     # Stash all repos
+  cr forall -c "pnpm install"                  # Install deps in all repos
+  cr forall --repo tooling -c "git log -5"     # Run in specific repo only
+  cr forall --include-manifest -c "git rebase origin/main"  # Include manifest
+  ```
+- **Priority**: Medium - eliminates the last reason to use raw `git` commands
 
 ---
 


### PR DESCRIPTION
Strengthen instructions to prevent falling back to raw git commands. Add cr forall improvement idea.