### PR TITLE
feat: improve check status messaging in gr pr merge

### DIFF
--- a/src/lib/linker.ts
+++ b/src/lib/linker.ts
@@ -1,4 +1,4 @@
-import type { LinkedPR, ManifestPR, RepoInfo } from '../types.js';
+import type { LinkedPR, ManifestPR, RepoInfo, CheckStatusDetails } from '../types.js';
 import { getPlatformAdapter } from './platform/index.js';
 import { loadState, saveState, getAllRepoInfo } from './manifest.js';
 import type { Manifest } from '../types.js';
@@ -71,6 +71,28 @@ export async function getLinkedPRInfo(
     state = pr.state;
   }
 
+  // Calculate detailed check status
+  const checkDetails: CheckStatusDetails = {
+    state: checks.state,
+    passed: 0,
+    failed: 0,
+    pending: 0,
+    skipped: 0,
+    total: checks.statuses.length,
+  };
+
+  for (const status of checks.statuses) {
+    if (status.state === 'success') {
+      checkDetails.passed++;
+    } else if (status.state === 'failure') {
+      checkDetails.failed++;
+    } else if (status.state === 'pending') {
+      checkDetails.pending++;
+    } else if (status.state === 'skipped') {
+      checkDetails.skipped++;
+    }
+  }
+
   return {
     repoName: repoInfo.name,
     owner: repoInfo.owner,
@@ -82,6 +104,7 @@ export async function getLinkedPRInfo(
     checksPass: checks.state === 'success',
     mergeable: pr.mergeable ?? false,
     platformType: repoInfo.platformType,
+    checkDetails,
   };
 }
 

--- a/src/lib/platform/github.ts
+++ b/src/lib/platform/github.ts
@@ -298,8 +298,10 @@ export class GitHubPlatform implements HostingPlatform {
       let state: string;
       if (run.status !== 'completed') {
         state = 'pending';
-      } else if (run.conclusion === 'success' || run.conclusion === 'skipped') {
+      } else if (run.conclusion === 'success') {
         state = 'success';
+      } else if (run.conclusion === 'skipped') {
+        state = 'skipped';
       } else if (run.conclusion === 'failure' || run.conclusion === 'timed_out' || run.conclusion === 'cancelled') {
         state = 'failure';
       } else {
@@ -324,7 +326,7 @@ export class GitHubPlatform implements HostingPlatform {
       return { state: 'pending', statuses };
     }
 
-    // All checks passed
+    // All checks passed (including skipped)
     return { state: 'success', statuses };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,24 @@ export interface RepoStatus {
 }
 
 /**
+ * Detailed check status information
+ */
+export interface CheckStatusDetails {
+  /** Overall state: success, failure, pending */
+  state: 'success' | 'failure' | 'pending';
+  /** Number of passed checks */
+  passed: number;
+  /** Number of failed checks */
+  failed: number;
+  /** Number of pending checks */
+  pending: number;
+  /** Number of skipped checks */
+  skipped: number;
+  /** Total number of checks */
+  total: number;
+}
+
+/**
  * A linked PR in a child repository
  */
 export interface LinkedPR {
@@ -213,6 +231,8 @@ export interface LinkedPR {
   mergeable: boolean;
   /** Hosting platform type */
   platformType?: PlatformType;
+  /** Detailed check status (optional for backward compatibility) */
+  checkDetails?: CheckStatusDetails;
 }
 
 /**


### PR DESCRIPTION
Closes #39

## Summary
- Add `CheckStatusDetails` type to track check counts (passed, failed, pending, skipped)
- Update `getLinkedPRInfo` to populate detailed check status
- Improve `gr pr merge` messaging to distinguish between:
  - "checks skipped" - all checks are skipped, safe to merge
  - "X failed, Y pending" - detailed breakdown when checks aren't passing
  - "no checks" - when no checks exist

## Example Output

Before:
```
tooling #33: not approved, checks not passing
```

After:
```
tooling #33: not approved, checks skipped
```

Or with details:
```
tooling #33: not approved, 1 failed, 2 pending
```