### PR TITLE
fix(sync): handle reset-refs when branch is locked in another worktree

### DIFF
--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -141,6 +141,28 @@ pub fn checkout_branch_at_upstream(
     Ok(())
 }
 
+/// Checkout a target in detached HEAD mode.
+///
+/// Useful when the corresponding local branch is locked in another worktree.
+pub fn checkout_detached(repo: &Repository, target: &str) -> Result<(), GitError> {
+    let repo_path = super::get_workdir(repo);
+
+    let mut cmd = Command::new("git");
+    cmd.args(["checkout", "--detach", "-f", target])
+        .current_dir(repo_path);
+    log_cmd(&cmd);
+    let output = cmd
+        .output()
+        .map_err(|e| GitError::OperationFailed(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GitError::OperationFailed(stderr.to_string()));
+    }
+
+    Ok(())
+}
+
 /// Check if a local branch exists
 pub fn branch_exists(repo: &Repository, branch_name: &str) -> bool {
     let repo_path = super::get_workdir(repo);


### PR DESCRIPTION
Issue: #264\n\nWhen sync reset-refs targets an upstream branch that is checked out in another worktree, checkout -B fails and sync reports a repo failure.\n\nThis change adds a fallback path for reference repos:\n- try checkout at upstream branch\n- if branch is locked in another worktree, fallback to detached checkout at upstream\n- hard reset to upstream in both paths\n\nAlso adds regression coverage for the locked-branch worktree scenario.