### PR TITLE
feat: auto-track griptree base branches to upstream defaults

### DIFF
--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -437,6 +437,31 @@ pub fn set_upstream_branch(repo: &Repository, remote: &str) -> Result<(), GitErr
     Ok(())
 }
 
+/// Set upstream tracking for a specific local branch.
+pub fn set_branch_upstream_ref(
+    repo: &Repository,
+    branch_name: &str,
+    upstream: &str,
+) -> Result<(), GitError> {
+    split_upstream_ref(upstream)?;
+
+    let repo_path = super::get_workdir(repo);
+    let mut cmd = Command::new("git");
+    cmd.args(["branch", "--set-upstream-to", upstream, branch_name])
+        .current_dir(repo_path);
+    log_cmd(&cmd);
+    let output = cmd
+        .output()
+        .map_err(|e| GitError::OperationFailed(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GitError::OperationFailed(stderr.to_string()));
+    }
+
+    Ok(())
+}
+
 /// Hard reset to a target
 pub fn reset_hard(repo: &Repository, target: &str) -> Result<(), GitError> {
     let repo_path = super::get_workdir(repo);

--- a/tests/common/git_helpers.rs
+++ b/tests/common/git_helpers.rs
@@ -88,6 +88,25 @@ pub fn current_branch(repo_path: &Path) -> String {
     git_output(repo_path, &["rev-parse", "--abbrev-ref", "HEAD"])
 }
 
+/// Get upstream tracking branch for a local branch.
+pub fn branch_upstream(repo_path: &Path, branch_name: &str) -> Option<String> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args([
+            "rev-parse",
+            "--abbrev-ref",
+            &format!("{}@{{upstream}}", branch_name),
+        ])
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run git rev-parse for upstream: {}", e));
+
+    if !output.status.success() {
+        return None;
+    }
+
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 /// Check if recent log output contains a message.
 pub fn log_contains(repo_path: &Path, message: &str) -> bool {
     git_output(repo_path, &["log", "--oneline", "-n", "10"]).contains(message)

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -122,6 +122,15 @@ fn test_tree_add_writes_repo_upstreams() {
 
     assert_eq!(config["repoUpstreams"]["app"], "origin/main");
     assert_eq!(config["repoUpstreams"]["lib"], "origin/dev");
+
+    assert_eq!(
+        git_helpers::branch_upstream(&tree_path.join("app"), "feat/upstream"),
+        Some("origin/main".to_string())
+    );
+    assert_eq!(
+        git_helpers::branch_upstream(&tree_path.join("lib"), "feat/upstream"),
+        Some("origin/dev".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What\n- set griptree worktree branches to track each repo's upstream default (for example  or ) during \n- teach 
Syncing 13 repositories...

✓ tooling: Branch 'feat/griptree-base-upstream' has local commits not in 'main'. Push your changes or merge manually.
✓ aider: pulled (origin/main)
✓ tabby: pulled (origin/main)
✓ crush: pulled (origin/main)
✓ openhands: pulled (origin/main)
✓ cline: pulled (origin/main)
✓ opencode: skipped - branch 'codi-gripspace' has local commits not in 'origin/dev'
✓ codex: pulled (origin/main)
✓ strategy: pulled (origin/main)
✓ private: pulled (origin/main)
✓ public: pulled (origin/main)
✓ homebrew-tap: pulled (origin/main)

⚠ 12 synced, 1 failed

  ✗ manifest: error - Operation failed: Branch 'main' is checked out in another worktree at '/Users/layne/Development/codi-workspace/.gitgrip/manifests'. Either use that worktree or create a new branch with 'gr branch <name>' to self-heal upstream tracking for griptree base branches based on \n- add integration coverage for tree creation tracking + sync repair behavior\n\n## Why\nThis removes manual alignment work in griptrees and keeps base branches consistently synced to upstream defaults.\n\n## Validation\n- \n- 