### PR TITLE
feat: add --move-commit option to gr branch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ program
   .option('-f, --force', 'Force delete even if unmerged (with -d)')
   .option('-r, --repo <repos...>', 'Only operate on specific repositories')
   .option('--include-manifest', 'Include manifest repo in branch operation')
+  .option('--move-commit <n>', 'Move N commits from current branch to new branch', parseInt)
   .action(async (name, options) => {
     try {
       if (name) {
@@ -116,6 +117,7 @@ program
           force: options.force,
           repo: options.repo,
           includeManifest: options.includeManifest,
+          moveCommit: options.moveCommit,
         });
       } else {
         await listBranches();

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -235,6 +235,15 @@ export async function isBranchMerged(repoPath: string, branchName: string, targe
 }
 
 /**
+ * Reset current branch to a specific commit (hard reset)
+ */
+export async function resetHard(repoPath: string, target: string): Promise<void> {
+  const git = getGitInstance(repoPath);
+  await git.reset(['--hard', target]);
+  statusCache.invalidate(repoPath);
+}
+
+/**
  * Pull latest changes from remote
  */
 export async function pullLatest(repoPath: string, remote = 'origin'): Promise<void> {


### PR DESCRIPTION
Closes #62

## Summary
- Add `--move-commit <n>` option to `gr branch` command
- Moves N commits from the current branch to a new branch
- Resets the original branch back by N commits

## Usage
```bash
# Accidentally committed to main? Move the last commit to a feature branch:
gr branch feat/my-feature --move-commit 1 --repo tooling

# Move the last 3 commits from main to feat/x:
gr branch feat/x --move-commit 3
```

## Workflow
1. Creates new branch at HEAD
2. Resets current branch back by N commits (hard reset)
3. Checks out the new branch

This allows quick recovery when commits are made to the wrong branch.