### PR TITLE
test: expand integration test coverage with 75 new tests

### DIFF
--- a/tests/test_ci.rs
+++ b/tests/test_ci.rs
@@ -1,0 +1,313 @@
+//! Integration tests for the CI pipeline commands (Phase 6).
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use std::fs;
+
+/// Helper: append workspace CI config to the existing manifest YAML.
+fn write_ci_manifest(ws: &common::fixtures::WorkspaceFixture, ci_yaml: &str) {
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let existing = fs::read_to_string(&manifest_path).unwrap();
+    let full = format!(
+        "{}\nworkspace:\n  ci:\n    pipelines:\n{}",
+        existing, ci_yaml
+    );
+    fs::write(&manifest_path, full).unwrap();
+}
+
+// ── ci list ──────────────────────────────────────────────────────
+
+#[test]
+fn test_ci_list_no_pipelines() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // No workspace.ci config → prints "No CI pipelines defined."
+    let result = gitgrip::cli::commands::ci::run_ci_list(&manifest, false);
+    assert!(
+        result.is_ok(),
+        "ci list with no pipelines should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_ci_list_pipelines() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      build:
+        description: "Build project"
+        steps:
+          - name: compile
+            command: "echo compiling"
+      test:
+        description: "Run tests"
+        steps:
+          - name: unit
+            command: "echo testing"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result = gitgrip::cli::commands::ci::run_ci_list(&manifest, false);
+    assert!(result.is_ok(), "ci list should succeed: {:?}", result.err());
+}
+
+#[test]
+fn test_ci_list_json() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      lint:
+        description: "Lint code"
+        steps:
+          - name: check
+            command: "echo linting"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result = gitgrip::cli::commands::ci::run_ci_list(&manifest, true);
+    assert!(
+        result.is_ok(),
+        "ci list json should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── ci run ──────────────────────────────────────────────────────
+
+#[test]
+fn test_ci_run_simple() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      build:
+        steps:
+          - name: step1
+            command: "echo hello"
+          - name: step2
+            command: "echo world"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result =
+        gitgrip::cli::commands::ci::run_ci_run(&ws.workspace_root, &manifest, "build", false);
+    assert!(
+        result.is_ok(),
+        "ci run simple should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_ci_run_step_failure_stops() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      fail-pipeline:
+        steps:
+          - name: pass
+            command: "echo ok"
+          - name: fail
+            command: "false"
+          - name: never-reached
+            command: "echo should not run"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result = gitgrip::cli::commands::ci::run_ci_run(
+        &ws.workspace_root,
+        &manifest,
+        "fail-pipeline",
+        false,
+    );
+    assert!(result.is_err(), "ci run should fail when a step fails");
+}
+
+#[test]
+fn test_ci_run_continue_on_error() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      resilient:
+        steps:
+          - name: flaky
+            command: "false"
+            continue_on_error: true
+          - name: after-flaky
+            command: "echo still running"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    // Even though flaky fails, continue_on_error lets it proceed.
+    // The pipeline still reports overall failure (the flaky step failed).
+    let result =
+        gitgrip::cli::commands::ci::run_ci_run(&ws.workspace_root, &manifest, "resilient", false);
+    // Pipeline overall fails because at least one step failed
+    assert!(
+        result.is_err(),
+        "pipeline should report failure even with continue_on_error"
+    );
+}
+
+#[test]
+fn test_ci_run_nonexistent_pipeline() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      real:
+        steps:
+          - name: step1
+            command: "echo hi"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result =
+        gitgrip::cli::commands::ci::run_ci_run(&ws.workspace_root, &manifest, "nonexistent", false);
+    assert!(result.is_err(), "should error on nonexistent pipeline");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("not found"),
+        "error should mention 'not found': {}",
+        err_msg
+    );
+}
+
+#[test]
+fn test_ci_run_cwd_resolution() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    // Create a subdirectory with a marker file
+    let subdir = ws.workspace_root.join("app");
+    fs::create_dir_all(&subdir).ok();
+
+    write_ci_manifest(
+        &ws,
+        r#"      cwd-test:
+        steps:
+          - name: in-app
+            command: "pwd"
+            cwd: "app"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result =
+        gitgrip::cli::commands::ci::run_ci_run(&ws.workspace_root, &manifest, "cwd-test", false);
+    assert!(
+        result.is_ok(),
+        "ci run with cwd should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_ci_run_json_output() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      json-test:
+        steps:
+          - name: echo
+            command: "echo json"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result =
+        gitgrip::cli::commands::ci::run_ci_run(&ws.workspace_root, &manifest, "json-test", true);
+    assert!(
+        result.is_ok(),
+        "ci run with json should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── ci result saved ──────────────────────────────────────────────
+
+#[test]
+fn test_ci_result_saved() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      save-test:
+        steps:
+          - name: echo
+            command: "echo saved"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    gitgrip::cli::commands::ci::run_ci_run(&ws.workspace_root, &manifest, "save-test", false)
+        .unwrap();
+
+    let result_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("ci-results")
+        .join("save-test.json");
+    assert!(
+        result_path.exists(),
+        "CI result file should exist at {}",
+        result_path.display()
+    );
+}
+
+// ── ci status ──────────────────────────────────────────────────────
+
+#[test]
+fn test_ci_status_no_results() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let result = gitgrip::cli::commands::ci::run_ci_status(&ws.workspace_root, false);
+    assert!(
+        result.is_ok(),
+        "ci status with no results should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_ci_status_after_run() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_manifest(
+        &ws,
+        r#"      status-test:
+        steps:
+          - name: echo
+            command: "echo done"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    gitgrip::cli::commands::ci::run_ci_run(&ws.workspace_root, &manifest, "status-test", false)
+        .unwrap();
+
+    // Now check status
+    let result = gitgrip::cli::commands::ci::run_ci_status(&ws.workspace_root, false);
+    assert!(
+        result.is_ok(),
+        "ci status after run should succeed: {:?}",
+        result.err()
+    );
+}

--- a/tests/test_edge_cases.rs
+++ b/tests/test_edge_cases.rs
@@ -1,0 +1,353 @@
+//! Additional edge case tests for improved coverage.
+//!
+//! Covers: group-filtered status, CI with workspace env vars,
+//! Bitbucket failure paths, diff staged mode, and more.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use common::git_helpers;
+use std::fs;
+
+// ── Status with group filter ──────────────────────────────────────
+
+#[test]
+fn test_status_group_filter() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_groups("frontend", vec!["ui"])
+        .add_repo_with_groups("backend", vec!["api"])
+        .add_repo_with_groups("shared", vec!["ui", "api"])
+        .build();
+
+    let manifest = ws.load_manifest();
+    let group = vec!["ui".to_string()];
+
+    let result = gitgrip::cli::commands::status::run_status(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        false,
+        Some(&group),
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "status with group filter should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_status_group_filter_json() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_groups("frontend", vec!["ui"])
+        .add_repo_with_groups("backend", vec!["api"])
+        .build();
+
+    let manifest = ws.load_manifest();
+    let group = vec!["api".to_string()];
+
+    let result = gitgrip::cli::commands::status::run_status(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        false,
+        Some(&group),
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "status json with group filter should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── Diff staged mode ──────────────────────────────────────────────
+
+#[test]
+fn test_diff_staged_no_changes() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::diff::run_diff(
+        &ws.workspace_root,
+        &manifest,
+        true, // staged
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "diff staged with no changes should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_diff_staged_json() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::diff::run_diff(
+        &ws.workspace_root,
+        &manifest,
+        true, // staged
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "diff staged json should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── Branch with group filter (JSON) ──────────────────────────────
+
+#[test]
+fn test_branch_group_filter_json() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_groups("frontend", vec!["ui"])
+        .add_repo_with_groups("backend", vec!["api"])
+        .build();
+
+    let manifest = ws.load_manifest();
+    let group = vec!["ui".to_string()];
+
+    let result = gitgrip::cli::commands::branch::run_branch(
+        &ws.workspace_root,
+        &manifest,
+        None, // list mode
+        false,
+        false,
+        None,
+        Some(&group),
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "branch json with group filter should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── CI with workspace env vars ──────────────────────────────────
+
+fn write_ci_env_manifest(ws: &common::fixtures::WorkspaceFixture, yaml: &str) {
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let existing = fs::read_to_string(&manifest_path).unwrap();
+    let full = format!("{}\nworkspace:\n{}", existing, yaml);
+    fs::write(&manifest_path, full).unwrap();
+}
+
+#[test]
+fn test_ci_run_with_workspace_env() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_env_manifest(
+        &ws,
+        r#"  env:
+    MY_VAR: hello
+  ci:
+    pipelines:
+      env-test:
+        steps:
+          - name: check-env
+            command: "echo $MY_VAR"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result =
+        gitgrip::cli::commands::ci::run_ci_run(&ws.workspace_root, &manifest, "env-test", false);
+    assert!(
+        result.is_ok(),
+        "CI with workspace env should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_ci_run_step_with_env_override() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_ci_env_manifest(
+        &ws,
+        r#"  ci:
+    pipelines:
+      env-override:
+        steps:
+          - name: with-env
+            command: "echo $STEP_VAR"
+            env:
+              STEP_VAR: step-value
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result = gitgrip::cli::commands::ci::run_ci_run(
+        &ws.workspace_root,
+        &manifest,
+        "env-override",
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "CI with step env override should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── Bitbucket URL parsing edge cases ──────────────────────────────
+
+#[test]
+fn test_bb_matches_enterprise_url() {
+    let adapter = gitgrip::platform::bitbucket::BitbucketAdapter::new(None);
+    use gitgrip::platform::traits::HostingPlatform;
+    assert!(adapter.matches_url("git@bitbucket.mycompany.com:team/repo.git"));
+    assert!(adapter.matches_url("https://bitbucket.mycompany.com/team/repo"));
+    assert!(!adapter.matches_url("git@github.com:owner/repo.git"));
+    assert!(!adapter.matches_url("https://gitlab.com/user/repo"));
+}
+
+#[test]
+fn test_bb_parse_enterprise_url() {
+    let adapter = gitgrip::platform::bitbucket::BitbucketAdapter::new(None);
+    use gitgrip::platform::traits::HostingPlatform;
+
+    let info = adapter.parse_repo_url("git@bitbucket.mycompany.com:team/enterprise-repo.git");
+    assert!(info.is_some(), "should parse enterprise Bitbucket SSH URL");
+    let info = info.unwrap();
+    assert_eq!(info.owner, "team");
+    assert_eq!(info.repo, "enterprise-repo");
+}
+
+#[test]
+fn test_bb_parse_invalid_url_returns_none() {
+    let adapter = gitgrip::platform::bitbucket::BitbucketAdapter::new(None);
+    use gitgrip::platform::traits::HostingPlatform;
+
+    assert!(
+        adapter
+            .parse_repo_url("git@github.com:owner/repo.git")
+            .is_none(),
+        "should not parse GitHub URL as Bitbucket"
+    );
+    assert!(
+        adapter.parse_repo_url("not-a-url").is_none(),
+        "should not parse invalid URL"
+    );
+}
+
+// ── Rebase continue with no rebase ──────────────────────────────
+
+#[test]
+fn test_rebase_continue_no_rebase() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Continue with no rebase in progress → should succeed (no-op)
+    let result = gitgrip::cli::commands::rebase::run_rebase(
+        &ws.workspace_root,
+        &manifest,
+        None,
+        false,
+        true, // continue
+    );
+    assert!(
+        result.is_ok(),
+        "continue with no rebase should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── Checkout back to main ──────────────────────────────────────
+
+#[test]
+fn test_checkout_main_from_feature() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+
+    let manifest = ws.load_manifest();
+
+    // Create feature branch
+    gitgrip::cli::commands::branch::run_branch(
+        &ws.workspace_root,
+        &manifest,
+        Some("feat/roundtrip"),
+        false,
+        false,
+        None,
+        None,
+        false,
+    )
+    .unwrap();
+
+    // Checkout main
+    let result =
+        gitgrip::cli::commands::checkout::run_checkout(&ws.workspace_root, &manifest, "main");
+    assert!(
+        result.is_ok(),
+        "checkout main should succeed: {:?}",
+        result.err()
+    );
+
+    common::assertions::assert_on_branch(&ws.repo_path("frontend"), "main");
+    common::assertions::assert_on_branch(&ws.repo_path("backend"), "main");
+}
+
+// ── GC with reference repos ──────────────────────────────────────
+
+#[test]
+fn test_gc_with_reference_repos() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_reference_repo("docs")
+        .build();
+
+    let manifest = ws.load_manifest();
+
+    let result =
+        gitgrip::cli::commands::gc::run_gc(&ws.workspace_root, &manifest, false, false, None, None);
+    assert!(
+        result.is_ok(),
+        "gc with reference repos should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── Commit amend flag ──────────────────────────────────────────
+
+#[test]
+fn test_commit_amend_with_changes() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Create a new file and stage it
+    fs::write(ws.repo_path("app").join("new.txt"), "content").unwrap();
+    git_helpers::commit_file(&ws.repo_path("app"), "new.txt", "content", "Initial");
+
+    // Modify and stage
+    fs::write(ws.repo_path("app").join("new.txt"), "amended content").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "new.txt"])
+        .current_dir(ws.repo_path("app"))
+        .output()
+        .unwrap();
+
+    let result = gitgrip::cli::commands::commit::run_commit(
+        &ws.workspace_root,
+        &manifest,
+        "amended message",
+        true, // amend
+    );
+    assert!(
+        result.is_ok(),
+        "commit amend should succeed: {:?}",
+        result.err()
+    );
+}

--- a/tests/test_json_output.rs
+++ b/tests/test_json_output.rs
@@ -1,0 +1,169 @@
+//! Integration tests for JSON output mode (Phase 6).
+//!
+//! Verifies that the `--json` flag on status, diff, and branch commands
+//! succeeds and produces output without errors.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use common::git_helpers;
+
+// ── status --json ──────────────────────────────────────────────
+
+#[test]
+fn test_status_json_clean() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::status::run_status(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        false,
+        None,
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "status json on clean workspace should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_status_json_with_changes() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+
+    let manifest = ws.load_manifest();
+
+    // Create an untracked file
+    std::fs::write(ws.repo_path("frontend").join("untracked.txt"), "test").unwrap();
+
+    let result = gitgrip::cli::commands::status::run_status(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        false,
+        None,
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "status json with changes should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_status_json_reference_repos() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_reference_repo("docs")
+        .build();
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::status::run_status(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        false,
+        None,
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "status json with reference repos should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── diff --json ──────────────────────────────────────────────
+
+#[test]
+fn test_diff_json_no_changes() {
+    let ws = WorkspaceBuilder::new().add_repo("frontend").build();
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::diff::run_diff(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "diff json no changes should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_diff_json_with_changes() {
+    let ws = WorkspaceBuilder::new().add_repo("frontend").build();
+
+    let manifest = ws.load_manifest();
+
+    // Modify an existing tracked file
+    std::fs::write(ws.repo_path("frontend").join("README.md"), "modified\n").unwrap();
+
+    let result = gitgrip::cli::commands::diff::run_diff(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "diff json with changes should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── branch --json ──────────────────────────────────────────────
+
+#[test]
+fn test_branch_json_list() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let manifest = ws.load_manifest();
+
+    // Create a branch first
+    gitgrip::cli::commands::branch::run_branch(
+        &ws.workspace_root,
+        &manifest,
+        Some("feat/test"),
+        false,
+        false,
+        None,
+        None,
+        false,
+    )
+    .unwrap();
+    git_helpers::checkout(&ws.repo_path("app"), "main");
+
+    // List branches in JSON mode
+    let result = gitgrip::cli::commands::branch::run_branch(
+        &ws.workspace_root,
+        &manifest,
+        None, // list mode
+        false,
+        false,
+        None,
+        None,
+        true, // json
+    );
+    assert!(
+        result.is_ok(),
+        "branch json list should succeed: {:?}",
+        result.err()
+    );
+}

--- a/tests/test_link.rs
+++ b/tests/test_link.rs
@@ -1,0 +1,215 @@
+//! Integration tests for the link command.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use std::fs;
+
+/// Helper: append copyfile/linkfile entries to a repo's manifest config.
+fn write_link_manifest(ws: &common::fixtures::WorkspaceFixture, repo_name: &str, link_yaml: &str) {
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let content = fs::read_to_string(&manifest_path).unwrap();
+
+    // Insert link config under the specified repo entry
+    let search = format!("  {}:", repo_name);
+    let updated = content.replace(&search, &format!("  {}:\n{}", repo_name, link_yaml));
+    fs::write(&manifest_path, updated).unwrap();
+}
+
+// ── link status ──────────────────────────────────────────────────────
+
+#[test]
+fn test_link_status_no_links() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::link::run_link(
+        &ws.workspace_root,
+        &manifest,
+        true,  // status
+        false, // not apply
+    );
+    assert!(
+        result.is_ok(),
+        "link status with no links should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_link_status_with_copyfile() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_files("config-repo", vec![("shared.config", "key=value")])
+        .build();
+
+    write_link_manifest(
+        &ws,
+        "config-repo",
+        "    copyfile:\n      - src: shared.config\n        dest: .shared.config",
+    );
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::link::run_link(
+        &ws.workspace_root,
+        &manifest,
+        true, // status
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "link status with copyfile should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_link_status_with_linkfile() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_files("config-repo", vec![("env.template", "ENV=dev")])
+        .build();
+
+    write_link_manifest(
+        &ws,
+        "config-repo",
+        "    linkfile:\n      - src: env.template\n        dest: .env.template",
+    );
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::link::run_link(
+        &ws.workspace_root,
+        &manifest,
+        true, // status
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "link status with linkfile should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── link apply ──────────────────────────────────────────────────────
+
+#[test]
+fn test_link_apply_copyfile() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_files("config-repo", vec![("shared.config", "key=value")])
+        .build();
+
+    write_link_manifest(
+        &ws,
+        "config-repo",
+        "    copyfile:\n      - src: shared.config\n        dest: .shared.config",
+    );
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::link::run_link(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        true, // apply
+    );
+    assert!(
+        result.is_ok(),
+        "link apply copyfile should succeed: {:?}",
+        result.err()
+    );
+
+    let dest = ws.workspace_root.join(".shared.config");
+    assert!(dest.exists(), "copied file should exist at destination");
+
+    let content = fs::read_to_string(&dest).unwrap();
+    assert_eq!(
+        content, "key=value",
+        "copied file should have correct content"
+    );
+}
+
+#[test]
+fn test_link_apply_linkfile() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_files("config-repo", vec![("env.template", "ENV=dev")])
+        .build();
+
+    write_link_manifest(
+        &ws,
+        "config-repo",
+        "    linkfile:\n      - src: env.template\n        dest: .env.template",
+    );
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::link::run_link(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        true, // apply
+    );
+    assert!(
+        result.is_ok(),
+        "link apply linkfile should succeed: {:?}",
+        result.err()
+    );
+
+    let dest = ws.workspace_root.join(".env.template");
+    assert!(dest.exists(), "symlink should exist at destination");
+    assert!(
+        dest.is_symlink(),
+        "destination should be a symlink, not a copy"
+    );
+}
+
+#[test]
+fn test_link_apply_missing_repo() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    // Remove the repo to simulate not-cloned
+    fs::remove_dir_all(ws.repo_path("app")).unwrap();
+
+    write_link_manifest(
+        &ws,
+        "app",
+        "    copyfile:\n      - src: config.json\n        dest: .config.json",
+    );
+
+    let manifest = ws.load_manifest();
+
+    // Should succeed (skip missing repos gracefully)
+    let result = gitgrip::cli::commands::link::run_link(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        true, // apply
+    );
+    assert!(
+        result.is_ok(),
+        "link apply with missing repo should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── link default (no flags = status) ──────────────────────────────
+
+#[test]
+fn test_link_default_shows_status() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let manifest = ws.load_manifest();
+
+    // No flags → defaults to status
+    let result =
+        gitgrip::cli::commands::link::run_link(&ws.workspace_root, &manifest, false, false);
+    assert!(
+        result.is_ok(),
+        "link default should succeed: {:?}",
+        result.err()
+    );
+}

--- a/tests/test_manifest_cmd.rs
+++ b/tests/test_manifest_cmd.rs
@@ -1,0 +1,171 @@
+//! Integration tests for manifest import and sync commands (Phase 6).
+
+mod common;
+
+use std::fs;
+use tempfile::TempDir;
+
+// ── manifest import ──────────────────────────────────────────────
+
+#[test]
+fn test_manifest_import_simple() {
+    let tmp = TempDir::new().unwrap();
+    let xml_path = tmp.path().join("default.xml");
+    let output_path = tmp.path().join("manifest.yaml");
+
+    fs::write(
+        &xml_path,
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="github" fetch="https://github.com/org/" />
+  <default remote="github" revision="main" />
+  <project name="frontend" path="frontend" />
+  <project name="backend" path="backend" />
+</manifest>"#,
+    )
+    .unwrap();
+
+    let result = gitgrip::cli::commands::manifest::run_manifest_import(
+        xml_path.to_str().unwrap(),
+        Some(output_path.to_str().unwrap()),
+    );
+    assert!(result.is_ok(), "import should succeed: {:?}", result.err());
+    assert!(output_path.exists(), "output YAML should be written");
+
+    let yaml = fs::read_to_string(&output_path).unwrap();
+    assert!(
+        yaml.contains("frontend"),
+        "YAML should contain frontend repo"
+    );
+    assert!(yaml.contains("backend"), "YAML should contain backend repo");
+}
+
+#[test]
+fn test_manifest_import_skips_gerrit() {
+    let tmp = TempDir::new().unwrap();
+    let xml_path = tmp.path().join("default.xml");
+    let output_path = tmp.path().join("manifest.yaml");
+
+    fs::write(
+        &xml_path,
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="github" fetch="https://github.com/org/" />
+  <remote name="gerrit" fetch="https://android.googlesource.com/" review="https://android-review.googlesource.com/" />
+  <default remote="github" revision="main" />
+  <project name="app" path="app" />
+  <project name="platform/build" path="build" remote="gerrit" />
+</manifest>"#,
+    )
+    .unwrap();
+
+    let result = gitgrip::cli::commands::manifest::run_manifest_import(
+        xml_path.to_str().unwrap(),
+        Some(output_path.to_str().unwrap()),
+    );
+    assert!(result.is_ok(), "import should succeed: {:?}", result.err());
+
+    let yaml = fs::read_to_string(&output_path).unwrap();
+    assert!(yaml.contains("app"), "YAML should contain non-Gerrit repo");
+}
+
+#[test]
+fn test_manifest_import_custom_output() {
+    let tmp = TempDir::new().unwrap();
+    let xml_path = tmp.path().join("default.xml");
+    let custom_output = tmp.path().join("custom").join("out.yaml");
+
+    fs::write(
+        &xml_path,
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="origin" fetch="https://github.com/test/" />
+  <default remote="origin" revision="main" />
+  <project name="myrepo" path="myrepo" />
+</manifest>"#,
+    )
+    .unwrap();
+
+    // Create parent dir
+    fs::create_dir_all(custom_output.parent().unwrap()).unwrap();
+
+    let result = gitgrip::cli::commands::manifest::run_manifest_import(
+        xml_path.to_str().unwrap(),
+        Some(custom_output.to_str().unwrap()),
+    );
+    assert!(
+        result.is_ok(),
+        "import with custom output should succeed: {:?}",
+        result.err()
+    );
+    assert!(custom_output.exists(), "custom output path should exist");
+}
+
+#[test]
+fn test_manifest_import_nonexistent() {
+    let result = gitgrip::cli::commands::manifest::run_manifest_import(
+        "/nonexistent/path/default.xml",
+        None,
+    );
+    assert!(result.is_err(), "import of nonexistent file should fail");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("not found"),
+        "error should mention not found: {}",
+        err_msg
+    );
+}
+
+// ── manifest sync ──────────────────────────────────────────────
+
+#[test]
+fn test_manifest_sync_repo_workspace() {
+    let tmp = TempDir::new().unwrap();
+    let workspace = tmp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    // Create .repo/ structure
+    let repo_dir = workspace.join(".repo");
+    let manifests_dir = repo_dir.join("manifests");
+    fs::create_dir_all(&manifests_dir).unwrap();
+
+    // Write XML manifest
+    fs::write(
+        repo_dir.join("manifest.xml"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="origin" fetch="https://github.com/org/" />
+  <default remote="origin" revision="main" />
+  <project name="core" path="core" />
+</manifest>"#,
+    )
+    .unwrap();
+
+    let workspace_path = workspace.to_path_buf();
+    let result = gitgrip::cli::commands::manifest::run_manifest_sync(&workspace_path);
+    assert!(
+        result.is_ok(),
+        "manifest sync should succeed: {:?}",
+        result.err()
+    );
+
+    let yaml_path = manifests_dir.join("manifest.yaml");
+    assert!(yaml_path.exists(), "synced YAML should be written");
+}
+
+#[test]
+fn test_manifest_sync_no_repo_dir() {
+    let tmp = TempDir::new().unwrap();
+    let workspace = tmp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    let workspace_path = workspace.to_path_buf();
+    let result = gitgrip::cli::commands::manifest::run_manifest_sync(&workspace_path);
+    assert!(result.is_err(), "sync without .repo/ should fail");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains(".repo"),
+        "error should mention .repo: {}",
+        err_msg
+    );
+}

--- a/tests/test_platform_bitbucket.rs
+++ b/tests/test_platform_bitbucket.rs
@@ -1,0 +1,185 @@
+//! Integration tests for the Bitbucket platform adapter using wiremock.
+//!
+//! Tests the BitbucketAdapter against mock HTTP responses, verifying correct
+//! API interaction without requiring real Bitbucket credentials or network access.
+
+mod common;
+
+use common::mock_platform::*;
+use gitgrip::platform::traits::HostingPlatform;
+use gitgrip::platform::CheckState;
+
+// ── PR Create ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bb_create_pr() {
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_create_pr(&server, 10).await;
+
+    let result = adapter
+        .create_pull_request("owner", "repo", "feat/test", "main", "Test PR", None, false)
+        .await;
+
+    assert!(result.is_ok(), "create PR should succeed: {:?}", result);
+    let pr = result.unwrap();
+    assert_eq!(pr.number, 10);
+    assert!(pr.url.contains("bitbucket.org"));
+}
+
+// ── PR Get ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bb_get_pr_open() {
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_get_pr(&server, 10, "OPEN").await;
+
+    let result = adapter.get_pull_request("owner", "repo", 10).await;
+
+    assert!(result.is_ok(), "get PR should succeed: {:?}", result);
+    let pr = result.unwrap();
+    assert_eq!(pr.number, 10);
+    assert!(!pr.merged);
+    assert_eq!(pr.state, gitgrip::platform::PRState::Open);
+    assert_eq!(pr.head.ref_name, "feat/test");
+    assert_eq!(pr.base.ref_name, "main");
+}
+
+#[tokio::test]
+async fn test_bb_get_pr_merged() {
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_get_pr(&server, 10, "MERGED").await;
+
+    let result = adapter.get_pull_request("owner", "repo", 10).await;
+
+    assert!(result.is_ok());
+    let pr = result.unwrap();
+    assert!(pr.merged);
+    assert_eq!(pr.state, gitgrip::platform::PRState::Merged);
+}
+
+// ── PR Merge ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bb_merge_pr() {
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_merge_pr(&server, 10).await;
+
+    let result = adapter
+        .merge_pull_request("owner", "repo", 10, None, false)
+        .await;
+
+    assert!(result.is_ok(), "merge should succeed: {:?}", result);
+    assert!(result.unwrap(), "PR should be merged");
+}
+
+// ── Find PR by Branch ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bb_find_pr_by_branch() {
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_find_pr(&server, vec![(10, "feat/test")]).await;
+
+    let result = adapter
+        .find_pr_by_branch("owner", "repo", "feat/test")
+        .await;
+
+    assert!(result.is_ok(), "find PR should succeed: {:?}", result);
+    let pr = result.unwrap();
+    assert!(pr.is_some(), "should find PR for branch");
+    assert_eq!(pr.unwrap().number, 10);
+}
+
+#[tokio::test]
+async fn test_bb_find_pr_not_found() {
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_find_pr(&server, vec![]).await;
+
+    let result = adapter
+        .find_pr_by_branch("owner", "repo", "feat/nonexistent")
+        .await;
+
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_none(), "should not find PR");
+}
+
+// ── Status Checks ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bb_status_checks() {
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_status_checks(
+        &server,
+        "abc123",
+        vec![("CI", "SUCCESSFUL"), ("Lint", "SUCCESSFUL")],
+    )
+    .await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(result.is_ok(), "should get checks: {:?}", result);
+    let checks = result.unwrap();
+    assert_eq!(checks.state, CheckState::Success);
+    assert_eq!(checks.statuses.len(), 2);
+}
+
+// ── Approval ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bb_is_approved() {
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_reviewers(&server, 10, vec![true, true]).await;
+
+    let result = adapter.is_pull_request_approved("owner", "repo", 10).await;
+
+    assert!(result.is_ok());
+    assert!(result.unwrap(), "PR with all approvals should be approved");
+}
+
+// ── URL Parsing ──────────────────────────────────────────────────
+
+#[test]
+fn test_bb_parse_repo_url_ssh() {
+    let adapter = gitgrip::platform::bitbucket::BitbucketAdapter::new(None);
+    let info = adapter
+        .parse_repo_url("git@bitbucket.org:myteam/my-repo.git")
+        .expect("should parse SSH URL");
+    assert_eq!(info.owner, "myteam");
+    assert_eq!(info.repo, "my-repo");
+}
+
+#[test]
+fn test_bb_parse_repo_url_https() {
+    let adapter = gitgrip::platform::bitbucket::BitbucketAdapter::new(None);
+    let info = adapter
+        .parse_repo_url("https://bitbucket.org/myteam/my-repo.git")
+        .expect("should parse HTTPS URL");
+    assert_eq!(info.owner, "myteam");
+    assert_eq!(info.repo, "my-repo");
+}
+
+// ── Linked PR Comment ──────────────────────────────────────────────
+
+#[test]
+fn test_bb_linked_pr_comment() {
+    let adapter = gitgrip::platform::bitbucket::BitbucketAdapter::new(None);
+
+    let links = vec![
+        gitgrip::platform::traits::LinkedPRRef {
+            repo_name: "frontend".to_string(),
+            number: 42,
+        },
+        gitgrip::platform::traits::LinkedPRRef {
+            repo_name: "backend".to_string(),
+            number: 99,
+        },
+    ];
+
+    let comment = adapter.generate_linked_pr_comment(&links);
+    let parsed = adapter.parse_linked_pr_comment(&comment);
+
+    assert_eq!(parsed.len(), 2);
+    assert_eq!(parsed[0].repo_name, "frontend");
+    assert_eq!(parsed[0].number, 42);
+    assert_eq!(parsed[1].repo_name, "backend");
+    assert_eq!(parsed[1].number, 99);
+}

--- a/tests/test_rebase.rs
+++ b/tests/test_rebase.rs
@@ -1,0 +1,106 @@
+//! Integration tests for the rebase command.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use common::git_helpers;
+
+#[test]
+fn test_rebase_on_default_branch_skips() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_repo("lib")
+        .build();
+
+    let manifest = ws.load_manifest();
+
+    // All repos are on main (default branch) → rebase should skip all and succeed
+    let result = gitgrip::cli::commands::rebase::run_rebase(
+        &ws.workspace_root,
+        &manifest,
+        None,
+        false,
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "rebase on default branch should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_rebase_on_feature_branch() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let manifest = ws.load_manifest();
+
+    // Create a feature branch
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/rebase-test");
+
+    // Add a commit on the feature branch
+    git_helpers::commit_file(
+        &ws.repo_path("app"),
+        "feature.txt",
+        "feature content",
+        "Add feature",
+    );
+
+    let result = gitgrip::cli::commands::rebase::run_rebase(
+        &ws.workspace_root,
+        &manifest,
+        Some("origin/main"),
+        false,
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "rebase on feature branch should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_rebase_abort_no_rebase() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let manifest = ws.load_manifest();
+
+    // Abort with no rebase in progress → should succeed (no-op)
+    let result = gitgrip::cli::commands::rebase::run_rebase(
+        &ws.workspace_root,
+        &manifest,
+        None,
+        true, // abort
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "abort with no rebase should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_rebase_missing_repo() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    // Remove the repo directory to simulate a missing repo
+    std::fs::remove_dir_all(ws.repo_path("app")).unwrap();
+
+    let manifest = ws.load_manifest();
+
+    // Should gracefully skip missing repos
+    let result = gitgrip::cli::commands::rebase::run_rebase(
+        &ws.workspace_root,
+        &manifest,
+        None,
+        false,
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "rebase with missing repo should succeed: {:?}",
+        result.err()
+    );
+}

--- a/tests/test_repo_commands.rs
+++ b/tests/test_repo_commands.rs
@@ -1,0 +1,292 @@
+//! Integration tests for the repo management commands (list, add, remove).
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use std::fs;
+
+// ── repo list ──────────────────────────────────────────────────────
+
+#[test]
+fn test_repo_list_basic() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::repo::run_repo_list(&ws.workspace_root, &manifest);
+    assert!(
+        result.is_ok(),
+        "repo list should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_repo_list_with_missing_repo() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+
+    // Remove one repo to simulate "not cloned"
+    fs::remove_dir_all(ws.repo_path("backend")).unwrap();
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::repo::run_repo_list(&ws.workspace_root, &manifest);
+    assert!(
+        result.is_ok(),
+        "repo list with missing repo should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_repo_list_with_reference_repos() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_reference_repo("docs")
+        .build();
+
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::repo::run_repo_list(&ws.workspace_root, &manifest);
+    assert!(
+        result.is_ok(),
+        "repo list with reference repos should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── repo add ──────────────────────────────────────────────────────
+
+#[test]
+fn test_repo_add_https_url() {
+    let ws = WorkspaceBuilder::new().add_repo("existing").build();
+
+    let result = gitgrip::cli::commands::repo::run_repo_add(
+        &ws.workspace_root,
+        "https://github.com/owner/new-repo.git",
+        None,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "repo add should succeed: {:?}",
+        result.err()
+    );
+
+    // Verify the manifest was updated
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let content = fs::read_to_string(&manifest_path).unwrap();
+    assert!(
+        content.contains("new-repo"),
+        "manifest should contain new repo"
+    );
+}
+
+#[test]
+fn test_repo_add_ssh_url() {
+    let ws = WorkspaceBuilder::new().add_repo("existing").build();
+
+    let result = gitgrip::cli::commands::repo::run_repo_add(
+        &ws.workspace_root,
+        "git@github.com:owner/ssh-repo.git",
+        None,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "repo add with SSH URL should succeed: {:?}",
+        result.err()
+    );
+
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let content = fs::read_to_string(&manifest_path).unwrap();
+    assert!(
+        content.contains("ssh-repo"),
+        "manifest should contain ssh-repo"
+    );
+}
+
+#[test]
+fn test_repo_add_custom_path() {
+    let ws = WorkspaceBuilder::new().add_repo("existing").build();
+
+    let result = gitgrip::cli::commands::repo::run_repo_add(
+        &ws.workspace_root,
+        "https://github.com/owner/repo.git",
+        Some("custom/path"),
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "repo add with custom path should succeed: {:?}",
+        result.err()
+    );
+
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let content = fs::read_to_string(&manifest_path).unwrap();
+    assert!(
+        content.contains("custom/path"),
+        "manifest should contain custom path"
+    );
+}
+
+#[test]
+fn test_repo_add_custom_branch() {
+    let ws = WorkspaceBuilder::new().add_repo("existing").build();
+
+    let result = gitgrip::cli::commands::repo::run_repo_add(
+        &ws.workspace_root,
+        "https://github.com/owner/repo.git",
+        None,
+        Some("develop"),
+    );
+    assert!(
+        result.is_ok(),
+        "repo add with custom branch should succeed: {:?}",
+        result.err()
+    );
+
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let content = fs::read_to_string(&manifest_path).unwrap();
+    assert!(
+        content.contains("develop"),
+        "manifest should contain develop branch"
+    );
+}
+
+#[test]
+fn test_repo_add_invalid_url() {
+    let ws = WorkspaceBuilder::new().add_repo("existing").build();
+
+    let result = gitgrip::cli::commands::repo::run_repo_add(
+        &ws.workspace_root,
+        "not-a-valid-url",
+        None,
+        None,
+    );
+    assert!(result.is_err(), "repo add with invalid URL should fail");
+}
+
+// ── repo remove ──────────────────────────────────────────────────────
+
+#[test]
+fn test_repo_remove_from_manifest() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+
+    let result = gitgrip::cli::commands::repo::run_repo_remove(
+        &ws.workspace_root,
+        "backend",
+        false, // don't delete files
+    );
+    assert!(
+        result.is_ok(),
+        "repo remove should succeed: {:?}",
+        result.err()
+    );
+
+    // Verify backend is no longer in manifest
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let content = fs::read_to_string(&manifest_path).unwrap();
+    assert!(
+        !content.contains("  backend:"),
+        "manifest should not contain backend repo entry"
+    );
+    // frontend should still be there
+    assert!(
+        content.contains("  frontend:"),
+        "manifest should still contain frontend"
+    );
+}
+
+#[test]
+fn test_repo_remove_with_delete_files() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+
+    let backend_path = ws.repo_path("backend");
+    assert!(backend_path.exists(), "backend should exist before removal");
+
+    let result = gitgrip::cli::commands::repo::run_repo_remove(
+        &ws.workspace_root,
+        "backend",
+        true, // delete files
+    );
+    assert!(
+        result.is_ok(),
+        "repo remove with delete should succeed: {:?}",
+        result.err()
+    );
+
+    assert!(
+        !backend_path.exists(),
+        "backend files should be deleted after removal"
+    );
+}
+
+#[test]
+fn test_repo_remove_nonexistent() {
+    let ws = WorkspaceBuilder::new().add_repo("frontend").build();
+
+    let result =
+        gitgrip::cli::commands::repo::run_repo_remove(&ws.workspace_root, "nonexistent", false);
+    assert!(result.is_err(), "removing nonexistent repo should fail");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("not found"),
+        "error should mention not found: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn test_repo_remove_preserves_files_by_default() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+
+    let backend_path = ws.repo_path("backend");
+
+    gitgrip::cli::commands::repo::run_repo_remove(
+        &ws.workspace_root,
+        "backend",
+        false, // don't delete files
+    )
+    .unwrap();
+
+    assert!(
+        backend_path.exists(),
+        "backend files should be preserved when delete_files=false"
+    );
+}

--- a/tests/test_run_env.rs
+++ b/tests/test_run_env.rs
@@ -1,0 +1,122 @@
+//! Integration tests for the run and env commands.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use std::fs;
+
+/// Helper: append workspace config with env and/or scripts to the manifest.
+fn write_workspace_manifest(ws: &common::fixtures::WorkspaceFixture, workspace_yaml: &str) {
+    let manifest_path = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let existing = fs::read_to_string(&manifest_path).unwrap();
+    let full = format!("{}\nworkspace:\n{}", existing, workspace_yaml);
+    fs::write(&manifest_path, full).unwrap();
+}
+
+// ── env ──────────────────────────────────────────────────────
+
+#[test]
+fn test_env_no_workspace_config() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::env::run_env(&ws.workspace_root, &manifest);
+    assert!(
+        result.is_ok(),
+        "env with no workspace config should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_env_with_vars() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_workspace_manifest(
+        &ws,
+        r#"  env:
+    NODE_ENV: production
+    LOG_LEVEL: debug
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result = gitgrip::cli::commands::env::run_env(&ws.workspace_root, &manifest);
+    assert!(
+        result.is_ok(),
+        "env with vars should succeed: {:?}",
+        result.err()
+    );
+}
+
+// ── run ──────────────────────────────────────────────────────
+
+#[test]
+fn test_run_list_no_scripts() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::run::run_run(
+        &ws.workspace_root,
+        &manifest,
+        None,
+        true, // list
+    );
+    assert!(
+        result.is_ok(),
+        "run list with no scripts should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_run_list_with_scripts() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    write_workspace_manifest(
+        &ws,
+        r#"  scripts:
+    build:
+      command: "echo building"
+    test:
+      command: "echo testing"
+"#,
+    );
+
+    let manifest = ws.load_manifest();
+    let result = gitgrip::cli::commands::run::run_run(
+        &ws.workspace_root,
+        &manifest,
+        None,
+        true, // list
+    );
+    assert!(
+        result.is_ok(),
+        "run list with scripts should succeed: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_run_nonexistent_script() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::run::run_run(
+        &ws.workspace_root,
+        &manifest,
+        Some("nonexistent"),
+        false,
+    );
+    assert!(result.is_err(), "running nonexistent script should fail");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("not found"),
+        "error should mention not found: {}",
+        err_msg
+    );
+}


### PR DESCRIPTION
## Summary

- Add 9 new integration test files covering previously untested commands and Phase 6 features
- Add Bitbucket mock helpers to `tests/common/mock_platform.rs`
- Total of ~75 new tests, all passing with clean clippy and fmt

## New Test Files

| File | Tests | Coverage |
|------|-------|----------|
| `test_ci.rs` | 12 | CI list, run, status, continue-on-error, JSON output |
| `test_manifest_cmd.rs` | 6 | Manifest import (XML to YAML), sync |
| `test_json_output.rs` | 6 | `--json` flag on status, diff, branch |
| `test_rebase.rs` | 4 | Rebase on default/feature branch, abort, missing repo |
| `test_run_env.rs` | 5 | Workspace scripts and env vars |
| `test_platform_bitbucket.rs` | 11 | Bitbucket adapter via wiremock mocks |
| `test_repo_commands.rs` | 12 | Repo list, add (HTTPS/SSH/custom), remove |
| `test_link.rs` | 7 | Link status, apply (copy/symlink), missing repo |
| `test_edge_cases.rs` | 14 | Group filters, staged diff, CI env, enterprise BB URLs, GC, commit amend |

## Test plan
- [x] `cargo build --tests` compiles cleanly
- [x] `cargo test` - all tests pass (0 failures)
- [x] `cargo clippy --all-features` - no warnings with `-D warnings`
- [x] `cargo fmt --check` - no formatting issues