### PR TITLE
refactor: rename griptree to tree

### DIFF
--- a/.claude/skills/gitgrip/SKILL.md
+++ b/.claude/skills/gitgrip/SKILL.md
@@ -109,30 +109,30 @@ gr bench --list              # List available benchmarks
 gr bench manifest-load -n 10 # Run specific benchmark
 ```
 
-### Griptrees (Multi-Branch Workspaces)
+### Trees (Multi-Branch Workspaces)
 
-Griptrees let you work on multiple feature branches simultaneously without switching branches. Each griptree is a parallel workspace using git worktrees.
+Trees let you work on multiple feature branches simultaneously without switching branches. Each tree is a parallel workspace using git worktrees.
 
 ```bash
-# Create a griptree for a feature branch
-gr griptree add feat/auth
+# Create a tree for a feature branch
+gr tree add feat/auth
 # Creates: ../feat-auth/ with all repos on feat/auth branch
 
-# List all griptrees
-gr griptree list
+# List all trees
+gr tree list
 
-# Work in a griptree
+# Work in a tree
 cd ../feat-auth
 gr status                    # Works just like main workspace
 gr commit -m "changes"
 gr push
 
-# Protect important griptrees
-gr griptree lock feat/auth   # Prevents accidental removal
+# Protect important trees
+gr tree lock feat/auth       # Prevents accidental removal
 
 # Cleanup when done
-gr griptree unlock feat/auth
-gr griptree remove feat/auth # Removes worktrees, keeps branches
+gr tree unlock feat/auth
+gr tree remove feat/auth     # Removes worktrees, keeps branches
 ```
 
 **Benefits:**
@@ -142,8 +142,8 @@ gr griptree remove feat/auth # Removes worktrees, keeps branches
 
 **Options:**
 ```bash
-gr griptree add feat/x --path ./custom-path  # Custom location
-gr griptree remove feat/x --force            # Remove even if locked
+gr tree add feat/x --path ./custom-path  # Custom location
+gr tree remove feat/x --force            # Remove even if locked
 ```
 
 ## Workflow Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2026-01-29
 
 ### Added
-- `gr griptree` commands for worktree-based multi-branch workspaces
-  - `gr griptree add <branch>` - create parallel workspace on a branch
-  - `gr griptree list` - show all griptrees
-  - `gr griptree remove <branch>` - remove a griptree
-  - `gr griptree lock/unlock <branch>` - protect griptrees from removal
+- `gr tree` commands for worktree-based multi-branch workspaces
+  - `gr tree add <branch>` - create parallel workspace on a branch
+  - `gr tree list` - show all trees
+  - `gr tree remove <branch>` - remove a tree
+  - `gr tree lock/unlock <branch>` - protect trees from removal
 - `GitStatusCache` class for caching git status calls within command execution
 - CI workflow with build/test/benchmarks on Node 18, 20, 22
-- Griptree documentation graphics (`assets/griptree-concept.svg`, `assets/griptree-workflow.svg`)
+- Tree documentation graphics (`assets/tree-concept.svg`, `assets/tree-workflow.svg`)
 
 ### Changed
 - **Performance:** Parallelized `push`, `sync`, and `commit` commands using `Promise.all()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ src/
 │   ├── env.ts            # gr env
 │   ├── bench.ts          # gr bench
 │   ├── forall.ts         # gr forall
-│   ├── griptree.ts       # gr griptree (worktree-based workspaces)
+│   ├── tree.ts           # gr tree (worktree-based workspaces)
 │   └── pr/               # PR subcommands
 │       ├── index.ts
 │       ├── create.ts
@@ -213,15 +213,15 @@ All commands use `gr` (or `gitgrip`):
 - `gr env` - Show workspace environment variables
 - `gr bench` - Run benchmarks
 - `gr forall -c "cmd"` - Run command in each repo
-- `gr griptree add/list/remove` - Manage worktree-based multi-branch workspaces
+- `gr tree add/list/remove` - Manage worktree-based multi-branch workspaces
 
-### Griptrees (Multi-Branch Workspaces)
+### Trees (Multi-Branch Workspaces)
 
-Griptrees allow you to work on multiple branches simultaneously without switching branches. Each griptree is a parallel workspace using git worktrees.
+Trees allow you to work on multiple branches simultaneously without switching branches. Each tree is a parallel workspace using git worktrees.
 
 ```bash
-# Create a griptree for a feature branch
-gr griptree add feat/auth
+# Create a tree for a feature branch
+gr tree add feat/auth
 
 # This creates a directory structure:
 # ../feat-auth/
@@ -229,14 +229,14 @@ gr griptree add feat/auth
 #   ├── codi-private/   # worktree of main/codi-private on feat/auth
 #   └── .gitgrip/manifests/  # worktree of manifest on feat/auth
 
-# List all griptrees
-gr griptree list
+# List all trees
+gr tree list
 
-# Lock a griptree to prevent accidental removal
-gr griptree lock feat/auth
+# Lock a tree to prevent accidental removal
+gr tree lock feat/auth
 
-# Remove a griptree (removes worktrees, not branches)
-gr griptree remove feat/auth
+# Remove a tree (removes worktrees, not branches)
+gr tree remove feat/auth
 ```
 
 **Benefits:**

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ gr sync
 | `gr pr merge` | Merge all linked PRs |
 | `gr repo add <url>` | Add a new repository to workspace |
 | `gr forall -c "cmd"` | Run command in each repo |
-| `gr griptree add <branch>` | Create a worktree-based workspace |
-| `gr griptree list` | List all griptrees |
-| `gr griptree remove <branch>` | Remove a griptree |
+| `gr tree add <branch>` | Create a worktree-based workspace |
+| `gr tree list` | List all trees |
+| `gr tree remove <branch>` | Remove a tree |
 
 ### Command Details
 
@@ -297,17 +297,17 @@ repos:
       baseUrl: https://gitlab.company.com
 ```
 
-## Griptrees (Multi-Branch Workspaces)
+## Trees (Multi-Branch Workspaces)
 
-Work on multiple branches simultaneously without switching. Griptrees use git worktrees to create parallel workspace directories.
+Work on multiple branches simultaneously without switching. Trees use git worktrees to create parallel workspace directories.
 
 <p align="center">
-  <img src="assets/griptree-concept.svg" alt="Griptrees Concept" width="700">
+  <img src="assets/tree-concept.svg" alt="Trees Concept" width="700">
 </p>
 
 ```bash
-# Create a griptree for a feature branch
-gr griptree add feat/new-feature
+# Create a tree for a feature branch
+gr tree add feat/new-feature
 
 # Creates a sibling directory with all repos on that branch:
 # ../feat-new-feature/
@@ -315,22 +315,22 @@ gr griptree add feat/new-feature
 #   ├── backend/
 #   └── shared/
 
-# Work in the griptree
+# Work in the tree
 cd ../feat-new-feature
 gr status
 
-# List all griptrees
-gr griptree list
+# List all trees
+gr tree list
 
 # Lock to prevent accidental removal
-gr griptree lock feat/new-feature
+gr tree lock feat/new-feature
 
 # Remove when done (branches are preserved)
-gr griptree remove feat/new-feature
+gr tree remove feat/new-feature
 ```
 
 <p align="center">
-  <img src="assets/griptree-workflow.svg" alt="Griptree Workflow" width="700">
+  <img src="assets/tree-workflow.svg" alt="Tree Workflow" width="700">
 </p>
 
 **Benefits:**

--- a/assets/tree-concept.svg
+++ b/assets/tree-concept.svg
@@ -21,7 +21,7 @@
   <rect width="800" height="500" fill="#0F172A"/>
 
   <!-- Title -->
-  <text x="400" y="45" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="bold" fill="#F8FAFC" text-anchor="middle">Griptrees: Multi-Branch Workspaces</text>
+  <text x="400" y="45" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="bold" fill="#F8FAFC" text-anchor="middle">Trees: Multi-Branch Workspaces</text>
   <text x="400" y="75" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#94A3B8" text-anchor="middle">Work on multiple features simultaneously without switching branches</text>
 
   <!-- Main Workspace Box -->
@@ -48,10 +48,10 @@
     </g>
   </g>
 
-  <!-- Griptree 1 -->
+  <!-- Tree 1 -->
   <g transform="translate(290, 110)">
     <rect x="0" y="0" width="220" height="280" rx="12" fill="url(#treeGrad)" filter="url(#shadow)"/>
-    <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Griptree: feat/auth</text>
+    <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Tree: feat/auth</text>
     <text x="110" y="50" font-family="monospace" font-size="12" fill="#BFDBFE" text-anchor="middle">branch: feat/auth</text>
 
     <!-- Repos as worktrees -->
@@ -72,10 +72,10 @@
     </g>
   </g>
 
-  <!-- Griptree 2 -->
+  <!-- Tree 2 -->
   <g transform="translate(530, 110)">
     <rect x="0" y="0" width="220" height="280" rx="12" fill="url(#treeGrad)" filter="url(#shadow)"/>
-    <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Griptree: feat/api</text>
+    <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Tree: feat/api</text>
     <text x="110" y="50" font-family="monospace" font-size="12" fill="#BFDBFE" text-anchor="middle">branch: feat/api</text>
 
     <!-- Repos as worktrees -->
@@ -103,7 +103,7 @@
     </marker>
   </defs>
 
-  <!-- Curved lines from main to griptrees -->
+  <!-- Curved lines from main to trees -->
   <path d="M 270 250 Q 280 200 290 250" stroke="#10B981" stroke-width="2" fill="none" stroke-dasharray="5,5"/>
   <path d="M 270 250 Q 400 150 530 250" stroke="#10B981" stroke-width="2" fill="none" stroke-dasharray="5,5"/>
 

--- a/assets/tree-workflow.svg
+++ b/assets/tree-workflow.svg
@@ -17,13 +17,13 @@
   <rect width="800" height="300" fill="#0F172A"/>
 
   <!-- Title -->
-  <text x="400" y="35" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="bold" fill="#F8FAFC" text-anchor="middle">Griptree Workflow</text>
+  <text x="400" y="35" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="bold" fill="#F8FAFC" text-anchor="middle">Tree Workflow</text>
 
   <!-- Step 1: Create -->
   <g transform="translate(60, 70)">
     <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#10B981" stroke-width="2"/>
     <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#10B981" text-anchor="middle">1. Create</text>
-    <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr griptree add</text>
+    <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr tree add</text>
     <text x="90" y="68" font-family="monospace" font-size="11" fill="#60A5FA" text-anchor="middle">feat/my-feature</text>
   </g>
 
@@ -55,7 +55,7 @@
   <g transform="translate(560, 70)">
     <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#F59E0B" stroke-width="2"/>
     <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#F59E0B" text-anchor="middle">3. Cleanup</text>
-    <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr griptree remove</text>
+    <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr tree remove</text>
     <text x="90" y="68" font-family="monospace" font-size="11" fill="#60A5FA" text-anchor="middle">feat/my-feature</text>
   </g>
 
@@ -64,16 +64,16 @@
     <rect x="0" y="0" width="680" height="90" rx="8" fill="#1E293B"/>
     <text x="20" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#F8FAFC">Quick Reference:</text>
 
-    <text x="20" y="50" font-family="monospace" font-size="11" fill="#10B981">gr griptree add &lt;branch&gt;</text>
+    <text x="20" y="50" font-family="monospace" font-size="11" fill="#10B981">gr tree add &lt;branch&gt;</text>
     <text x="200" y="50" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Create parallel workspace</text>
 
-    <text x="20" y="70" font-family="monospace" font-size="11" fill="#10B981">gr griptree list</text>
-    <text x="200" y="70" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Show all griptrees</text>
+    <text x="20" y="70" font-family="monospace" font-size="11" fill="#10B981">gr tree list</text>
+    <text x="200" y="70" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Show all trees</text>
 
-    <text x="380" y="50" font-family="monospace" font-size="11" fill="#10B981">gr griptree lock &lt;branch&gt;</text>
+    <text x="380" y="50" font-family="monospace" font-size="11" fill="#10B981">gr tree lock &lt;branch&gt;</text>
     <text x="560" y="50" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Protect from removal</text>
 
-    <text x="380" y="70" font-family="monospace" font-size="11" fill="#10B981">gr griptree remove &lt;branch&gt;</text>
+    <text x="380" y="70" font-family="monospace" font-size="11" fill="#10B981">gr tree remove &lt;branch&gt;</text>
     <text x="590" y="70" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Remove worktrees</text>
   </g>
 </svg>

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { add } from './commands/add.js';
 import { diff } from './commands/diff.js';
 import { forall } from './commands/forall.js';
 import { repoAdd } from './commands/repo.js';
-import { griptreeAdd, griptreeList, griptreeRemove, griptreeLock, griptreeUnlock } from './commands/griptree.js';
+import { treeAdd, treeList, treeRemove, treeLock, treeUnlock } from './commands/tree.js';
 import { TimingContext, formatTimingReport, setTimingContext, getTimingContext } from './lib/timing.js';
 
 const program = new Command();
@@ -362,60 +362,60 @@ repo.command('add <url>')
     }
   });
 
-// Griptree commands - worktree-based multi-branch workspaces
-const griptree = program.command('griptree').description('Manage griptrees (worktree-based multi-branch workspaces)');
+// Tree commands - worktree-based multi-branch workspaces
+const tree = program.command('tree').description('Manage trees (worktree-based multi-branch workspaces)');
 
-griptree.command('add <branch>')
-  .description('Create a griptree for a branch')
-  .option('-p, --path <path>', 'Custom path for the griptree directory')
+tree.command('add <branch>')
+  .description('Create a tree for a branch')
+  .option('-p, --path <path>', 'Custom path for the tree directory')
   .action(async (branch, options) => {
     try {
-      await griptreeAdd(branch, { path: options.path });
+      await treeAdd(branch, { path: options.path });
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));
       process.exit(1);
     }
   });
 
-griptree.command('list')
-  .description('List all griptrees')
+tree.command('list')
+  .description('List all trees')
   .action(async () => {
     try {
-      await griptreeList();
+      await treeList();
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));
       process.exit(1);
     }
   });
 
-griptree.command('remove <branch>')
-  .description('Remove a griptree')
+tree.command('remove <branch>')
+  .description('Remove a tree')
   .option('-f, --force', 'Force removal even if locked')
   .action(async (branch, options) => {
     try {
-      await griptreeRemove(branch, { force: options.force });
+      await treeRemove(branch, { force: options.force });
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));
       process.exit(1);
     }
   });
 
-griptree.command('lock <branch>')
-  .description('Lock a griptree to prevent accidental removal')
+tree.command('lock <branch>')
+  .description('Lock a tree to prevent accidental removal')
   .action(async (branch) => {
     try {
-      await griptreeLock(branch);
+      await treeLock(branch);
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));
       process.exit(1);
     }
   });
 
-griptree.command('unlock <branch>')
-  .description('Unlock a griptree')
+tree.command('unlock <branch>')
+  .description('Unlock a tree')
   .action(async (branch) => {
     try {
-      await griptreeUnlock(branch);
+      await treeUnlock(branch);
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));
       process.exit(1);

--- a/src/types.ts
+++ b/src/types.ts
@@ -371,23 +371,23 @@ export interface BenchmarkResult {
 }
 
 /**
- * Information about a griptree (worktree-based workspace)
+ * Information about a tree (worktree-based workspace)
  */
-export interface GriptreeInfo {
-  /** Branch name this griptree is for */
+export interface TreeInfo {
+  /** Branch name this tree is for */
   branch: string;
-  /** Absolute path to the griptree directory */
+  /** Absolute path to the tree directory */
   path: string;
-  /** Whether the griptree is locked (prevents accidental removal) */
+  /** Whether the tree is locked (prevents accidental removal) */
   locked: boolean;
   /** Per-repo worktree info */
-  repos: GriptreeRepoInfo[];
+  repos: TreeRepoInfo[];
 }
 
 /**
- * Per-repo information within a griptree
+ * Per-repo information within a tree
  */
-export interface GriptreeRepoInfo {
+export interface TreeRepoInfo {
   /** Repository name */
   name: string;
   /** Worktree path */


### PR DESCRIPTION
## Summary
- Renamed `griptree` command to `tree` to avoid the awkward "gitgrip griptree" naming with duplicate "grip"
- The command is now `gr tree add`, `gr tree list`, `gr tree remove`, etc.

## Changes
- Renamed command: `gr griptree` → `gr tree`
- Renamed file: `src/commands/griptree.ts` → `src/commands/tree.ts`
- Renamed types: `GriptreeInfo` → `TreeInfo`, `GriptreeRepoInfo` → `TreeRepoInfo`
- Renamed assets: `griptree-*.svg` → `tree-*.svg`
- Config file: `.griptree` → `.tree`
- Updated all documentation (README, CLAUDE.md, CHANGELOG, SKILL.md)

## Test plan
- [x] Build succeeds (`pnpm build`)
- [x] All tests pass (`pnpm test`)
- [x] `gr tree --help` shows correct subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)