### PR TITLE
chore: release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-02-09
+
+### Fixed
+- **Griptree registry resolution** - `gr tree list` now resolves griptrees from the main workspace when run inside a griptree (#263)
+  - Also applies to `gr tree remove`, `gr tree lock`, and `gr tree unlock`
+  - Added regression coverage for list/remove/lock from griptree workspaces
+- **Worktree-safe ref reset** - `gr sync --reset-refs` now falls back to detached checkout when target branch is locked by another worktree (#265)
+  - Prevents false failures when refs are shared across multiple worktrees
+  - Keeps hard reset behavior and adds explicit fallback status output
+
 ## [0.11.1] - 2026-02-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
Release prep for v0.11.2:\n- bump Cargo version to 0.11.2\n- update Cargo.lock package version\n- add CHANGELOG entry for #263 and #265\n\nValidation:\n- cargo build --release