### PR TITLE
feat: track griptree upstreams

### DIFF
--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -7,6 +7,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
+use gitgrip::core::griptree::GriptreeConfig;
+
 use super::git_helpers;
 
 /// A test workspace with temporary directories that are cleaned up on drop.
@@ -56,6 +58,16 @@ impl WorkspaceFixture {
         });
         gitgrip::core::manifest::Manifest::parse(&content).expect("failed to parse manifest")
     }
+}
+
+/// Write a minimal griptree config with a single repo upstream mapping.
+pub fn write_griptree_config(workspace_root: &Path, branch: &str, repo: &str, upstream: &str) {
+    let mut config = GriptreeConfig::new(branch, &workspace_root.to_string_lossy());
+    config
+        .repo_upstreams
+        .insert(repo.to_string(), upstream.to_string());
+    let config_path = workspace_root.join(".gitgrip").join("griptree.json");
+    config.save(&config_path).unwrap();
 }
 
 /// Builder for creating test workspaces.

--- a/tests/common/git_helpers.rs
+++ b/tests/common/git_helpers.rs
@@ -54,6 +54,15 @@ pub fn push_branch(repo_path: &Path, remote: &str, branch: &str) {
     git(repo_path, &["push", remote, branch]);
 }
 
+/// Fetch from a remote (optionally a single branch).
+pub fn fetch(repo_path: &Path, remote: &str, branch: Option<&str>) {
+    let mut args = vec!["fetch", remote];
+    if let Some(branch) = branch {
+        args.push(branch);
+    }
+    git(repo_path, &args);
+}
+
 /// Push with set-upstream.
 pub fn push_upstream(repo_path: &Path, remote: &str, branch: &str) {
     git(repo_path, &["push", "-u", remote, branch]);

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -139,7 +139,6 @@ fn test_checkout_create_flag() {
     assert_on_branch(&ws.repo_path("frontend"), "feat/new-feature");
     assert_on_branch(&ws.repo_path("backend"), "feat/new-feature");
 }
-
 #[test]
 fn test_checkout_skips_non_git_repo() {
     let ws = WorkspaceBuilder::new()


### PR DESCRIPTION
Add griptree metadata for per-repo upstream defaults, update sync/rebase to use them, and add checkout --base. Includes a plan doc in docs/.