### PR TITLE
fix: cr pr status/merge now work when repos are on different branches

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -7,10 +7,10 @@ Items here should be reviewed before creating GitHub issues.
 
 ## Pending Review
 
-#### `cr pr create` should work when repos are on different branches
-- **Problem**: `cr pr create` fails with "Repositories are on different branches" even when only a subset of repos have changes. This forces fallback to raw `gh` commands.
-- **Example**: When only `tooling` and `manifest` have changes but `public/private/strategy` are on `main`, `cr pr create` refuses to run.
-- **Proposal**: Only check branch consistency for repos that actually have commits ahead. Repos on `main` with no changes shouldn't block PR creation for repos that do have changes.
+#### `cr pr status` and `cr pr merge` should work when repos are on different branches
+- **Problem**: Similar to the `cr pr create` issue (now fixed), `cr pr status` and `cr pr merge` check the branch of ALL repos instead of repos with PRs/changes.
+- **Example**: After fixing `cr pr create`, I still had to use raw `gh pr merge` because `cr pr merge` couldn't find the PRs - it was looking at `main` branch instead of the feature branch.
+- **Proposal**: Apply the same fix as `cr pr create` - only check branch consistency for repos that have open PRs.
 
 ---
 
@@ -23,6 +23,10 @@ _No items approved._
 ## Completed
 
 _Items that have been implemented. Keep for historical reference._
+
+### `cr pr create` branch check fix
+- **Added in**: PR #19
+- **Description**: `cr pr create` now only checks branch consistency for repos with changes. Repos on `main` with no changes no longer block PR creation.
 
 ### `cr forall` command (Issue #15)
 - **Added in**: PR #17


### PR DESCRIPTION
Each repo is checked for PRs based on its own current branch.
Repos on their default branch are skipped (no PR expected).

## Changes

- `cr pr status`: Now finds PRs by checking each repo's branch individually
- `cr pr merge`: Same fix - finds PRs by each repo's own branch
- Both commands skip repos on default branch (no PR expected there)

## Before

```
cr pr status
> PR Status for branch: main
> No open PRs found for this branch.
```

## After

```
cr pr status
> PR Status for branch: fix/my-feature
> (shows PRs for repos on feature branches)
```

Closes #20