### PR TITLE
fix: improve error handling for pr merge failures

### DIFF
--- a/src/lib/platform/github.ts
+++ b/src/lib/platform/github.ts
@@ -13,6 +13,7 @@ import type {
   PRMergeOptions,
   PRReview,
   StatusCheckResult,
+  AllowedMergeMethods,
 } from './types.js';
 
 /**
@@ -272,6 +273,23 @@ export class GitHubPlatform implements HostingPlatform {
         context: s.context,
         state: s.state,
       })),
+    };
+  }
+
+  /**
+   * Get allowed merge methods for a repository
+   */
+  async getAllowedMergeMethods(
+    owner: string,
+    repo: string
+  ): Promise<AllowedMergeMethods> {
+    const octokit = await this.getOctokit();
+    const response = await octokit.repos.get({ owner, repo });
+
+    return {
+      merge: response.data.allow_merge_commit ?? true,
+      squash: response.data.allow_squash_merge ?? true,
+      rebase: response.data.allow_rebase_merge ?? true,
     };
   }
 

--- a/src/lib/platform/types.ts
+++ b/src/lib/platform/types.ts
@@ -86,6 +86,15 @@ export interface StatusCheckResult {
 }
 
 /**
+ * Allowed merge methods for a repository
+ */
+export interface AllowedMergeMethods {
+  merge: boolean;
+  squash: boolean;
+  rebase: boolean;
+}
+
+/**
  * Interface for hosting platform adapters
  * Each platform (GitHub, GitLab, Azure DevOps) implements this interface
  */
@@ -180,6 +189,15 @@ export interface HostingPlatform {
     repo: string,
     ref: string
   ): Promise<StatusCheckResult>;
+
+  /**
+   * Get allowed merge methods for a repository
+   * Used to determine fallback methods when merge fails
+   */
+  getAllowedMergeMethods?(
+    owner: string,
+    repo: string
+  ): Promise<AllowedMergeMethods>;
 
   // URL Parsing
   /**


### PR DESCRIPTION
## Summary
- Add `getAllowedMergeMethods` to GitHub platform adapter
- Try fallback merge methods (squash, rebase) when default fails with 405
- Provide better error messages with suggestions
- Show which merge method was used when fallback succeeds

## Test plan
- [ ] PR merge with repo that only allows squash should auto-fallback
- [ ] Error message shows suggestion when all methods fail

Fixes #25