### PR TITLE
feat: implement PR workflow commands (Phase 5)

### DIFF
--- a/rust/src/cli/commands/mod.rs
+++ b/rust/src/cli/commands/mod.rs
@@ -7,16 +7,16 @@ pub mod branch;
 pub mod checkout;
 pub mod commit;
 pub mod diff;
+pub mod pr;
 pub mod push;
 pub mod status;
 pub mod sync;
 
-// To be implemented in Phase 5-6
+// To be implemented in Phase 6
 // pub mod env;
 // pub mod forall;
 // pub mod init;
 // pub mod link;
-// pub mod pr;
 // pub mod rebase;
 // pub mod repo;
 // pub mod run;

--- a/rust/src/cli/commands/pr/checks.rs
+++ b/rust/src/cli/commands/pr/checks.rs
@@ -1,0 +1,153 @@
+//! PR checks command implementation
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::{get_current_branch, open_repo, path_exists};
+use crate::platform::{detect_platform, get_platform_adapter, CheckState};
+use std::path::PathBuf;
+
+/// Run the PR checks command
+pub async fn run_pr_checks(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    json_output: bool,
+) -> anyhow::Result<()> {
+    if !json_output {
+        Output::header("CI/CD Check Status");
+        println!();
+    }
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    #[derive(serde::Serialize)]
+    struct CheckInfo {
+        context: String,
+        state: String,
+    }
+
+    #[derive(serde::Serialize)]
+    struct RepoChecks {
+        repo: String,
+        pr_number: Option<u64>,
+        overall_state: String,
+        checks: Vec<CheckInfo>,
+    }
+
+    let mut all_checks: Vec<RepoChecks> = Vec::new();
+    let mut total_passed = 0;
+    let mut total_failed = 0;
+    let mut total_pending = 0;
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        let git_repo = match open_repo(&repo.absolute_path) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        let branch = match get_current_branch(&git_repo) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+
+        // Skip if on default branch
+        if branch == repo.default_branch {
+            continue;
+        }
+
+        let platform_type = detect_platform(&repo.url);
+        let platform = get_platform_adapter(platform_type, None);
+
+        // Find PR number (optional, for display)
+        let pr_number = match platform.find_pr_by_branch(&repo.owner, &repo.repo, &branch).await {
+            Ok(Some(pr)) => Some(pr.number),
+            _ => None,
+        };
+
+        // Get status checks for the branch
+        match platform.get_status_checks(&repo.owner, &repo.repo, &branch).await {
+            Ok(status_result) => {
+                let check_infos: Vec<CheckInfo> = status_result.statuses
+                    .iter()
+                    .map(|s| {
+                        let state = s.state.to_lowercase();
+                        match state.as_str() {
+                            "success" => total_passed += 1,
+                            "failure" | "error" => total_failed += 1,
+                            _ => total_pending += 1,
+                        }
+                        CheckInfo {
+                            context: s.context.clone(),
+                            state,
+                        }
+                    })
+                    .collect();
+
+                if !json_output {
+                    // Print status with indicator
+                    let overall = match status_result.state {
+                        CheckState::Success => "✓",
+                        CheckState::Failure => "✗",
+                        CheckState::Pending => "●",
+                    };
+
+                    let pr_str = pr_number.map(|n| format!(" #{}", n)).unwrap_or_default();
+                    println!("{} {}{}", overall, repo.name, pr_str);
+
+                    for check in &check_infos {
+                        let indicator = match check.state.as_str() {
+                            "success" => "  ✓",
+                            "failure" | "error" => "  ✗",
+                            _ => "  ●",
+                        };
+                        println!("  {} {} {}", indicator, check.context, check.state);
+                    }
+                    println!();
+                }
+
+                all_checks.push(RepoChecks {
+                    repo: repo.name.clone(),
+                    pr_number,
+                    overall_state: format!("{:?}", status_result.state).to_lowercase(),
+                    checks: check_infos,
+                });
+            }
+            Err(e) => {
+                if !json_output {
+                    Output::error(&format!("{}: {}", repo.name, e));
+                }
+            }
+        }
+    }
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&all_checks)?);
+        return Ok(());
+    }
+
+    // Summary
+    if total_passed + total_failed + total_pending > 0 {
+        println!(
+            "Summary: {} passed, {} failed, {} pending",
+            total_passed, total_failed, total_pending
+        );
+
+        if total_failed > 0 {
+            Output::warning("Some checks are failing.");
+        } else if total_pending > 0 {
+            Output::info("Some checks are still pending.");
+        } else {
+            Output::success("All checks passing!");
+        }
+    }
+
+    Ok(())
+}

--- a/rust/src/cli/commands/pr/create.rs
+++ b/rust/src/cli/commands/pr/create.rs
@@ -1,0 +1,221 @@
+//! PR create command implementation
+
+use crate::cli::output::Output;
+use crate::core::manifest::{Manifest, PlatformType};
+use crate::core::repo::RepoInfo;
+use crate::core::state::StateFile;
+use crate::git::{get_current_branch, open_repo, path_exists};
+use crate::platform::{detect_platform, get_platform_adapter};
+use std::path::PathBuf;
+
+/// Run the PR create command
+pub async fn run_pr_create(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    title: Option<&str>,
+    draft: bool,
+    push_first: bool,
+) -> anyhow::Result<()> {
+    Output::header("Creating pull requests...");
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    // Get current branch for all repos and verify consistency
+    let mut branch_name: Option<String> = None;
+    let mut repos_with_changes: Vec<&RepoInfo> = Vec::new();
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        match open_repo(&repo.absolute_path) {
+            Ok(git_repo) => {
+                let current = match get_current_branch(&git_repo) {
+                    Ok(b) => b,
+                    Err(_) => continue,
+                };
+
+                // Skip if on default branch
+                if current == repo.default_branch {
+                    continue;
+                }
+
+                // Check for changes ahead of default branch
+                if has_commits_ahead(&git_repo, &current, &repo.default_branch)? {
+                    if let Some(ref bn) = branch_name {
+                        if bn != &current {
+                            anyhow::bail!(
+                                "Repositories are on different branches: {} vs {}",
+                                bn,
+                                current
+                            );
+                        }
+                    } else {
+                        branch_name = Some(current);
+                    }
+                    repos_with_changes.push(repo);
+                }
+            }
+            Err(e) => Output::error(&format!("{}: {}", repo.name, e)),
+        }
+    }
+
+    let branch = match branch_name {
+        Some(b) => b,
+        None => {
+            println!("No repositories have changes to create PRs for.");
+            return Ok(());
+        }
+    };
+
+    // Get title from argument or use branch name as fallback
+    let pr_title = title.map(|s| s.to_string()).unwrap_or_else(|| {
+        // Convert branch name to title: feat/my-feature -> My feature
+        let title = branch
+            .trim_start_matches("feat/")
+            .trim_start_matches("fix/")
+            .trim_start_matches("chore/")
+            .replace('-', " ")
+            .replace('_', " ");
+        let mut chars = title.chars();
+        match chars.next() {
+            None => title,
+            Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        }
+    });
+
+    // Push if requested
+    if push_first {
+        Output::info("Pushing branches first...");
+        for repo in &repos_with_changes {
+            if let Ok(git_repo) = open_repo(&repo.absolute_path) {
+                let spinner = Output::spinner(&format!("Pushing {}...", repo.name));
+                match crate::git::remote::push_branch(&git_repo, &branch, "origin", true) {
+                    Ok(()) => spinner.finish_with_message(format!("{}: pushed", repo.name)),
+                    Err(e) => spinner.finish_with_message(format!("{}: push failed - {}", repo.name, e)),
+                }
+            }
+        }
+        println!();
+    }
+
+    // Create PRs for each repo
+    let mut created_prs: Vec<(String, u64, String)> = Vec::new(); // (repo_name, pr_number, url)
+
+    for repo in &repos_with_changes {
+        let platform_type = detect_platform(&repo.url);
+        let platform = get_platform_adapter(platform_type, None);
+
+        let spinner = Output::spinner(&format!("Creating PR for {}...", repo.name));
+
+        match platform.create_pull_request(
+            &repo.owner,
+            &repo.repo,
+            &branch,
+            &repo.default_branch,
+            &pr_title,
+            None,
+            draft,
+        ).await {
+            Ok(pr) => {
+                spinner.finish_with_message(format!(
+                    "{}: created PR #{} - {}",
+                    repo.name,
+                    pr.number,
+                    pr.url
+                ));
+                created_prs.push((repo.name.clone(), pr.number, pr.url.clone()));
+            }
+            Err(e) => {
+                spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));
+            }
+        }
+    }
+
+    // Save state
+    if !created_prs.is_empty() {
+        let state_path = workspace_root.join(".gitgrip").join("state.json");
+        let mut state = if state_path.exists() {
+            let content = std::fs::read_to_string(&state_path)?;
+            StateFile::parse(&content).unwrap_or_default()
+        } else {
+            StateFile::default()
+        };
+
+        // Use the first PR number for branch mapping
+        if let Some((_, first_pr_number, _)) = created_prs.first() {
+            state.set_pr_for_branch(&branch, *first_pr_number);
+        }
+
+        let state_json = serde_json::to_string_pretty(&state)?;
+        std::fs::write(&state_path, state_json)?;
+    }
+
+    // Summary
+    println!();
+    if created_prs.is_empty() {
+        Output::warning("No PRs were created.");
+    } else {
+        Output::success(&format!("Created {} PR(s):", created_prs.len()));
+        for (repo_name, pr_number, url) in &created_prs {
+            println!("  {}: #{} - {}", repo_name, pr_number, url);
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if a branch has commits ahead of another branch
+fn has_commits_ahead(
+    repo: &git2::Repository,
+    branch: &str,
+    base: &str,
+) -> anyhow::Result<bool> {
+    let local_ref = format!("refs/heads/{}", branch);
+    let base_ref = format!("refs/remotes/origin/{}", base);
+
+    let local = match repo.find_reference(&local_ref) {
+        Ok(r) => r,
+        Err(_) => return Ok(false),
+    };
+
+    let base_branch = match repo.find_reference(&base_ref) {
+        Ok(r) => r,
+        Err(_) => {
+            // Try local base branch
+            match repo.find_reference(&format!("refs/heads/{}", base)) {
+                Ok(r) => r,
+                Err(_) => return Ok(false),
+            }
+        }
+    };
+
+    let local_oid = local.target().ok_or_else(|| anyhow::anyhow!("No local target"))?;
+    let base_oid = base_branch.target().ok_or_else(|| anyhow::anyhow!("No base target"))?;
+
+    let (ahead, _behind) = repo.graph_ahead_behind(local_oid, base_oid)?;
+    Ok(ahead > 0)
+}
+
+/// Get authentication token for platform
+#[allow(dead_code)]
+pub fn get_token_for_platform(platform: &PlatformType) -> Option<String> {
+    match platform {
+        PlatformType::GitHub => {
+            std::env::var("GITHUB_TOKEN").ok()
+                .or_else(|| std::env::var("GH_TOKEN").ok())
+        }
+        PlatformType::GitLab => {
+            std::env::var("GITLAB_TOKEN").ok()
+        }
+        PlatformType::AzureDevOps => {
+            std::env::var("AZURE_DEVOPS_TOKEN").ok()
+        }
+    }
+}

--- a/rust/src/cli/commands/pr/diff.rs
+++ b/rust/src/cli/commands/pr/diff.rs
@@ -1,0 +1,155 @@
+//! PR diff command implementation
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::{get_current_branch, open_repo, path_exists};
+use crate::platform::{detect_platform, get_platform_adapter};
+use std::path::PathBuf;
+
+/// Run the PR diff command
+pub async fn run_pr_diff(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    stat_only: bool,
+) -> anyhow::Result<()> {
+    if !stat_only {
+        Output::header("PR Diff");
+        println!();
+    }
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    let mut total_files = 0;
+    let mut total_additions = 0;
+    let mut total_deletions = 0;
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        let git_repo = match open_repo(&repo.absolute_path) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        let branch = match get_current_branch(&git_repo) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+
+        // Skip if on default branch
+        if branch == repo.default_branch {
+            continue;
+        }
+
+        let platform_type = detect_platform(&repo.url);
+        let platform = get_platform_adapter(platform_type, None);
+
+        match platform.find_pr_by_branch(&repo.owner, &repo.repo, &branch).await {
+            Ok(Some(pr)) => {
+                match platform.get_pull_request_diff(&repo.owner, &repo.repo, pr.number).await {
+                    Ok(diff) => {
+                        if stat_only {
+                            // Parse diff for stats
+                            let stats = parse_diff_stats(&diff);
+                            println!("{} #{}:", repo.name, pr.number);
+                            println!(
+                                "  {} file(s), +{}, -{}",
+                                stats.files, stats.additions, stats.deletions
+                            );
+                            total_files += stats.files;
+                            total_additions += stats.additions;
+                            total_deletions += stats.deletions;
+                        } else {
+                            println!("=== {} #{} ===", repo.name, pr.number);
+                            println!("{}", diff);
+                            println!();
+                        }
+                    }
+                    Err(e) => {
+                        Output::error(&format!("{}: {}", repo.name, e));
+                    }
+                }
+            }
+            Ok(None) => {
+                Output::info(&format!("{}: no open PR for this branch", repo.name));
+            }
+            Err(e) => {
+                Output::error(&format!("{}: {}", repo.name, e));
+            }
+        }
+    }
+
+    if stat_only && (total_files > 0 || total_additions > 0 || total_deletions > 0) {
+        println!();
+        println!("Total:");
+        println!(
+            "  {} file(s), +{}, -{}",
+            total_files, total_additions, total_deletions
+        );
+    }
+
+    Ok(())
+}
+
+struct DiffStats {
+    files: usize,
+    additions: usize,
+    deletions: usize,
+}
+
+fn parse_diff_stats(diff: &str) -> DiffStats {
+    let mut files = 0;
+    let mut additions = 0;
+    let mut deletions = 0;
+
+    for line in diff.lines() {
+        if line.starts_with("diff --git") || line.starts_with("Index:") {
+            files += 1;
+        } else if line.starts_with('+') && !line.starts_with("+++") {
+            additions += 1;
+        } else if line.starts_with('-') && !line.starts_with("---") {
+            deletions += 1;
+        }
+    }
+
+    DiffStats {
+        files,
+        additions,
+        deletions,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_diff_stats() {
+        let diff = r#"diff --git a/file1.rs b/file1.rs
+--- a/file1.rs
++++ b/file1.rs
+@@ -1,3 +1,4 @@
+ line1
+-old line
++new line
++added line
+diff --git a/file2.rs b/file2.rs
+--- a/file2.rs
++++ b/file2.rs
+@@ -1,2 +1,2 @@
+-removed
++added
+"#;
+        let stats = parse_diff_stats(diff);
+        assert_eq!(stats.files, 2);
+        assert_eq!(stats.additions, 3);
+        assert_eq!(stats.deletions, 2);
+    }
+}

--- a/rust/src/cli/commands/pr/merge.rs
+++ b/rust/src/cli/commands/pr/merge.rs
@@ -1,0 +1,186 @@
+//! PR merge command implementation
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::{get_current_branch, open_repo, path_exists};
+use crate::platform::{detect_platform, get_platform_adapter, CheckState, MergeMethod};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Run the PR merge command
+pub async fn run_pr_merge(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    method: Option<&str>,
+    force: bool,
+) -> anyhow::Result<()> {
+    Output::header("Merging pull requests...");
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    let merge_method = match method {
+        Some("squash") => MergeMethod::Squash,
+        Some("rebase") => MergeMethod::Rebase,
+        _ => MergeMethod::Merge,
+    };
+
+    // Collect PRs to merge
+    struct PRToMerge {
+        repo_name: String,
+        owner: String,
+        repo: String,
+        pr_number: u64,
+        platform: Arc<dyn crate::platform::HostingPlatform>,
+        approved: bool,
+        checks_pass: bool,
+        mergeable: bool,
+    }
+
+    let mut prs_to_merge: Vec<PRToMerge> = Vec::new();
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        let git_repo = match open_repo(&repo.absolute_path) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        let branch = match get_current_branch(&git_repo) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+
+        // Skip if on default branch
+        if branch == repo.default_branch {
+            continue;
+        }
+
+        let platform_type = detect_platform(&repo.url);
+        let platform = get_platform_adapter(platform_type, None);
+
+        match platform.find_pr_by_branch(&repo.owner, &repo.repo, &branch).await {
+            Ok(Some(pr)) => {
+                // Get PR details
+                let (approved, mergeable) = match platform.get_pull_request(&repo.owner, &repo.repo, pr.number).await {
+                    Ok(full_pr) => {
+                        let is_approved = platform.is_pull_request_approved(&repo.owner, &repo.repo, pr.number).await.unwrap_or(false);
+                        (is_approved, full_pr.mergeable.unwrap_or(false))
+                    }
+                    Err(_) => (false, false),
+                };
+
+                // Get status checks
+                let checks_pass = match platform.get_status_checks(&repo.owner, &repo.repo, &branch).await {
+                    Ok(status) => status.state == CheckState::Success,
+                    Err(_) => false,
+                };
+
+                prs_to_merge.push(PRToMerge {
+                    repo_name: repo.name.clone(),
+                    owner: repo.owner.clone(),
+                    repo: repo.repo.clone(),
+                    pr_number: pr.number,
+                    platform,
+                    approved,
+                    checks_pass,
+                    mergeable,
+                });
+            }
+            Ok(None) => {
+                Output::info(&format!("{}: no open PR for this branch", repo.name));
+            }
+            Err(e) => {
+                Output::error(&format!("{}: {}", repo.name, e));
+            }
+        }
+    }
+
+    if prs_to_merge.is_empty() {
+        println!("No PRs to merge.");
+        return Ok(());
+    }
+
+    // Check readiness if not forcing
+    if !force {
+        let mut issues = Vec::new();
+        for pr in &prs_to_merge {
+            if !pr.approved {
+                issues.push(format!("{} PR #{}: not approved", pr.repo_name, pr.pr_number));
+            }
+            if !pr.checks_pass {
+                issues.push(format!("{} PR #{}: checks failing", pr.repo_name, pr.pr_number));
+            }
+            if !pr.mergeable {
+                issues.push(format!("{} PR #{}: not mergeable (conflicts?)", pr.repo_name, pr.pr_number));
+            }
+        }
+
+        if !issues.is_empty() {
+            Output::warning("Some PRs have issues:");
+            for issue in &issues {
+                println!("  - {}", issue);
+            }
+            println!();
+            println!("Use --force to merge anyway.");
+            return Ok(());
+        }
+    }
+
+    // Merge PRs
+    let mut success_count = 0;
+    let mut error_count = 0;
+
+    for pr in prs_to_merge {
+        let spinner = Output::spinner(&format!("Merging {} PR #{}...", pr.repo_name, pr.pr_number));
+
+        match pr.platform.merge_pull_request(
+            &pr.owner,
+            &pr.repo,
+            pr.pr_number,
+            Some(merge_method),
+            true, // delete branch
+        ).await {
+            Ok(merged) => {
+                if merged {
+                    spinner.finish_with_message(format!("{}: merged PR #{}", pr.repo_name, pr.pr_number));
+                    success_count += 1;
+                } else {
+                    spinner.finish_with_message(format!("{}: PR #{} was already merged", pr.repo_name, pr.pr_number));
+                    success_count += 1;
+                }
+            }
+            Err(e) => {
+                spinner.finish_with_message(format!("{}: failed - {}", pr.repo_name, e));
+                error_count += 1;
+
+                // Check for all-or-nothing merge strategy
+                if manifest.settings.merge_strategy == crate::core::manifest::MergeStrategy::AllOrNothing {
+                    Output::error("Stopping due to all-or-nothing merge strategy.");
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    // Summary
+    println!();
+    if error_count == 0 {
+        Output::success(&format!("Successfully merged {} PR(s).", success_count));
+    } else {
+        Output::warning(&format!(
+            "{} merged, {} failed",
+            success_count, error_count
+        ));
+    }
+
+    Ok(())
+}

--- a/rust/src/cli/commands/pr/mod.rs
+++ b/rust/src/cli/commands/pr/mod.rs
@@ -1,0 +1,15 @@
+//! PR command implementations
+//!
+//! Subcommands for pull request operations.
+
+mod create;
+mod status;
+mod merge;
+mod checks;
+mod diff;
+
+pub use create::run_pr_create;
+pub use status::run_pr_status;
+pub use merge::run_pr_merge;
+pub use checks::run_pr_checks;
+pub use diff::run_pr_diff;

--- a/rust/src/cli/commands/pr/status.rs
+++ b/rust/src/cli/commands/pr/status.rs
@@ -1,0 +1,157 @@
+//! PR status command implementation
+
+use crate::cli::output::{Output, Table};
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::{get_current_branch, open_repo, path_exists};
+use crate::platform::{detect_platform, get_platform_adapter};
+use std::path::PathBuf;
+
+/// Run the PR status command
+pub async fn run_pr_status(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    json_output: bool,
+) -> anyhow::Result<()> {
+    if !json_output {
+        Output::header("Pull Request Status");
+        println!();
+    }
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    #[derive(serde::Serialize)]
+    struct PRStatusInfo {
+        repo: String,
+        branch: String,
+        pr_number: Option<u64>,
+        state: String,
+        approved: bool,
+        checks_pass: bool,
+        mergeable: bool,
+        url: Option<String>,
+    }
+
+    let mut statuses: Vec<PRStatusInfo> = Vec::new();
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        let git_repo = match open_repo(&repo.absolute_path) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        let branch = match get_current_branch(&git_repo) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+
+        // Skip if on default branch
+        if branch == repo.default_branch {
+            continue;
+        }
+
+        let platform_type = detect_platform(&repo.url);
+        let platform = get_platform_adapter(platform_type, None);
+
+        match platform.find_pr_by_branch(&repo.owner, &repo.repo, &branch).await {
+            Ok(Some(pr)) => {
+                // Get PR details including approval and mergeable status
+                let (approved, mergeable) = match platform.get_pull_request(&repo.owner, &repo.repo, pr.number).await {
+                    Ok(full_pr) => {
+                        let is_approved = platform.is_pull_request_approved(&repo.owner, &repo.repo, pr.number).await.unwrap_or(false);
+                        (is_approved, full_pr.mergeable.unwrap_or(false))
+                    }
+                    Err(_) => (false, false),
+                };
+
+                // Get status checks
+                let checks_pass = match platform.get_status_checks(&repo.owner, &repo.repo, &branch).await {
+                    Ok(status) => status.state == crate::platform::CheckState::Success,
+                    Err(_) => false,
+                };
+
+                statuses.push(PRStatusInfo {
+                    repo: repo.name.clone(),
+                    branch: branch.clone(),
+                    pr_number: Some(pr.number),
+                    state: "open".to_string(),
+                    approved,
+                    checks_pass,
+                    mergeable,
+                    url: Some(pr.url.clone()),
+                });
+            }
+            Ok(None) => {
+                statuses.push(PRStatusInfo {
+                    repo: repo.name.clone(),
+                    branch: branch.clone(),
+                    pr_number: None,
+                    state: "none".to_string(),
+                    approved: false,
+                    checks_pass: false,
+                    mergeable: false,
+                    url: None,
+                });
+            }
+            Err(e) => {
+                if !json_output {
+                    Output::error(&format!("{}: {}", repo.name, e));
+                }
+            }
+        }
+    }
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&statuses)?);
+        return Ok(());
+    }
+
+    if statuses.is_empty() {
+        println!("No repositories have changes on feature branches.");
+        return Ok(());
+    }
+
+    // Display table
+    let mut table = Table::new(vec!["Repo", "PR#", "State", "Approved", "Checks", "Mergeable"]);
+
+    for status in &statuses {
+        let pr_num = status.pr_number.map(|n| format!("#{}", n)).unwrap_or_else(|| "-".to_string());
+        let approved = if status.approved { "✓" } else { "✗" };
+        let checks = if status.checks_pass { "✓" } else { "✗" };
+        let mergeable = if status.mergeable { "✓" } else { "✗" };
+
+        table.add_row(vec![
+            &status.repo,
+            &pr_num,
+            &status.state,
+            approved,
+            checks,
+            mergeable,
+        ]);
+    }
+
+    table.print();
+
+    // Summary
+    println!();
+    let with_prs = statuses.iter().filter(|s| s.pr_number.is_some()).count();
+    let ready = statuses.iter().filter(|s| {
+        s.pr_number.is_some() && s.approved && s.checks_pass && s.mergeable
+    }).count();
+
+    if ready == with_prs && with_prs > 0 {
+        Output::success(&format!("All {} PRs ready to merge!", with_prs));
+    } else if with_prs > 0 {
+        println!("{}/{} PRs ready to merge", ready, with_prs);
+    }
+
+    Ok(())
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -142,17 +142,32 @@ enum PrCommands {
         draft: bool,
     },
     /// Show PR status
-    Status,
+    Status {
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Merge pull requests
     Merge {
         /// Merge method (merge, squash, rebase)
         #[arg(short, long)]
         method: Option<String>,
+        /// Force merge without readiness checks
+        #[arg(short, long)]
+        force: bool,
     },
     /// Check CI status
-    Checks,
+    Checks {
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Show PR diff
-    Diff,
+    Diff {
+        /// Show stat summary only
+        #[arg(long)]
+        stat: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -257,11 +272,54 @@ async fn main() -> anyhow::Result<()> {
             let (workspace_root, manifest) = load_workspace()?;
             gitgrip::cli::commands::push::run_push(&workspace_root, &manifest, set_upstream, force)?;
         }
+        Some(Commands::Pr { action }) => {
+            let (workspace_root, manifest) = load_workspace()?;
+            match action {
+                PrCommands::Create { title, push, draft } => {
+                    gitgrip::cli::commands::pr::run_pr_create(
+                        &workspace_root,
+                        &manifest,
+                        title.as_deref(),
+                        draft,
+                        push,
+                    ).await?;
+                }
+                PrCommands::Status { json } => {
+                    gitgrip::cli::commands::pr::run_pr_status(
+                        &workspace_root,
+                        &manifest,
+                        json,
+                    ).await?;
+                }
+                PrCommands::Merge { method, force } => {
+                    gitgrip::cli::commands::pr::run_pr_merge(
+                        &workspace_root,
+                        &manifest,
+                        method.as_deref(),
+                        force,
+                    ).await?;
+                }
+                PrCommands::Checks { json } => {
+                    gitgrip::cli::commands::pr::run_pr_checks(
+                        &workspace_root,
+                        &manifest,
+                        json,
+                    ).await?;
+                }
+                PrCommands::Diff { stat } => {
+                    gitgrip::cli::commands::pr::run_pr_diff(
+                        &workspace_root,
+                        &manifest,
+                        stat,
+                    ).await?;
+                }
+            }
+        }
         Some(Commands::Bench { name, iterations }) => {
             run_benchmarks(name.as_deref(), iterations).await?;
         }
         Some(_) => {
-            println!("Command not yet implemented - coming in Phase 5-6");
+            println!("Command not yet implemented - coming in Phase 6");
         }
         None => {
             println!("gitgrip - Multi-repo workflow tool");


### PR DESCRIPTION
## Summary
- Implements PR subcommands for gitgrip CLI in Rust
- All commands use async platform operations via HostingPlatform trait
- 68 tests passing

## PR Commands Implemented
| Command | Description |
|---------|-------------|
| `pr create` | Create PRs across all repos with changes |
| `pr status` | Show PR status (approval, checks, mergeable) |
| `pr merge` | Merge all PRs with merge strategy support |
| `pr checks` | Show CI/CD check status |
| `pr diff` | Show PR diff with stats option |

## Features
- JSON output option for `pr status` and `pr checks`
- All-or-nothing merge strategy support
- Force merge option to bypass readiness checks
- Diff stats parsing for quick summaries

## Test plan
- [x] All 68 unit tests pass
- [x] Code compiles without errors
- [ ] Manual testing of PR commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)