### PR TITLE
chore: release v0.9.0

### DIFF
--- a/.claude/skills/gitgrip/SKILL.md
+++ b/.claude/skills/gitgrip/SKILL.md
@@ -83,7 +83,9 @@ gr pr status --json
 gr pr merge                  # Default merge
 gr pr merge -m squash        # Squash merge
 gr pr merge -m rebase        # Rebase merge
-gr pr merge --no-delete-branch  # Keep branches after merge
+gr pr merge --update         # Update branch from base if behind, then merge
+gr pr merge --auto           # Enable auto-merge (merges when checks pass)
+gr pr merge --force          # Merge even if checks pending
 ```
 
 ### File Linking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-02-05
+
+### Added
+- `gr pr merge --update` flag - automatically update branch from base when behind, then retry merge
+- `gr pr merge --auto` flag - enable auto-merge so PRs merge when all required checks pass
+- `BranchBehind` error variant - detects when PR branch is behind base and provides actionable hint
+- `BranchProtected` error variant - detects branch protection rule violations and suggests `--auto` or `--admin`
+- `update_branch` platform trait method with GitHub implementation (PUT update-branch API)
+- `enable_auto_merge` platform trait method with GitHub implementation (via `gh` CLI)
+- wiremock tests for branch-behind, branch-protected, update-branch success, and update-branch conflict scenarios
+
+### Changed
+- `merge_pull_request` in GitHub adapter now uses raw HTTP instead of octocrab for proper error classification
+  - octocrab swallowed HTTP response bodies, making it impossible to distinguish error types
+  - Now correctly parses 405 (branch behind), 403 (branch protected), and other failure modes
+- CI workflow no longer uses path filters - runs on every push/PR to main (#175)
+
+### Fixed
+- `gr pr merge` "not mergeable" message now suggests `--update` when branch may be behind base
+
 ## [0.8.0] - 2026-02-04
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,9 @@ All commands use `gr` (or `gitgrip`):
 - `gr commit` - Commit staged changes across all repos
 - `gr push` - Push current branch in all repos
 - `gr pr create/status/merge/checks/diff` - Linked PR workflow
+  - `gr pr merge --update` - Update branch from base if behind, then merge
+  - `gr pr merge --auto` - Enable auto-merge (merges when checks pass)
+  - `gr pr merge --force` - Merge even if checks pending
 - `gr repo add/list/remove` - Manage repositories
 - `gr link` - Manage copyfile/linkfile entries
 - `gr run` - Execute workspace scripts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"

--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ Merge all linked PRs atomically.
 | Option | Description |
 |--------|-------------|
 | `-m, --method <method>` | merge, squash, or rebase |
-| `--no-delete-branch` | Keep branches after merge |
 | `-f, --force` | Merge even if checks pending |
+| `-u, --update` | Update branch from base if behind, then retry merge |
+| `--auto` | Enable auto-merge (merges when all checks pass) |
 
 #### `gr repo add <url>`
 


### PR DESCRIPTION
## Summary
- Bump version 0.8.0 → 0.9.0
- Add CHANGELOG entry for v0.9.0 features (--update, --auto, better merge error handling)
- Update all documentation (README, CLAUDE.md, SKILL.md) with current pr merge flags
- Remove documentation for non-existent --no-delete-branch flag

## Changes in v0.9.0
- `gr pr merge --update` - update branch from base if behind, then retry merge
- `gr pr merge --auto` - enable auto-merge when checks pass
- Better error classification for merge failures (BranchBehind, BranchProtected)
- CI path filters removed (#175)