### PR TITLE
chore: simplify improvements workflow - create issues directly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,22 +356,19 @@ Test files are alongside the modules they test or in `tests/`.
 
 ## Continuous Improvement
 
-gitgrip is self-improving. When using `gr` commands, capture any friction or ideas in:
+gitgrip is self-improving. When you encounter friction, missing features, or bugs:
 
-```
-./IMPROVEMENTS.md
-```
+1. **Tell the user** about the friction point
+2. **Ask if they want a GitHub issue created** - e.g., "Want me to create an issue for this?"
+3. **Create the issue directly** with `gh issue create` if approved
 
-**Do NOT create GitHub issues directly.** Instead:
-1. Add observations to IMPROVEMENTS.md under "Pending Review"
-2. Prompt the user: "I added [observation] to IMPROVEMENTS.md. Want me to create an issue?"
-3. Only create issues after user approval
+No need to document in IMPROVEMENTS.md first - create issues directly to reduce overhead.
 
-### CRITICAL: Document When Falling Back to Raw Commands
+### CRITICAL: Report When Falling Back to Raw Commands
 
 **If you ever use raw `git` or `gh` commands, you MUST immediately:**
 
-1. Add an entry to `IMPROVEMENTS.md` explaining why `gr` couldn't handle the use case
-2. Tell the user about the friction point
+1. Tell the user about the friction point
+2. Ask if they want a GitHub issue created
 
 This is mandatory. Every workaround reveals a gap in `gr` that should be fixed.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -887,3 +887,27 @@ gh pr create --title "..." --body "..." --repo laynepenney/codi-workspace
 - The manifest repo wasn't being tracked as having changes by `gr`
 
 ---
+
+### Friction: `gr rebase` doesn't handle rebasing onto remote main
+
+**Discovered**: 2026-02-05 during PR merge tests implementation
+
+**Problem**: Feature branch was based on older version of main. When CI failed due to a function signature change on main (new `update` and `auto` parameters added to `run_pr_merge`), needed to rebase onto latest main to get the updated code.
+
+**Workaround used**: Raw `git fetch origin main && git rebase origin/main` followed by `gr push --force`
+
+**Raw commands used**:
+```bash
+git fetch origin main
+git rebase origin/main
+gr push --force
+```
+
+**Expected behavior**: `gr rebase main` or `gr rebase --onto main` that:
+1. Fetches latest from origin
+2. Rebases current branch onto origin/main across all repos with changes
+3. Handles conflicts with helpful messaging
+
+**Note**: This friction occurred twice during the same PR - once after the initial CI failure, and again after the first rebase when function signatures changed further.
+
+---


### PR DESCRIPTION
Simplify the IMPROVEMENTS.md workflow:

- Instead of documenting friction in IMPROVEMENTS.md first and then asking to create an issue, create issues directly
- Reduces overhead: no need to create a PR just to document a friction point
- IMPROVEMENTS.md remains for historical reference

Updated both workspace-level and gitgrip-level CLAUDE.md files.