### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-02-08
+
+### Fixed
+- **Reference repo sync alignment** - `gr sync --reset-refs` now checks out the correct upstream branch before hard-resetting (#259)
+  - Warns before discarding uncommitted changes or unpushed commits
+  - Properly aligns reference repos to upstream branch (e.g., `origin/dev`) instead of staying on wrong branch
+  - New `checkout_branch_at_upstream` git helper with worktree conflict detection
+
+### Added
+- `gr tree return` command to switch back to main workspace (#254)
+- `gr sync --reset-refs` flag to hard-reset reference repos to upstream (#255)
+
 ## [0.11.0] - 2026-02-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
## Summary
- Bump version to 0.11.1
- Add CHANGELOG entry for v0.11.1 (reference repo sync fix, tree return, reset-refs)
- Update Cargo.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)