### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-01-29
 
 ### Added
 - `gr griptree` commands for worktree-based multi-branch workspaces
@@ -14,10 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `gr griptree remove <branch>` - remove a griptree
   - `gr griptree lock/unlock <branch>` - protect griptrees from removal
 - `GitStatusCache` class for caching git status calls within command execution
+- CI workflow with build/test/benchmarks on Node 18, 20, 22
+- Griptree documentation graphics (`assets/griptree-concept.svg`, `assets/griptree-workflow.svg`)
 
 ### Changed
 - **Performance:** Parallelized `push`, `sync`, and `commit` commands using `Promise.all()`
-  - Expected 3-5x speedup for workspaces with 5+ repos
+  - 3.4x speedup on `status` operation
+  - 1.8x speedup on `branch-check` operation
 
 ## [0.3.1] - 2026-01-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitgrip",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "git a grip - Multi-repo workflow tool",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const program = new Command();
 program
   .name('gitgrip')
   .description('git a grip - Multi-repo workflow tool\n\nShorthand: Use "gr" instead of "gitgrip"')
-  .version('0.3.1')
+  .version('0.4.0')
   .option('--timing', 'Show timing breakdown for operations');
 
 // Set up timing hooks


### PR DESCRIPTION
## Release v0.4.0

### Highlights

- **Griptrees** - Work on multiple branches simultaneously with worktree-based parallel workspaces
- **Performance** - 3.4x speedup on status, 1.8x on branch-check via parallelization
- **CI** - Automated build/test/benchmarks on Node 18, 20, 22

### New Commands

```bash
gr griptree add <branch>     # Create parallel workspace
gr griptree list             # Show all griptrees
gr griptree remove <branch>  # Remove a griptree
gr griptree lock <branch>    # Protect from removal
gr griptree unlock <branch>  # Allow removal
```

### Version Changes

- package.json: 0.3.1 → 0.4.0
- src/index.ts: 0.3.1 → 0.4.0
- CHANGELOG.md: [Unreleased] → [0.4.0]

### After Merge

1. Create GitHub release: `gh release create v0.4.0 --generate-notes`
2. Update Homebrew formula with new version and SHA256