### PR TITLE
feat: implement advanced CLI commands (Phase 6)

### DIFF
--- a/rust/src/cli/commands/env.rs
+++ b/rust/src/cli/commands/env.rs
@@ -1,0 +1,33 @@
+//! Env command implementation
+//!
+//! Displays workspace environment variables.
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use std::path::PathBuf;
+
+/// Run the env command
+pub fn run_env(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+) -> anyhow::Result<()> {
+    Output::header("Workspace Environment");
+    println!();
+
+    // Built-in environment variables
+    println!("  GITGRIP_WORKSPACE={}", workspace_root.display());
+    println!("  GITGRIP_MANIFEST={}", workspace_root.join(".gitgrip/manifests/manifest.yaml").display());
+
+    // Workspace-defined environment variables
+    if let Some(ref workspace) = manifest.workspace {
+        if let Some(ref env_vars) = workspace.env {
+            println!();
+            println!("Workspace variables:");
+            for (key, value) in env_vars {
+                println!("  {}={}", key, value);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/src/cli/commands/forall.rs
+++ b/rust/src/cli/commands/forall.rs
@@ -1,0 +1,188 @@
+//! Forall command implementation
+//!
+//! Runs a command in each repository.
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::path_exists;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Run the forall command
+pub fn run_forall(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    command: &str,
+    parallel: bool,
+    changed_only: bool,
+) -> anyhow::Result<()> {
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    if parallel {
+        run_parallel(&repos, command, changed_only)?;
+    } else {
+        run_sequential(&repos, command, changed_only)?;
+    }
+
+    Ok(())
+}
+
+fn run_sequential(repos: &[RepoInfo], command: &str, changed_only: bool) -> anyhow::Result<()> {
+    let mut success_count = 0;
+    let mut error_count = 0;
+    let mut skip_count = 0;
+
+    for repo in repos {
+        if !path_exists(&repo.absolute_path) {
+            Output::warning(&format!("{}: not cloned, skipping", repo.name));
+            skip_count += 1;
+            continue;
+        }
+
+        // Check if repo has changes (if changed_only flag is set)
+        if changed_only && !has_changes(&repo.absolute_path)? {
+            skip_count += 1;
+            continue;
+        }
+
+        Output::header(&format!("{}:", repo.name));
+
+        let output = Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .current_dir(&repo.absolute_path)
+            .env("REPO_NAME", &repo.name)
+            .env("REPO_PATH", &repo.absolute_path)
+            .env("REPO_URL", &repo.url)
+            .env("REPO_BRANCH", &repo.default_branch)
+            .output()?;
+
+        if output.status.success() {
+            print!("{}", String::from_utf8_lossy(&output.stdout));
+            if !output.stderr.is_empty() {
+                eprint!("{}", String::from_utf8_lossy(&output.stderr));
+            }
+            success_count += 1;
+        } else {
+            print!("{}", String::from_utf8_lossy(&output.stdout));
+            eprint!("{}", String::from_utf8_lossy(&output.stderr));
+            Output::error(&format!("Command failed with exit code: {:?}", output.status.code()));
+            error_count += 1;
+        }
+        println!();
+    }
+
+    // Summary
+    if error_count == 0 {
+        Output::success(&format!(
+            "Command completed in {} repo(s){}",
+            success_count,
+            if skip_count > 0 { format!(", {} skipped", skip_count) } else { String::new() }
+        ));
+    } else {
+        Output::warning(&format!(
+            "{} succeeded, {} failed, {} skipped",
+            success_count, error_count, skip_count
+        ));
+    }
+
+    Ok(())
+}
+
+fn run_parallel(repos: &[RepoInfo], command: &str, changed_only: bool) -> anyhow::Result<()> {
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    let results = Arc::new(Mutex::new(Vec::new()));
+    let mut handles = vec![];
+
+    for repo in repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        if changed_only && !has_changes(&repo.absolute_path).unwrap_or(false) {
+            continue;
+        }
+
+        let repo_name = repo.name.clone();
+        let repo_path = repo.absolute_path.clone();
+        let repo_url = repo.url.clone();
+        let repo_branch = repo.default_branch.clone();
+        let cmd = command.to_string();
+        let results = Arc::clone(&results);
+
+        let handle = thread::spawn(move || {
+            let output = Command::new("sh")
+                .arg("-c")
+                .arg(&cmd)
+                .current_dir(&repo_path)
+                .env("REPO_NAME", &repo_name)
+                .env("REPO_PATH", &repo_path)
+                .env("REPO_URL", &repo_url)
+                .env("REPO_BRANCH", &repo_branch)
+                .output();
+
+            let mut results = results.lock().unwrap();
+            results.push((repo_name, output));
+        });
+
+        handles.push(handle);
+    }
+
+    // Wait for all threads
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    // Print results
+    let results = results.lock().unwrap();
+    let mut success_count = 0;
+    let mut error_count = 0;
+
+    for (repo_name, output) in results.iter() {
+        Output::header(&format!("{}:", repo_name));
+        match output {
+            Ok(output) => {
+                print!("{}", String::from_utf8_lossy(&output.stdout));
+                if !output.stderr.is_empty() {
+                    eprint!("{}", String::from_utf8_lossy(&output.stderr));
+                }
+                if output.status.success() {
+                    success_count += 1;
+                } else {
+                    error_count += 1;
+                }
+            }
+            Err(e) => {
+                Output::error(&format!("Failed to run command: {}", e));
+                error_count += 1;
+            }
+        }
+        println!();
+    }
+
+    if error_count == 0 {
+        Output::success(&format!("Command completed in {} repo(s)", success_count));
+    } else {
+        Output::warning(&format!("{} succeeded, {} failed", success_count, error_count));
+    }
+
+    Ok(())
+}
+
+/// Check if a repository has uncommitted changes
+fn has_changes(repo_path: &PathBuf) -> anyhow::Result<bool> {
+    match crate::git::open_repo(repo_path) {
+        Ok(repo) => {
+            let statuses = repo.statuses(None)?;
+            Ok(!statuses.is_empty())
+        }
+        Err(_) => Ok(false),
+    }
+}

--- a/rust/src/cli/commands/init.rs
+++ b/rust/src/cli/commands/init.rs
@@ -1,0 +1,129 @@
+//! Init command implementation
+//!
+//! Initializes a new gitgrip workspace.
+
+use crate::cli::output::Output;
+use crate::git::clone_repo;
+use std::path::PathBuf;
+
+/// Run the init command
+pub fn run_init(
+    url: Option<&str>,
+    path: Option<&str>,
+) -> anyhow::Result<()> {
+    let manifest_url = match url {
+        Some(u) => u.to_string(),
+        None => {
+            anyhow::bail!("Manifest URL required. Usage: gr init <manifest-url>");
+        }
+    };
+
+    // Determine target directory
+    let target_dir = match path {
+        Some(p) => PathBuf::from(p),
+        None => {
+            // Extract repo name from URL for directory name
+            let name = extract_repo_name(&manifest_url)
+                .unwrap_or_else(|| "workspace".to_string());
+            std::env::current_dir()?.join(name)
+        }
+    };
+
+    Output::header(&format!("Initializing workspace in {:?}", target_dir));
+    println!();
+
+    // Create workspace directory
+    if target_dir.exists() {
+        anyhow::bail!("Directory already exists: {:?}", target_dir);
+    }
+    std::fs::create_dir_all(&target_dir)?;
+
+    // Create .gitgrip directory structure
+    let gitgrip_dir = target_dir.join(".gitgrip");
+    let manifests_dir = gitgrip_dir.join("manifests");
+    std::fs::create_dir_all(&manifests_dir)?;
+
+    // Clone manifest repository
+    let spinner = Output::spinner("Cloning manifest repository...");
+    match clone_repo(&manifest_url, &manifests_dir, None) {
+        Ok(_) => {
+            spinner.finish_with_message("Manifest cloned successfully");
+        }
+        Err(e) => {
+            spinner.finish_with_message(format!("Failed to clone manifest: {}", e));
+            // Clean up on failure
+            let _ = std::fs::remove_dir_all(&target_dir);
+            return Err(e.into());
+        }
+    }
+
+    // Verify manifest.yaml exists
+    let manifest_path = manifests_dir.join("manifest.yaml");
+    if !manifest_path.exists() {
+        let _ = std::fs::remove_dir_all(&target_dir);
+        anyhow::bail!("No manifest.yaml found in repository");
+    }
+
+    // Create state file
+    let state_path = gitgrip_dir.join("state.json");
+    std::fs::write(&state_path, "{}")?;
+
+    println!();
+    Output::success("Workspace initialized successfully!");
+    println!();
+    println!("Next steps:");
+    println!("  cd {:?}", target_dir);
+    println!("  gr sync    # Clone all repositories");
+
+    Ok(())
+}
+
+/// Extract repository name from URL
+fn extract_repo_name(url: &str) -> Option<String> {
+    // Handle SSH URLs: git@github.com:owner/repo.git
+    if url.starts_with("git@") {
+        let parts: Vec<&str> = url.split('/').collect();
+        if let Some(last) = parts.last() {
+            return Some(last.trim_end_matches(".git").to_string());
+        }
+    }
+
+    // Handle HTTPS URLs: https://github.com/owner/repo.git
+    if url.starts_with("https://") || url.starts_with("http://") {
+        let parts: Vec<&str> = url.split('/').collect();
+        if let Some(last) = parts.last() {
+            return Some(last.trim_end_matches(".git").to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_repo_name_ssh() {
+        assert_eq!(
+            extract_repo_name("git@github.com:user/my-workspace.git"),
+            Some("my-workspace".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_repo_name_https() {
+        assert_eq!(
+            extract_repo_name("https://github.com/user/my-workspace.git"),
+            Some("my-workspace".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_repo_name_no_extension() {
+        assert_eq!(
+            extract_repo_name("https://github.com/user/workspace"),
+            Some("workspace".to_string())
+        );
+    }
+}

--- a/rust/src/cli/commands/link.rs
+++ b/rust/src/cli/commands/link.rs
@@ -1,0 +1,241 @@
+//! Link command implementation
+//!
+//! Manages copyfile and linkfile entries.
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::path_exists;
+use std::path::PathBuf;
+
+/// Run the link command
+pub fn run_link(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    status: bool,
+    apply: bool,
+) -> anyhow::Result<()> {
+    if status {
+        show_link_status(workspace_root, manifest)?;
+    } else if apply {
+        apply_links(workspace_root, manifest)?;
+    } else {
+        // Default: show status
+        show_link_status(workspace_root, manifest)?;
+    }
+
+    Ok(())
+}
+
+fn show_link_status(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Result<()> {
+    Output::header("File Link Status");
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    let mut total_links = 0;
+    let mut valid_links = 0;
+    let mut broken_links = 0;
+
+    for (name, config) in &manifest.repos {
+        let repo = repos.iter().find(|r| &r.name == name);
+
+        // Check copyfiles
+        if let Some(ref copyfiles) = config.copyfile {
+            for copyfile in copyfiles {
+                total_links += 1;
+                let source = repo.map(|r| r.absolute_path.join(&copyfile.src))
+                    .unwrap_or_else(|| workspace_root.join(&config.path).join(&copyfile.src));
+                let dest = workspace_root.join(&copyfile.dest);
+
+                let status = if source.exists() && dest.exists() {
+                    valid_links += 1;
+                    "✓"
+                } else if !source.exists() {
+                    broken_links += 1;
+                    "✗ (source missing)"
+                } else {
+                    broken_links += 1;
+                    "✗ (dest missing)"
+                };
+
+                println!("  [copy] {} -> {} {}", copyfile.src, copyfile.dest, status);
+            }
+        }
+
+        // Check linkfiles
+        if let Some(ref linkfiles) = config.linkfile {
+            for linkfile in linkfiles {
+                total_links += 1;
+                let source = repo.map(|r| r.absolute_path.join(&linkfile.src))
+                    .unwrap_or_else(|| workspace_root.join(&config.path).join(&linkfile.src));
+                let dest = workspace_root.join(&linkfile.dest);
+
+                let status = if source.exists() && dest.exists() && dest.is_symlink() {
+                    valid_links += 1;
+                    "✓"
+                } else if !source.exists() {
+                    broken_links += 1;
+                    "✗ (source missing)"
+                } else if !dest.exists() {
+                    broken_links += 1;
+                    "✗ (link missing)"
+                } else {
+                    broken_links += 1;
+                    "✗ (not a symlink)"
+                };
+
+                println!("  [link] {} -> {} {}", linkfile.src, linkfile.dest, status);
+            }
+        }
+    }
+
+    println!();
+    if total_links == 0 {
+        println!("No file links defined in manifest.");
+    } else if broken_links == 0 {
+        Output::success(&format!("All {} link(s) valid", valid_links));
+    } else {
+        Output::warning(&format!(
+            "{} valid, {} broken out of {} total",
+            valid_links, broken_links, total_links
+        ));
+        println!();
+        println!("Run 'gr link --apply' to fix broken links.");
+    }
+
+    Ok(())
+}
+
+fn apply_links(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Result<()> {
+    Output::header("Applying File Links");
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    let mut applied = 0;
+    let mut errors = 0;
+
+    for (name, config) in &manifest.repos {
+        let repo = repos.iter().find(|r| &r.name == name);
+
+        if !repo.map(|r| path_exists(&r.absolute_path)).unwrap_or(false) {
+            continue;
+        }
+
+        // Apply copyfiles
+        if let Some(ref copyfiles) = config.copyfile {
+            for copyfile in copyfiles {
+                let source = repo.map(|r| r.absolute_path.join(&copyfile.src))
+                    .unwrap_or_else(|| workspace_root.join(&config.path).join(&copyfile.src));
+                let dest = workspace_root.join(&copyfile.dest);
+
+                if !source.exists() {
+                    Output::warning(&format!("Source not found: {:?}", source));
+                    errors += 1;
+                    continue;
+                }
+
+                // Create parent directory if needed
+                if let Some(parent) = dest.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+
+                match std::fs::copy(&source, &dest) {
+                    Ok(_) => {
+                        Output::success(&format!("[copy] {} -> {}", copyfile.src, copyfile.dest));
+                        applied += 1;
+                    }
+                    Err(e) => {
+                        Output::error(&format!("Failed to copy: {}", e));
+                        errors += 1;
+                    }
+                }
+            }
+        }
+
+        // Apply linkfiles
+        if let Some(ref linkfiles) = config.linkfile {
+            for linkfile in linkfiles {
+                let source = repo.map(|r| r.absolute_path.join(&linkfile.src))
+                    .unwrap_or_else(|| workspace_root.join(&config.path).join(&linkfile.src));
+                let dest = workspace_root.join(&linkfile.dest);
+
+                if !source.exists() {
+                    Output::warning(&format!("Source not found: {:?}", source));
+                    errors += 1;
+                    continue;
+                }
+
+                // Create parent directory if needed
+                if let Some(parent) = dest.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+
+                // Remove existing link/file if present
+                if dest.exists() || dest.is_symlink() {
+                    let _ = std::fs::remove_file(&dest);
+                }
+
+                #[cfg(unix)]
+                {
+                    match std::os::unix::fs::symlink(&source, &dest) {
+                        Ok(_) => {
+                            Output::success(&format!("[link] {} -> {}", linkfile.src, linkfile.dest));
+                            applied += 1;
+                        }
+                        Err(e) => {
+                            Output::error(&format!("Failed to create symlink: {}", e));
+                            errors += 1;
+                        }
+                    }
+                }
+
+                #[cfg(windows)]
+                {
+                    // On Windows, use junction for directories, symlink for files
+                    if source.is_dir() {
+                        match std::os::windows::fs::symlink_dir(&source, &dest) {
+                            Ok(_) => {
+                                Output::success(&format!("[link] {} -> {}", linkfile.src, linkfile.dest));
+                                applied += 1;
+                            }
+                            Err(e) => {
+                                Output::error(&format!("Failed to create symlink: {}", e));
+                                errors += 1;
+                            }
+                        }
+                    } else {
+                        match std::os::windows::fs::symlink_file(&source, &dest) {
+                            Ok(_) => {
+                                Output::success(&format!("[link] {} -> {}", linkfile.src, linkfile.dest));
+                                applied += 1;
+                            }
+                            Err(e) => {
+                                Output::error(&format!("Failed to create symlink: {}", e));
+                                errors += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    println!();
+    if errors == 0 {
+        Output::success(&format!("Applied {} link(s)", applied));
+    } else {
+        Output::warning(&format!("{} applied, {} errors", applied, errors));
+    }
+
+    Ok(())
+}

--- a/rust/src/cli/commands/mod.rs
+++ b/rust/src/cli/commands/mod.rs
@@ -7,17 +7,15 @@ pub mod branch;
 pub mod checkout;
 pub mod commit;
 pub mod diff;
+pub mod env;
+pub mod forall;
+pub mod init;
+pub mod link;
 pub mod pr;
 pub mod push;
+pub mod rebase;
+pub mod repo;
+pub mod run;
 pub mod status;
 pub mod sync;
-
-// To be implemented in Phase 6
-// pub mod env;
-// pub mod forall;
-// pub mod init;
-// pub mod link;
-// pub mod rebase;
-// pub mod repo;
-// pub mod run;
-// pub mod tree;
+pub mod tree;

--- a/rust/src/cli/commands/rebase.rs
+++ b/rust/src/cli/commands/rebase.rs
@@ -1,0 +1,187 @@
+//! Rebase command implementation
+//!
+//! Rebases branches across repositories.
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::{get_current_branch, open_repo, path_exists};
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Run the rebase command
+pub fn run_rebase(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    onto: Option<&str>,
+    abort: bool,
+    _continue: bool,
+) -> anyhow::Result<()> {
+    if abort {
+        return run_rebase_abort(workspace_root, manifest);
+    }
+
+    if _continue {
+        return run_rebase_continue(workspace_root, manifest);
+    }
+
+    let target = onto.unwrap_or("origin/main");
+    Output::header(&format!("Rebasing onto {}", target));
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    let mut success_count = 0;
+    let mut skip_count = 0;
+    let mut error_count = 0;
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            skip_count += 1;
+            continue;
+        }
+
+        let git_repo = match open_repo(&repo.absolute_path) {
+            Ok(r) => r,
+            Err(_) => {
+                skip_count += 1;
+                continue;
+            }
+        };
+
+        let branch = match get_current_branch(&git_repo) {
+            Ok(b) => b,
+            Err(_) => {
+                skip_count += 1;
+                continue;
+            }
+        };
+
+        // Skip if on default branch
+        if branch == repo.default_branch {
+            skip_count += 1;
+            continue;
+        }
+
+        let spinner = Output::spinner(&format!("Rebasing {}...", repo.name));
+
+        // Use git command for rebase (git2 doesn't support interactive rebase well)
+        let output = Command::new("git")
+            .args(["rebase", target])
+            .current_dir(&repo.absolute_path)
+            .output()?;
+
+        if output.status.success() {
+            spinner.finish_with_message(format!("{}: rebased", repo.name));
+            success_count += 1;
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("CONFLICT") {
+                spinner.finish_with_message(format!("{}: conflicts - resolve and run 'gr rebase --continue'", repo.name));
+            } else {
+                spinner.finish_with_message(format!("{}: failed", repo.name));
+            }
+            error_count += 1;
+        }
+    }
+
+    println!();
+    if error_count == 0 {
+        Output::success(&format!(
+            "Rebased {} repo(s){}",
+            success_count,
+            if skip_count > 0 { format!(", {} skipped", skip_count) } else { String::new() }
+        ));
+    } else {
+        Output::warning(&format!(
+            "{} rebased, {} failed, {} skipped",
+            success_count, error_count, skip_count
+        ));
+        println!();
+        println!("To continue after resolving conflicts: gr rebase --continue");
+        println!("To abort the rebase: gr rebase --abort");
+    }
+
+    Ok(())
+}
+
+fn run_rebase_abort(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Result<()> {
+    Output::header("Aborting rebase");
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        // Check if rebase is in progress
+        let rebase_dir = repo.absolute_path.join(".git/rebase-merge");
+        let rebase_apply_dir = repo.absolute_path.join(".git/rebase-apply");
+
+        if rebase_dir.exists() || rebase_apply_dir.exists() {
+            let output = Command::new("git")
+                .args(["rebase", "--abort"])
+                .current_dir(&repo.absolute_path)
+                .output()?;
+
+            if output.status.success() {
+                Output::success(&format!("{}: rebase aborted", repo.name));
+            } else {
+                Output::error(&format!("{}: failed to abort", repo.name));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn run_rebase_continue(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Result<()> {
+    Output::header("Continuing rebase");
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        // Check if rebase is in progress
+        let rebase_dir = repo.absolute_path.join(".git/rebase-merge");
+        let rebase_apply_dir = repo.absolute_path.join(".git/rebase-apply");
+
+        if rebase_dir.exists() || rebase_apply_dir.exists() {
+            let output = Command::new("git")
+                .args(["rebase", "--continue"])
+                .current_dir(&repo.absolute_path)
+                .output()?;
+
+            if output.status.success() {
+                Output::success(&format!("{}: rebase continued", repo.name));
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                if stderr.contains("CONFLICT") {
+                    Output::warning(&format!("{}: still has conflicts", repo.name));
+                } else {
+                    Output::error(&format!("{}: failed to continue", repo.name));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/src/cli/commands/repo.rs
+++ b/rust/src/cli/commands/repo.rs
@@ -1,0 +1,195 @@
+//! Repo command implementation
+//!
+//! Manages repositories in the workspace.
+
+use crate::cli::output::{Output, Table};
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::path_exists;
+use std::path::PathBuf;
+
+/// Run repo list command
+pub fn run_repo_list(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+) -> anyhow::Result<()> {
+    Output::header("Repositories");
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    let mut table = Table::new(vec!["Name", "Path", "Branch", "Status"]);
+
+    for repo in &repos {
+        let status = if path_exists(&repo.absolute_path) {
+            "cloned"
+        } else {
+            "not cloned"
+        };
+
+        table.add_row(vec![
+            &repo.name,
+            &repo.path,
+            &repo.default_branch,
+            status,
+        ]);
+    }
+
+    table.print();
+
+    println!();
+    let cloned = repos.iter().filter(|r| path_exists(&r.absolute_path)).count();
+    println!("{}/{} repositories cloned", cloned, repos.len());
+
+    Ok(())
+}
+
+/// Run repo add command
+pub fn run_repo_add(
+    workspace_root: &PathBuf,
+    url: &str,
+    path: Option<&str>,
+    default_branch: Option<&str>,
+) -> anyhow::Result<()> {
+    Output::header("Adding repository");
+    println!();
+
+    // Parse URL to get repo name
+    let repo_name = extract_repo_name(url)
+        .ok_or_else(|| anyhow::anyhow!("Could not parse repository name from URL"))?;
+
+    let repo_path = path.map(|p| p.to_string())
+        .unwrap_or_else(|| repo_name.clone());
+
+    let branch = default_branch.unwrap_or("main").to_string();
+
+    // Load manifest
+    let manifest_path = workspace_root.join(".gitgrip/manifests/manifest.yaml");
+    let content = std::fs::read_to_string(&manifest_path)?;
+
+    // Simple YAML append (for a proper implementation, use serde_yaml to read/write)
+    let new_repo_yaml = format!(
+        r#"
+  {}:
+    url: {}
+    path: {}
+    default_branch: {}"#,
+        repo_name, url, repo_path, branch
+    );
+
+    // Check if repos section exists and append
+    let updated_content = if content.contains("repos:") {
+        // Find the end of repos section and insert before next top-level key
+        let mut lines: Vec<&str> = content.lines().collect();
+        let mut insert_index = lines.len();
+
+        // Find where to insert (before settings, workspace, or at end)
+        for (i, line) in lines.iter().enumerate() {
+            if (line.starts_with("settings:") || line.starts_with("workspace:") || line.starts_with("manifest:"))
+                && i > 0 {
+                insert_index = i;
+                break;
+            }
+        }
+
+        lines.insert(insert_index, &new_repo_yaml);
+        lines.join("\n")
+    } else {
+        format!("{}repos:{}", content, new_repo_yaml)
+    };
+
+    std::fs::write(&manifest_path, updated_content)?;
+
+    Output::success(&format!("Added repository '{}' to manifest", repo_name));
+    println!();
+    println!("Run 'gr sync' to clone the repository.");
+
+    Ok(())
+}
+
+/// Run repo remove command
+pub fn run_repo_remove(
+    workspace_root: &PathBuf,
+    name: &str,
+    delete_files: bool,
+) -> anyhow::Result<()> {
+    Output::header(&format!("Removing repository '{}'", name));
+    println!();
+
+    // Load manifest to get repo path
+    let manifest_path = workspace_root.join(".gitgrip/manifests/manifest.yaml");
+    let content = std::fs::read_to_string(&manifest_path)?;
+    let manifest = Manifest::parse(&content)?;
+
+    let repo_config = manifest.repos.get(name)
+        .ok_or_else(|| anyhow::anyhow!("Repository '{}' not found in manifest", name))?;
+
+    // Delete files if requested
+    if delete_files {
+        let repo_path = workspace_root.join(&repo_config.path);
+        if repo_path.exists() {
+            let spinner = Output::spinner("Removing repository files...");
+            std::fs::remove_dir_all(&repo_path)?;
+            spinner.finish_with_message("Files removed");
+        }
+    }
+
+    // Remove from manifest (simple string replacement)
+    // For a proper implementation, use serde_yaml to read/write
+    let repo_pattern = format!("  {}:", name);
+    let lines: Vec<&str> = content.lines().collect();
+    let mut new_lines: Vec<&str> = Vec::new();
+    let mut skip_until_next_repo = false;
+
+    for line in lines {
+        if line.starts_with(&repo_pattern) {
+            skip_until_next_repo = true;
+            continue;
+        }
+
+        if skip_until_next_repo {
+            // Check if this is a new repo entry or top-level key
+            if line.starts_with("  ") && !line.starts_with("    ") && line.contains(':') {
+                skip_until_next_repo = false;
+            } else if !line.starts_with("  ") && !line.starts_with("    ") {
+                skip_until_next_repo = false;
+            } else {
+                continue;
+            }
+        }
+
+        if !skip_until_next_repo {
+            new_lines.push(line);
+        }
+    }
+
+    std::fs::write(&manifest_path, new_lines.join("\n"))?;
+
+    Output::success(&format!("Removed repository '{}' from manifest", name));
+    Ok(())
+}
+
+/// Extract repository name from URL
+fn extract_repo_name(url: &str) -> Option<String> {
+    // Handle SSH URLs: git@github.com:owner/repo.git
+    if url.starts_with("git@") {
+        let parts: Vec<&str> = url.split('/').collect();
+        if let Some(last) = parts.last() {
+            return Some(last.trim_end_matches(".git").to_string());
+        }
+    }
+
+    // Handle HTTPS URLs: https://github.com/owner/repo.git
+    if url.starts_with("https://") || url.starts_with("http://") {
+        let parts: Vec<&str> = url.split('/').collect();
+        if let Some(last) = parts.last() {
+            return Some(last.trim_end_matches(".git").to_string());
+        }
+    }
+
+    None
+}

--- a/rust/src/cli/commands/run.rs
+++ b/rust/src/cli/commands/run.rs
@@ -1,0 +1,92 @@
+//! Run command implementation
+//!
+//! Runs workspace scripts defined in manifest.
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Run the run command
+pub fn run_run(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    script_name: Option<&str>,
+    list: bool,
+) -> anyhow::Result<()> {
+    let scripts = manifest.workspace.as_ref()
+        .and_then(|w| w.scripts.as_ref());
+
+    if list || script_name.is_none() {
+        // List available scripts
+        Output::header("Workspace Scripts");
+        println!();
+
+        match scripts {
+            Some(scripts) if !scripts.is_empty() => {
+                for (name, script) in scripts {
+                    let desc = script.command.as_ref()
+                        .map(|c| c.as_str())
+                        .or_else(|| script.steps.as_ref().map(|_| "[multi-step]"))
+                        .unwrap_or("[no command]");
+                    println!("  {} - {}", name, desc);
+                }
+            }
+            _ => {
+                println!("  No scripts defined in manifest.");
+                println!();
+                println!("Define scripts in manifest.yaml:");
+                println!("  workspace:");
+                println!("    scripts:");
+                println!("      build:");
+                println!("        command: pnpm build");
+            }
+        }
+        return Ok(());
+    }
+
+    let name = script_name.unwrap();
+
+    // Find the script
+    let script = scripts
+        .and_then(|s| s.get(name))
+        .ok_or_else(|| anyhow::anyhow!("Script '{}' not found", name))?;
+
+    Output::header(&format!("Running script: {}", name));
+    println!();
+
+    // Execute the script
+    if let Some(ref command) = script.command {
+        // Single command script
+        run_command(workspace_root, command)?;
+    } else if let Some(ref steps) = script.steps {
+        // Multi-step script
+        for (i, step) in steps.iter().enumerate() {
+            println!("Step {}/{}: {} - {}", i + 1, steps.len(), step.name, step.command);
+            let working_dir = step.cwd.as_ref()
+                .map(|p| workspace_root.join(p))
+                .unwrap_or_else(|| workspace_root.clone());
+            run_command(&working_dir, &step.command)?;
+            println!();
+        }
+    } else {
+        anyhow::bail!("Script '{}' has no command or steps defined", name);
+    }
+
+    Output::success(&format!("Script '{}' completed", name));
+    Ok(())
+}
+
+fn run_command(working_dir: &PathBuf, command: &str) -> anyhow::Result<()> {
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(working_dir)
+        .status()?;
+
+    if !status.success() {
+        anyhow::bail!("Command failed with exit code: {:?}", status.code());
+    }
+
+    Ok(())
+}

--- a/rust/src/cli/commands/tree.rs
+++ b/rust/src/cli/commands/tree.rs
@@ -1,0 +1,307 @@
+//! Tree command implementation
+//!
+//! Manages griptrees (worktree-based parallel workspaces).
+
+use crate::cli::output::Output;
+use crate::core::griptree::GriptreeConfig;
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::{open_repo, path_exists};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Griptrees list file structure
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+struct GriptreesList {
+    griptrees: HashMap<String, GriptreeEntry>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct GriptreeEntry {
+    path: String,
+    branch: String,
+    locked: bool,
+    lock_reason: Option<String>,
+}
+
+/// Run tree add command
+pub fn run_tree_add(
+    workspace_root: &PathBuf,
+    manifest: &Manifest,
+    branch: &str,
+) -> anyhow::Result<()> {
+    Output::header(&format!("Creating griptree for branch '{}'", branch));
+    println!();
+
+    // Load or create griptrees list
+    let config_path = workspace_root.join(".gitgrip").join("griptrees.json");
+    let mut griptrees: GriptreesList = if config_path.exists() {
+        let content = std::fs::read_to_string(&config_path)?;
+        serde_json::from_str(&content)?
+    } else {
+        GriptreesList::default()
+    };
+
+    // Check if griptree already exists
+    if griptrees.griptrees.contains_key(branch) {
+        anyhow::bail!("Griptree for '{}' already exists", branch);
+    }
+
+    // Calculate griptree path (sibling to workspace)
+    let tree_name = branch.replace('/', "-");
+    let tree_path = workspace_root
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine parent directory"))?
+        .join(&tree_name);
+
+    if tree_path.exists() {
+        anyhow::bail!("Directory already exists: {:?}", tree_path);
+    }
+
+    // Create griptree directory
+    std::fs::create_dir_all(&tree_path)?;
+
+    // Get all repos
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| RepoInfo::from_config(name, config, workspace_root))
+        .collect();
+
+    let mut success_count = 0;
+    let mut error_count = 0;
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            Output::warning(&format!("{}: not cloned, skipping", repo.name));
+            continue;
+        }
+
+        let worktree_path = tree_path.join(&repo.path);
+        let spinner = Output::spinner(&format!("Creating worktree for {}...", repo.name));
+
+        match create_worktree(&repo.absolute_path, &worktree_path, branch) {
+            Ok(_) => {
+                spinner.finish_with_message(format!("{}: created", repo.name));
+                success_count += 1;
+            }
+            Err(e) => {
+                spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));
+                error_count += 1;
+            }
+        }
+    }
+
+    // Create .gitgrip structure in griptree
+    let tree_gitgrip = tree_path.join(".gitgrip");
+    std::fs::create_dir_all(&tree_gitgrip)?;
+
+    // Save griptree config in the griptree directory
+    let griptree_config = GriptreeConfig::new(branch, &tree_path.to_string_lossy());
+    let griptree_config_path = tree_gitgrip.join("griptree.json");
+    griptree_config.save(&griptree_config_path)?;
+
+    // Add to griptrees list
+    griptrees.griptrees.insert(branch.to_string(), GriptreeEntry {
+        path: tree_path.to_string_lossy().to_string(),
+        branch: branch.to_string(),
+        locked: false,
+        lock_reason: None,
+    });
+
+    // Save griptrees list
+    let config_json = serde_json::to_string_pretty(&griptrees)?;
+    std::fs::write(&config_path, config_json)?;
+
+    println!();
+    if error_count == 0 {
+        Output::success(&format!(
+            "Griptree created at {:?} with {} repo(s)",
+            tree_path, success_count
+        ));
+    } else {
+        Output::warning(&format!(
+            "Griptree created with {} success, {} errors",
+            success_count, error_count
+        ));
+    }
+
+    println!();
+    println!("To use the griptree:");
+    println!("  cd {:?}", tree_path);
+
+    Ok(())
+}
+
+/// Run tree list command
+pub fn run_tree_list(workspace_root: &PathBuf) -> anyhow::Result<()> {
+    Output::header("Griptrees");
+    println!();
+
+    let config_path = workspace_root.join(".gitgrip").join("griptrees.json");
+    if !config_path.exists() {
+        println!("No griptrees configured.");
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&config_path)?;
+    let griptrees: GriptreesList = serde_json::from_str(&content)?;
+
+    if griptrees.griptrees.is_empty() {
+        println!("No griptrees configured.");
+        return Ok(());
+    }
+
+    for (branch, entry) in &griptrees.griptrees {
+        let exists = PathBuf::from(&entry.path).exists();
+        let status = if !exists {
+            " (missing)"
+        } else if entry.locked {
+            " (locked)"
+        } else {
+            ""
+        };
+
+        println!("  {} -> {}{}", branch, entry.path, status);
+        if let Some(ref reason) = entry.lock_reason {
+            println!("    Lock reason: {}", reason);
+        }
+    }
+
+    Ok(())
+}
+
+/// Run tree remove command
+pub fn run_tree_remove(
+    workspace_root: &PathBuf,
+    branch: &str,
+    force: bool,
+) -> anyhow::Result<()> {
+    Output::header(&format!("Removing griptree for '{}'", branch));
+    println!();
+
+    let config_path = workspace_root.join(".gitgrip").join("griptrees.json");
+    if !config_path.exists() {
+        anyhow::bail!("No griptrees configured");
+    }
+
+    let content = std::fs::read_to_string(&config_path)?;
+    let mut griptrees: GriptreesList = serde_json::from_str(&content)?;
+
+    let entry = griptrees.griptrees.get(branch)
+        .ok_or_else(|| anyhow::anyhow!("Griptree '{}' not found", branch))?;
+
+    if entry.locked && !force {
+        anyhow::bail!(
+            "Griptree '{}' is locked{}. Use --force to remove anyway.",
+            branch,
+            entry.lock_reason.as_ref().map(|r| format!(": {}", r)).unwrap_or_default()
+        );
+    }
+
+    let tree_path = PathBuf::from(&entry.path);
+
+    // Remove directory
+    if tree_path.exists() {
+        let spinner = Output::spinner("Removing griptree directory...");
+        std::fs::remove_dir_all(&tree_path)?;
+        spinner.finish_with_message("Directory removed");
+    }
+
+    // Update griptrees list
+    griptrees.griptrees.remove(branch);
+    let config_json = serde_json::to_string_pretty(&griptrees)?;
+    std::fs::write(&config_path, config_json)?;
+
+    Output::success(&format!("Griptree '{}' removed", branch));
+    Ok(())
+}
+
+/// Run tree lock command
+pub fn run_tree_lock(
+    workspace_root: &PathBuf,
+    branch: &str,
+    reason: Option<&str>,
+) -> anyhow::Result<()> {
+    let config_path = workspace_root.join(".gitgrip").join("griptrees.json");
+    if !config_path.exists() {
+        anyhow::bail!("No griptrees configured");
+    }
+
+    let content = std::fs::read_to_string(&config_path)?;
+    let mut griptrees: GriptreesList = serde_json::from_str(&content)?;
+
+    let entry = griptrees.griptrees.get_mut(branch)
+        .ok_or_else(|| anyhow::anyhow!("Griptree '{}' not found", branch))?;
+
+    entry.locked = true;
+    entry.lock_reason = reason.map(|s| s.to_string());
+
+    let config_json = serde_json::to_string_pretty(&griptrees)?;
+    std::fs::write(&config_path, config_json)?;
+
+    Output::success(&format!("Griptree '{}' locked", branch));
+    Ok(())
+}
+
+/// Run tree unlock command
+pub fn run_tree_unlock(workspace_root: &PathBuf, branch: &str) -> anyhow::Result<()> {
+    let config_path = workspace_root.join(".gitgrip").join("griptrees.json");
+    if !config_path.exists() {
+        anyhow::bail!("No griptrees configured");
+    }
+
+    let content = std::fs::read_to_string(&config_path)?;
+    let mut griptrees: GriptreesList = serde_json::from_str(&content)?;
+
+    let entry = griptrees.griptrees.get_mut(branch)
+        .ok_or_else(|| anyhow::anyhow!("Griptree '{}' not found", branch))?;
+
+    entry.locked = false;
+    entry.lock_reason = None;
+
+    let config_json = serde_json::to_string_pretty(&griptrees)?;
+    std::fs::write(&config_path, config_json)?;
+
+    Output::success(&format!("Griptree '{}' unlocked", branch));
+    Ok(())
+}
+
+/// Create a git worktree
+fn create_worktree(repo_path: &PathBuf, worktree_path: &PathBuf, branch: &str) -> anyhow::Result<()> {
+    let repo = open_repo(repo_path)?;
+
+    // Create parent directory if needed
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Check if branch exists, create if not
+    let branch_exists = repo.find_branch(branch, git2::BranchType::Local).is_ok();
+
+    if branch_exists {
+        // Add worktree with existing branch
+        repo.worktree(
+            branch,
+            worktree_path,
+            Some(git2::WorktreeAddOptions::new().reference(
+                Some(&repo.find_branch(branch, git2::BranchType::Local)?.into_reference())
+            )),
+        )?;
+    } else {
+        // Create branch and worktree
+        let head = repo.head()?;
+        let commit = head.peel_to_commit()?;
+        repo.branch(branch, &commit, false)?;
+
+        repo.worktree(
+            branch,
+            worktree_path,
+            Some(git2::WorktreeAddOptions::new().reference(
+                Some(&repo.find_branch(branch, git2::BranchType::Local)?.into_reference())
+            )),
+        )?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Implements all remaining gitgrip CLI commands in Rust
- All commands now fully wired up in main.rs
- 71 tests passing

## Commands Implemented
| Command | Description |
|---------|-------------|
| `init` | Initialize a new workspace from manifest URL |
| `tree add/list/remove/lock/unlock` | Griptree (worktree) management |
| `forall` | Run command in each repo (sequential/parallel) |
| `rebase` | Rebase branches with abort/continue support |
| `link` | Manage copyfile/linkfile entries |
| `run` | Run workspace scripts |
| `env` | Show workspace environment variables |
| `repo list/add/remove` | Repository management |

## Features
- Parallel execution for forall command
- Changed-only filtering for forall
- Cross-platform symlink support for link command
- Multi-step script support for run command
- Lock/unlock for griptrees with reasons

## Test plan
- [x] All 71 unit tests pass
- [x] Code compiles without errors
- [ ] Manual testing of commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)