### PR TITLE
feat: gr forall defaults to changed repos only

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -378,11 +378,14 @@ program
 // Forall command - run command in all repos (like AOSP repo forall)
 program
   .command('forall')
-  .description('Run a command in each repository (like AOSP repo forall)')
+  .description('Run a command in repositories with changes (use --all for all repos)')
   .requiredOption('-c, --command <command>', 'Command to run in each repo')
   .option('-r, --repo <repos...>', 'Only run in specific repositories')
   .option('--include-manifest', 'Include manifest repo')
   .option('--continue-on-error', 'Continue running in other repos if command fails')
+  .option('--all', 'Run in ALL repos, not just those with changes')
+  .option('--staged', 'Run only in repos with staged changes')
+  .option('--ahead', 'Run only in repos with commits ahead of remote')
   .action(async (options) => {
     try {
       await forall({
@@ -390,6 +393,9 @@ program
         repo: options.repo,
         includeManifest: options.includeManifest,
         continueOnError: options.continueOnError,
+        all: options.all,
+        staged: options.staged,
+        ahead: options.ahead,
       });
     } catch (error) {
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));


### PR DESCRIPTION
Closes #61

## Summary
- `gr forall` now defaults to running only in repos with uncommitted changes
- Add `--all` flag to run in ALL repos (previous default behavior)
- Add `--staged` flag to run only in repos with staged changes
- Add `--ahead` flag to run only in repos with commits ahead of remote

## Usage
```bash
# Run tests only in repos with changes (new default)
gr forall -c "pnpm test"

# Run in ALL repos (old behavior)
gr forall -c "pnpm build" --all

# Run only in repos with staged changes
gr forall -c "pnpm lint" --staged

# Run only in repos with commits ahead
gr forall -c "pnpm test" --ahead
```

## Benefits
- Faster feedback - only tests changed repos by default
- Less wasteful - skips repos with no changes
- More control - filter by staged or ahead status