### PR TITLE
feat: Rust implementation Phase 3 - Platform Adapters

### DIFF
--- a/rust/src/platform/github.rs
+++ b/rust/src/platform/github.rs
@@ -1,0 +1,541 @@
+//! GitHub platform adapter
+
+use async_trait::async_trait;
+use octocrab::Octocrab;
+use std::env;
+
+use super::traits::{HostingPlatform, LinkedPRRef, PlatformError};
+use super::types::*;
+use crate::core::manifest::PlatformType;
+
+/// GitHub API adapter
+pub struct GitHubAdapter {
+    base_url: Option<String>,
+}
+
+impl GitHubAdapter {
+    /// Create a new GitHub adapter
+    pub fn new(base_url: Option<&str>) -> Self {
+        Self {
+            base_url: base_url.map(|s| s.to_string()),
+        }
+    }
+
+    /// Get configured Octocrab instance
+    async fn get_client(&self) -> Result<Octocrab, PlatformError> {
+        let token = self.get_token().await?;
+
+        let mut builder = Octocrab::builder().personal_token(token);
+
+        if let Some(ref base_url) = self.base_url {
+            builder = builder.base_uri(base_url).map_err(|e| {
+                PlatformError::ApiError(format!("Invalid base URL: {}", e))
+            })?;
+        }
+
+        builder
+            .build()
+            .map_err(|e| PlatformError::ApiError(format!("Failed to create client: {}", e)))
+    }
+}
+
+#[async_trait]
+impl HostingPlatform for GitHubAdapter {
+    fn platform_type(&self) -> PlatformType {
+        PlatformType::GitHub
+    }
+
+    async fn get_token(&self) -> Result<String, PlatformError> {
+        // Try environment variables first
+        if let Ok(token) = env::var("GITHUB_TOKEN") {
+            return Ok(token);
+        }
+        if let Ok(token) = env::var("GH_TOKEN") {
+            return Ok(token);
+        }
+
+        // Try gh CLI auth
+        let output = tokio::process::Command::new("gh")
+            .args(["auth", "token"])
+            .output()
+            .await
+            .map_err(|e| PlatformError::AuthError(format!("Failed to run gh auth: {}", e)))?;
+
+        if output.status.success() {
+            let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !token.is_empty() {
+                return Ok(token);
+            }
+        }
+
+        Err(PlatformError::AuthError(
+            "No GitHub token found. Set GITHUB_TOKEN or run 'gh auth login'".to_string(),
+        ))
+    }
+
+    async fn create_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: Option<&str>,
+        draft: bool,
+    ) -> Result<PRCreateResult, PlatformError> {
+        let client = self.get_client().await?;
+
+        let pr = client
+            .pulls(owner, repo)
+            .create(title, head, base)
+            .body(body.unwrap_or(""))
+            .draft(draft)
+            .send()
+            .await
+            .map_err(|e| PlatformError::ApiError(format!("Failed to create PR: {}", e)))?;
+
+        Ok(PRCreateResult {
+            number: pr.number,
+            url: pr.html_url.map(|u| u.to_string()).unwrap_or_default(),
+        })
+    }
+
+    async fn get_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<PullRequest, PlatformError> {
+        let client = self.get_client().await?;
+
+        let pr = client
+            .pulls(owner, repo)
+            .get(pull_number)
+            .await
+            .map_err(|e| {
+                if e.to_string().contains("404") {
+                    PlatformError::NotFound(format!("PR #{} not found", pull_number))
+                } else {
+                    PlatformError::ApiError(format!("Failed to get PR: {}", e))
+                }
+            })?;
+
+        let state = if pr.merged_at.is_some() {
+            PRState::Merged
+        } else {
+            match pr.state {
+                Some(octocrab::models::IssueState::Open) => PRState::Open,
+                Some(octocrab::models::IssueState::Closed) => PRState::Closed,
+                _ => PRState::Open,
+            }
+        };
+
+        Ok(PullRequest {
+            number: pr.number,
+            url: pr.html_url.map(|u| u.to_string()).unwrap_or_default(),
+            title: pr.title.clone().unwrap_or_default(),
+            body: pr.body.clone().unwrap_or_default(),
+            state,
+            merged: pr.merged_at.is_some(),
+            mergeable: pr.mergeable,
+            head: PRHead {
+                ref_name: pr.head.ref_field.clone(),
+                sha: pr.head.sha.clone(),
+            },
+            base: PRBase {
+                ref_name: pr.base.ref_field.clone(),
+            },
+        })
+    }
+
+    async fn update_pull_request_body(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        body: &str,
+    ) -> Result<(), PlatformError> {
+        let client = self.get_client().await?;
+
+        client
+            .pulls(owner, repo)
+            .update(pull_number)
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| PlatformError::ApiError(format!("Failed to update PR body: {}", e)))?;
+
+        Ok(())
+    }
+
+    async fn merge_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        method: Option<MergeMethod>,
+        _delete_branch: bool,
+    ) -> Result<bool, PlatformError> {
+        let client = self.get_client().await?;
+
+        let merge_method = match method.unwrap_or(MergeMethod::Merge) {
+            MergeMethod::Merge => octocrab::params::pulls::MergeMethod::Merge,
+            MergeMethod::Squash => octocrab::params::pulls::MergeMethod::Squash,
+            MergeMethod::Rebase => octocrab::params::pulls::MergeMethod::Rebase,
+        };
+
+        let result = client
+            .pulls(owner, repo)
+            .merge(pull_number)
+            .method(merge_method)
+            .send()
+            .await;
+
+        match result {
+            Ok(merge) => Ok(merge.merged),
+            Err(e) => {
+                let error_str = e.to_string();
+                if error_str.contains("405") || error_str.contains("not mergeable") {
+                    Ok(false)
+                } else {
+                    Err(PlatformError::ApiError(format!("Failed to merge PR: {}", e)))
+                }
+            }
+        }
+    }
+
+    async fn find_pr_by_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Result<Option<PRCreateResult>, PlatformError> {
+        let client = self.get_client().await?;
+
+        let prs = client
+            .pulls(owner, repo)
+            .list()
+            .state(octocrab::params::State::Open)
+            .head(format!("{}:{}", owner, branch))
+            .send()
+            .await
+            .map_err(|e| PlatformError::ApiError(format!("Failed to find PR: {}", e)))?;
+
+        if let Some(pr) = prs.items.first() {
+            Ok(Some(PRCreateResult {
+                number: pr.number,
+                url: pr.html_url.as_ref().map(|u| u.to_string()).unwrap_or_default(),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn is_pull_request_approved(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<bool, PlatformError> {
+        let reviews = self.get_pull_request_reviews(owner, repo, pull_number).await?;
+
+        // Check for at least one approval and no changes requested
+        let has_approval = reviews.iter().any(|r| r.state == "APPROVED");
+        let has_changes_requested = reviews.iter().any(|r| r.state == "CHANGES_REQUESTED");
+
+        Ok(has_approval && !has_changes_requested)
+    }
+
+    async fn get_pull_request_reviews(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<Vec<PRReview>, PlatformError> {
+        let client = self.get_client().await?;
+
+        let reviews = client
+            .pulls(owner, repo)
+            .list_reviews(pull_number)
+            .send()
+            .await
+            .map_err(|e| PlatformError::ApiError(format!("Failed to get reviews: {}", e)))?;
+
+        Ok(reviews
+            .items
+            .iter()
+            .map(|r| PRReview {
+                state: r.state.clone().map(|s| format!("{:?}", s)).unwrap_or_default(),
+                user: r.user.as_ref().map(|u| u.login.clone()).unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    async fn get_status_checks(
+        &self,
+        owner: &str,
+        repo: &str,
+        ref_name: &str,
+    ) -> Result<StatusCheckResult, PlatformError> {
+        // Get combined status using raw API call
+        let token = self.get_token().await?;
+        let base_url = self.base_url.as_deref().unwrap_or("https://api.github.com");
+        let url = format!("{}/repos/{}/{}/commits/{}/status", base_url, owner, repo, ref_name);
+
+        let http_client = reqwest::Client::new();
+        let response = http_client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Accept", "application/vnd.github.v3+json")
+            .header("User-Agent", "gitgrip")
+            .send()
+            .await
+            .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(PlatformError::ApiError(format!(
+                "Failed to get status: {}",
+                response.status()
+            )));
+        }
+
+        #[derive(serde::Deserialize)]
+        struct CombinedStatus {
+            state: String,
+            statuses: Vec<StatusEntry>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct StatusEntry {
+            context: Option<String>,
+            state: String,
+        }
+
+        let status: CombinedStatus = response
+            .json()
+            .await
+            .map_err(|e| PlatformError::ParseError(e.to_string()))?;
+
+        let state = match status.state.as_str() {
+            "success" => CheckState::Success,
+            "failure" | "error" => CheckState::Failure,
+            _ => CheckState::Pending,
+        };
+
+        let statuses = status
+            .statuses
+            .iter()
+            .map(|s| StatusCheck {
+                context: s.context.clone().unwrap_or_default(),
+                state: s.state.clone(),
+            })
+            .collect();
+
+        Ok(StatusCheckResult { state, statuses })
+    }
+
+    async fn get_allowed_merge_methods(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<AllowedMergeMethods, PlatformError> {
+        let client = self.get_client().await?;
+
+        let repo_info = client
+            .repos(owner, repo)
+            .get()
+            .await
+            .map_err(|e| PlatformError::ApiError(format!("Failed to get repo: {}", e)))?;
+
+        Ok(AllowedMergeMethods {
+            merge: repo_info.allow_merge_commit.unwrap_or(true),
+            squash: repo_info.allow_squash_merge.unwrap_or(true),
+            rebase: repo_info.allow_rebase_merge.unwrap_or(true),
+        })
+    }
+
+    async fn get_pull_request_diff(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<String, PlatformError> {
+        let token = self.get_token().await?;
+        let base_url = self.base_url.as_deref().unwrap_or("https://api.github.com");
+
+        let url = format!("{}/repos/{}/{}/pulls/{}", base_url, owner, repo, pull_number);
+
+        let client = reqwest::Client::new();
+        let response = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Accept", "application/vnd.github.v3.diff")
+            .header("User-Agent", "gitgrip")
+            .send()
+            .await
+            .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(PlatformError::ApiError(format!(
+                "Failed to get diff: {}",
+                response.status()
+            )));
+        }
+
+        response
+            .text()
+            .await
+            .map_err(|e| PlatformError::NetworkError(e.to_string()))
+    }
+
+    fn parse_repo_url(&self, url: &str) -> Option<ParsedRepoInfo> {
+        // SSH format: git@github.com:owner/repo.git
+        if url.starts_with("git@github.com:") {
+            let path = url.trim_start_matches("git@github.com:");
+            let path = path.trim_end_matches(".git");
+            let parts: Vec<&str> = path.split('/').collect();
+            if parts.len() >= 2 {
+                return Some(ParsedRepoInfo {
+                    owner: parts[0].to_string(),
+                    repo: parts[parts.len() - 1].to_string(),
+                    project: None,
+                    platform: Some(PlatformType::GitHub),
+                });
+            }
+        }
+
+        // HTTPS format: https://github.com/owner/repo.git
+        if url.contains("github.com") {
+            let url = url.trim_end_matches(".git");
+            let parts: Vec<&str> = url.split('/').collect();
+            if parts.len() >= 2 {
+                let owner_idx = parts.iter().position(|&p| p == "github.com")? + 1;
+                if owner_idx + 1 < parts.len() {
+                    return Some(ParsedRepoInfo {
+                        owner: parts[owner_idx].to_string(),
+                        repo: parts[owner_idx + 1].to_string(),
+                        project: None,
+                        platform: Some(PlatformType::GitHub),
+                    });
+                }
+            }
+        }
+
+        None
+    }
+
+    fn matches_url(&self, url: &str) -> bool {
+        url.contains("github.com")
+    }
+
+    fn generate_linked_pr_comment(&self, links: &[LinkedPRRef]) -> String {
+        if links.is_empty() {
+            return String::new();
+        }
+
+        let mut comment = String::from("<!-- gitgrip-linked-prs\n");
+        for link in links {
+            comment.push_str(&format!("{}:{}\n", link.repo_name, link.number));
+        }
+        comment.push_str("-->");
+        comment
+    }
+
+    fn parse_linked_pr_comment(&self, body: &str) -> Vec<LinkedPRRef> {
+        let start_marker = "<!-- gitgrip-linked-prs";
+        let end_marker = "-->";
+
+        let Some(start) = body.find(start_marker) else {
+            return Vec::new();
+        };
+
+        let content_start = start + start_marker.len();
+        let Some(end) = body[content_start..].find(end_marker) else {
+            return Vec::new();
+        };
+
+        let content = &body[content_start..content_start + end];
+
+        content
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() {
+                    return None;
+                }
+
+                let parts: Vec<&str> = line.splitn(2, ':').collect();
+                if parts.len() != 2 {
+                    return None;
+                }
+
+                let number = parts[1].parse().ok()?;
+                Some(LinkedPRRef {
+                    repo_name: parts[0].to_string(),
+                    number,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_github_ssh_url() {
+        let adapter = GitHubAdapter::new(None);
+
+        let result = adapter.parse_repo_url("git@github.com:user/repo.git");
+        assert!(result.is_some());
+        let info = result.unwrap();
+        assert_eq!(info.owner, "user");
+        assert_eq!(info.repo, "repo");
+    }
+
+    #[test]
+    fn test_parse_github_https_url() {
+        let adapter = GitHubAdapter::new(None);
+
+        let result = adapter.parse_repo_url("https://github.com/user/repo.git");
+        assert!(result.is_some());
+        let info = result.unwrap();
+        assert_eq!(info.owner, "user");
+        assert_eq!(info.repo, "repo");
+    }
+
+    #[test]
+    fn test_matches_url() {
+        let adapter = GitHubAdapter::new(None);
+
+        assert!(adapter.matches_url("git@github.com:user/repo.git"));
+        assert!(adapter.matches_url("https://github.com/user/repo.git"));
+        assert!(!adapter.matches_url("git@gitlab.com:user/repo.git"));
+    }
+
+    #[test]
+    fn test_linked_pr_comment_roundtrip() {
+        let adapter = GitHubAdapter::new(None);
+
+        let links = vec![
+            LinkedPRRef {
+                repo_name: "frontend".to_string(),
+                number: 42,
+            },
+            LinkedPRRef {
+                repo_name: "backend".to_string(),
+                number: 123,
+            },
+        ];
+
+        let comment = adapter.generate_linked_pr_comment(&links);
+        let parsed = adapter.parse_linked_pr_comment(&comment);
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].repo_name, "frontend");
+        assert_eq!(parsed[0].number, 42);
+        assert_eq!(parsed[1].repo_name, "backend");
+        assert_eq!(parsed[1].number, 123);
+    }
+}

--- a/rust/src/platform/mod.rs
+++ b/rust/src/platform/mod.rs
@@ -2,11 +2,94 @@
 //!
 //! Provides a unified interface for GitHub, GitLab, and Azure DevOps.
 
+pub mod github;
+pub mod traits;
 pub mod types;
 
-// Platform adapters will be added in Phase 3
-// pub mod github;
-// pub mod gitlab;
-// pub mod azure;
+pub use traits::HostingPlatform;
+pub use types::{
+    AllowedMergeMethods, CheckState, CheckStatusDetails, MergeMethod, PRBase, PRCreateResult,
+    PRHead, PRReview, PRState, ParsedRepoInfo, PullRequest, StatusCheck, StatusCheckResult,
+};
 
-pub use types::*;
+use crate::core::manifest::PlatformType;
+use std::sync::Arc;
+
+/// Get a platform adapter for the given platform type
+pub fn get_platform_adapter(
+    platform_type: PlatformType,
+    base_url: Option<&str>,
+) -> Arc<dyn HostingPlatform> {
+    match platform_type {
+        PlatformType::GitHub => Arc::new(github::GitHubAdapter::new(base_url)),
+        // TODO: Implement GitLab and Azure DevOps adapters
+        PlatformType::GitLab => Arc::new(github::GitHubAdapter::new(base_url)), // Placeholder
+        PlatformType::AzureDevOps => Arc::new(github::GitHubAdapter::new(base_url)), // Placeholder
+    }
+}
+
+/// Detect platform type from a git URL
+pub fn detect_platform(url: &str) -> PlatformType {
+    // Check GitHub first (most common)
+    if url.contains("github.com") {
+        return PlatformType::GitHub;
+    }
+
+    // Check Azure DevOps before GitLab (avoid false positives)
+    if url.contains("dev.azure.com") || url.contains("visualstudio.com") {
+        return PlatformType::AzureDevOps;
+    }
+
+    // Check GitLab - ensure it's in hostname, not just path
+    if url.contains("gitlab.com") || url.contains("gitlab.") {
+        return PlatformType::GitLab;
+    }
+
+    // Default to GitHub for backward compatibility
+    PlatformType::GitHub
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_github() {
+        assert_eq!(
+            detect_platform("git@github.com:user/repo.git"),
+            PlatformType::GitHub
+        );
+        assert_eq!(
+            detect_platform("https://github.com/user/repo.git"),
+            PlatformType::GitHub
+        );
+    }
+
+    #[test]
+    fn test_detect_gitlab() {
+        assert_eq!(
+            detect_platform("git@gitlab.com:user/repo.git"),
+            PlatformType::GitLab
+        );
+    }
+
+    #[test]
+    fn test_detect_azure() {
+        assert_eq!(
+            detect_platform("https://dev.azure.com/org/project/_git/repo"),
+            PlatformType::AzureDevOps
+        );
+        assert_eq!(
+            detect_platform("git@ssh.dev.azure.com:v3/org/project/repo"),
+            PlatformType::AzureDevOps
+        );
+    }
+
+    #[test]
+    fn test_default_to_github() {
+        assert_eq!(
+            detect_platform("git@unknown.com:user/repo.git"),
+            PlatformType::GitHub
+        );
+    }
+}

--- a/rust/src/platform/traits.rs
+++ b/rust/src/platform/traits.rs
@@ -1,0 +1,361 @@
+//! Hosting platform trait definition
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use super::types::*;
+use crate::core::manifest::PlatformType;
+
+/// Errors that can occur during platform operations
+#[derive(Error, Debug)]
+pub enum PlatformError {
+    #[error("Authentication failed: {0}")]
+    AuthError(String),
+
+    #[error("API error: {0}")]
+    ApiError(String),
+
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    #[error("Rate limited")]
+    RateLimited,
+
+    #[error("Network error: {0}")]
+    NetworkError(String),
+
+    #[error("Parse error: {0}")]
+    ParseError(String),
+}
+
+/// Linked PR reference for cross-repo tracking
+#[derive(Debug, Clone)]
+pub struct LinkedPRRef {
+    pub repo_name: String,
+    pub number: u64,
+}
+
+/// Interface for hosting platform adapters
+/// Each platform (GitHub, GitLab, Azure DevOps) implements this trait
+#[async_trait]
+pub trait HostingPlatform: Send + Sync {
+    /// Platform type identifier
+    fn platform_type(&self) -> PlatformType;
+
+    /// Get authentication token for API calls
+    async fn get_token(&self) -> Result<String, PlatformError>;
+
+    /// Create a pull request
+    async fn create_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: Option<&str>,
+        draft: bool,
+    ) -> Result<PRCreateResult, PlatformError>;
+
+    /// Get pull request details
+    async fn get_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<PullRequest, PlatformError>;
+
+    /// Update pull request body
+    async fn update_pull_request_body(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        body: &str,
+    ) -> Result<(), PlatformError>;
+
+    /// Merge a pull request
+    async fn merge_pull_request(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+        method: Option<MergeMethod>,
+        delete_branch: bool,
+    ) -> Result<bool, PlatformError>;
+
+    /// Find an open PR by branch name
+    async fn find_pr_by_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Result<Option<PRCreateResult>, PlatformError>;
+
+    /// Check if PR is approved
+    async fn is_pull_request_approved(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<bool, PlatformError>;
+
+    /// Get reviews for a PR
+    async fn get_pull_request_reviews(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<Vec<PRReview>, PlatformError>;
+
+    /// Get CI/CD status checks for a commit
+    async fn get_status_checks(
+        &self,
+        owner: &str,
+        repo: &str,
+        ref_name: &str,
+    ) -> Result<StatusCheckResult, PlatformError>;
+
+    /// Get allowed merge methods for a repository
+    async fn get_allowed_merge_methods(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<AllowedMergeMethods, PlatformError>;
+
+    /// Get the diff for a pull request
+    async fn get_pull_request_diff(
+        &self,
+        owner: &str,
+        repo: &str,
+        pull_number: u64,
+    ) -> Result<String, PlatformError>;
+
+    /// Parse a git URL to extract owner/repo information
+    fn parse_repo_url(&self, url: &str) -> Option<ParsedRepoInfo>;
+
+    /// Check if a URL belongs to this platform
+    fn matches_url(&self, url: &str) -> bool;
+
+    /// Generate HTML comment for linked PR tracking
+    fn generate_linked_pr_comment(&self, links: &[LinkedPRRef]) -> String {
+        if links.is_empty() {
+            return String::new();
+        }
+
+        let mut comment = String::from("<!-- gitgrip-linked-prs\n");
+        for link in links {
+            comment.push_str(&format!("{}:{}\n", link.repo_name, link.number));
+        }
+        comment.push_str("-->");
+        comment
+    }
+
+    /// Parse linked PR references from PR body
+    fn parse_linked_pr_comment(&self, body: &str) -> Vec<LinkedPRRef> {
+        let start_marker = "<!-- gitgrip-linked-prs";
+        let end_marker = "-->";
+
+        let Some(start) = body.find(start_marker) else {
+            return Vec::new();
+        };
+
+        let content_start = start + start_marker.len();
+        let Some(end) = body[content_start..].find(end_marker) else {
+            return Vec::new();
+        };
+
+        let content = &body[content_start..content_start + end];
+
+        content
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() {
+                    return None;
+                }
+
+                let parts: Vec<&str> = line.splitn(2, ':').collect();
+                if parts.len() != 2 {
+                    return None;
+                }
+
+                let number = parts[1].parse().ok()?;
+                Some(LinkedPRRef {
+                    repo_name: parts[0].to_string(),
+                    number,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockPlatform;
+
+    #[async_trait]
+    impl HostingPlatform for MockPlatform {
+        fn platform_type(&self) -> PlatformType {
+            PlatformType::GitHub
+        }
+
+        async fn get_token(&self) -> Result<String, PlatformError> {
+            Ok("mock-token".to_string())
+        }
+
+        async fn create_pull_request(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _head: &str,
+            _base: &str,
+            _title: &str,
+            _body: Option<&str>,
+            _draft: bool,
+        ) -> Result<PRCreateResult, PlatformError> {
+            unimplemented!()
+        }
+
+        async fn get_pull_request(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _pull_number: u64,
+        ) -> Result<PullRequest, PlatformError> {
+            unimplemented!()
+        }
+
+        async fn update_pull_request_body(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _pull_number: u64,
+            _body: &str,
+        ) -> Result<(), PlatformError> {
+            unimplemented!()
+        }
+
+        async fn merge_pull_request(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _pull_number: u64,
+            _method: Option<MergeMethod>,
+            _delete_branch: bool,
+        ) -> Result<bool, PlatformError> {
+            unimplemented!()
+        }
+
+        async fn find_pr_by_branch(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _branch: &str,
+        ) -> Result<Option<PRCreateResult>, PlatformError> {
+            unimplemented!()
+        }
+
+        async fn is_pull_request_approved(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _pull_number: u64,
+        ) -> Result<bool, PlatformError> {
+            unimplemented!()
+        }
+
+        async fn get_pull_request_reviews(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _pull_number: u64,
+        ) -> Result<Vec<PRReview>, PlatformError> {
+            unimplemented!()
+        }
+
+        async fn get_status_checks(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _ref_name: &str,
+        ) -> Result<StatusCheckResult, PlatformError> {
+            unimplemented!()
+        }
+
+        async fn get_allowed_merge_methods(
+            &self,
+            _owner: &str,
+            _repo: &str,
+        ) -> Result<AllowedMergeMethods, PlatformError> {
+            unimplemented!()
+        }
+
+        async fn get_pull_request_diff(
+            &self,
+            _owner: &str,
+            _repo: &str,
+            _pull_number: u64,
+        ) -> Result<String, PlatformError> {
+            unimplemented!()
+        }
+
+        fn parse_repo_url(&self, _url: &str) -> Option<ParsedRepoInfo> {
+            None
+        }
+
+        fn matches_url(&self, _url: &str) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn test_generate_linked_pr_comment() {
+        let platform = MockPlatform;
+        let links = vec![
+            LinkedPRRef {
+                repo_name: "app".to_string(),
+                number: 123,
+            },
+            LinkedPRRef {
+                repo_name: "lib".to_string(),
+                number: 456,
+            },
+        ];
+
+        let comment = platform.generate_linked_pr_comment(&links);
+        assert!(comment.contains("app:123"));
+        assert!(comment.contains("lib:456"));
+    }
+
+    #[test]
+    fn test_parse_linked_pr_comment() {
+        let platform = MockPlatform;
+        let body = r#"
+Some PR description
+
+<!-- gitgrip-linked-prs
+app:123
+lib:456
+-->
+
+More content
+"#;
+
+        let links = platform.parse_linked_pr_comment(body);
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0].repo_name, "app");
+        assert_eq!(links[0].number, 123);
+        assert_eq!(links[1].repo_name, "lib");
+        assert_eq!(links[1].number, 456);
+    }
+
+    #[test]
+    fn test_parse_empty_comment() {
+        let platform = MockPlatform;
+        let links = platform.parse_linked_pr_comment("No linked PRs here");
+        assert!(links.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Implements platform adapters for the Rust port (Phase 3):

### Platform Module Components

- **`platform/traits.rs`** - `HostingPlatform` trait defining the full platform API
- **`platform/github.rs`** - GitHub adapter using octocrab + raw API
- **`platform/mod.rs`** - Platform factory and detection

### HostingPlatform Trait Methods

| Method | Description |
|--------|-------------|
| `get_token` | Get auth token (env var or `gh auth token`) |
| `create_pull_request` | Create a new PR |
| `get_pull_request` | Get PR details |
| `update_pull_request_body` | Update PR description |
| `merge_pull_request` | Merge with method selection |
| `find_pr_by_branch` | Find open PR for branch |
| `is_pull_request_approved` | Check review approval |
| `get_pull_request_reviews` | Get review list |
| `get_status_checks` | Get CI status |
| `get_allowed_merge_methods` | Get repo merge settings |
| `get_pull_request_diff` | Get PR diff |
| `parse_repo_url` | Extract owner/repo from URL |
| `matches_url` | Check if URL matches platform |
| `generate_linked_pr_comment` | Create cross-repo PR links |
| `parse_linked_pr_comment` | Parse cross-repo PR links |

### Files Added/Modified

| File | Description |
|------|-------------|
| `rust/src/platform/traits.rs` | Platform trait definition |
| `rust/src/platform/github.rs` | GitHub adapter implementation |
| `rust/src/platform/mod.rs` | Factory and detection |

### Test Results

```
running 56 tests
...
test result: ok. 56 passed; 0 failed
```

### Test Plan

- [x] `cargo test` - All 56 tests passing
- [x] URL parsing tests (SSH and HTTPS)
- [x] Linked PR comment roundtrip test
- [x] Platform detection tests

---
Generated with [Claude Code](https://claude.com/claude-code)