### PR TITLE
chore: update README badge colors to burnt orange

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/gitgrip"><img src="https://img.shields.io/npm/v/gitgrip.svg?style=flat-square&color=10B981" alt="npm version"></a>
-  <a href="https://github.com/laynepenney/gitgrip/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/gitgrip.svg?style=flat-square&color=059669" alt="license"></a>
-  <a href="https://www.npmjs.com/package/gitgrip"><img src="https://img.shields.io/npm/dm/gitgrip.svg?style=flat-square&color=047857" alt="downloads"></a>
+  <a href="https://www.npmjs.com/package/gitgrip"><img src="https://img.shields.io/npm/v/gitgrip.svg?style=flat-square&color=9A3412" alt="npm version"></a>
+  <a href="https://github.com/laynepenney/gitgrip/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/gitgrip.svg?style=flat-square&color=7C2D12" alt="license"></a>
+  <a href="https://www.npmjs.com/package/gitgrip"><img src="https://img.shields.io/npm/dm/gitgrip.svg?style=flat-square&color=431407" alt="downloads"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Update npm badge colors from green to burnt orange (#9A3412, #7C2D12, #431407)

🤖 Generated with [Claude Code](https://claude.com/claude-code)