### PR TITLE
docs: add griptree graphics and update documentation

### DIFF
--- a/.claude/skills/gitgrip/SKILL.md
+++ b/.claude/skills/gitgrip/SKILL.md
@@ -109,6 +109,43 @@ gr bench --list              # List available benchmarks
 gr bench manifest-load -n 10 # Run specific benchmark
 ```
 
+### Griptrees (Multi-Branch Workspaces)
+
+Griptrees let you work on multiple feature branches simultaneously without switching branches. Each griptree is a parallel workspace using git worktrees.
+
+```bash
+# Create a griptree for a feature branch
+gr griptree add feat/auth
+# Creates: ../feat-auth/ with all repos on feat/auth branch
+
+# List all griptrees
+gr griptree list
+
+# Work in a griptree
+cd ../feat-auth
+gr status                    # Works just like main workspace
+gr commit -m "changes"
+gr push
+
+# Protect important griptrees
+gr griptree lock feat/auth   # Prevents accidental removal
+
+# Cleanup when done
+gr griptree unlock feat/auth
+gr griptree remove feat/auth # Removes worktrees, keeps branches
+```
+
+**Benefits:**
+- No branch switching - work on multiple features in parallel
+- Shared git objects - minimal disk usage, instant creation
+- Independent working directories - separate node_modules, build artifacts
+
+**Options:**
+```bash
+gr griptree add feat/x --path ./custom-path  # Custom location
+gr griptree remove feat/x --force            # Remove even if locked
+```
+
 ## Workflow Rules
 
 1. **Always run `gr sync` before starting new work**

--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ repos:
 
 Work on multiple branches simultaneously without switching. Griptrees use git worktrees to create parallel workspace directories.
 
+<p align="center">
+  <img src="assets/griptree-concept.svg" alt="Griptrees Concept" width="700">
+</p>
+
 ```bash
 # Create a griptree for a feature branch
 gr griptree add feat/new-feature
@@ -324,6 +328,10 @@ gr griptree lock feat/new-feature
 # Remove when done (branches are preserved)
 gr griptree remove feat/new-feature
 ```
+
+<p align="center">
+  <img src="assets/griptree-workflow.svg" alt="Griptree Workflow" width="700">
+</p>
 
 **Benefits:**
 - No branch switching required

--- a/assets/griptree-concept.svg
+++ b/assets/griptree-concept.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="mainGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="treeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3B82F6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1D4ED8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="repoGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#374151;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1F2937;stop-opacity:1" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="2" dy="4" stdDeviation="4" flood-opacity="0.2"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="500" fill="#0F172A"/>
+
+  <!-- Title -->
+  <text x="400" y="45" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="bold" fill="#F8FAFC" text-anchor="middle">Griptrees: Multi-Branch Workspaces</text>
+  <text x="400" y="75" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#94A3B8" text-anchor="middle">Work on multiple features simultaneously without switching branches</text>
+
+  <!-- Main Workspace Box -->
+  <g transform="translate(50, 110)">
+    <rect x="0" y="0" width="220" height="280" rx="12" fill="url(#mainGrad)" filter="url(#shadow)"/>
+    <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Main Workspace</text>
+    <text x="110" y="50" font-family="monospace" font-size="12" fill="#D1FAE5" text-anchor="middle">branch: main</text>
+
+    <!-- Repos in main -->
+    <g transform="translate(20, 70)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#10B981">frontend/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">.git/objects (shared)</text>
+    </g>
+    <g transform="translate(20, 125)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#10B981">backend/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">.git/objects (shared)</text>
+    </g>
+    <g transform="translate(20, 180)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#10B981">shared/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">.git/objects (shared)</text>
+    </g>
+  </g>
+
+  <!-- Griptree 1 -->
+  <g transform="translate(290, 110)">
+    <rect x="0" y="0" width="220" height="280" rx="12" fill="url(#treeGrad)" filter="url(#shadow)"/>
+    <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Griptree: feat/auth</text>
+    <text x="110" y="50" font-family="monospace" font-size="12" fill="#BFDBFE" text-anchor="middle">branch: feat/auth</text>
+
+    <!-- Repos as worktrees -->
+    <g transform="translate(20, 70)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">frontend/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
+    </g>
+    <g transform="translate(20, 125)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">backend/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
+    </g>
+    <g transform="translate(20, 180)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">shared/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
+    </g>
+  </g>
+
+  <!-- Griptree 2 -->
+  <g transform="translate(530, 110)">
+    <rect x="0" y="0" width="220" height="280" rx="12" fill="url(#treeGrad)" filter="url(#shadow)"/>
+    <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Griptree: feat/api</text>
+    <text x="110" y="50" font-family="monospace" font-size="12" fill="#BFDBFE" text-anchor="middle">branch: feat/api</text>
+
+    <!-- Repos as worktrees -->
+    <g transform="translate(20, 70)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">frontend/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
+    </g>
+    <g transform="translate(20, 125)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">backend/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
+    </g>
+    <g transform="translate(20, 180)">
+      <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">shared/</text>
+      <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
+    </g>
+  </g>
+
+  <!-- Connecting arrows showing shared objects -->
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <!-- Curved lines from main to griptrees -->
+  <path d="M 270 250 Q 280 200 290 250" stroke="#10B981" stroke-width="2" fill="none" stroke-dasharray="5,5"/>
+  <path d="M 270 250 Q 400 150 530 250" stroke="#10B981" stroke-width="2" fill="none" stroke-dasharray="5,5"/>
+
+  <!-- Legend -->
+  <g transform="translate(50, 420)">
+    <rect x="0" y="0" width="700" height="65" rx="8" fill="#1E293B"/>
+    <text x="20" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#F8FAFC">Benefits:</text>
+    <text x="20" y="48" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#94A3B8">No branch switching needed</text>
+    <text x="200" y="48" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#94A3B8">Shared git objects (minimal disk)</text>
+    <text x="430" y="48" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#94A3B8">Instant creation via git worktree</text>
+  </g>
+</svg>

--- a/assets/griptree-workflow.svg
+++ b/assets/griptree-workflow.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 300">
+  <defs>
+    <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#10B981"/>
+      <stop offset="100%" style="stop-color:#059669"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="300" fill="#0F172A"/>
+
+  <!-- Title -->
+  <text x="400" y="35" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="bold" fill="#F8FAFC" text-anchor="middle">Griptree Workflow</text>
+
+  <!-- Step 1: Create -->
+  <g transform="translate(60, 70)">
+    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#10B981" stroke-width="2"/>
+    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#10B981" text-anchor="middle">1. Create</text>
+    <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr griptree add</text>
+    <text x="90" y="68" font-family="monospace" font-size="11" fill="#60A5FA" text-anchor="middle">feat/my-feature</text>
+  </g>
+
+  <!-- Arrow 1 -->
+  <path d="M 250 115 L 300 115" stroke="#10B981" stroke-width="2" marker-end="url(#arrow)"/>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 Z" fill="#10B981"/>
+    </marker>
+  </defs>
+
+  <!-- Step 2: Work -->
+  <g transform="translate(310, 70)">
+    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#3B82F6" stroke-width="2"/>
+    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#3B82F6" text-anchor="middle">2. Work</text>
+    <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">cd ../feat-my-feature</text>
+    <text x="90" y="68" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr status / commit / push</text>
+  </g>
+
+  <!-- Arrow 2 -->
+  <path d="M 500 115 L 550 115" stroke="#3B82F6" stroke-width="2" marker-end="url(#arrow2)"/>
+  <defs>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 Z" fill="#3B82F6"/>
+    </marker>
+  </defs>
+
+  <!-- Step 3: Remove -->
+  <g transform="translate(560, 70)">
+    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#F59E0B" stroke-width="2"/>
+    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#F59E0B" text-anchor="middle">3. Cleanup</text>
+    <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr griptree remove</text>
+    <text x="90" y="68" font-family="monospace" font-size="11" fill="#60A5FA" text-anchor="middle">feat/my-feature</text>
+  </g>
+
+  <!-- Commands reference -->
+  <g transform="translate(60, 190)">
+    <rect x="0" y="0" width="680" height="90" rx="8" fill="#1E293B"/>
+    <text x="20" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#F8FAFC">Quick Reference:</text>
+
+    <text x="20" y="50" font-family="monospace" font-size="11" fill="#10B981">gr griptree add &lt;branch&gt;</text>
+    <text x="200" y="50" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Create parallel workspace</text>
+
+    <text x="20" y="70" font-family="monospace" font-size="11" fill="#10B981">gr griptree list</text>
+    <text x="200" y="70" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Show all griptrees</text>
+
+    <text x="380" y="50" font-family="monospace" font-size="11" fill="#10B981">gr griptree lock &lt;branch&gt;</text>
+    <text x="560" y="50" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Protect from removal</text>
+
+    <text x="380" y="70" font-family="monospace" font-size="11" fill="#10B981">gr griptree remove &lt;branch&gt;</text>
+    <text x="590" y="70" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Remove worktrees</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Add visual graphics and documentation for the griptree feature - a key differentiator for gitgrip.

## Changes

### New Graphics
- `assets/griptree-concept.svg` - Visual diagram showing multi-branch workspaces with shared git objects
- `assets/griptree-workflow.svg` - Workflow diagram with quick reference commands

### Documentation Updates
- `README.md` - Added graphics to griptrees section
- `.claude/skills/gitgrip/SKILL.md` - Added complete griptree commands documentation

## Preview

The concept graphic shows:
- Main workspace on `main` branch
- Two griptrees (`feat/auth`, `feat/api`) as parallel workspaces
- Shared git objects between all workspaces
- Benefits listed at bottom