### PR TITLE
chore: update branding to burnt orange color scheme

### DIFF
--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,13 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" width="800" height="200">
   <defs>
-    <linearGradient id="banner-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10B981"/>
-      <stop offset="50%" style="stop-color:#059669"/>
-      <stop offset="100%" style="stop-color:#047857"/>
+    <linearGradient id="icon-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9A3412"/>
+      <stop offset="50%" style="stop-color:#7C2D12"/>
+      <stop offset="100%" style="stop-color:#431407"/>
     </linearGradient>
     <linearGradient id="bg-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0a0f"/>
       <stop offset="100%" style="stop-color:#111827"/>
+    </linearGradient>
+    <linearGradient id="text-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#FB923C"/>
+      <stop offset="100%" style="stop-color:#FDBA74"/>
     </linearGradient>
   </defs>
 
@@ -15,57 +19,61 @@
   <rect width="800" height="200" fill="url(#bg-gradient)"/>
 
   <!-- Decorative git branch lines in background -->
-  <g opacity="0.15" stroke="#10B981" stroke-width="1.5">
+  <g opacity="0.15" stroke="#FB923C" stroke-width="1.5">
     <!-- Left side branches -->
     <path d="M40 100 Q80 60 120 80" fill="none"/>
     <path d="M40 100 Q80 140 120 120" fill="none"/>
-    <circle cx="40" cy="100" r="4" fill="#10B981"/>
-    <circle cx="120" cy="80" r="3" fill="#059669"/>
-    <circle cx="120" cy="120" r="3" fill="#059669"/>
+    <circle cx="40" cy="100" r="4" fill="#FB923C"/>
+    <circle cx="120" cy="80" r="3" fill="#FDBA74"/>
+    <circle cx="120" cy="120" r="3" fill="#FDBA74"/>
 
     <!-- Right side branches -->
     <path d="M760 100 Q720 60 680 80" fill="none"/>
     <path d="M760 100 Q720 140 680 120" fill="none"/>
-    <circle cx="760" cy="100" r="4" fill="#10B981"/>
-    <circle cx="680" cy="80" r="3" fill="#059669"/>
-    <circle cx="680" cy="120" r="3" fill="#059669"/>
+    <circle cx="760" cy="100" r="4" fill="#FB923C"/>
+    <circle cx="680" cy="80" r="3" fill="#FDBA74"/>
+    <circle cx="680" cy="120" r="3" fill="#FDBA74"/>
   </g>
 
   <!-- Floating particles -->
-  <circle cx="150" cy="40" r="2" fill="#10B981" opacity="0.3"/>
-  <circle cx="200" cy="160" r="1.5" fill="#059669" opacity="0.25"/>
-  <circle cx="600" cy="30" r="2" fill="#047857" opacity="0.3"/>
-  <circle cx="650" cy="170" r="1.5" fill="#10B981" opacity="0.25"/>
+  <circle cx="150" cy="40" r="2" fill="#FDBA74" opacity="0.3"/>
+  <circle cx="200" cy="160" r="1.5" fill="#FDBA74" opacity="0.25"/>
+  <circle cx="600" cy="30" r="2" fill="#FB923C" opacity="0.3"/>
+  <circle cx="650" cy="170" r="1.5" fill="#FDBA74" opacity="0.25"/>
 
   <!-- Main logo group centered -->
   <g transform="translate(220, 45)">
     <!-- Icon background -->
-    <rect x="0" y="0" width="110" height="110" rx="22" fill="url(#banner-gradient)"/>
+    <rect x="0" y="0" width="110" height="110" rx="22" fill="url(#icon-gradient)"/>
 
-    <!-- Central grip hub -->
-    <circle cx="55" cy="55" r="14" fill="white" opacity="0.95"/>
+    <!-- Cupped hand constellation (scaled for banner) -->
+    <g stroke="#FB923C" stroke-width="2.5" opacity="0.8" fill="none" transform="scale(1.72)">
+      <line x1="10" y1="24" x2="14" y2="32"/><line x1="14" y1="32" x2="20" y2="40"/>
+      <line x1="16" y1="14" x2="18" y2="24"/><line x1="18" y1="24" x2="24" y2="36"/>
+      <line x1="28" y1="10" x2="28" y2="22"/><line x1="28" y1="22" x2="30" y2="36"/>
+      <line x1="40" y1="12" x2="40" y2="24"/><line x1="40" y1="24" x2="38" y2="38"/>
+      <line x1="54" y1="28" x2="48" y2="36"/><line x1="48" y1="36" x2="42" y2="42"/>
+      <line x1="20" y1="40" x2="30" y2="44"/><line x1="30" y1="44" x2="42" y2="42"/>
+      <line x1="20" y1="40" x2="22" y2="54"/><line x1="42" y1="42" x2="40" y2="54"/>
+      <line x1="22" y1="54" x2="40" y2="54"/>
+    </g>
 
-    <!-- Three branches being gripped -->
-    <!-- Top branch -->
-    <path d="M55 41 L55 24" stroke="white" stroke-width="4" stroke-linecap="round"/>
-    <circle cx="55" cy="20" r="6" fill="white"/>
-
-    <!-- Bottom-left branch -->
-    <path d="M44 63 L28 79" stroke="white" stroke-width="4" stroke-linecap="round"/>
-    <circle cx="24" cy="83" r="6" fill="white"/>
-
-    <!-- Bottom-right branch -->
-    <path d="M66 63 L82 79" stroke="white" stroke-width="4" stroke-linecap="round"/>
-    <circle cx="86" cy="83" r="6" fill="white"/>
-
-    <!-- Inner grip detail -->
-    <circle cx="55" cy="55" r="6" fill="url(#banner-gradient)"/>
+    <!-- Star nodes (scaled for banner) -->
+    <g fill="#FDBA74" transform="scale(1.72)">
+      <circle cx="10" cy="24" r="3"/><circle cx="14" cy="32" r="2.5"/><circle cx="20" cy="40" r="2.5"/>
+      <circle cx="16" cy="14" r="3.5"/><circle cx="18" cy="24" r="2.5"/><circle cx="24" cy="36" r="2"/>
+      <circle cx="28" cy="10" r="4"/><circle cx="28" cy="22" r="2.5"/><circle cx="30" cy="36" r="2"/>
+      <circle cx="40" cy="12" r="3.5"/><circle cx="40" cy="24" r="2.5"/><circle cx="38" cy="38" r="2"/>
+      <circle cx="54" cy="28" r="3.5"/><circle cx="48" cy="36" r="2.5"/><circle cx="42" cy="42" r="2.5"/>
+      <circle cx="30" cy="44" r="2"/>
+      <circle cx="22" cy="54" r="2.5"/><circle cx="40" cy="54" r="2.5"/>
+    </g>
 
     <!-- Text "gitgrip" -->
-    <text x="130" y="72" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="60" font-weight="700" fill="white">gitgrip</text>
+    <text x="130" y="72" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="60" font-weight="700" fill="url(#text-gradient)">gitgrip</text>
   </g>
 
   <!-- Tagline -->
-  <text x="400" y="178" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="500" fill="#6EE7B7">git a grip</text>
+  <text x="400" y="178" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="20" font-weight="500" fill="#FB923C">git a grip</text>
   <text x="400" y="198" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="14" fill="#9CA3AF">Multi-repo workflow tool</text>
 </svg>

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,31 +1,35 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
   <defs>
     <linearGradient id="icon-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10B981"/>
-      <stop offset="50%" style="stop-color:#059669"/>
-      <stop offset="100%" style="stop-color:#047857"/>
+      <stop offset="0%" style="stop-color:#9A3412"/>
+      <stop offset="50%" style="stop-color:#7C2D12"/>
+      <stop offset="100%" style="stop-color:#431407"/>
     </linearGradient>
   </defs>
 
   <!-- Outer rounded square -->
   <rect x="4" y="4" width="56" height="56" rx="12" fill="url(#icon-gradient)"/>
 
-  <!-- Central grip hub -->
-  <circle cx="32" cy="32" r="9" fill="white" opacity="0.95"/>
+  <!-- Cupped hand constellation -->
+  <g stroke="#FB923C" stroke-width="1.5" opacity="0.8" fill="none">
+    <line x1="10" y1="24" x2="14" y2="32"/><line x1="14" y1="32" x2="20" y2="40"/>
+    <line x1="16" y1="14" x2="18" y2="24"/><line x1="18" y1="24" x2="24" y2="36"/>
+    <line x1="28" y1="10" x2="28" y2="22"/><line x1="28" y1="22" x2="30" y2="36"/>
+    <line x1="40" y1="12" x2="40" y2="24"/><line x1="40" y1="24" x2="38" y2="38"/>
+    <line x1="54" y1="28" x2="48" y2="36"/><line x1="48" y1="36" x2="42" y2="42"/>
+    <line x1="20" y1="40" x2="30" y2="44"/><line x1="30" y1="44" x2="42" y2="42"/>
+    <line x1="20" y1="40" x2="22" y2="54"/><line x1="42" y1="42" x2="40" y2="54"/>
+    <line x1="22" y1="54" x2="40" y2="54"/>
+  </g>
 
-  <!-- Three branches being gripped -->
-  <!-- Top branch -->
-  <path d="M32 23 L32 12" stroke="white" stroke-width="3" stroke-linecap="round"/>
-  <circle cx="32" cy="10" r="4" fill="white"/>
-
-  <!-- Bottom-left branch -->
-  <path d="M25 37 L14 48" stroke="white" stroke-width="3" stroke-linecap="round"/>
-  <circle cx="12" cy="50" r="4" fill="white"/>
-
-  <!-- Bottom-right branch -->
-  <path d="M39 37 L50 48" stroke="white" stroke-width="3" stroke-linecap="round"/>
-  <circle cx="52" cy="50" r="4" fill="white"/>
-
-  <!-- Inner grip detail -->
-  <circle cx="32" cy="32" r="4" fill="url(#icon-gradient)"/>
+  <!-- Star nodes -->
+  <g fill="#FDBA74">
+    <circle cx="10" cy="24" r="3"/><circle cx="14" cy="32" r="2.5"/><circle cx="20" cy="40" r="2.5"/>
+    <circle cx="16" cy="14" r="3.5"/><circle cx="18" cy="24" r="2.5"/><circle cx="24" cy="36" r="2"/>
+    <circle cx="28" cy="10" r="4"/><circle cx="28" cy="22" r="2.5"/><circle cx="30" cy="36" r="2"/>
+    <circle cx="40" cy="12" r="3.5"/><circle cx="40" cy="24" r="2.5"/><circle cx="38" cy="38" r="2"/>
+    <circle cx="54" cy="28" r="3.5"/><circle cx="48" cy="36" r="2.5"/><circle cx="42" cy="42" r="2.5"/>
+    <circle cx="30" cy="44" r="2"/>
+    <circle cx="22" cy="54" r="2.5"/><circle cx="40" cy="54" r="2.5"/>
+  </g>
 </svg>

--- a/assets/logo-dark.svg
+++ b/assets/logo-dark.svg
@@ -1,9 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 60" width="220" height="60">
   <defs>
     <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10B981"/>
-      <stop offset="50%" style="stop-color:#059669"/>
-      <stop offset="100%" style="stop-color:#047857"/>
+      <stop offset="0%" style="stop-color:#9A3412"/>
+      <stop offset="50%" style="stop-color:#7C2D12"/>
+      <stop offset="100%" style="stop-color:#431407"/>
+    </linearGradient>
+    <linearGradient id="text-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#FB923C"/>
+      <stop offset="100%" style="stop-color:#FDBA74"/>
     </linearGradient>
   </defs>
 
@@ -12,26 +16,30 @@
     <!-- Outer rounded square -->
     <rect x="0" y="0" width="46" height="46" rx="10" fill="url(#gradient)"/>
 
-    <!-- Central grip hub -->
-    <circle cx="23" cy="23" r="6" fill="white" opacity="0.95"/>
+    <!-- Cupped hand constellation (scaled) -->
+    <g stroke="#FB923C" stroke-width="1.2" opacity="0.8" fill="none" transform="scale(0.72)">
+      <line x1="10" y1="24" x2="14" y2="32"/><line x1="14" y1="32" x2="20" y2="40"/>
+      <line x1="16" y1="14" x2="18" y2="24"/><line x1="18" y1="24" x2="24" y2="36"/>
+      <line x1="28" y1="10" x2="28" y2="22"/><line x1="28" y1="22" x2="30" y2="36"/>
+      <line x1="40" y1="12" x2="40" y2="24"/><line x1="40" y1="24" x2="38" y2="38"/>
+      <line x1="54" y1="28" x2="48" y2="36"/><line x1="48" y1="36" x2="42" y2="42"/>
+      <line x1="20" y1="40" x2="30" y2="44"/><line x1="30" y1="44" x2="42" y2="42"/>
+      <line x1="20" y1="40" x2="22" y2="54"/><line x1="42" y1="42" x2="40" y2="54"/>
+      <line x1="22" y1="54" x2="40" y2="54"/>
+    </g>
 
-    <!-- Three branches being gripped -->
-    <!-- Top branch -->
-    <path d="M23 17 L23 8" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-    <circle cx="23" cy="6" r="3" fill="white"/>
-
-    <!-- Bottom-left branch -->
-    <path d="M18 27 L10 35" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-    <circle cx="8" cy="37" r="3" fill="white"/>
-
-    <!-- Bottom-right branch -->
-    <path d="M28 27 L36 35" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-    <circle cx="38" cy="37" r="3" fill="white"/>
-
-    <!-- Inner grip detail -->
-    <circle cx="23" cy="23" r="2.5" fill="url(#gradient)"/>
+    <!-- Star nodes (scaled) -->
+    <g fill="#FDBA74" transform="scale(0.72)">
+      <circle cx="10" cy="24" r="3"/><circle cx="14" cy="32" r="2.5"/><circle cx="20" cy="40" r="2.5"/>
+      <circle cx="16" cy="14" r="3.5"/><circle cx="18" cy="24" r="2.5"/><circle cx="24" cy="36" r="2"/>
+      <circle cx="28" cy="10" r="4"/><circle cx="28" cy="22" r="2.5"/><circle cx="30" cy="36" r="2"/>
+      <circle cx="40" cy="12" r="3.5"/><circle cx="40" cy="24" r="2.5"/><circle cx="38" cy="38" r="2"/>
+      <circle cx="54" cy="28" r="3.5"/><circle cx="48" cy="36" r="2.5"/><circle cx="42" cy="42" r="2.5"/>
+      <circle cx="30" cy="44" r="2"/>
+      <circle cx="22" cy="54" r="2.5"/><circle cx="40" cy="54" r="2.5"/>
+    </g>
   </g>
 
-  <!-- Text "gitgrip" in white for dark backgrounds -->
-  <text x="60" y="42" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="32" font-weight="700" fill="white">gitgrip</text>
+  <!-- Text "gitgrip" - for dark backgrounds -->
+  <text x="60" y="42" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="32" font-weight="700" fill="url(#text-gradient)">gitgrip</text>
 </svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,9 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 60" width="220" height="60">
   <defs>
     <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10B981"/>
-      <stop offset="50%" style="stop-color:#059669"/>
-      <stop offset="100%" style="stop-color:#047857"/>
+      <stop offset="0%" style="stop-color:#9A3412"/>
+      <stop offset="50%" style="stop-color:#7C2D12"/>
+      <stop offset="100%" style="stop-color:#431407"/>
+    </linearGradient>
+    <linearGradient id="text-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#FB923C"/>
+      <stop offset="100%" style="stop-color:#FDBA74"/>
     </linearGradient>
   </defs>
 
@@ -12,26 +16,30 @@
     <!-- Outer rounded square -->
     <rect x="0" y="0" width="46" height="46" rx="10" fill="url(#gradient)"/>
 
-    <!-- Central grip hub -->
-    <circle cx="23" cy="23" r="6" fill="white" opacity="0.95"/>
+    <!-- Cupped hand constellation (scaled) -->
+    <g stroke="#FB923C" stroke-width="1.2" opacity="0.8" fill="none" transform="scale(0.72)">
+      <line x1="10" y1="24" x2="14" y2="32"/><line x1="14" y1="32" x2="20" y2="40"/>
+      <line x1="16" y1="14" x2="18" y2="24"/><line x1="18" y1="24" x2="24" y2="36"/>
+      <line x1="28" y1="10" x2="28" y2="22"/><line x1="28" y1="22" x2="30" y2="36"/>
+      <line x1="40" y1="12" x2="40" y2="24"/><line x1="40" y1="24" x2="38" y2="38"/>
+      <line x1="54" y1="28" x2="48" y2="36"/><line x1="48" y1="36" x2="42" y2="42"/>
+      <line x1="20" y1="40" x2="30" y2="44"/><line x1="30" y1="44" x2="42" y2="42"/>
+      <line x1="20" y1="40" x2="22" y2="54"/><line x1="42" y1="42" x2="40" y2="54"/>
+      <line x1="22" y1="54" x2="40" y2="54"/>
+    </g>
 
-    <!-- Three branches being gripped -->
-    <!-- Top branch -->
-    <path d="M23 17 L23 8" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-    <circle cx="23" cy="6" r="3" fill="white"/>
-
-    <!-- Bottom-left branch -->
-    <path d="M18 27 L10 35" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-    <circle cx="8" cy="37" r="3" fill="white"/>
-
-    <!-- Bottom-right branch -->
-    <path d="M28 27 L36 35" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
-    <circle cx="38" cy="37" r="3" fill="white"/>
-
-    <!-- Inner grip detail -->
-    <circle cx="23" cy="23" r="2.5" fill="url(#gradient)"/>
+    <!-- Star nodes (scaled) -->
+    <g fill="#FDBA74" transform="scale(0.72)">
+      <circle cx="10" cy="24" r="3"/><circle cx="14" cy="32" r="2.5"/><circle cx="20" cy="40" r="2.5"/>
+      <circle cx="16" cy="14" r="3.5"/><circle cx="18" cy="24" r="2.5"/><circle cx="24" cy="36" r="2"/>
+      <circle cx="28" cy="10" r="4"/><circle cx="28" cy="22" r="2.5"/><circle cx="30" cy="36" r="2"/>
+      <circle cx="40" cy="12" r="3.5"/><circle cx="40" cy="24" r="2.5"/><circle cx="38" cy="38" r="2"/>
+      <circle cx="54" cy="28" r="3.5"/><circle cx="48" cy="36" r="2.5"/><circle cx="42" cy="42" r="2.5"/>
+      <circle cx="30" cy="44" r="2"/>
+      <circle cx="22" cy="54" r="2.5"/><circle cx="40" cy="54" r="2.5"/>
+    </g>
   </g>
 
   <!-- Text "gitgrip" -->
-  <text x="60" y="42" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="32" font-weight="700" fill="url(#gradient)">gitgrip</text>
+  <text x="60" y="42" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="32" font-weight="700" fill="url(#text-gradient)">gitgrip</text>
 </svg>


### PR DESCRIPTION
## Summary
- Update all branding assets to use orange-05-burnt palette
- Background gradient: #9A3412 → #7C2D12 → #431407
- Stroke: #FB923C, Fill: #FDBA74

## Files Changed
- `assets/icon.svg`
- `assets/logo.svg`
- `assets/logo-dark.svg`
- `assets/banner.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)