### PR TITLE
fix: pr merge should recognize passing GitHub Actions check runs

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -72,6 +72,50 @@ Added `gr completions <shell>` command using clap_complete crate.
 
 ## Pending Review
 
+### Missing: `gr sync` shows which repos failed
+
+**Discovered**: 2026-02-01
+
+**Problem**: `gr sync` reports "X failed" with no details about which repositories failed or why.
+
+**Reproduction**:
+```bash
+gr sync
+# Output: ⚠ 7 synced, 1 failed
+```
+
+**Expected**: Show which repositories failed and why:
+```
+Syncing 8 repositories...
+✓ tooling: synced
+✓ codex: synced
+⚠ opencode: not cloned
+✗ private: failed - Failed to fetch: authentication required
+```
+
+**Root cause**: Error aggregation code doesn't show per-repo details on failure.
+
+---
+
+### Missing: `gr push` shows which repos failed
+
+**Discovered**: 2026-02-01
+
+**Problem**: `gr push` reports "X failed, Y skipped" with no details about which repositories failed or were skipped.
+
+**Reproduction**:
+```bash
+gr push
+# Output: ⚠ 5 pushed, 2 failed, 1 skipped
+```
+
+**Expected**: Show detailed results including which repos failed and why, and which were skipped.
+
+**Root cause**: Similar to `gr sync`, error aggregation code doesn't show per-repo details.
+
+---
+
+
 ### Feature: Reference repos (read-only repos excluded from branch/PR operations) → Issue #113
 
 **Discovered**: 2026-02-01 during Rust migration planning
@@ -299,6 +343,41 @@ gr forall -c "pnpm lint" --ahead
 ---
 
 ## Session Reports
+
+### PR merge check runs fix (2026-02-01)
+
+**Task**: Fix #93 - gr pr merge doesn't recognize passing GitHub checks
+
+**Overall Assessment**: gr workflow was smooth, minor friction with PR creation body flag.
+
+#### What Worked Well ✅
+
+1. **`gr branch`** - Created feature branch across all repos seamlessly
+2. **`gr add`** - Staged changes correctly in tooling repo
+3. **`gr commit`** - Committed with descriptive message
+4. **`gr pr create`** (via gh) - Created PR successfully
+
+#### Issues Created
+
+| Issue | Title |
+|-------|-------|
+| #63 | fix: gr pr create command times out |
+
+#### Raw Commands Used (Friction Log)
+
+| Raw Command | Why `gr` Couldn't Handle It | Issue |
+|-------------|----------------------------|-------|
+| `gh pr create --body` | `gr pr create` lacks `--body` flag for PR body | #58 |
+
+#### Minor Friction (No Raw Commands Needed)
+
+| Observation | Notes |
+|-------------|-------|
+| `gr sync` - 1 failed | "7 synced, 1 failed" with no details on which repo failed | New friction point |
+| `gr push` - 2 failed | "5 pushed, 2 failed, 1 skipped" with no error details | New friction point |
+
+---
+
 
 ### Multi-Platform Support Implementation (2026-01-29)
 

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -333,17 +333,88 @@ impl HostingPlatform for GitHubAdapter {
         repo: &str,
         ref_name: &str,
     ) -> Result<StatusCheckResult, PlatformError> {
-        // Get combined status using raw API call
         let token = self.get_token().await?;
         let base_url = self.base_url.as_deref().unwrap_or("https://api.github.com");
-        let url = format!(
-            "{}/repos/{}/{}/commits/{}/status",
+
+        // Try Check Runs API first (newer GitHub Actions)
+        let check_runs_url = format!(
+            "{}/repos/{}/{}/commits/{}/check-runs",
             base_url, owner, repo, ref_name
         );
 
         let http_client = reqwest::Client::new();
         let response = http_client
-            .get(&url)
+            .get(&check_runs_url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Accept", "application/vnd.github.v3+json")
+            .header("User-Agent", "gitgrip")
+            .send()
+            .await
+            .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        if response.status().is_success() {
+            #[derive(serde::Deserialize)]
+            struct CheckRunsResponse {
+                total_count: i64,
+                check_runs: Vec<CheckRun>,
+            }
+
+            #[derive(serde::Deserialize)]
+            struct CheckRun {
+                name: String,
+                status: String,
+                conclusion: Option<String>,
+            }
+
+            let check_runs: CheckRunsResponse = response
+                .json()
+                .await
+                .map_err(|e| PlatformError::ParseError(e.to_string()))?;
+
+            if check_runs.total_count > 0 {
+                // Determine overall state from check runs
+                let (aggregate_state, statuses): (CheckState, Vec<StatusCheck>) = check_runs
+                    .check_runs
+                    .into_iter()
+                    .fold(
+                        (CheckState::Success, Vec::new()),
+                        |(aggregate_state, mut acc), cr| {
+                            let check_state = match cr.conclusion.as_deref() {
+                                Some("success") => CheckState::Success,
+                                Some("failure") | Some("timed_out") => CheckState::Failure,
+                                Some("cancelled") => CheckState::Failure,
+                                _ => CheckState::Pending,  // "in_progress", "queued", "neutral", or null
+                            };
+
+                            // Aggregate: any failure = failure, any pending = pending
+                            let new_aggregate = match (aggregate_state, check_state) {
+                                (CheckState::Failure, _) => CheckState::Failure,
+                                (_, CheckState::Failure) => CheckState::Failure,
+                                (CheckState::Pending, _) | (_, CheckState::Pending) => CheckState::Pending,
+                                (CheckState::Success, CheckState::Success) => CheckState::Success,
+                            };
+
+                            acc.push(StatusCheck {
+                                context: cr.name.clone(),
+                                state: cr.conclusion.unwrap_or(cr.status),
+                            });
+
+                            (new_aggregate, acc)
+                        }
+                    );
+
+                return Ok(StatusCheckResult { state: aggregate_state, statuses });
+            }
+        }
+
+        // Fallback to legacy status checks API
+        let status_url = format!(
+            "{}/repos/{}/{}/commits/{}/status",
+            base_url, owner, repo, ref_name
+        );
+
+        let response = http_client
+            .get(&status_url)
             .header("Authorization", format!("Bearer {}", token))
             .header("Accept", "application/vnd.github.v3+json")
             .header("User-Agent", "gitgrip")

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -373,24 +373,24 @@ impl HostingPlatform for GitHubAdapter {
 
             if check_runs.total_count > 0 {
                 // Determine overall state from check runs
-                let (aggregate_state, statuses): (CheckState, Vec<StatusCheck>) = check_runs
-                    .check_runs
-                    .into_iter()
-                    .fold(
+                let (aggregate_state, statuses): (CheckState, Vec<StatusCheck>) =
+                    check_runs.check_runs.into_iter().fold(
                         (CheckState::Success, Vec::new()),
                         |(aggregate_state, mut acc), cr| {
                             let check_state = match cr.conclusion.as_deref() {
                                 Some("success") => CheckState::Success,
                                 Some("failure") | Some("timed_out") => CheckState::Failure,
                                 Some("cancelled") => CheckState::Failure,
-                                _ => CheckState::Pending,  // "in_progress", "queued", "neutral", or null
+                                _ => CheckState::Pending, // "in_progress", "queued", "neutral", or null
                             };
 
                             // Aggregate: any failure = failure, any pending = pending
                             let new_aggregate = match (aggregate_state, check_state) {
                                 (CheckState::Failure, _) => CheckState::Failure,
                                 (_, CheckState::Failure) => CheckState::Failure,
-                                (CheckState::Pending, _) | (_, CheckState::Pending) => CheckState::Pending,
+                                (CheckState::Pending, _) | (_, CheckState::Pending) => {
+                                    CheckState::Pending
+                                }
                                 (CheckState::Success, CheckState::Success) => CheckState::Success,
                             };
 
@@ -400,10 +400,13 @@ impl HostingPlatform for GitHubAdapter {
                             });
 
                             (new_aggregate, acc)
-                        }
+                        },
                     );
 
-                return Ok(StatusCheckResult { state: aggregate_state, statuses });
+                return Ok(StatusCheckResult {
+                    state: aggregate_state,
+                    statuses,
+                });
             }
         }
 


### PR DESCRIPTION
Fix #93: gr pr merge reports 'checks not passing' even when all GitHub Actions check runs have passed.

The get_status_checks method was only using the legacy status checks API (/repos/.../commits/.../status), which doesn't include GitHub Actions check runs. This caused gr pr merge to report 'checks not passing' even when all CI checks were passing.

**What changed:**
- Try Check Runs API first (/repos/.../commits/.../check-runs)
- Aggregate check runs correctly (success, failure, timed_out, cancelled, pending)
- Fallback to legacy status checks API for backward compatibility

**Testing:**
- Modified gitgrip to use GitHub Actions for CI
- All checks passing but gr pr merge still reported failure
- This fix now correctly detects passing GitHub Actions checks

Fixes #93, #99 (duplicate)