### PR TITLE
feat: add cr forall command

### DIFF
--- a/.claude/skills/codi-repo/SKILL.md
+++ b/.claude/skills/codi-repo/SKILL.md
@@ -95,6 +95,20 @@ cr run build -- --verbose    # Pass arguments to script
 cr env                       # Show workspace environment variables
 ```
 
+### Run Commands Across Repos (like AOSP repo forall)
+```bash
+cr forall -c "pwd"                           # Run command in all repos
+cr forall -c "git rebase origin/main"        # Rebase all repos
+cr forall -c "npm test" --repo frontend      # Run in specific repo only
+cr forall -c "git stash" --include-manifest  # Include manifest repo
+cr forall -c "npm install" --continue-on-error  # Continue past failures
+```
+
+Environment variables available in command:
+- `REPO_NAME` - Repository name
+- `REPO_PATH` - Absolute path to repo
+- `REPO_URL` - Repository URL
+
 ### Benchmarking & Timing
 ```bash
 cr status --timing           # Show timing breakdown for any command

--- a/CODI.md
+++ b/CODI.md
@@ -148,6 +148,7 @@ src/
 │   ├── run.ts            # cr run
 │   ├── env.ts            # cr env
 │   ├── bench.ts          # cr bench
+│   ├── forall.ts         # cr forall (run command in each repo)
 │   └── pr/               # PR subcommands
 │       ├── index.ts
 │       ├── create.ts     # Includes manifest PR
@@ -188,6 +189,7 @@ All commands use `cr` alias:
 - `cr run` - Execute workspace scripts
 - `cr env` - Show workspace environment variables
 - `cr bench` - Run benchmarks
+- `cr forall -c "cmd"` - Run command in each repo (like AOSP repo forall)
 
 ### File Linking
 - `copyfile`: Copy file from repo to workspace

--- a/README.md
+++ b/README.md
@@ -135,6 +135,34 @@ Pull request management subcommands:
 - `cr pr status` - Show status of linked PRs (including manifest PR)
 - `cr pr merge` - Merge all linked PRs atomically (including manifest PR)
 
+### `cr forall -c "<command>"`
+
+Run a command in each repository (like AOSP's `repo forall`).
+
+| Option | Description |
+|--------|-------------|
+| `-c, --command` | Command to run (required) |
+| `-r, --repo <repos...>` | Only run in specific repos |
+| `--include-manifest` | Include manifest repo |
+| `--continue-on-error` | Continue if command fails in a repo |
+
+Environment variables available in command:
+- `REPO_NAME` - Repository name
+- `REPO_PATH` - Absolute path to repo
+- `REPO_URL` - Repository URL
+
+Example:
+```bash
+# Show current branch in all repos
+cr forall -c "git rev-parse --abbrev-ref HEAD"
+
+# Rebase all repos onto main
+cr forall -c "git rebase origin/main"
+
+# Run only in specific repos
+cr forall -c "npm test" --repo frontend --repo backend
+```
+
 ## Manifest Format
 
 The manifest file (`manifest.yaml`) defines your workspace:

--- a/src/commands/forall.ts
+++ b/src/commands/forall.ts
@@ -1,0 +1,153 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { loadManifest, getAllRepoInfo, getManifestRepoInfo } from '../lib/manifest.js';
+import { pathExists, isGitRepo } from '../lib/git.js';
+import type { RepoInfo } from '../types.js';
+
+const execAsync = promisify(exec);
+
+interface ForallOptions {
+  command: string;
+  repo?: string[];
+  includeManifest?: boolean;
+  continueOnError?: boolean;
+}
+
+interface ForallResult {
+  repo: RepoInfo;
+  success: boolean;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+}
+
+/**
+ * Run a command in each repository directory
+ * Similar to AOSP's `repo forall -c "command"`
+ */
+export async function forall(options: ForallOptions): Promise<void> {
+  const { command, continueOnError = false } = options;
+
+  if (!command || command.trim().length === 0) {
+    console.log(chalk.red('Error: Command is required. Use -c "command" to specify.'));
+    return;
+  }
+
+  const { manifest, rootDir } = await loadManifest();
+  let repos: RepoInfo[] = getAllRepoInfo(manifest, rootDir);
+
+  // Filter by --repo flag if specified
+  if (options.repo && options.repo.length > 0) {
+    const requestedRepos = new Set(options.repo);
+    const filteredRepos = repos.filter((r) => requestedRepos.has(r.name));
+
+    // Check for unknown repo names
+    const knownNames = new Set(repos.map((r) => r.name));
+    const unknownRepos = options.repo.filter((name) => !knownNames.has(name));
+    if (unknownRepos.length > 0) {
+      console.log(chalk.yellow(`Unknown repositories: ${unknownRepos.join(', ')}`));
+      console.log(chalk.dim(`Available: ${repos.map((r) => r.name).join(', ')}\n`));
+    }
+
+    repos = filteredRepos;
+  }
+
+  // Include manifest if flag is set
+  if (options.includeManifest) {
+    const manifestInfo = getManifestRepoInfo(manifest, rootDir);
+    if (manifestInfo && (await isGitRepo(manifestInfo.absolutePath))) {
+      repos = [...repos, manifestInfo];
+    }
+  }
+
+  if (repos.length === 0) {
+    console.log(chalk.red('No repositories to run command in.'));
+    return;
+  }
+
+  // Filter to existing repos only
+  const existingRepos: RepoInfo[] = [];
+  for (const repo of repos) {
+    if (await pathExists(repo.absolutePath)) {
+      existingRepos.push(repo);
+    }
+  }
+
+  if (existingRepos.length === 0) {
+    console.log(chalk.red('No cloned repositories found.'));
+    return;
+  }
+
+  console.log(chalk.blue(`Running command in ${existingRepos.length} repo(s): ${chalk.dim(command)}\n`));
+
+  const results: ForallResult[] = [];
+  let hasFailure = false;
+
+  for (const repo of existingRepos) {
+    const spinner = ora(`${repo.name}...`).start();
+
+    try {
+      const { stdout, stderr } = await execAsync(command, {
+        cwd: repo.absolutePath,
+        env: {
+          ...process.env,
+          REPO_NAME: repo.name,
+          REPO_PATH: repo.absolutePath,
+          REPO_URL: repo.url,
+        },
+        maxBuffer: 10 * 1024 * 1024, // 10MB buffer
+      });
+
+      spinner.succeed(`${repo.name}`);
+
+      // Print output if there is any
+      if (stdout.trim()) {
+        console.log(chalk.dim(stdout.trim().split('\n').map(line => `  ${line}`).join('\n')));
+      }
+      if (stderr.trim()) {
+        console.log(chalk.yellow(stderr.trim().split('\n').map(line => `  ${line}`).join('\n')));
+      }
+
+      results.push({ repo, success: true, stdout, stderr });
+    } catch (error) {
+      hasFailure = true;
+      const err = error as { stdout?: string; stderr?: string; message?: string };
+      const errorMsg = err.stderr || err.message || String(error);
+
+      spinner.fail(`${repo.name}`);
+
+      // Print error output
+      if (err.stdout?.trim()) {
+        console.log(chalk.dim(err.stdout.trim().split('\n').map(line => `  ${line}`).join('\n')));
+      }
+      if (errorMsg.trim()) {
+        console.log(chalk.red(errorMsg.trim().split('\n').map(line => `  ${line}`).join('\n')));
+      }
+
+      results.push({ repo, success: false, stdout: err.stdout, stderr: err.stderr, error: errorMsg });
+
+      if (!continueOnError) {
+        console.log('');
+        console.log(chalk.red(`Stopping due to error. Use --continue-on-error to continue past failures.`));
+        break;
+      }
+    }
+
+    console.log(''); // Blank line between repos
+  }
+
+  // Summary
+  const succeeded = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+  const skipped = existingRepos.length - results.length;
+
+  if (failed === 0 && skipped === 0) {
+    console.log(chalk.green(`Completed successfully in ${succeeded} repo(s).`));
+  } else if (skipped > 0) {
+    console.log(chalk.yellow(`Completed in ${succeeded} repo(s). ${skipped} skipped due to earlier error.`));
+  } else {
+    console.log(chalk.yellow(`Completed in ${succeeded} repo(s). ${failed} failed.`));
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { commit } from './commands/commit.js';
 import { push } from './commands/push.js';
 import { add } from './commands/add.js';
 import { diff } from './commands/diff.js';
+import { forall } from './commands/forall.js';
 import { TimingContext, formatTimingReport, setTimingContext, getTimingContext } from './lib/timing.js';
 
 const program = new Command();
@@ -323,6 +324,28 @@ program
         staged: options.staged,
         stat: options.stat,
         nameOnly: options.nameOnly,
+      });
+    } catch (error) {
+      console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+      process.exit(1);
+    }
+  });
+
+// Forall command - run command in all repos (like AOSP repo forall)
+program
+  .command('forall')
+  .description('Run a command in each repository (like AOSP repo forall)')
+  .requiredOption('-c, --command <command>', 'Command to run in each repo')
+  .option('-r, --repo <repos...>', 'Only run in specific repositories')
+  .option('--include-manifest', 'Include manifest repo')
+  .option('--continue-on-error', 'Continue running in other repos if command fails')
+  .action(async (options) => {
+    try {
+      await forall({
+        command: options.command,
+        repo: options.repo,
+        includeManifest: options.includeManifest,
+        continueOnError: options.continueOnError,
       });
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));


### PR DESCRIPTION
Adds `cr forall -c "command"` to run arbitrary commands in each repository, similar to AOSP's `repo forall`.

## Features

- Run any command across all repos
- Filter with `--repo` to run in specific repos only
- Include manifest with `--include-manifest`
- Continue past failures with `--continue-on-error`
- Environment variables available: `REPO_NAME`, `REPO_PATH`, `REPO_URL`

## Example

```bash
# Rebase all repos
cr forall -c "git rebase origin/main"

# Run tests in specific repos
cr forall -c "npm test" --repo frontend --repo backend
```

Closes #15