### PR TITLE
chore: release gitgrip v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - 2026-02-09
+
+### Changed
+- **Griptree branch tracking at creation** - `gr tree add` now sets each repo's griptree branch to track its upstream default (`origin/main`, `origin/dev`, etc.) (#267)
+- **Griptree sync self-healing** - `gr sync` now repairs branch upstream tracking when on the griptree base branch, using per-repo mapping from `griptree.json` (#267)
+
+### Documentation
+- Updated workflow docs to prefer `gr checkout --base` after merge cleanup
+- Updated command docs to include `gr tree return` and `gr sync --reset-refs`
+
+### Testing
+- Added integration coverage for upstream tracking during `gr tree add`
+- Added integration coverage for upstream tracking repair during `gr sync`
+
 ## [0.11.2] - 2026-02-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ gr sync
 | `gr tree add <branch>` | Create a worktree-based workspace |
 | `gr tree list` | List all griptrees |
 | `gr tree remove <branch>` | Remove a griptree |
+| `gr tree return` | Return to griptree base branch, sync, and optionally prune feature branch |
 | `gr pull` | Pull latest changes across repos |
 | `gr rebase` | Rebase across repos |
 | `gr rebase --upstream` | Rebase onto per-repo upstream (griptree-aware) |
@@ -206,6 +207,7 @@ Pull latest changes from the manifest and all repositories. Syncs in parallel by
 | `--sequential` | Sync repos one at a time (slower but ordered output) |
 | `--group <name>` | Only sync repos in this group |
 | `-f, --force` | Force sync even with local changes |
+| `--reset-refs` | Hard-reset reference repos to configured upstream branches |
 
 #### `gr status`
 
@@ -424,7 +426,11 @@ gr tree remove feat/new-feature
 Each griptree records per-repo upstream defaults so repos can track different branches:
 
 ```bash
+# tree add sets branch tracking to each repo's configured upstream
+gr tree add feat/new-feature
+
 # Sync uses per-repo upstream when on the griptree base branch
+# and repairs missing upstream tracking automatically
 gr sync
 
 # Rebase onto each repo's configured upstream
@@ -432,6 +438,9 @@ gr rebase --upstream
 
 # Return to the griptree base branch
 gr checkout --base
+
+# Optional all-in-one post-merge return flow
+gr tree return --autostash --prune-current --prune-remote
 ```
 
 **Benefits:**

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -17,6 +17,7 @@ gr branch feat/name          # Create branch across all repos
 gr checkout feat/name        # Switch branch across all repos
 gr checkout -b feat/name     # Create and switch to new branch
 gr checkout --base           # Return to griptree base branch
+gr tree return               # Return + sync + optional prune flow
 gr add .                     # Stage all changes
 gr diff                      # Show diff across all repos
 gr commit -m "message"       # Commit staged changes
@@ -44,6 +45,7 @@ gr prune --execute           # Actually delete merged branches
 gr sync                      # Pull + process links + run hooks (parallel)
 gr sync --sequential         # Sync repos one at a time
 gr sync --group core         # Sync only repos in 'core' group
+gr sync --reset-refs         # Hard-reset reference repos to upstream
 ```
 
 ### Branching
@@ -122,9 +124,10 @@ gr tree lock feat/auth       # Prevent accidental removal
 gr tree unlock feat/auth     # Allow removal
 gr tree remove feat/auth     # Remove when done
 gr checkout --base           # Return to griptree base branch
+gr tree return --prune-current --prune-remote # Return + cleanup
 ```
 
-**Upstream Tracking:** Each griptree records per-repo upstream defaults. `gr sync` and `gr rebase --upstream` use these automatically when on the griptree base branch.
+**Upstream Tracking:** Each griptree records per-repo upstream defaults. `gr tree add` sets tracking for the griptree branch, and `gr sync`/`gr rebase --upstream` use this mapping automatically when on the griptree base branch.
 
 ### Maintenance
 ```bash
@@ -175,7 +178,7 @@ gr pr create -t "feat: my feature"
 # Wait for CI, review
 gr pr merge
 gr sync
-gr checkout main
+gr checkout --base
 gr prune --execute           # Clean up merged branches
 ```
 


### PR DESCRIPTION
What:\n- bump gitgrip crate version to 0.11.3\n- add changelog entry for griptree upstream-tracking auto-repair and tree-add tracking behavior\n- align docs with current workflows (gr tree return, gr sync --reset-refs, and gr checkout --base)\n\nValidation:\n- cargo test --test test_tree test_tree_add_writes_repo_upstreams -- --nocapture\n- cargo test --test test_sync test_sync_sets_tracking_upstream_for_griptree_base_branch -- --nocapture