### PR TITLE
fix: griptree architecture and linking fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.5.8"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"

--- a/src/core/griptree.rs
+++ b/src/core/griptree.rs
@@ -127,8 +127,10 @@ pub struct GriptreePointer {
     /// Manifest branch for this griptree (optional for backwards compat)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest_branch: Option<String>,
+    /// Manifest worktree name (for cleanup)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_worktree_name: Option<String>,
 }
-
 
 /// Per-repo griptree info (tracked in pointer file)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -140,6 +142,15 @@ pub struct GriptreeRepoInfo {
     pub original_branch: String,
     /// Whether this is a reference repo
     pub is_reference: bool,
+    /// The name passed to git worktree add (for cleanup)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_name: Option<String>,
+    /// Absolute path to the worktree in the griptree
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+    /// Absolute path to the main repo (for worktree cleanup)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub main_repo_path: Option<String>,
 }
 
 impl GriptreePointer {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -64,20 +64,45 @@ pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
 }
 
 /// Clone a repository
+///
+/// If a branch is specified but doesn't exist on the remote, falls back to
+/// cloning without a branch (using the remote's default branch).
 pub fn clone_repo<P: AsRef<Path>>(
     url: &str,
     path: P,
     branch: Option<&str>,
 ) -> Result<Repository, GitError> {
     let path = path.as_ref();
+    let path_str = path.to_str().unwrap_or(".");
 
-    let mut args = vec!["clone"];
+    // Try cloning with specified branch first
     if let Some(b) = branch {
-        args.push("-b");
-        args.push(b);
+        let args = vec!["clone", "-b", b, url, path_str];
+
+        let output = Command::new("git")
+            .args(&args)
+            .output()
+            .map_err(|e| GitError::OperationFailed(e.to_string()))?;
+
+        if output.status.success() {
+            return open_repo(path);
+        }
+
+        // Check if failure was due to branch not found
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("Remote branch") && stderr.contains("not found") {
+            // Fall through to clone without branch
+        } else {
+            // Other error - return it
+            return Err(GitError::OperationFailed(format!(
+                "git clone failed: {}",
+                stderr
+            )));
+        }
     }
-    args.push(url);
-    args.push(path.to_str().unwrap_or("."));
+
+    // Clone without -b flag (uses remote's default branch)
+    let args = vec!["clone", url, path_str];
 
     let output = Command::new("git")
         .args(&args)

--- a/tests/griptree_tests.rs
+++ b/tests/griptree_tests.rs
@@ -15,6 +15,9 @@ fn test_griptree_repo_info_serialization() {
         name: "codi".to_string(),
         original_branch: "main".to_string(),
         is_reference: false,
+        worktree_name: Some("main".to_string()),
+        worktree_path: Some("/path/to/worktree".to_string()),
+        main_repo_path: Some("/workspace/codi".to_string()),
     };
 
     let json = serde_json::to_string(&repo_info).unwrap();
@@ -23,6 +26,9 @@ fn test_griptree_repo_info_serialization() {
     assert_eq!(deserialized.name, repo_info.name);
     assert_eq!(deserialized.original_branch, repo_info.original_branch);
     assert_eq!(deserialized.is_reference, repo_info.is_reference);
+    assert_eq!(deserialized.worktree_name, repo_info.worktree_name);
+    assert_eq!(deserialized.worktree_path, repo_info.worktree_path);
+    assert_eq!(deserialized.main_repo_path, repo_info.main_repo_path);
 }
 
 /// Test that GriptreePointer handles backwards compatibility
@@ -43,7 +49,10 @@ fn test_griptree_pointer_backwards_compat() {
     assert_eq!(pointer.branch, "feat/test");
     assert_eq!(pointer.main_workspace, "/workspace");
     assert!(pointer.repos.is_empty(), "repos should default to empty");
-    assert!(pointer.manifest_branch.is_none(), "manifest_branch should default to None");
+    assert!(
+        pointer.manifest_branch.is_none(),
+        "manifest_branch should default to None"
+    );
 }
 
 /// Test that GriptreePointer includes repos and manifest_branch
@@ -74,7 +83,10 @@ fn test_griptree_pointer_new_fields() {
     assert_eq!(pointer.repos[0].name, "codi");
     assert_eq!(pointer.repos[0].original_branch, "main");
     assert_eq!(pointer.repos[0].is_reference, false);
-    assert_eq!(pointer.manifest_branch, Some("griptree-feat-test".to_string()));
+    assert_eq!(
+        pointer.manifest_branch,
+        Some("griptree-feat-test".to_string())
+    );
 }
 
 /// Test that manifest directory is correctly detected
@@ -97,9 +109,7 @@ fn test_griptree_manifest_path() {
     let temp = TempDir::new().unwrap();
     let griptree_path = PathBuf::from(temp.path());
 
-    let griptree_manifest_dir = griptree_path
-        .join(".gitgrip")
-        .join("manifests");
+    let griptree_manifest_dir = griptree_path.join(".gitgrip").join("manifests");
 
     // Create the directory structure
     fs::create_dir_all(&griptree_manifest_dir).unwrap();
@@ -122,7 +132,11 @@ fn test_manifest_worktree_git_dir() {
     assert!(!manifests_git_dir.exists());
 
     // Simulate git worktree by creating .git file (worktree use file, not dir)
-    fs::write(&manifests_git_dir, "gitdir: /some/other/path/.git/worktrees/mymain").unwrap();
+    fs::write(
+        &manifests_git_dir,
+        "gitdir: /some/other/path/.git/worktrees/mymain",
+    )
+    .unwrap();
 
     // After creation
     assert!(manifests_git_dir.exists());
@@ -159,6 +173,7 @@ fn test_griptree_pointer_empty_repos() {
         created_at: None,
         repos: vec![],
         manifest_branch: None,
+        manifest_worktree_name: None,
     };
 
     let json = serde_json::to_string_pretty(&pointer).unwrap();
@@ -178,6 +193,9 @@ fn test_griptree_repo_info_camel_case() {
         name: "codi-private".to_string(),
         original_branch: "develop".to_string(),
         is_reference: false,
+        worktree_name: None,
+        worktree_path: None,
+        main_repo_path: None,
     };
 
     let json = serde_json::to_string(&repo_info).unwrap();


### PR DESCRIPTION
## Summary

This PR fixes critical issues with griptree (git worktree) management, manifest linking, and clone operations.

- **Clone fallback**: `clone_repo()` now falls back to remote's default branch when specified branch doesn't exist
- **Branch reporting**: `sync` command reports actual branch if different from manifest's `default_branch`
- **Manifest links**: `link` command now processes `manifest.manifest.linkfile` and `manifest.manifest.copyfile`
- **Worktree tracking**: Added `worktree_name`, `worktree_path` to `GriptreeRepoInfo` and `manifest_worktree_name` to `GriptreePointer`
- **State initialization**: Griptrees now get their own `state.json` for PR link tracking
- **Proper cleanup**: `tree remove` now properly prunes git worktrees before deleting directory
- **Rollback support**: Partial griptree creation failures now trigger rollback
- **Legacy discovery**: `tree list` discovers unregistered griptrees in sibling directories

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (all 176 tests)
- [x] `cargo clippy` shows only pre-existing warnings
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)