### PR TITLE
chore: update griptree diagrams with burnt orange branding

### DIFF
--- a/assets/griptree-concept.svg
+++ b/assets/griptree-concept.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
   <defs>
     <linearGradient id="mainGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10B981;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#059669;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#9A3412;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#7C2D12;stop-opacity:1" />
     </linearGradient>
     <linearGradient id="treeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3B82F6;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1D4ED8;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#7C2D12;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#431407;stop-opacity:1" />
     </linearGradient>
     <linearGradient id="repoGrad" x1="0%" y1="0%" x2="0%" y2="100%">
       <stop offset="0%" style="stop-color:#374151;stop-opacity:1" />
@@ -28,22 +28,22 @@
   <g transform="translate(50, 110)">
     <rect x="0" y="0" width="220" height="280" rx="12" fill="url(#mainGrad)" filter="url(#shadow)"/>
     <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Main Workspace</text>
-    <text x="110" y="50" font-family="monospace" font-size="12" fill="#D1FAE5" text-anchor="middle">branch: main</text>
+    <text x="110" y="50" font-family="monospace" font-size="12" fill="#FDBA74" text-anchor="middle">branch: main</text>
 
     <!-- Repos in main -->
     <g transform="translate(20, 70)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#10B981">frontend/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FB923C">frontend/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">.git/objects (shared)</text>
     </g>
     <g transform="translate(20, 125)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#10B981">backend/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FB923C">backend/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">.git/objects (shared)</text>
     </g>
     <g transform="translate(20, 180)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#10B981">shared/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FB923C">shared/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">.git/objects (shared)</text>
     </g>
   </g>
@@ -52,22 +52,22 @@
   <g transform="translate(290, 110)">
     <rect x="0" y="0" width="220" height="280" rx="12" fill="url(#treeGrad)" filter="url(#shadow)"/>
     <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Griptree: feat/auth</text>
-    <text x="110" y="50" font-family="monospace" font-size="12" fill="#BFDBFE" text-anchor="middle">branch: feat/auth</text>
+    <text x="110" y="50" font-family="monospace" font-size="12" fill="#FDBA74" text-anchor="middle">branch: feat/auth</text>
 
     <!-- Repos as worktrees -->
     <g transform="translate(20, 70)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">frontend/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FDBA74">frontend/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
     </g>
     <g transform="translate(20, 125)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">backend/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FDBA74">backend/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
     </g>
     <g transform="translate(20, 180)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">shared/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FDBA74">shared/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
     </g>
   </g>
@@ -76,22 +76,22 @@
   <g transform="translate(530, 110)">
     <rect x="0" y="0" width="220" height="280" rx="12" fill="url(#treeGrad)" filter="url(#shadow)"/>
     <text x="110" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Griptree: feat/api</text>
-    <text x="110" y="50" font-family="monospace" font-size="12" fill="#BFDBFE" text-anchor="middle">branch: feat/api</text>
+    <text x="110" y="50" font-family="monospace" font-size="12" fill="#FDBA74" text-anchor="middle">branch: feat/api</text>
 
     <!-- Repos as worktrees -->
     <g transform="translate(20, 70)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">frontend/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FDBA74">frontend/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
     </g>
     <g transform="translate(20, 125)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">backend/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FDBA74">backend/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
     </g>
     <g transform="translate(20, 180)">
       <rect x="0" y="0" width="180" height="45" rx="6" fill="url(#repoGrad)"/>
-      <text x="15" y="20" font-family="monospace" font-size="11" fill="#60A5FA">shared/</text>
+      <text x="15" y="20" font-family="monospace" font-size="11" fill="#FDBA74">shared/</text>
       <text x="15" y="35" font-family="monospace" font-size="10" fill="#6B7280">worktree (instant)</text>
     </g>
   </g>
@@ -99,13 +99,13 @@
   <!-- Connecting arrows showing shared objects -->
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+      <polygon points="0 0, 10 3.5, 0 7" fill="#FB923C"/>
     </marker>
   </defs>
 
   <!-- Curved lines from main to griptrees -->
-  <path d="M 270 250 Q 280 200 290 250" stroke="#10B981" stroke-width="2" fill="none" stroke-dasharray="5,5"/>
-  <path d="M 270 250 Q 400 150 530 250" stroke="#10B981" stroke-width="2" fill="none" stroke-dasharray="5,5"/>
+  <path d="M 270 250 Q 280 200 290 250" stroke="#FB923C" stroke-width="2" fill="none" stroke-dasharray="5,5"/>
+  <path d="M 270 250 Q 400 150 530 250" stroke="#FB923C" stroke-width="2" fill="none" stroke-dasharray="5,5"/>
 
   <!-- Legend -->
   <g transform="translate(50, 420)">

--- a/assets/griptree-workflow.svg
+++ b/assets/griptree-workflow.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 300">
   <defs>
     <linearGradient id="cmdGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#10B981"/>
-      <stop offset="100%" style="stop-color:#059669"/>
+      <stop offset="0%" style="stop-color:#9A3412"/>
+      <stop offset="100%" style="stop-color:#7C2D12"/>
     </linearGradient>
     <filter id="glow">
       <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
@@ -21,42 +21,42 @@
 
   <!-- Step 1: Create -->
   <g transform="translate(60, 70)">
-    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#10B981" stroke-width="2"/>
-    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#10B981" text-anchor="middle">1. Create</text>
+    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#FB923C" stroke-width="2"/>
+    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#FB923C" text-anchor="middle">1. Create</text>
     <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr tree add</text>
-    <text x="90" y="68" font-family="monospace" font-size="11" fill="#60A5FA" text-anchor="middle">feat/my-feature</text>
+    <text x="90" y="68" font-family="monospace" font-size="11" fill="#FDBA74" text-anchor="middle">feat/my-feature</text>
   </g>
 
   <!-- Arrow 1 -->
-  <path d="M 250 115 L 300 115" stroke="#10B981" stroke-width="2" marker-end="url(#arrow)"/>
+  <path d="M 250 115 L 300 115" stroke="#FB923C" stroke-width="2" marker-end="url(#arrow)"/>
   <defs>
     <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 Z" fill="#10B981"/>
+      <path d="M 0 0 L 10 5 L 0 10 Z" fill="#FB923C"/>
     </marker>
   </defs>
 
   <!-- Step 2: Work -->
   <g transform="translate(310, 70)">
-    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#3B82F6" stroke-width="2"/>
-    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#3B82F6" text-anchor="middle">2. Work</text>
+    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#FDBA74" stroke-width="2"/>
+    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#FDBA74" text-anchor="middle">2. Work</text>
     <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">cd ../feat-my-feature</text>
     <text x="90" y="68" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr status / commit / push</text>
   </g>
 
   <!-- Arrow 2 -->
-  <path d="M 500 115 L 550 115" stroke="#3B82F6" stroke-width="2" marker-end="url(#arrow2)"/>
+  <path d="M 500 115 L 550 115" stroke="#FDBA74" stroke-width="2" marker-end="url(#arrow2)"/>
   <defs>
     <marker id="arrow2" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 Z" fill="#3B82F6"/>
+      <path d="M 0 0 L 10 5 L 0 10 Z" fill="#FDBA74"/>
     </marker>
   </defs>
 
   <!-- Step 3: Remove -->
   <g transform="translate(560, 70)">
-    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#F59E0B" stroke-width="2"/>
-    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#F59E0B" text-anchor="middle">3. Cleanup</text>
+    <rect x="0" y="0" width="180" height="90" rx="10" fill="#1E293B" stroke="#7C2D12" stroke-width="2"/>
+    <text x="90" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="bold" fill="#7C2D12" text-anchor="middle">3. Cleanup</text>
     <text x="90" y="50" font-family="monospace" font-size="11" fill="#94A3B8" text-anchor="middle">gr tree remove</text>
-    <text x="90" y="68" font-family="monospace" font-size="11" fill="#60A5FA" text-anchor="middle">feat/my-feature</text>
+    <text x="90" y="68" font-family="monospace" font-size="11" fill="#FDBA74" text-anchor="middle">feat/my-feature</text>
   </g>
 
   <!-- Commands reference -->
@@ -64,16 +64,16 @@
     <rect x="0" y="0" width="680" height="90" rx="8" fill="#1E293B"/>
     <text x="20" y="25" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="bold" fill="#F8FAFC">Quick Reference:</text>
 
-    <text x="20" y="50" font-family="monospace" font-size="11" fill="#10B981">gr tree add &lt;branch&gt;</text>
+    <text x="20" y="50" font-family="monospace" font-size="11" fill="#FB923C">gr tree add &lt;branch&gt;</text>
     <text x="200" y="50" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Create parallel workspace</text>
 
-    <text x="20" y="70" font-family="monospace" font-size="11" fill="#10B981">gr tree list</text>
+    <text x="20" y="70" font-family="monospace" font-size="11" fill="#FB923C">gr tree list</text>
     <text x="200" y="70" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Show all griptrees</text>
 
-    <text x="380" y="50" font-family="monospace" font-size="11" fill="#10B981">gr tree lock &lt;branch&gt;</text>
+    <text x="380" y="50" font-family="monospace" font-size="11" fill="#FB923C">gr tree lock &lt;branch&gt;</text>
     <text x="560" y="50" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Protect from removal</text>
 
-    <text x="380" y="70" font-family="monospace" font-size="11" fill="#10B981">gr tree remove &lt;branch&gt;</text>
+    <text x="380" y="70" font-family="monospace" font-size="11" fill="#FB923C">gr tree remove &lt;branch&gt;</text>
     <text x="590" y="70" font-family="system-ui, sans-serif" font-size="11" fill="#6B7280">Remove griptree</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- Update griptree-concept.svg and griptree-workflow.svg to use burnt orange color scheme
- Matches the logo/icon branding from #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)