### PR TITLE
fix: gr repo add correctly inserts repos under repos: section

### DIFF
--- a/src/cli/commands/repo.rs
+++ b/src/cli/commands/repo.rs
@@ -79,16 +79,22 @@ pub fn run_repo_add(
 
     // Check if repos section exists and append
     let updated_content = if content.contains("repos:") {
-        // Find the end of repos section and insert before next top-level key
+        // Find where to insert - after repos: and before next top-level key
         let mut lines: Vec<&str> = content.lines().collect();
+        let mut after_repos = false;
         let mut insert_index = lines.len();
 
-        // Find where to insert (before settings, workspace, or at end)
         for (i, line) in lines.iter().enumerate() {
-            if (line.starts_with("settings:")
-                || line.starts_with("workspace:")
-                || line.starts_with("manifest:"))
-                && i > 0
+            if line.starts_with("repos:") {
+                after_repos = true;
+                continue;
+            }
+
+            // If we're after repos: section and hit a new top-level key, insert here
+            if after_repos
+                && (line == "settings:"
+                    || line == "workspace:"
+                    || line == "manifest:")
             {
                 insert_index = i;
                 break;


### PR DESCRIPTION
Fix #112: gr repo add was placing new repo entries in the wrong location, corrupting the manifest.yaml structure.

## Problem

`gr repo add` placed new repo entries between `version:` and `manifest:` sections instead of under the `repos:` section:

```yaml
version: 1

  newrepo:                              # <-- WRONG! Placed here
    url: https://github.com/example/repo.git
manifest:
  url: ...
```

## Root Cause

The YAML insertion logic didn't track when we were inside the `repos:` section. It would insert before top-level keys (`settings:`, `workspace:`, `manifest:`), which placed entries in the wrong location.

## Fix

Updated the insertion logic to:
1. Find the `repos:` line and set `after_repos = true`
2. Continue scanning lines
3. Insert before the next top-level key (`settings:`, `workspace:`, `manifest:`)
4. If no top-level key found, insert at end of file

Now correctly places new repo entries under the `repos:` section:

```yaml
version: 1

manifest:
  url: ...

repos:
  # ... existing repos ...

  newrepo:                              # <-- Correctly placed here
    url: https://github.com/example/repo.git
```

Fixes #112