### PR TITLE
feat: gr forall defaults to repos with changes only

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,9 +115,9 @@ enum Commands {
         /// Run in parallel
         #[arg(short, long)]
         parallel: bool,
-        /// Only run in repos with changes
-        #[arg(long)]
-        changed: bool,
+        /// Run in ALL repos (default: only repos with changes)
+        #[arg(short, long)]
+        all: bool,
         /// Disable git command interception (use CLI for all commands)
         #[arg(long)]
         no_intercept: bool,
@@ -434,7 +434,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Forall {
             command,
             parallel,
-            changed,
+            all,
             no_intercept,
         }) => {
             let (workspace_root, manifest) = load_workspace()?;
@@ -443,7 +443,7 @@ async fn main() -> anyhow::Result<()> {
                 &manifest,
                 &command,
                 parallel,
-                changed,
+                !all, // Default: only repos with changes (changed_only=true unless --all)
                 no_intercept,
             )?;
         }


### PR DESCRIPTION
## Summary
`gr forall` now only runs in repos with uncommitted changes by default.

## Breaking Change
- **Old behavior**: `gr forall -c "cmd"` ran in ALL repos
- **New behavior**: `gr forall -c "cmd"` runs only in repos with changes
- **Migration**: Use `--all` flag to get old behavior

## Changes
- Default: only repos with changes
- New `--all` flag: run in all repos (previous default)
- Removed `--changed` flag (now the default behavior)

## Rationale
This is a safer default that prevents running expensive commands (like tests, builds) in repos that haven't been modified.

## Test plan
- [x] `gr forall -c "git branch"` → runs only in changed repos
- [x] `gr forall -c "git branch" --all` → runs in all repos
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)