### PR TITLE
docs: Add worktree conflict troubleshooting to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,3 +215,26 @@ This creates the PR for `github.com/laynepenney/gitgrip`, not the workspace mani
 - **CONTRIBUTING.md** - This file
 - **docs/** - Additional documentation
 
+
+## Worktree Conflicts
+
+If you see an error like:
+```
+fatal: 'main' is already used by worktree at '...'
+```
+
+This happens when gitgrip has multiple worktrees (e.g., in codi-workspace and codi-dev).
+
+**To resolve:**
+1. Create a new branch instead of checking out main:
+   ```bash
+   git checkout -b fix/my-feature
+   gr branch fix/my-feature
+   ```
+
+2. Or use the existing worktree at codi-workspace for gitgrip-related work
+
+**Prevention:**
+- Keep main checked out in one workspace (codi-workspace recommended)
+- Use other workspaces for feature branches
+- Or use `gr branch` which handles this automatically


### PR DESCRIPTION
Fixes #142

## Summary

Added troubleshooting section to CONTRIBUTING.md explaining how to handle git worktree conflicts.

## Changes

- Added Worktree Conflicts section to CONTRIBUTING.md with:
  - Explanation of the error message
  - Step-by-step resolution instructions
  - Prevention tips

## Example

When users see:
```
fatal: 'main' is already used by worktree at '...'
```

They can now refer to CONTRIBUTING.md for help.

Fixes #142