### PR TITLE
docs: Document IMPROVEMENTS.md merge conflict behavior

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -5,6 +5,14 @@ Items here should be reviewed before creating GitHub issues.
 
 > **Note**: Historical entries may reference `cr` (the old command name). The current command is `gr`.
 
+> **Merge Conflicts**: When rebasing feature branches, you may encounter merge conflicts in this file when other PRs also add entries. This is expected behavior. To resolve:
+>
+> 1. Use `git rebase --skip` to skip documentation-only commits from other branches
+> 2. Or manually merge both sets of entries
+> 3. The alternative would be to use a dedicated documentation file, but we accept this tradeoff for now
+>
+> See issue #143 for context.
+
 ---
 
 ### PR Creation Timeout Issue


### PR DESCRIPTION
Fixes #143

## Summary

Added documentation to IMPROVEMENTS.md explaining that merge conflicts are expected when rebasing, with clear resolution steps.

## Changes

- Added a note in the IMPROVEMENTS.md header explaining:
  - Why merge conflicts occur when rebasing
  - How to resolve: `git rebase --skip` or manual merge
  - Why we accept this behavior instead of alternative solutions

## Resolution Strategy

When users encounter conflicts:
1. Skip the conflicting commit: `git rebase --skip`
2. Or manually merge both sets of entries

This is documented as expected behavior rather than implementing complex auto-merge tooling.

Fixes #143