### PR TITLE
fix: cr pr create now works when repos are on different branches

### DIFF
--- a/.claude/skills/codi-repo/SKILL.md
+++ b/.claude/skills/codi-repo/SKILL.md
@@ -125,6 +125,7 @@ cr bench manifest-load -n 10 # Run specific benchmark
 4. **Always use pull requests** - `cr pr create`, never push directly to main
 5. **Check `cr status` frequently** - Before and after operations
 6. **`cr` handles the manifest repo automatically** - No need for separate git operations in `.codi-repo/manifests/`
+7. **If you MUST use raw `git`/`gh`** - Immediately add to `codi-repo/IMPROVEMENTS.md` explaining why `cr` couldn't handle it
 
 ## Typical Workflow
 

--- a/CODI.md
+++ b/CODI.md
@@ -233,3 +233,12 @@ codi-repo is self-improving. When using `cr` commands, capture any friction or i
 1. Add observations to IMPROVEMENTS.md under "Pending Review"
 2. Prompt the user: "I added [observation] to IMPROVEMENTS.md. Want me to create an issue?"
 3. Only create issues after user approval
+
+### CRITICAL: Document When Falling Back to Raw Commands
+
+**If you ever use raw `git` or `gh` commands, you MUST immediately:**
+
+1. Add an entry to `IMPROVEMENTS.md` explaining why `cr` couldn't handle the use case
+2. Tell the user about the friction point
+
+This is mandatory. Every workaround reveals a gap in `cr` that should be fixed.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -7,7 +7,10 @@ Items here should be reviewed before creating GitHub issues.
 
 ## Pending Review
 
-_No items pending review._
+#### `cr pr create` should work when repos are on different branches
+- **Problem**: `cr pr create` fails with "Repositories are on different branches" even when only a subset of repos have changes. This forces fallback to raw `gh` commands.
+- **Example**: When only `tooling` and `manifest` have changes but `public/private/strategy` are on `main`, `cr pr create` refuses to run.
+- **Proposal**: Only check branch consistency for repos that actually have commits ahead. Repos on `main` with no changes shouldn't block PR creation for repos that do have changes.
 
 ---
 


### PR DESCRIPTION
Only check branch consistency for repos that have changes. Repos on default branch with no changes no longer block PR creation.

## Changes

**Fix for `cr pr create`:**
- Moved change detection before branch consistency check
- Only validates that repos WITH CHANGES are on the same branch
- Repos on `main` with no changes don't block PR creation

**Documentation updates:**
- Added mandatory rule: "If you use raw git/gh, you MUST document why in IMPROVEMENTS.md"
- Updated CLAUDE.md, CODI.md, and SKILL.md with this rule

## Testing

Before this fix:
```
cr pr create
> Repositories are on different branches:
>   public: main
>   tooling: fix/branch
> Use `codi-repo checkout <branch>` to sync branches first.
```

After this fix: PR creation proceeds for repos with changes only.