### PR TITLE
feat: add --move flag to gr branch for moving commits

### DIFF
--- a/src/cli/commands/branch.rs
+++ b/src/cli/commands/branch.rs
@@ -15,6 +15,7 @@ pub fn run_branch(
     manifest: &Manifest,
     name: Option<&str>,
     delete: bool,
+    move_commits: bool,
     repos_filter: Option<&[String]>,
 ) -> anyhow::Result<()> {
     let repos: Vec<RepoInfo> = manifest
@@ -56,6 +57,138 @@ pub fn run_branch(
                     Err(e) => Output::error(&format!("{}: {}", repo.name, e)),
                 }
             }
+        }
+        Some(branch_name) if move_commits => {
+            // Move commits to new branch (create branch, reset current to remote, checkout new)
+            Output::header(&format!(
+                "Moving commits to branch '{}' in {} repos...",
+                branch_name,
+                repos.len()
+            ));
+            println!();
+
+            for repo in &repos {
+                if !repo.exists() {
+                    Output::warning(&format!("{}: not cloned", repo.name));
+                    continue;
+                }
+
+                match open_repo(&repo.absolute_path) {
+                    Ok(git_repo) => {
+                        let current = match get_current_branch(&git_repo) {
+                            Ok(b) => b,
+                            Err(e) => {
+                                Output::error(&format!(
+                                    "{}: failed to get current branch - {}",
+                                    repo.name, e
+                                ));
+                                continue;
+                            }
+                        };
+
+                        if branch_exists(&git_repo, branch_name) {
+                            Output::error(&format!(
+                                "{}: branch '{}' already exists",
+                                repo.name, branch_name
+                            ));
+                            continue;
+                        }
+
+                        // Create branch at current HEAD
+                        let head = match git_repo.head() {
+                            Ok(h) => h,
+                            Err(e) => {
+                                Output::error(&format!(
+                                    "{}: failed to get HEAD - {}",
+                                    repo.name, e
+                                ));
+                                continue;
+                            }
+                        };
+                        let head_commit = match head.peel_to_commit() {
+                            Ok(c) => c,
+                            Err(e) => {
+                                Output::error(&format!(
+                                    "{}: failed to get HEAD commit - {}",
+                                    repo.name, e
+                                ));
+                                continue;
+                            }
+                        };
+
+                        if let Err(e) = git_repo.branch(branch_name, &head_commit, false) {
+                            Output::error(&format!(
+                                "{}: failed to create branch - {}",
+                                repo.name, e
+                            ));
+                            continue;
+                        }
+
+                        // Reset current branch to origin/<current>
+                        let remote_ref = format!("refs/remotes/origin/{}", current);
+                        let remote_commit = match git_repo.revparse_single(&remote_ref) {
+                            Ok(obj) => match obj.peel_to_commit() {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    Output::error(&format!(
+                                        "{}: failed to find remote commit - {}",
+                                        repo.name, e
+                                    ));
+                                    continue;
+                                }
+                            },
+                            Err(e) => {
+                                Output::error(&format!(
+                                    "{}: no remote tracking branch origin/{} - {}",
+                                    repo.name, current, e
+                                ));
+                                continue;
+                            }
+                        };
+
+                        if let Err(e) =
+                            git_repo.reset(remote_commit.as_object(), git2::ResetType::Hard, None)
+                        {
+                            Output::error(&format!(
+                                "{}: failed to reset to origin/{} - {}",
+                                repo.name, current, e
+                            ));
+                            continue;
+                        }
+
+                        // Checkout the new branch
+                        if let Err(e) = git_repo.set_head(&format!("refs/heads/{}", branch_name)) {
+                            Output::error(&format!(
+                                "{}: failed to checkout new branch - {}",
+                                repo.name, e
+                            ));
+                            continue;
+                        }
+
+                        if let Err(e) = git_repo
+                            .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+                        {
+                            Output::error(&format!(
+                                "{}: failed to update working tree - {}",
+                                repo.name, e
+                            ));
+                            continue;
+                        }
+
+                        Output::success(&format!(
+                            "{}: moved commits from {} to {}",
+                            repo.name, current, branch_name
+                        ));
+                    }
+                    Err(e) => Output::error(&format!("{}: {}", repo.name, e)),
+                }
+            }
+
+            println!();
+            println!(
+                "Commits moved to branch: {}",
+                Output::branch_name(branch_name)
+            );
         }
         Some(branch_name) => {
             // Create branch

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,12 @@ enum Commands {
         /// Delete branch
         #[arg(short, long)]
         delete: bool,
+        /// Move recent commits to new branch (resets current branch to remote)
+        #[arg(short, long)]
+        r#move: bool,
+        /// Only operate on specific repos
+        #[arg(long, value_delimiter = ',')]
+        repo: Option<Vec<String>>,
         /// Include manifest repo
         #[arg(long)]
         include_manifest: bool,
@@ -294,6 +300,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Branch {
             name,
             delete,
+            r#move,
+            repo,
             include_manifest: _,
         }) => {
             let (workspace_root, manifest) = load_workspace()?;
@@ -302,7 +310,8 @@ async fn main() -> anyhow::Result<()> {
                 &manifest,
                 name.as_deref(),
                 delete,
-                None,
+                r#move,
+                repo.as_deref(),
             )?;
         }
         Some(Commands::Checkout { name }) => {


### PR DESCRIPTION
## Summary
Adds `--move` flag to `gr branch` for fixing accidental commits to wrong branch.

## Use Case
When you accidentally commit to main instead of a feature branch:
```bash
# Before: manually doing 3 git commands
cd repo
git branch feat/x
git reset --hard origin/main
git checkout feat/x

# After: single gr command
gr branch feat/x --move --repo tooling
```

## Changes
- New `--move` flag: creates branch at HEAD, resets current branch to remote, checkouts new branch
- New `--repo` flag: filter which repos to operate on (e.g., `--repo tooling,private`)

## Test plan
- [x] `gr branch --help` shows new flags
- [x] `cargo test` passes
- [x] Manual testing of --move flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)