### PR TITLE
feat: Add --dry-run for PR create preview

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,9 @@ enum PrCommands {
         /// Create as draft
         #[arg(long)]
         draft: bool,
+        /// Preview without creating PR
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Show PR status
     Status {
@@ -334,13 +337,19 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Pr { action }) => {
             let (workspace_root, manifest) = load_workspace()?;
             match action {
-                PrCommands::Create { title, push, draft } => {
+                PrCommands::Create {
+                    title,
+                    push,
+                    draft,
+                    dry_run,
+                } => {
                     gitgrip::cli::commands::pr::run_pr_create(
                         &workspace_root,
                         &manifest,
                         title.as_deref(),
                         draft,
                         push,
+                        dry_run,
                     )
                     .await?;
                 }


### PR DESCRIPTION
Fixes #146

## Summary

Added `--dry-run` flag to `gr pr create` that shows what PRs would be created without actually creating them.

## Changes

- Added `dry_run: bool` to `PrCommands::Create` enum
- Updated `run_pr_create()` to accept and handle dry_run parameter
- Added preview output showing:
  - Branch name
  - PR title  
  - Whether draft
  - List of repositories that would create PRs

## Example Usage

```bash
# Preview what would happen
gr pr create --dry-run
# Output:
# ## PR Preview
# 
# Branch: feat/my-feature
# Title: My feature
# Type: Draft PR
# 
# Repositories that would create PRs:
#   - tooling (tooling-ai/tooling)
#   - codi (laynepenney/codi)
# 
# ⚠ Run without --dry-run to actually create the PRs.

# Actually create PRs
gr pr create
# Creates the PRs as shown in preview
```

## Problem Solved

Prevents PR contamination by showing exactly which repositories and files would be included before creating the PR.

Fixes #146