### PR TITLE
feat: Phase 2 - wiremock platform tests and error scenarios

### DIFF
--- a/tests/common/mock_platform.rs
+++ b/tests/common/mock_platform.rs
@@ -1,0 +1,489 @@
+//! wiremock-based mock helpers for hosting platform API tests.
+//!
+//! Provides response builders for GitHub, GitLab, and Azure DevOps APIs,
+//! allowing fully offline testing of platform adapter methods.
+
+use serde_json::{json, Map, Value};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Start a wiremock server and configure GITHUB_TOKEN env var.
+/// Returns the server and a GitHubAdapter pointed at it.
+pub async fn setup_github_mock() -> (MockServer, gitgrip::platform::github::GitHubAdapter) {
+    let server = MockServer::start().await;
+    // Set token so get_token() succeeds without gh CLI
+    unsafe {
+        std::env::set_var("GITHUB_TOKEN", "mock-test-token");
+    }
+    let adapter = gitgrip::platform::github::GitHubAdapter::new(Some(&server.uri()));
+    (server, adapter)
+}
+
+/// Generate a complete GitHub Author JSON object matching octocrab's Author struct.
+fn github_user_json(login: &str, id: u64) -> Value {
+    let api = format!("https://api.github.com/users/{}", login);
+    let mut m = Map::new();
+    m.insert("login".into(), json!(login));
+    m.insert("id".into(), json!(id));
+    m.insert("node_id".into(), json!(format!("MDQ6VXNlcjE{}", id)));
+    m.insert(
+        "avatar_url".into(),
+        json!(format!(
+            "https://avatars.githubusercontent.com/u/{}?v=4",
+            id
+        )),
+    );
+    m.insert("gravatar_id".into(), json!(""));
+    m.insert("url".into(), json!(&api));
+    m.insert(
+        "html_url".into(),
+        json!(format!("https://github.com/{}", login)),
+    );
+    m.insert("followers_url".into(), json!(format!("{}/followers", api)));
+    m.insert(
+        "following_url".into(),
+        json!(format!("{}/following{{/other_user}}", api)),
+    );
+    m.insert(
+        "gists_url".into(),
+        json!(format!("{}/gists{{/gist_id}}", api)),
+    );
+    m.insert(
+        "starred_url".into(),
+        json!(format!("{}/starred{{/owner}}{{/repo}}", api)),
+    );
+    m.insert(
+        "subscriptions_url".into(),
+        json!(format!("{}/subscriptions", api)),
+    );
+    m.insert("organizations_url".into(), json!(format!("{}/orgs", api)));
+    m.insert("repos_url".into(), json!(format!("{}/repos", api)));
+    m.insert(
+        "events_url".into(),
+        json!(format!("{}/events{{/privacy}}", api)),
+    );
+    m.insert(
+        "received_events_url".into(),
+        json!(format!("{}/received_events", api)),
+    );
+    m.insert("type".into(), json!("User"));
+    m.insert("site_admin".into(), json!(false));
+    Value::Object(m)
+}
+
+/// Generate a complete GitHub repository JSON object that octocrab can deserialize.
+/// Built programmatically to avoid macro recursion limits.
+fn github_repo_json(owner: &str, repo: &str) -> Value {
+    let base = format!("https://api.github.com/repos/{}/{}", owner, repo);
+    let html = format!("https://github.com/{}/{}", owner, repo);
+
+    let mut m = Map::new();
+    m.insert("id".into(), json!(1));
+    m.insert("node_id".into(), json!("MDEwOlJlcG9zaXRvcnkx"));
+    m.insert("name".into(), json!(repo));
+    m.insert("full_name".into(), json!(format!("{}/{}", owner, repo)));
+    m.insert("private".into(), json!(false));
+    m.insert("owner".into(), github_user_json(owner, 1));
+    m.insert("html_url".into(), json!(html));
+    m.insert("description".into(), Value::Null);
+    m.insert("fork".into(), json!(false));
+    m.insert("url".into(), json!(&base));
+
+    // All the *_url fields octocrab expects
+    let url_fields = [
+        ("forks_url", "/forks"),
+        ("keys_url", "/keys{/key_id}"),
+        ("collaborators_url", "/collaborators{/collaborator}"),
+        ("teams_url", "/teams"),
+        ("hooks_url", "/hooks"),
+        ("issue_events_url", "/issues/events{/number}"),
+        ("events_url", "/events"),
+        ("assignees_url", "/assignees{/user}"),
+        ("branches_url", "/branches{/branch}"),
+        ("tags_url", "/tags"),
+        ("blobs_url", "/git/blobs{/sha}"),
+        ("git_tags_url", "/git/tags{/sha}"),
+        ("git_refs_url", "/git/refs{/sha}"),
+        ("trees_url", "/git/trees{/sha}"),
+        ("statuses_url", "/statuses/{sha}"),
+        ("languages_url", "/languages"),
+        ("stargazers_url", "/stargazers"),
+        ("contributors_url", "/contributors"),
+        ("subscribers_url", "/subscribers"),
+        ("subscription_url", "/subscription"),
+        ("commits_url", "/commits{/sha}"),
+        ("git_commits_url", "/git/commits{/sha}"),
+        ("comments_url", "/comments{/number}"),
+        ("issue_comment_url", "/issues/comments{/number}"),
+        ("contents_url", "/contents/{+path}"),
+        ("compare_url", "/compare/{base}...{head}"),
+        ("merges_url", "/merges"),
+        ("archive_url", "/{archive_format}{/ref}"),
+        ("downloads_url", "/downloads"),
+        ("issues_url", "/issues{/number}"),
+        ("pulls_url", "/pulls{/number}"),
+        ("milestones_url", "/milestones{/number}"),
+        (
+            "notifications_url",
+            "/notifications{?since,all,participating}",
+        ),
+        ("labels_url", "/labels{/name}"),
+        ("releases_url", "/releases{/id}"),
+        ("deployments_url", "/deployments"),
+    ];
+
+    for (field, suffix) in url_fields {
+        m.insert(field.into(), json!(format!("{}{}", base, suffix)));
+    }
+
+    m.insert("created_at".into(), json!("2024-01-01T00:00:00Z"));
+    m.insert("updated_at".into(), json!("2024-01-01T00:00:00Z"));
+    m.insert("pushed_at".into(), json!("2024-01-01T00:00:00Z"));
+    m.insert(
+        "git_url".into(),
+        json!(format!("git://github.com/{}/{}.git", owner, repo)),
+    );
+    m.insert(
+        "ssh_url".into(),
+        json!(format!("git@github.com:{}/{}.git", owner, repo)),
+    );
+    m.insert(
+        "clone_url".into(),
+        json!(format!("https://github.com/{}/{}.git", owner, repo)),
+    );
+    m.insert("svn_url".into(), json!(html));
+    m.insert("homepage".into(), Value::Null);
+    m.insert("size".into(), json!(0));
+    m.insert("stargazers_count".into(), json!(0));
+    m.insert("watchers_count".into(), json!(0));
+    m.insert("language".into(), json!("Rust"));
+    m.insert("has_issues".into(), json!(true));
+    m.insert("has_projects".into(), json!(true));
+    m.insert("has_downloads".into(), json!(true));
+    m.insert("has_wiki".into(), json!(true));
+    m.insert("has_pages".into(), json!(false));
+    m.insert("forks_count".into(), json!(0));
+    m.insert("mirror_url".into(), Value::Null);
+    m.insert("archived".into(), json!(false));
+    m.insert("disabled".into(), json!(false));
+    m.insert("open_issues_count".into(), json!(0));
+    m.insert("license".into(), Value::Null);
+    m.insert("forks".into(), json!(0));
+    m.insert("open_issues".into(), json!(0));
+    m.insert("watchers".into(), json!(0));
+    m.insert("default_branch".into(), json!("main"));
+    m.insert("allow_squash_merge".into(), json!(true));
+    m.insert("allow_merge_commit".into(), json!(true));
+    m.insert("allow_rebase_merge".into(), json!(true));
+
+    Value::Object(m)
+}
+
+/// Generate a complete GitHub PR JSON response that octocrab can deserialize.
+fn github_pr_json(
+    number: u64,
+    state: &str,
+    head_branch: &str,
+    base_branch: &str,
+    merged: bool,
+    body: &str,
+) -> Value {
+    let repo = github_repo_json("owner", "repo");
+    let api_base = format!("https://api.github.com/repos/owner/repo");
+
+    let mut m = Map::new();
+    m.insert("id".into(), json!(number));
+    m.insert("number".into(), json!(number));
+    m.insert("node_id".into(), json!(format!("PR_{}", number)));
+    m.insert("state".into(), json!(state));
+    m.insert("title".into(), json!("Test PR"));
+    m.insert(
+        "html_url".into(),
+        json!(format!("https://github.com/owner/repo/pull/{}", number)),
+    );
+    m.insert(
+        "diff_url".into(),
+        json!(format!(
+            "https://github.com/owner/repo/pull/{}.diff",
+            number
+        )),
+    );
+    m.insert(
+        "patch_url".into(),
+        json!(format!(
+            "https://github.com/owner/repo/pull/{}.patch",
+            number
+        )),
+    );
+    m.insert(
+        "issue_url".into(),
+        json!(format!("{}/issues/{}", api_base, number)),
+    );
+    m.insert(
+        "commits_url".into(),
+        json!(format!("{}/pulls/{}/commits", api_base, number)),
+    );
+    m.insert(
+        "review_comments_url".into(),
+        json!(format!("{}/pulls/{}/comments", api_base, number)),
+    );
+    m.insert(
+        "review_comment_url".into(),
+        json!(format!("{}/pulls/comments{{/number}}", api_base)),
+    );
+    m.insert(
+        "comments_url".into(),
+        json!(format!("{}/issues/{}/comments", api_base, number)),
+    );
+    m.insert(
+        "statuses_url".into(),
+        json!(format!("{}/statuses/abc123def456", api_base)),
+    );
+
+    // Head
+    m.insert(
+        "head".into(),
+        json!({
+            "ref": head_branch,
+            "sha": "abc123def456",
+            "label": format!("owner:{}", head_branch),
+            "repo": repo.clone(),
+            "user": github_user_json("owner", 1)
+        }),
+    );
+
+    // Base
+    m.insert(
+        "base".into(),
+        json!({
+            "ref": base_branch,
+            "sha": "def456abc123",
+            "label": format!("owner:{}", base_branch),
+            "repo": repo,
+            "user": github_user_json("owner", 1)
+        }),
+    );
+
+    m.insert("body".into(), json!(body));
+    m.insert("draft".into(), json!(false));
+    m.insert("locked".into(), json!(false));
+    m.insert("user".into(), github_user_json("testuser", 2));
+    m.insert("merged".into(), json!(merged));
+    m.insert(
+        "merged_at".into(),
+        if merged {
+            json!("2024-01-02T00:00:00Z")
+        } else {
+            Value::Null
+        },
+    );
+    m.insert("mergeable".into(), json!(!merged));
+    m.insert("mergeable_state".into(), json!("clean"));
+    m.insert(
+        "merge_commit_sha".into(),
+        if merged {
+            json!("merge123")
+        } else {
+            Value::Null
+        },
+    );
+    m.insert(
+        "url".into(),
+        json!(format!("{}/pulls/{}", api_base, number)),
+    );
+    m.insert("created_at".into(), json!("2024-01-01T00:00:00Z"));
+    m.insert("updated_at".into(), json!("2024-01-01T00:00:00Z"));
+    m.insert(
+        "closed_at".into(),
+        if state == "closed" || merged {
+            json!("2024-01-02T00:00:00Z")
+        } else {
+            Value::Null
+        },
+    );
+    m.insert("labels".into(), json!([]));
+    m.insert("milestone".into(), Value::Null);
+    m.insert("assignee".into(), Value::Null);
+    m.insert("assignees".into(), json!([]));
+    m.insert("requested_reviewers".into(), json!([]));
+    m.insert("requested_teams".into(), json!([]));
+    m.insert("active_lock_reason".into(), Value::Null);
+
+    Value::Object(m)
+}
+
+/// GitHub API response for creating a PR (POST /repos/:owner/:repo/pulls).
+pub async fn mock_create_pr(server: &MockServer, number: u64, html_url: &str) {
+    let mut body = github_pr_json(number, "open", "feat/test", "main", false, "");
+    body["html_url"] = json!(html_url);
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/pulls"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// GitHub API response for getting a PR (GET /repos/:owner/:repo/pulls/:number).
+pub async fn mock_get_pr(server: &MockServer, number: u64, state: &str, merged: bool) {
+    let body = github_pr_json(
+        number,
+        state,
+        "feat/test",
+        "main",
+        merged,
+        "PR description\n<!-- gitgrip-linked-prs\nfrontend:42\n-->",
+    );
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/pulls/{}", number)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// GitHub API response for listing PRs (GET /repos/:owner/:repo/pulls).
+pub async fn mock_list_prs(server: &MockServer, prs: Vec<(u64, &str)>) {
+    let items: Vec<Value> = prs
+        .iter()
+        .map(|(number, branch)| github_pr_json(*number, "open", branch, "main", false, ""))
+        .collect();
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(items))
+        .mount(server)
+        .await;
+}
+
+/// GitHub API response for merging a PR (PUT /repos/:owner/:repo/pulls/:number/merge).
+pub async fn mock_merge_pr(server: &MockServer, number: u64, merged: bool) {
+    let body = json!({
+        "sha": "merge-sha-123",
+        "merged": merged,
+        "message": if merged { "Pull Request successfully merged" } else { "Pull Request is not mergeable" }
+    });
+
+    Mock::given(method("PUT"))
+        .and(path(format!("/repos/owner/repo/pulls/{}/merge", number)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// GitHub API response for PR reviews (GET /repos/:owner/:repo/pulls/:number/reviews).
+pub async fn mock_pr_reviews(server: &MockServer, number: u64, reviews: Vec<(&str, &str)>) {
+    let items: Vec<Value> = reviews
+        .iter()
+        .enumerate()
+        .map(|(i, (state, user))| {
+            json!({
+                "id": i + 1,
+                "node_id": format!("PRR_{}", i + 1),
+                "state": state,
+                "user": github_user_json(user, (i + 1) as u64),
+                "body": "",
+                "html_url": format!("https://github.com/owner/repo/pull/{}", number),
+                "pull_request_url": format!("https://api.github.com/repos/owner/repo/pulls/{}", number),
+                "submitted_at": "2024-01-01T00:00:00Z",
+                "commit_id": "abc123def456",
+                "_links": {
+                    "html": { "href": format!("https://github.com/owner/repo/pull/{}", number) },
+                    "pull_request": { "href": format!("https://api.github.com/repos/owner/repo/pulls/{}", number) }
+                }
+            })
+        })
+        .collect();
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/pulls/{}/reviews", number)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(items))
+        .mount(server)
+        .await;
+}
+
+/// GitHub API response for check runs (GET /repos/:owner/:repo/commits/:ref/check-runs).
+pub async fn mock_check_runs(
+    server: &MockServer,
+    ref_name: &str,
+    checks: Vec<(&str, &str, Option<&str>)>,
+) {
+    let check_runs: Vec<Value> = checks
+        .iter()
+        .enumerate()
+        .map(|(i, (name, status, conclusion))| {
+            let mut run = json!({
+                "id": i + 1,
+                "name": name,
+                "status": status,
+                "head_sha": "abc123"
+            });
+            if let Some(c) = conclusion {
+                run["conclusion"] = json!(c);
+            }
+            run
+        })
+        .collect();
+
+    let body = json!({
+        "total_count": check_runs.len(),
+        "check_runs": check_runs
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/owner/repo/commits/{}/check-runs",
+            ref_name
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// GitHub API response for PR diff (GET /repos/:owner/:repo/pulls/:number with Accept: diff).
+pub async fn mock_pr_diff(server: &MockServer, number: u64, diff_content: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/pulls/{}", number)))
+        .and(header("Accept", "application/vnd.github.v3.diff"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(diff_content))
+        .mount(server)
+        .await;
+}
+
+/// Mock a 404 response for any GET to a specific path.
+pub async fn mock_not_found(server: &MockServer, path_str: &str) {
+    let body = json!({
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest"
+    });
+
+    Mock::given(method("GET"))
+        .and(path(path_str))
+        .respond_with(ResponseTemplate::new(404).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// Mock a server error (500).
+pub async fn mock_server_error(server: &MockServer, path_str: &str) {
+    let body = json!({
+        "message": "Internal Server Error"
+    });
+
+    Mock::given(method("GET"))
+        .and(path(path_str))
+        .respond_with(ResponseTemplate::new(500).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// Mock a GitHub repo info response (GET /repos/:owner/:repo).
+pub async fn mock_repo_info(server: &MockServer, owner: &str, repo: &str) {
+    let body = github_repo_json(owner, repo);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{}/{}", owner, repo)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
 pub mod assertions;
 pub mod fixtures;
 pub mod git_helpers;
+pub mod mock_platform;

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -1,0 +1,252 @@
+//! Error scenario tests for gitgrip.
+//!
+//! Tests that various error conditions are handled gracefully:
+//! - Invalid manifests
+//! - Missing/broken repos
+//! - Operations on non-existent branches
+//! - Workspace boundary violations
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+
+// ── Invalid Manifest ──────────────────────────────────────────────
+
+#[test]
+fn test_invalid_yaml_manifest() {
+    let result = gitgrip::core::manifest::Manifest::parse("{{{{not yaml");
+    assert!(result.is_err(), "should fail on invalid YAML");
+}
+
+#[test]
+fn test_empty_repos_manifest() {
+    let yaml = "version: 1\nrepos:\n";
+    let result = gitgrip::core::manifest::Manifest::parse(yaml);
+    assert!(result.is_err(), "should fail with empty repos");
+}
+
+#[test]
+fn test_manifest_missing_url() {
+    let yaml = r#"
+version: 1
+repos:
+  myrepo:
+    path: myrepo
+    default_branch: main
+"#;
+    let result = gitgrip::core::manifest::Manifest::parse(yaml);
+    // Should either fail to parse or fail validation (URL is required)
+    assert!(
+        result.is_err(),
+        "should fail when repo is missing URL field"
+    );
+}
+
+#[test]
+fn test_manifest_path_traversal() {
+    let yaml = r#"
+version: 1
+repos:
+  evil:
+    url: https://github.com/test/repo.git
+    path: ../../etc/passwd
+    default_branch: main
+"#;
+    let result = gitgrip::core::manifest::Manifest::parse(yaml);
+    assert!(result.is_err(), "should reject path traversal");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("Path escapes") || err.contains("traversal") || err.contains("boundary"),
+        "error should mention path escaping: {}",
+        err
+    );
+}
+
+// ── Missing/Broken Repos ──────────────────────────────────────────
+
+#[test]
+fn test_status_with_missing_repo() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_repo("broken")
+        .build();
+
+    // Delete the "broken" repo to simulate a missing clone
+    std::fs::remove_dir_all(ws.repo_path("broken")).unwrap();
+
+    let manifest = ws.load_manifest();
+    let result =
+        gitgrip::cli::commands::status::run_status(&ws.workspace_root, &manifest, false, false);
+    // Status should succeed even with a missing repo (reports "not cloned")
+    assert!(
+        result.is_ok(),
+        "status should handle missing repos gracefully: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_commit_with_no_staged_changes() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Try to commit with nothing staged
+    let result = gitgrip::cli::commands::commit::run_commit(
+        &ws.workspace_root,
+        &manifest,
+        "should not commit",
+        false,
+    );
+    // Should succeed but report "no changes to commit"
+    assert!(
+        result.is_ok(),
+        "commit with no changes should not error: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_checkout_nonexistent_branch() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::checkout::run_checkout(
+        &ws.workspace_root,
+        &manifest,
+        "nonexistent-branch",
+    );
+    // Should succeed (returns Ok) but skip repos where branch doesn't exist
+    assert!(
+        result.is_ok(),
+        "checkout nonexistent branch should not crash: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_branch_already_exists() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Create branch first time
+    gitgrip::cli::commands::branch::run_branch(
+        &ws.workspace_root,
+        &manifest,
+        Some("feat/exists"),
+        false,
+        false,
+        None,
+    )
+    .unwrap();
+
+    // Switch back to main
+    gitgrip::cli::commands::checkout::run_checkout(&ws.workspace_root, &manifest, "main").unwrap();
+
+    // Try creating same branch again - should handle gracefully
+    let result = gitgrip::cli::commands::branch::run_branch(
+        &ws.workspace_root,
+        &manifest,
+        Some("feat/exists"),
+        false,
+        false,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "creating existing branch should not crash: {:?}",
+        result.err()
+    );
+}
+
+// ── Sync with Broken Remote ──────────────────────────────────────
+
+#[test]
+fn test_sync_with_deleted_remote() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    // Delete the bare remote to simulate inaccessible remote
+    std::fs::remove_dir_all(ws.remote_path("app")).unwrap();
+
+    let manifest = ws.load_manifest();
+    // Sync should still succeed (or fail gracefully) even if remote is gone
+    let result =
+        gitgrip::cli::commands::sync::run_sync(&ws.workspace_root, &manifest, false, false);
+    // The fetch will fail but the command should handle it
+    // (might error or might report per-repo failure - either is acceptable)
+    // Just verify it doesn't panic
+    let _ = result;
+}
+
+// ── Push Without Remote Branch ──────────────────────────────────
+
+#[test]
+fn test_push_on_main_nothing_to_push() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Push on main with no new commits - should succeed silently
+    let result =
+        gitgrip::cli::commands::push::run_push(&ws.workspace_root, &manifest, false, false, false);
+    assert!(
+        result.is_ok(),
+        "push with nothing should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── Forall with Failing Command ──────────────────────────────────
+
+#[test]
+fn test_forall_with_nonexistent_command() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_repo("lib")
+        .build();
+    let manifest = ws.load_manifest();
+
+    // Run a command that will fail in all repos
+    let result = gitgrip::cli::commands::forall::run_forall(
+        &ws.workspace_root,
+        &manifest,
+        "nonexistent-command-that-doesnt-exist-12345",
+        false, // parallel
+        false, // changed_only
+        false, // no_intercept
+    );
+    // Forall should handle per-repo command failures gracefully
+    // (might return error or might succeed with failure reports)
+    let _ = result;
+}
+
+// ── Add with No Changes ──────────────────────────────────────────
+
+#[test]
+fn test_add_with_no_changes() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Add when there's nothing to add
+    let files = vec![".".to_string()];
+    let result = gitgrip::cli::commands::add::run_add(&ws.workspace_root, &manifest, &files);
+    assert!(
+        result.is_ok(),
+        "add with no changes should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── Platform Detection Edge Cases ────────────────────────────────
+
+#[test]
+fn test_detect_platform_unknown_url() {
+    let platform = gitgrip::platform::detect_platform("https://unknown-host.example.com/repo.git");
+    // Should default to GitHub for unknown hosts
+    assert_eq!(platform, gitgrip::core::manifest::PlatformType::GitHub);
+}
+
+#[test]
+fn test_detect_platform_file_url() {
+    let platform = gitgrip::platform::detect_platform("file:///tmp/repo.git");
+    // File URLs should default to GitHub (no platform detection possible)
+    assert_eq!(platform, gitgrip::core::manifest::PlatformType::GitHub);
+}

--- a/tests/test_platform_github.rs
+++ b/tests/test_platform_github.rs
@@ -1,0 +1,407 @@
+//! Integration tests for the GitHub platform adapter using wiremock.
+//!
+//! Tests the GitHubAdapter against mock HTTP responses, verifying correct
+//! API interaction without requiring real GitHub credentials or network access.
+
+mod common;
+
+use common::mock_platform::*;
+use gitgrip::platform::traits::HostingPlatform;
+use gitgrip::platform::{CheckState, MergeMethod};
+
+// ── PR Create ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_create_pr() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_create_pr(&server, 42, "https://github.com/owner/repo/pull/42").await;
+
+    let result = adapter
+        .create_pull_request("owner", "repo", "feat/test", "main", "Test PR", None, false)
+        .await;
+
+    assert!(result.is_ok(), "create PR should succeed: {:?}", result);
+    let pr = result.unwrap();
+    assert_eq!(pr.number, 42);
+    assert_eq!(pr.url, "https://github.com/owner/repo/pull/42");
+}
+
+#[tokio::test]
+async fn test_github_create_pr_with_body_and_draft() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_create_pr(&server, 99, "https://github.com/owner/repo/pull/99").await;
+
+    let result = adapter
+        .create_pull_request(
+            "owner",
+            "repo",
+            "feat/draft",
+            "main",
+            "Draft PR",
+            Some("This is a draft"),
+            true,
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "create draft PR should succeed: {:?}",
+        result
+    );
+    let pr = result.unwrap();
+    assert_eq!(pr.number, 99);
+}
+
+// ── PR Get ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_get_pr_open() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_get_pr(&server, 42, "open", false).await;
+
+    let result = adapter.get_pull_request("owner", "repo", 42).await;
+
+    assert!(result.is_ok(), "get PR should succeed: {:?}", result);
+    let pr = result.unwrap();
+    assert_eq!(pr.number, 42);
+    assert_eq!(pr.title, "Test PR");
+    assert!(!pr.merged);
+    assert_eq!(pr.head.ref_name, "feat/test");
+    assert_eq!(pr.base.ref_name, "main");
+    assert_eq!(pr.head.sha, "abc123def456");
+}
+
+#[tokio::test]
+async fn test_github_get_pr_merged() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_get_pr(&server, 42, "closed", true).await;
+
+    let result = adapter.get_pull_request("owner", "repo", 42).await;
+
+    assert!(result.is_ok());
+    let pr = result.unwrap();
+    assert!(pr.merged);
+    assert_eq!(
+        pr.state,
+        gitgrip::platform::PRState::Merged,
+        "merged PR should have Merged state"
+    );
+}
+
+#[tokio::test]
+async fn test_github_get_pr_not_found() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_not_found(&server, "/repos/owner/repo/pulls/999").await;
+
+    let result = adapter.get_pull_request("owner", "repo", 999).await;
+
+    assert!(result.is_err(), "should fail for nonexistent PR");
+    // Note: octocrab's error for 404 doesn't include "404" in the message,
+    // so the adapter classifies it as ApiError rather than NotFound.
+    // This is a known limitation of the error classification.
+}
+
+// ── PR Merge ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_merge_pr() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_merge_pr(&server, 42, true).await;
+
+    let result = adapter
+        .merge_pull_request("owner", "repo", 42, Some(MergeMethod::Squash), false)
+        .await;
+
+    assert!(result.is_ok(), "merge should succeed: {:?}", result);
+    assert!(result.unwrap(), "PR should be merged");
+}
+
+#[tokio::test]
+async fn test_github_merge_pr_not_mergeable() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_merge_pr(&server, 42, false).await;
+
+    let result = adapter
+        .merge_pull_request("owner", "repo", 42, None, false)
+        .await;
+
+    // The adapter returns Ok(false) when merge response says merged=false
+    assert!(result.is_ok());
+    assert!(!result.unwrap(), "PR should not be merged");
+}
+
+// ── Find PR by Branch ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_find_pr_by_branch_found() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_list_prs(&server, vec![(42, "feat/test")]).await;
+
+    let result = adapter
+        .find_pr_by_branch("owner", "repo", "feat/test")
+        .await;
+
+    assert!(result.is_ok(), "find PR should succeed: {:?}", result);
+    let pr = result.unwrap();
+    assert!(pr.is_some(), "should find PR for branch");
+    let pr = pr.unwrap();
+    assert_eq!(pr.number, 42);
+}
+
+#[tokio::test]
+async fn test_github_find_pr_by_branch_not_found() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_list_prs(&server, vec![]).await;
+
+    let result = adapter
+        .find_pr_by_branch("owner", "repo", "feat/nonexistent")
+        .await;
+
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_none(), "should not find PR");
+}
+
+// ── PR Reviews ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_pr_approved() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_pr_reviews(&server, 42, vec![("APPROVED", "reviewer1")]).await;
+
+    let result = adapter.is_pull_request_approved("owner", "repo", 42).await;
+
+    assert!(result.is_ok());
+    assert!(result.unwrap(), "PR with approval should be approved");
+}
+
+#[tokio::test]
+async fn test_github_pr_changes_requested() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_pr_reviews(
+        &server,
+        42,
+        vec![
+            ("APPROVED", "reviewer1"),
+            ("CHANGES_REQUESTED", "reviewer2"),
+        ],
+    )
+    .await;
+
+    let result = adapter.is_pull_request_approved("owner", "repo", 42).await;
+
+    assert!(result.is_ok());
+    assert!(
+        !result.unwrap(),
+        "PR with changes requested should not be approved"
+    );
+}
+
+#[tokio::test]
+async fn test_github_pr_no_reviews() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_pr_reviews(&server, 42, vec![]).await;
+
+    let result = adapter.is_pull_request_approved("owner", "repo", 42).await;
+
+    assert!(result.is_ok());
+    assert!(
+        !result.unwrap(),
+        "PR with no reviews should not be approved"
+    );
+}
+
+#[tokio::test]
+async fn test_github_get_reviews() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_pr_reviews(
+        &server,
+        42,
+        vec![("APPROVED", "alice"), ("COMMENTED", "bob")],
+    )
+    .await;
+
+    let result = adapter.get_pull_request_reviews("owner", "repo", 42).await;
+
+    assert!(result.is_ok());
+    let reviews = result.unwrap();
+    assert_eq!(reviews.len(), 2);
+    assert_eq!(reviews[0].user, "alice");
+    assert_eq!(reviews[0].state, "Approved");
+    assert_eq!(reviews[1].user, "bob");
+}
+
+// ── Status Checks ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_status_checks_all_pass() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_check_runs(
+        &server,
+        "abc123",
+        vec![
+            ("CI", "completed", Some("success")),
+            ("Lint", "completed", Some("success")),
+        ],
+    )
+    .await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(result.is_ok(), "should get checks: {:?}", result);
+    let checks = result.unwrap();
+    assert_eq!(checks.state, CheckState::Success);
+    assert_eq!(checks.statuses.len(), 2);
+}
+
+#[tokio::test]
+async fn test_github_status_checks_with_failure() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_check_runs(
+        &server,
+        "abc123",
+        vec![
+            ("CI", "completed", Some("success")),
+            ("Tests", "completed", Some("failure")),
+        ],
+    )
+    .await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(result.is_ok());
+    let checks = result.unwrap();
+    assert_eq!(checks.state, CheckState::Failure);
+}
+
+#[tokio::test]
+async fn test_github_status_checks_pending() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_check_runs(
+        &server,
+        "abc123",
+        vec![
+            ("CI", "completed", Some("success")),
+            ("Deploy", "in_progress", None),
+        ],
+    )
+    .await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(result.is_ok());
+    let checks = result.unwrap();
+    assert_eq!(checks.state, CheckState::Pending);
+}
+
+// ── PR Diff ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_get_pr_diff() {
+    let (server, adapter) = setup_github_mock().await;
+    let diff =
+        "diff --git a/file.rs b/file.rs\n--- a/file.rs\n+++ b/file.rs\n@@ -1 +1 @@\n-old\n+new\n";
+    mock_pr_diff(&server, 42, diff).await;
+
+    let result = adapter.get_pull_request_diff("owner", "repo", 42).await;
+
+    assert!(result.is_ok(), "should get diff: {:?}", result);
+    let got_diff = result.unwrap();
+    assert!(got_diff.contains("+new"));
+    assert!(got_diff.contains("-old"));
+}
+
+// ── Linked PR Comment Parsing ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_linked_pr_in_body() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_get_pr(&server, 42, "open", false).await;
+
+    let result = adapter.get_pull_request("owner", "repo", 42).await;
+    assert!(result.is_ok());
+
+    let pr = result.unwrap();
+    let links = adapter.parse_linked_pr_comment(&pr.body);
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].repo_name, "frontend");
+    assert_eq!(links[0].number, 42);
+}
+
+// ── Error Scenarios ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_github_auth_error_no_token() {
+    let server = wiremock::MockServer::start().await;
+    // Clear all token env vars
+    unsafe {
+        std::env::remove_var("GITHUB_TOKEN");
+        std::env::remove_var("GH_TOKEN");
+    }
+
+    let adapter = gitgrip::platform::github::GitHubAdapter::new(Some(&server.uri()));
+    let result = adapter.get_pull_request("owner", "repo", 42).await;
+
+    // Restore token for other tests
+    unsafe {
+        std::env::set_var("GITHUB_TOKEN", "mock-test-token");
+    }
+
+    assert!(result.is_err(), "should fail without token");
+    let err = result.unwrap_err();
+    let err_str = err.to_string();
+    assert!(
+        err_str.contains("Authentication") || err_str.contains("token") || err_str.contains("auth"),
+        "error should mention auth: {}",
+        err_str
+    );
+}
+
+#[tokio::test]
+async fn test_github_server_error_on_checks() {
+    let (server, adapter) = setup_github_mock().await;
+    mock_server_error(&server, "/repos/owner/repo/commits/abc123/check-runs").await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    // When check-runs returns 500, the adapter falls back to legacy status API
+    // which also won't have a mock, so it should error
+    assert!(result.is_err(), "should fail on server error");
+}
+
+// ── URL Parsing ──────────────────────────────────────────────────
+
+#[test]
+fn test_github_parse_ssh_url() {
+    let adapter = gitgrip::platform::github::GitHubAdapter::new(None);
+    let info = adapter
+        .parse_repo_url("git@github.com:org/my-repo.git")
+        .expect("should parse SSH URL");
+    assert_eq!(info.owner, "org");
+    assert_eq!(info.repo, "my-repo");
+}
+
+#[test]
+fn test_github_parse_https_url() {
+    let adapter = gitgrip::platform::github::GitHubAdapter::new(None);
+    let info = adapter
+        .parse_repo_url("https://github.com/org/my-repo.git")
+        .expect("should parse HTTPS URL");
+    assert_eq!(info.owner, "org");
+    assert_eq!(info.repo, "my-repo");
+}
+
+#[test]
+fn test_github_parse_invalid_url() {
+    let adapter = gitgrip::platform::github::GitHubAdapter::new(None);
+    let result = adapter.parse_repo_url("https://gitlab.com/org/repo.git");
+    assert!(result.is_none(), "should not parse non-GitHub URL");
+}
+
+#[test]
+fn test_github_matches_url() {
+    let adapter = gitgrip::platform::github::GitHubAdapter::new(None);
+    assert!(adapter.matches_url("git@github.com:user/repo.git"));
+    assert!(adapter.matches_url("https://github.com/user/repo"));
+    assert!(!adapter.matches_url("git@gitlab.com:user/repo.git"));
+    assert!(!adapter.matches_url("https://dev.azure.com/org/proj/_git/repo"));
+}


### PR DESCRIPTION
## Summary

- Add 24 GitHub platform adapter tests using wiremock for fully offline testing of PR operations (create, get, merge, find by branch, reviews, status checks, diff)
- Add 14 error scenario tests covering invalid manifests, missing repos, path traversal, and graceful degradation
- Fix bug in `is_pull_request_approved()` where review state comparison was case/format sensitive (octocrab formats as "Approved" but code compared against "APPROVED")

## Details

### wiremock Platform Tests (`test_platform_github.rs`)
Tests the `GitHubAdapter` against mock HTTP responses with complete GitHub API response shapes that octocrab can deserialize. Covers:
- PR CRUD operations (create, get open/merged, not found)
- PR merge (success, not mergeable)
- Find PR by branch (found, not found)
- Reviews (approved, changes requested, no reviews)
- Status checks (all pass, failure, pending)
- PR diff retrieval
- Linked PR comment parsing
- Auth errors, server errors
- URL parsing and platform detection

### Error Scenario Tests (`test_errors.rs`)
- Invalid YAML manifest parsing
- Empty repos manifest validation
- Missing URL field validation
- Path traversal detection
- Status with missing repo (graceful)
- Commit with no staged changes
- Checkout nonexistent branch
- Branch already exists
- Sync with deleted remote
- Push with nothing to push
- Forall with nonexistent command
- Add with no changes
- Platform detection edge cases

### Bug Fix
`is_pull_request_approved()` compared review states using exact string match (`"APPROVED"`) but octocrab's `ReviewState` debug formatting produces title-case without underscores (`"Approved"`, `"ChangesRequested"`). Fixed with normalized comparison that strips underscores and uses case-insensitive matching.

## Test plan
- [x] All 259 tests pass locally (155 unit + 104 integration)
- [x] `cargo clippy` - no new warnings
- [x] `cargo fmt --check` - clean
- [x] CI should pass on all platforms (Ubuntu, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)