### PR TITLE
feat: gr push shows which repos failed and why

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -72,6 +72,50 @@ Added `gr completions <shell>` command using clap_complete crate.
 
 ## Pending Review
 
+### Missing: `gr sync` shows which repos failed
+
+**Discovered**: 2026-02-01
+
+**Problem**: `gr sync` reports "X failed" with no details about which repositories failed or why.
+
+**Reproduction**:
+```bash
+gr sync
+# Output: ⚠ 7 synced, 1 failed
+```
+
+**Expected**: Show which repositories failed and why:
+```
+Syncing 8 repositories...
+✓ tooling: synced
+✓ codex: synced
+⚠ opencode: not cloned
+✗ private: failed - Failed to fetch: authentication required
+```
+
+**Root cause**: Error aggregation code doesn't show per-repo details on failure.
+
+---
+
+### Missing: `gr push` shows which repos failed
+
+**Discovered**: 2026-02-01
+
+**Problem**: `gr push` reports "X failed, Y skipped" with no details about which repositories failed or were skipped.
+
+**Reproduction**:
+```bash
+gr push
+# Output: ⚠ 5 pushed, 2 failed, 1 skipped
+```
+
+**Expected**: Show detailed results including which repos failed and why, and which were skipped.
+
+**Root cause**: Similar to `gr sync`, error aggregation code doesn't show per-repo details.
+
+---
+
+
 ### Feature: Reference repos (read-only repos excluded from branch/PR operations) → Issue #113
 
 **Discovered**: 2026-02-01 during Rust migration planning
@@ -299,6 +343,41 @@ gr forall -c "pnpm lint" --ahead
 ---
 
 ## Session Reports
+
+### PR merge check runs fix (2026-02-01)
+
+**Task**: Fix #93 - gr pr merge doesn't recognize passing GitHub checks
+
+**Overall Assessment**: gr workflow was smooth, minor friction with PR creation body flag.
+
+#### What Worked Well ✅
+
+1. **`gr branch`** - Created feature branch across all repos seamlessly
+2. **`gr add`** - Staged changes correctly in tooling repo
+3. **`gr commit`** - Committed with descriptive message
+4. **`gr pr create`** (via gh) - Created PR successfully
+
+#### Issues Created
+
+| Issue | Title |
+|-------|-------|
+| #63 | fix: gr pr create command times out |
+
+#### Raw Commands Used (Friction Log)
+
+| Raw Command | Why `gr` Couldn't Handle It | Issue |
+|-------------|----------------------------|-------|
+| `gh pr create --body` | `gr pr create` lacks `--body` flag for PR body | #58 |
+
+#### Minor Friction (No Raw Commands Needed)
+
+| Observation | Notes |
+|-------------|-------|
+| `gr sync` - 1 failed | "7 synced, 1 failed" with no details on which repo failed | New friction point |
+| `gr push` - 2 failed | "5 pushed, 2 failed, 1 skipped" with no error details | New friction point |
+
+---
+
 
 ### Multi-Platform Support Implementation (2026-01-29)
 

--- a/src/cli/commands/push.rs
+++ b/src/cli/commands/push.rs
@@ -32,6 +32,7 @@ pub fn run_push(
     let mut success_count = 0;
     let mut skip_count = 0;
     let mut error_count = 0;
+    let mut failed_repos: Vec<(String, String)> = Vec::new();  // (repo_name, error_message)
 
     for repo in &repos {
         if !path_exists(&repo.absolute_path) {
@@ -79,14 +80,28 @@ pub fn run_push(
                         success_count += 1;
                     }
                     Err(e) => {
-                        spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));
-                        error_count += 1;
+                        // Check if this is a "nothing to push" situation
+                        let error_msg = e.to_string().to_lowercase();
+                        if error_msg.contains("everything up-to-date") 
+                            || error_msg.contains("nothing to commit")
+                            || error_msg.contains("nothing to push")
+                            || error_msg.contains("no changes")
+                            || error_msg.contains("already up to date")
+                        {
+                            spinner.finish_with_message(format!("{}: skipped (nothing to push)", repo.name));
+                            skip_count += 1;
+                        } else {
+                            spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));
+                            error_count += 1;
+                            failed_repos.push((repo.name.clone(), format!("Error: {}", e)));
+                        }
                     }
                 }
             }
             Err(e) => {
                 Output::error(&format!("{}: {}", repo.name, e));
                 error_count += 1;
+                failed_repos.push((repo.name.clone(), format!("Error: {}", e)));
             }
         }
     }
@@ -116,6 +131,14 @@ pub fn run_push(
             error_count,
             skip_count
         ));
+
+        // Show which repos failed and why
+        if !failed_repos.is_empty() {
+            println!();
+            for (repo_name, error_msg) in &failed_repos {
+                println!("  ✗ {}: {}", repo_name, error_msg);
+            }
+        }
     }
 
     Ok(())

--- a/src/cli/commands/push.rs
+++ b/src/cli/commands/push.rs
@@ -32,7 +32,7 @@ pub fn run_push(
     let mut success_count = 0;
     let mut skip_count = 0;
     let mut error_count = 0;
-    let mut failed_repos: Vec<(String, String)> = Vec::new();  // (repo_name, error_message)
+    let mut failed_repos: Vec<(String, String)> = Vec::new(); // (repo_name, error_message)
 
     for repo in &repos {
         if !path_exists(&repo.absolute_path) {
@@ -82,13 +82,16 @@ pub fn run_push(
                     Err(e) => {
                         // Check if this is a "nothing to push" situation
                         let error_msg = e.to_string().to_lowercase();
-                        if error_msg.contains("everything up-to-date") 
+                        if error_msg.contains("everything up-to-date")
                             || error_msg.contains("nothing to commit")
                             || error_msg.contains("nothing to push")
                             || error_msg.contains("no changes")
                             || error_msg.contains("already up to date")
                         {
-                            spinner.finish_with_message(format!("{}: skipped (nothing to push)", repo.name));
+                            spinner.finish_with_message(format!(
+                                "{}: skipped (nothing to push)",
+                                repo.name
+                            ));
                             skip_count += 1;
                         } else {
                             spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -333,17 +333,88 @@ impl HostingPlatform for GitHubAdapter {
         repo: &str,
         ref_name: &str,
     ) -> Result<StatusCheckResult, PlatformError> {
-        // Get combined status using raw API call
         let token = self.get_token().await?;
         let base_url = self.base_url.as_deref().unwrap_or("https://api.github.com");
-        let url = format!(
-            "{}/repos/{}/{}/commits/{}/status",
+
+        // Try Check Runs API first (newer GitHub Actions)
+        let check_runs_url = format!(
+            "{}/repos/{}/{}/commits/{}/check-runs",
             base_url, owner, repo, ref_name
         );
 
         let http_client = reqwest::Client::new();
         let response = http_client
-            .get(&url)
+            .get(&check_runs_url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Accept", "application/vnd.github.v3+json")
+            .header("User-Agent", "gitgrip")
+            .send()
+            .await
+            .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        if response.status().is_success() {
+            #[derive(serde::Deserialize)]
+            struct CheckRunsResponse {
+                total_count: i64,
+                check_runs: Vec<CheckRun>,
+            }
+
+            #[derive(serde::Deserialize)]
+            struct CheckRun {
+                name: String,
+                status: String,
+                conclusion: Option<String>,
+            }
+
+            let check_runs: CheckRunsResponse = response
+                .json()
+                .await
+                .map_err(|e| PlatformError::ParseError(e.to_string()))?;
+
+            if check_runs.total_count > 0 {
+                // Determine overall state from check runs
+                let (aggregate_state, statuses): (CheckState, Vec<StatusCheck>) = check_runs
+                    .check_runs
+                    .into_iter()
+                    .fold(
+                        (CheckState::Success, Vec::new()),
+                        |(aggregate_state, mut acc), cr| {
+                            let check_state = match cr.conclusion.as_deref() {
+                                Some("success") => CheckState::Success,
+                                Some("failure") | Some("timed_out") => CheckState::Failure,
+                                Some("cancelled") => CheckState::Failure,
+                                _ => CheckState::Pending,  // "in_progress", "queued", "neutral", or null
+                            };
+
+                            // Aggregate: any failure = failure, any pending = pending
+                            let new_aggregate = match (aggregate_state, check_state) {
+                                (CheckState::Failure, _) => CheckState::Failure,
+                                (_, CheckState::Failure) => CheckState::Failure,
+                                (CheckState::Pending, _) | (_, CheckState::Pending) => CheckState::Pending,
+                                (CheckState::Success, CheckState::Success) => CheckState::Success,
+                            };
+
+                            acc.push(StatusCheck {
+                                context: cr.name.clone(),
+                                state: cr.conclusion.unwrap_or(cr.status),
+                            });
+
+                            (new_aggregate, acc)
+                        }
+                    );
+
+                return Ok(StatusCheckResult { state: aggregate_state, statuses });
+            }
+        }
+
+        // Fallback to legacy status checks API
+        let status_url = format!(
+            "{}/repos/{}/{}/commits/{}/status",
+            base_url, owner, repo, ref_name
+        );
+
+        let response = http_client
+            .get(&status_url)
             .header("Authorization", format!("Bearer {}", token))
             .header("Accept", "application/vnd.github.v3+json")
             .header("User-Agent", "gitgrip")


### PR DESCRIPTION
Fix #120: gr push now displays per-repo failure details.

## Problem

Pushing changes...

ℹ public: nothing to push
ℹ strategy: nothing to push
ℹ private: nothing to push
ℹ tooling: nothing to push
ℹ homebrew-tap: nothing to push

Nothing to push. only reported summary counts like "X pushed, Y failed, Z skipped" with no details about which repositories failed or were skipped.

## Expected Behavior
```bash
gr push
# Now shows:
# ⚠ 5 pushed, 2 failed, 1 skipped
# 
#   ✗ private: Error: authentication required
#   ✗ public: Error: rejected, remote contains work you do not have
```

## Solution
Similar to issue #119 (gr sync), added per-repo error tracking and summary display:
- Track  vector with (repo_name, error_message)
- Display summary at end showing which repos failed
- Combined with fix for #129: repos with no changes show as 'skipped' instead of 'failed'

## Changes
- Added  to track failures  
- Track errors from:
  - Push failures (actual errors, not "nothing to push" cases)
  - Branch retrieval errors
  - Open repository errors
- Display failure summary at end if there are failures
- Includes PR #129 fix for "nothing to push" detection

## Example Output
```
⚠ 5 pushed, 2 failed, 1 skipped

  ✗ private: Error: authentication required
  ✗ public: Error: rejected, remote contains work you do not have
```

Fixes #120