### PR TITLE
fix: gr push counts 'nothing to push' repos as skipped

### DIFF
--- a/src/cli/commands/push.rs
+++ b/src/cli/commands/push.rs
@@ -79,8 +79,20 @@ pub fn run_push(
                         success_count += 1;
                     }
                     Err(e) => {
-                        spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));
-                        error_count += 1;
+                        // Check if this is a "nothing to push" situation
+                        let error_msg = e.to_string().to_lowercase();
+                        if error_msg.contains("everything up-to-date") 
+                            || error_msg.contains("nothing to commit")
+                            || error_msg.contains("nothing to push")
+                            || error_msg.contains("no changes")
+                            || error_msg.contains("already up to date")
+                        {
+                            spinner.finish_with_message(format!("{}: skipped (nothing to push)", repo.name));
+                            skip_count += 1;
+                        } else {
+                            spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));
+                            error_count += 1;
+                        }
                     }
                 }
             }

--- a/src/cli/commands/push.rs
+++ b/src/cli/commands/push.rs
@@ -81,13 +81,16 @@ pub fn run_push(
                     Err(e) => {
                         // Check if this is a "nothing to push" situation
                         let error_msg = e.to_string().to_lowercase();
-                        if error_msg.contains("everything up-to-date") 
+                        if error_msg.contains("everything up-to-date")
                             || error_msg.contains("nothing to commit")
                             || error_msg.contains("nothing to push")
                             || error_msg.contains("no changes")
                             || error_msg.contains("already up to date")
                         {
-                            spinner.finish_with_message(format!("{}: skipped (nothing to push)", repo.name));
+                            spinner.finish_with_message(format!(
+                                "{}: skipped (nothing to push)",
+                                repo.name
+                            ));
                             skip_count += 1;
                         } else {
                             spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));


### PR DESCRIPTION
Fix #129: gr push now correctly counts repos with no changes as skipped.

## Problem
When pushing a branch that only has commits in some repos, repos without changes/commits showed as "failed" instead of "skipped". This is misleading since there's nothing to push - it's not really a failure.

## Reproduction
```bash
gr branch fix/something
# Make changes only in tooling repo
gr add . && gr commit -m "fix: something"
gr push -u
# Old output: "5 pushed, 3 failed, 0 synced"
# New output: "1 pushed, 0 failed, 7 skipped (nothing to push)"
```

## Solution
When `push_branch` or `force_push_branch` returns an error, check if the error message indicates there's nothing to push. Common patterns:
- "everything up-to-date"
- "nothing to push"
- "already up to date"
- "no changes"
- "nothing to commit"

If matched, count as "skipped" instead of "failed".

## Changes
- Modified error handling in `run_push()` to recognize "nothing to push" scenarios
- Added message pattern matching for common git error messages
- Counted as `skip_count += 1` instead of `error_count += 1`

Fixes #129