### PR TITLE
Integrate gripspace-layout into gripspace-includes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ src/
 ## Key Concepts
 
 ### Manifest
-Workspace configuration in `.gitgrip/manifests/manifest.yaml`:
+Workspace configuration in `.gitgrip/spaces/main/gripspace.yml`:
 - `repos`: Repository definitions with URL, path, default_branch
 - `manifest`: Self-tracking for the manifest repo itself
 - `workspace`: Scripts, hooks, and environment variables
@@ -324,7 +324,7 @@ gr tree add feat/auth
 # ../feat-auth/
 #   ├── codi/           # worktree of main/codi on feat/auth
 #   ├── codi-private/   # worktree of main/codi-private on feat/auth
-#   └── .gitgrip/manifests/  # worktree of manifest on feat/auth
+#   └── .gitgrip/spaces/main/  # worktree of manifest on feat/auth
 
 # List all griptrees
 gr tree list

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cargo install --path .
 
 ### 1. Create a manifest repository
 
-Create a new repo to hold your workspace manifest (e.g., `my-workspace`), then add a `manifest.yaml`:
+Create a new repo to hold your workspace config (e.g., `my-workspace`), then add a `gripspace.yml`:
 
 ```yaml
 version: 1
@@ -110,7 +110,7 @@ gr init --from-dirs --dirs ./frontend ./backend
 gr init --from-dirs --interactive
 ```
 
-This creates `.gitgrip/manifests/` with the manifest configuration.
+This creates `.gitgrip/spaces/main/gripspace.yml` (with legacy `.gitgrip/manifests/manifest.yaml` compatibility).
 
 ### 3. Start working
 
@@ -283,9 +283,9 @@ Environment variables available in command:
 - `REPO_PATH` - Absolute path to repo
 - `REPO_URL` - Repository URL
 
-## Manifest Format
+## Gripspace Format
 
-The manifest file (`manifest.yaml`) defines your workspace:
+The workspace file (`gripspace.yml`) defines your workspace:
 
 ```yaml
 version: 1

--- a/docs/GRIPSPACE_LAYOUT_PLAN.md
+++ b/docs/GRIPSPACE_LAYOUT_PLAN.md
@@ -1,0 +1,107 @@
+# Gripspace Layout Plan
+
+## Status
+
+- Implemented in codebase now:
+  - Canonical workspace file path: `.gitgrip/spaces/main/gripspace.yml`
+  - Legacy fallback reads:
+    - `.gitgrip/manifests/manifest.yaml`
+    - `.gitgrip/manifests/manifest.yml`
+  - Command path resolution now prefers canonical layout and falls back to legacy.
+- Not yet implemented:
+  - Loading and merging `.gitgrip/spaces/local/gripspace.yml`
+  - `include:` expansion across gripspace files
+
+## Goals
+
+1. Make `gripspace.yml` the default, explicit workspace format.
+2. Separate shareable workspace config (`main`) from user/local overrides (`local`).
+3. Support reusable composition with `include:` while keeping deterministic behavior.
+4. Preserve backward compatibility for existing workspaces during migration.
+
+## Canonical Layout
+
+```text
+.gitgrip/
+  spaces/
+    main/
+      gripspace.yml        # tracked/shared workspace definition
+    local/
+      gripspace.yml        # optional local overrides (not shared by default)
+```
+
+Legacy compatibility during migration:
+
+```text
+.gitgrip/manifests/manifest.yaml
+.gitgrip/manifests/manifest.yml
+```
+
+## Merge Model (Main + Local)
+
+Load order (lowest to highest precedence):
+
+1. `spaces/main/gripspace.yml`
+2. `spaces/local/gripspace.yml` (if present)
+
+Proposed merge rules:
+
+- Scalars (`version`, `settings.*`): local overrides main.
+- Maps (`repos`, `workspace.env`, `workspace.scripts`, `workspace.ci.pipelines`): deep-merge by key, local key wins on conflict.
+- Arrays:
+  - `groups`: union with stable order (main first, then new local entries).
+  - `copyfile` / `linkfile`: concatenate with de-dup by `(src,dest)`, local wins on duplicate.
+
+## `include:` Design
+
+Proposed schema extension (top-level):
+
+```yaml
+include:
+  - ../shared/base.gripspace.yml
+  - ./team/mobile.gripspace.yml
+```
+
+Rules:
+
+- Includes are resolved relative to the file that declares them.
+- Includes are processed depth-first, then merged in declaration order.
+- Current file overrides included content.
+- Cycles are rejected with a clear error chain.
+- Missing include file is a hard error by default.
+
+## Validation and Guardrails
+
+- Enforce workspace-bound paths after normalization.
+- Reject path traversal (`..`) and absolute include paths by default.
+- Error messages should include:
+  - failing file path
+  - include parent path
+  - merge key conflict context where possible
+
+## Migration Plan
+
+1. **Read compatibility** (done): prefer canonical, fallback to legacy.
+2. **Write default** (done): new workspaces write `spaces/main/gripspace.yml`.
+3. **Optional migration command** (planned):
+   - `gr manifest migrate-layout`
+   - Moves/copies legacy manifest to canonical layout.
+   - Optionally leaves a compatibility mirror.
+4. **Deprecation window**:
+   - keep legacy reads for N minor versions
+   - emit warnings when legacy path is the active source
+
+## Testing Plan
+
+- Unit tests:
+  - path resolution preference/fallback
+  - include cycle detection
+  - merge conflict behavior
+- Integration tests:
+  - commands run from canonical layout only
+  - commands run with legacy-only layout
+  - main+local overlay behavior
+  - include chains and error paths
+- Regression tests:
+  - griptree add/remove/return with manifest worktree at `spaces/main`
+  - sync/rebase/status behavior unchanged for non-manifest repos

--- a/docs/MANIFEST.md
+++ b/docs/MANIFEST.md
@@ -1,6 +1,8 @@
-# Manifest Reference
+# Gripspace Reference
 
-The manifest file (`manifest.yaml`) defines your multi-repository workspace configuration. It is typically located at `.gitgrip/manifests/manifest.yaml`.
+The workspace file (`gripspace.yml`) defines your multi-repository workspace configuration. The canonical location is `.gitgrip/spaces/main/gripspace.yml`.
+
+Legacy locations (`.gitgrip/manifests/manifest.yaml` and `.gitgrip/manifests/manifest.yml`) are still read for backward compatibility.
 
 ## Quick Start
 

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -198,7 +198,7 @@ gr pr create -t "title"
 
 ## Manifest Location
 
-The workspace manifest is at `.gitgrip/manifests/manifest.yaml`. Use `gr manifest schema` to view the schema.
+The canonical workspace manifest is `.gitgrip/spaces/main/gripspace.yml` (legacy `.gitgrip/manifests/manifest.yaml` is still supported). Use `gr manifest schema` to view the schema.
 
 ## Multi-Platform Support
 

--- a/docs/manifest-schema.yaml
+++ b/docs/manifest-schema.yaml
@@ -1,8 +1,8 @@
 # gitgrip Manifest Schema Specification
 # Version: 1
 #
-# This document describes the structure of a gitgrip manifest.yaml file.
-# The manifest defines a multi-repository workspace configuration.
+# This document describes the structure of a gitgrip gripspace.yml file.
+# The workspace file defines a multi-repository workspace configuration.
 
 # Schema version (required)
 version: 1

--- a/src/cli/commands/commit.rs
+++ b/src/cli/commands/commit.rs
@@ -2,6 +2,7 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
+use crate::core::manifest_paths;
 use crate::core::repo::RepoInfo;
 use crate::git::cache::invalidate_status_cache;
 use crate::git::{get_workdir, open_repo, path_exists};
@@ -61,28 +62,29 @@ pub fn run_commit(
     }
 
     // Also handle manifest worktree if it exists (in griptree scenario)
-    let manifests_dir = workspace_root.join(".gitgrip").join("manifests");
-    let manifests_git_dir = manifests_dir.join(".git");
-    if manifests_git_dir.exists() && path_exists(&manifests_dir) {
-        match open_repo(&manifests_dir) {
-            Ok(git_repo) => {
-                if has_staged_changes(&git_repo)? {
-                    match create_commit(&git_repo, message, amend) {
-                        Ok(commit_id) => {
-                            let short_id = &commit_id[..7.min(commit_id.len())];
-                            if amend {
-                                Output::success(&format!("manifest: amended ({})", short_id));
-                            } else {
-                                Output::success(&format!("manifest: committed ({})", short_id));
+    if let Some(manifests_dir) = manifest_paths::resolve_manifest_repo_dir(workspace_root) {
+        let manifests_git_dir = manifests_dir.join(".git");
+        if manifests_git_dir.exists() && path_exists(&manifests_dir) {
+            match open_repo(&manifests_dir) {
+                Ok(git_repo) => {
+                    if has_staged_changes(&git_repo)? {
+                        match create_commit(&git_repo, message, amend) {
+                            Ok(commit_id) => {
+                                let short_id = &commit_id[..7.min(commit_id.len())];
+                                if amend {
+                                    Output::success(&format!("manifest: amended ({})", short_id));
+                                } else {
+                                    Output::success(&format!("manifest: committed ({})", short_id));
+                                }
+                                success_count += 1;
+                                invalidate_status_cache(&manifests_dir);
                             }
-                            success_count += 1;
-                            invalidate_status_cache(&manifests_dir);
+                            Err(e) => Output::error(&format!("manifest: {}", e)),
                         }
-                        Err(e) => Output::error(&format!("manifest: {}", e)),
                     }
                 }
+                Err(e) => Output::warning(&format!("manifest: {}", e)),
             }
-            Err(e) => Output::warning(&format!("manifest: {}", e)),
         }
     }
 

--- a/src/cli/commands/env.rs
+++ b/src/cli/commands/env.rs
@@ -4,6 +4,7 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
+use crate::core::manifest_paths;
 use std::path::PathBuf;
 
 /// Run the env command
@@ -13,12 +14,10 @@ pub fn run_env(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Result<
 
     // Built-in environment variables
     println!("  GITGRIP_WORKSPACE={}", workspace_root.display());
-    println!(
-        "  GITGRIP_MANIFEST={}",
-        workspace_root
-            .join(".gitgrip/manifests/manifest.yaml")
-            .display()
-    );
+    let manifest_path = manifest_paths::resolve_workspace_manifest_path(workspace_root)
+        .or_else(|| manifest_paths::resolve_repo_manifest_path(workspace_root))
+        .unwrap_or_else(|| manifest_paths::default_workspace_manifest_path(workspace_root));
+    println!("  GITGRIP_MANIFEST={}", manifest_path.display());
 
     // Workspace-defined environment variables
     if let Some(ref workspace) = manifest.workspace {

--- a/src/cli/commands/group.rs
+++ b/src/cli/commands/group.rs
@@ -4,6 +4,7 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
+use crate::core::manifest_paths;
 use crate::core::repo::RepoInfo;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -229,31 +230,16 @@ pub fn run_group_create(_workspace_root: &PathBuf, name: &str) -> anyhow::Result
     Ok(())
 }
 
-/// Find the manifest.yaml path
+/// Find the workspace manifest path.
 fn find_manifest_path(workspace_root: &PathBuf) -> anyhow::Result<PathBuf> {
-    // Check .gitgrip/manifests/manifest.yaml first
-    let gitgrip_path = workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
-
-    if gitgrip_path.exists() {
-        return Ok(gitgrip_path);
+    if let Some(path) = manifest_paths::resolve_workspace_manifest_path(workspace_root) {
+        return Ok(path);
     }
-
-    // Check .repo/manifests/manifest.yaml
-    let repo_path = workspace_root
-        .join(".repo")
-        .join("manifests")
-        .join("manifest.yaml");
-
-    if repo_path.exists() {
-        return Ok(repo_path);
+    if let Some(path) = manifest_paths::resolve_repo_manifest_path(workspace_root) {
+        return Ok(path);
     }
 
     anyhow::bail!(
-        "No manifest.yaml found. Expected at:\n  {}\n  {}",
-        gitgrip_path.display(),
-        repo_path.display()
+        "No workspace manifest found in .gitgrip/spaces/main, .gitgrip/manifests, or .repo/manifests"
     )
 }

--- a/src/cli/commands/group.rs
+++ b/src/cli/commands/group.rs
@@ -121,7 +121,8 @@ pub fn run_group_add(
 
     // Write back
     let yaml = serde_yaml::to_string(&manifest)?;
-    std::fs::write(&manifest_path, yaml)?;
+    std::fs::write(&manifest_path, &yaml)?;
+    manifest_paths::sync_legacy_mirror_if_present(workspace_root, &manifest_path, &yaml)?;
 
     println!();
     if added_count > 0 {
@@ -200,7 +201,8 @@ pub fn run_group_remove(
 
     // Write back
     let yaml = serde_yaml::to_string(&manifest)?;
-    std::fs::write(&manifest_path, yaml)?;
+    std::fs::write(&manifest_path, &yaml)?;
+    manifest_paths::sync_legacy_mirror_if_present(workspace_root, &manifest_path, &yaml)?;
 
     println!();
     if removed_count > 0 {

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -449,10 +449,12 @@ async fn run_init_from_dirs(
         println!();
         println!("Next steps:");
         println!("  1. Review the manifest: cat .gitgrip/spaces/main/gripspace.yml");
+        println!("     (legacy mirror at .gitgrip/manifests/manifest.yaml for compatibility)");
         println!("  2. Run 'gr status' to verify your workspace");
     } else {
         println!("Next steps:");
         println!("  1. Review the manifest: cat .gitgrip/spaces/main/gripspace.yml");
+        println!("     (legacy mirror at .gitgrip/manifests/manifest.yaml for compatibility)");
         println!("  2. Add a remote to the manifest repo:");
         println!("     cd .gitgrip/spaces/main && git remote add origin <your-manifest-url>");
         println!("  3. Run 'gr status' to verify your workspace");

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -7,6 +7,7 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::{Manifest, PlatformType, RepoConfig};
+use crate::core::manifest_paths;
 use crate::git::clone_repo;
 use crate::platform;
 use crate::util::log_cmd;
@@ -173,8 +174,10 @@ fn run_init_from_url(url: Option<&str>, path: Option<&str>) -> anyhow::Result<()
 
     // Create .gitgrip directory structure
     let gitgrip_dir = target_dir.join(".gitgrip");
-    let manifests_dir = gitgrip_dir.join("manifests");
+    let manifests_dir = manifest_paths::main_space_dir(&target_dir);
+    let local_space_dir = manifest_paths::local_space_dir(&target_dir);
     std::fs::create_dir_all(&manifests_dir)?;
+    std::fs::create_dir_all(&local_space_dir)?;
 
     // Clone manifest repository
     let spinner = Output::spinner("Cloning manifest repository...");
@@ -190,13 +193,13 @@ fn run_init_from_url(url: Option<&str>, path: Option<&str>) -> anyhow::Result<()
         }
     }
 
-    // Verify manifest.yaml exists
-    let manifest_path = manifests_dir.join("manifest.yaml");
-    if !manifest_path.exists() {
+    // Verify a supported manifest filename exists in the space repo.
+    let manifest_path = manifest_paths::resolve_manifest_file_in_dir(&manifests_dir);
+    if manifest_path.is_none() {
         let _ = std::fs::remove_dir_all(&target_dir);
         anyhow::bail!(
-            "No manifest.yaml found in repository. \
-             Ensure the repository contains a manifest.yaml file at its root."
+            "No workspace manifest found in repository. \
+             Expected gripspace.yml (preferred) or manifest.yaml/manifest.yml at repo root."
         );
     }
 
@@ -279,13 +282,23 @@ async fn run_init_from_dirs(
     };
 
     // Create .gitgrip directory structure
-    let manifests_dir = gitgrip_dir.join("manifests");
+    let manifests_dir = manifest_paths::main_space_dir(&workspace_root);
+    let local_space_dir = manifest_paths::local_space_dir(&workspace_root);
     std::fs::create_dir_all(&manifests_dir)?;
+    std::fs::create_dir_all(&local_space_dir)?;
 
     // Write manifest
-    let manifest_path = manifests_dir.join("manifest.yaml");
+    let manifest_path = manifests_dir.join(manifest_paths::PRIMARY_FILE_NAME);
     let yaml_content = manifest_to_yaml(&manifest)?;
     std::fs::write(&manifest_path, &yaml_content)?;
+
+    // Compatibility mirror for legacy tooling/scripts.
+    let legacy_manifest_path = manifest_paths::legacy_manifest_dir(&workspace_root)
+        .join(manifest_paths::LEGACY_FILE_NAMES[0]);
+    if let Some(parent) = legacy_manifest_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&legacy_manifest_path, &yaml_content)?;
 
     // Create state file
     let state_path = gitgrip_dir.join("state.json");
@@ -395,13 +408,13 @@ async fn run_init_from_dirs(
         println!("Manifest remote: {}", url);
         println!();
         println!("Next steps:");
-        println!("  1. Review the manifest: cat .gitgrip/manifests/manifest.yaml");
+        println!("  1. Review the manifest: cat .gitgrip/spaces/main/gripspace.yml");
         println!("  2. Run 'gr status' to verify your workspace");
     } else {
         println!("Next steps:");
-        println!("  1. Review the manifest: cat .gitgrip/manifests/manifest.yaml");
+        println!("  1. Review the manifest: cat .gitgrip/spaces/main/gripspace.yml");
         println!("  2. Add a remote to the manifest repo:");
-        println!("     cd .gitgrip/manifests && git remote add origin <your-manifest-url>");
+        println!("     cd .gitgrip/spaces/main && git remote add origin <your-manifest-url>");
         println!("  3. Run 'gr status' to verify your workspace");
     }
 
@@ -636,7 +649,7 @@ fn run_interactive_init(
                 let yaml = manifest_to_yaml(&manifest)?;
 
                 println!();
-                println!("Generated manifest.yaml:");
+                println!("Generated gripspace.yml:");
                 println!("─────────────────────────────────────────");
                 println!("{}", yaml);
                 println!("─────────────────────────────────────────");
@@ -746,16 +759,19 @@ fn init_manifest_repo(manifests_dir: &Path) -> anyhow::Result<()> {
         anyhow::bail!("Failed to initialize manifest git repo: {}", stderr);
     }
 
-    // Stage manifest.yaml
+    let manifest_file = manifest_paths::resolve_manifest_file_in_dir(manifests_dir)
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .unwrap_or_else(|| manifest_paths::PRIMARY_FILE_NAME.to_string());
+
+    // Stage manifest file
     let mut cmd = Command::new("git");
-    cmd.args(["add", "manifest.yaml"])
-        .current_dir(manifests_dir);
+    cmd.args(["add", &manifest_file]).current_dir(manifests_dir);
     log_cmd(&cmd);
     let output = cmd.output()?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Failed to stage manifest.yaml: {}", stderr);
+        anyhow::bail!("Failed to stage {}: {}", manifest_file, stderr);
     }
 
     // Create initial commit

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -216,14 +216,14 @@ fn run_init_from_url(url: Option<&str>, path: Option<&str>) -> anyhow::Result<()
 
     if let Some(ref gripspaces) = manifest.gripspaces {
         if !gripspaces.is_empty() {
-            let gripspaces_dir = gitgrip_dir.join("gripspaces");
+            let spaces_dir = manifest_paths::spaces_dir(&target_dir);
             let spinner = Output::spinner(&format!(
                 "Cloning {} gripspace(s)...",
                 gripspaces.len()
             ));
 
             for gs_config in gripspaces {
-                if let Err(e) = ensure_gripspace(&gripspaces_dir, gs_config) {
+                if let Err(e) = ensure_gripspace(&spaces_dir, gs_config) {
                     Output::warning(&format!(
                         "Gripspace '{}' clone failed: {}",
                         gs_config.url, e
@@ -236,7 +236,7 @@ fn run_init_from_url(url: Option<&str>, path: Option<&str>) -> anyhow::Result<()
             spinner.finish_with_message("Gripspaces cloned");
 
             // Resolve gripspace includes
-            if let Err(e) = resolve_all_gripspaces(&mut manifest, &gripspaces_dir) {
+            if let Err(e) = resolve_all_gripspaces(&mut manifest, &spaces_dir) {
                 Output::warning(&format!("Gripspace resolution failed: {}", e));
             }
         }

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -4,6 +4,7 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
+use crate::core::manifest_paths;
 use crate::core::repo::RepoInfo;
 use crate::git::path_exists;
 use std::path::PathBuf;
@@ -98,7 +99,7 @@ fn show_link_status(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Re
 
     // Process manifest repo links
     if let Some(ref manifest_config) = manifest.manifest {
-        let manifests_dir = workspace_root.join(".gitgrip").join("manifests");
+        let manifests_dir = manifest_paths::resolve_manifest_content_dir(workspace_root);
 
         // Check manifest copyfiles
         if let Some(ref copyfiles) = manifest_config.copyfile {
@@ -303,7 +304,7 @@ fn apply_links(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Result<
 
     // Apply manifest repo links
     if let Some(ref manifest_config) = manifest.manifest {
-        let manifests_dir = workspace_root.join(".gitgrip").join("manifests");
+        let manifests_dir = manifest_paths::resolve_manifest_content_dir(workspace_root);
 
         if manifests_dir.exists() {
             // Apply manifest copyfiles
@@ -617,7 +618,7 @@ mod tests {
         let workspace = temp.path().to_path_buf();
 
         // Create manifest directory and source file
-        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let manifests_dir = workspace.join(".gitgrip").join("spaces").join("main");
         std::fs::create_dir_all(&manifests_dir).unwrap();
         std::fs::write(manifests_dir.join("CLAUDE.md"), "# Claude Guide").unwrap();
 

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -101,7 +101,7 @@ fn show_link_status(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Re
     // Process manifest repo links
     if let Some(ref manifest_config) = manifest.manifest {
         let manifests_dir = manifest_paths::resolve_manifest_content_dir(workspace_root);
-        let gripspaces_dir = workspace_root.join(".gitgrip").join("gripspaces");
+        let gripspaces_dir = manifest_paths::spaces_dir(workspace_root);
 
         // Check manifest copyfiles
         if let Some(ref copyfiles) = manifest_config.copyfile {
@@ -381,7 +381,7 @@ fn apply_links(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Result<
     // Apply manifest repo links
     if let Some(ref manifest_config) = manifest.manifest {
         let manifests_dir = manifest_paths::resolve_manifest_content_dir(workspace_root);
-        let gripspaces_dir = workspace_root.join(".gitgrip").join("gripspaces");
+        let gripspaces_dir = manifest_paths::spaces_dir(workspace_root);
 
         if manifests_dir.exists() {
             // Apply manifest copyfiles

--- a/src/cli/commands/manifest.rs
+++ b/src/cli/commands/manifest.rs
@@ -33,7 +33,7 @@ pub fn run_manifest_import(path: &str, output_path: Option<&str>) -> anyhow::Res
     let yaml = serde_yaml::to_string(&result.manifest)?;
 
     // Write output
-    let dest = output_path.unwrap_or("manifest.yaml");
+    let dest = output_path.unwrap_or("gripspace.yml");
     std::fs::write(dest, &yaml)?;
 
     println!();
@@ -63,11 +63,12 @@ pub fn run_manifest_sync(workspace_root: &std::path::PathBuf) -> anyhow::Result<
         result.total_projects, result.gerrit_skipped, result.non_gerrit_imported
     ));
 
-    // Write to .repo/manifests/manifest.yaml
+    // Write to .repo/manifests/gripspace.yml (with legacy mirror)
     let yaml = serde_yaml::to_string(&result.manifest)?;
     let manifests_dir = repo_dir.join("manifests");
-    let yaml_path = manifests_dir.join("manifest.yaml");
+    let yaml_path = manifests_dir.join("gripspace.yml");
     std::fs::write(&yaml_path, &yaml)?;
+    std::fs::write(manifests_dir.join("manifest.yaml"), &yaml)?;
 
     println!();
     Output::success(&format!("Updated: {}", yaml_path.display()));
@@ -107,8 +108,8 @@ fn print_schema_markdown() {
 
 ## Overview
 
-The manifest file (`manifest.yaml`) defines a multi-repository workspace configuration.
-It is typically located at `.gitgrip/manifests/manifest.yaml`.
+The workspace file (`gripspace.yml`) defines a multi-repository workspace configuration.
+It is typically located at `.gitgrip/spaces/main/gripspace.yml`.
 
 ## Top-Level Fields
 

--- a/src/cli/commands/repo.rs
+++ b/src/cli/commands/repo.rs
@@ -109,7 +109,12 @@ pub fn run_repo_add(
         format!("{}repos:{}", content, new_repo_yaml)
     };
 
-    std::fs::write(&manifest_path, updated_content)?;
+    std::fs::write(&manifest_path, &updated_content)?;
+    manifest_paths::sync_legacy_mirror_if_present(
+        workspace_root,
+        &manifest_path,
+        &updated_content,
+    )?;
 
     Output::success(&format!("Added repository '{}' to manifest", repo_name));
     println!();
@@ -177,7 +182,13 @@ pub fn run_repo_remove(
         }
     }
 
-    std::fs::write(&manifest_path, new_lines.join("\n"))?;
+    let updated_content = new_lines.join("\n");
+    std::fs::write(&manifest_path, &updated_content)?;
+    manifest_paths::sync_legacy_mirror_if_present(
+        workspace_root,
+        &manifest_path,
+        &updated_content,
+    )?;
 
     Output::success(&format!("Removed repository '{}' from manifest", name));
     Ok(())

--- a/src/cli/commands/repo.rs
+++ b/src/cli/commands/repo.rs
@@ -4,6 +4,7 @@
 
 use crate::cli::output::{Output, Table};
 use crate::core::manifest::Manifest;
+use crate::core::manifest_paths;
 use crate::core::repo::RepoInfo;
 use crate::git::path_exists;
 use std::path::PathBuf;
@@ -64,7 +65,8 @@ pub fn run_repo_add(
     let branch = default_branch.unwrap_or("main").to_string();
 
     // Load manifest
-    let manifest_path = workspace_root.join(".gitgrip/manifests/manifest.yaml");
+    let manifest_path = manifest_paths::resolve_manifest_path_for_update(workspace_root)
+        .ok_or_else(|| anyhow::anyhow!("No workspace manifest found to update"))?;
     let content = std::fs::read_to_string(&manifest_path)?;
 
     // Simple YAML append (for a proper implementation, use serde_yaml to read/write)
@@ -126,7 +128,8 @@ pub fn run_repo_remove(
     println!();
 
     // Load manifest to get repo path
-    let manifest_path = workspace_root.join(".gitgrip/manifests/manifest.yaml");
+    let manifest_path = manifest_paths::resolve_manifest_path_for_update(workspace_root)
+        .ok_or_else(|| anyhow::anyhow!("No workspace manifest found to update"))?;
     let content = std::fs::read_to_string(&manifest_path)?;
     let manifest = Manifest::parse(&content)?;
 

--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -35,7 +35,7 @@ pub fn run_run(
             _ => {
                 println!("  No scripts defined in manifest.");
                 println!();
-                println!("Define scripts in manifest.yaml:");
+                println!("Define scripts in gripspace.yml:");
                 println!("  workspace:");
                 println!("    scripts:");
                 println!("      build:");
@@ -83,7 +83,7 @@ pub fn run_run(
     } else {
         anyhow::bail!(
             "Script '{}' has no command or steps defined. \
-             Check your manifest.yaml workspace.scripts section.",
+             Check your gripspace.yml workspace.scripts section.",
             name
         );
     }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -132,13 +132,15 @@ pub fn run_status(
     // Show gripspace status
     if let Some(ref gripspaces) = manifest.gripspaces {
         if !gripspaces.is_empty() && !quiet {
-            let gripspaces_dir = workspace_root.join(".gitgrip").join("gripspaces");
+            let spaces_dir = manifest_paths::spaces_dir(workspace_root);
             println!();
             let mut gs_table = Table::new(vec!["Gripspace", "Rev", "Status"]);
 
             for gs in gripspaces {
                 let name = gripspace_name(&gs.url);
-                let gs_path = gripspaces_dir.join(&name);
+                let dir_name = crate::core::gripspace::resolve_space_name(&gs.url, &spaces_dir)
+                    .unwrap_or_else(|_| name.clone());
+                let gs_path = spaces_dir.join(&dir_name);
 
                 let (rev, status_str) = if gs_path.exists() {
                     let rev = get_gripspace_rev(&gs_path).unwrap_or_else(|| "unknown".to_string());

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -138,8 +138,16 @@ pub fn run_status(
 
             for gs in gripspaces {
                 let name = gripspace_name(&gs.url);
-                let dir_name = crate::core::gripspace::resolve_space_name(&gs.url, &spaces_dir)
-                    .unwrap_or_else(|_| name.clone());
+                let dir_name = match crate::core::gripspace::resolve_space_name(&gs.url, &spaces_dir)
+                {
+                    Ok(dir_name) => dir_name,
+                    Err(e) => {
+                        let rev = "—".to_string();
+                        let status_str = format!("error: {}", e);
+                        gs_table.add_row(vec![&Output::repo_name(&name), &rev, &status_str]);
+                        continue;
+                    }
+                };
                 let gs_path = spaces_dir.join(&dir_name);
 
                 let (rev, status_str) = if gs_path.exists() {

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -143,7 +143,12 @@ pub fn run_status(
                     Ok(dir_name) => dir_name,
                     Err(e) => {
                         let rev = "—".to_string();
-                        let status_str = format!("error: {}", e);
+                        // Extract the inner message from ManifestError::GripspaceError
+                        let msg = match &e {
+                            crate::core::manifest::ManifestError::GripspaceError(msg) => msg.clone(),
+                            other => other.to_string(),
+                        };
+                        let status_str = format!("error: {}", msg);
                         gs_table.add_row(vec![&Output::repo_name(&name), &rev, &status_str]);
                         continue;
                     }

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -2,6 +2,7 @@
 
 use crate::cli::output::{Output, Table};
 use crate::core::manifest::Manifest;
+use crate::core::manifest_paths;
 use crate::core::repo::{filter_repos, RepoInfo};
 use crate::git::path_exists;
 use crate::git::status::{get_repo_status, RepoStatus};
@@ -88,37 +89,43 @@ pub fn run_status(
     }
 
     // Show manifest worktree status if it exists
-    let manifests_dir = workspace_root.join(".gitgrip").join("manifests");
-    let manifests_git_dir = manifests_dir.join(".git");
-    if manifests_git_dir.exists() && path_exists(&manifests_dir) {
-        println!();
-        // Create a minimal RepoInfo for the manifest
-        let manifest_repo_info = RepoInfo {
-            name: "manifest".to_string(),
-            url: String::new(),
-            path: ".gitgrip/manifests".to_string(),
-            absolute_path: manifests_dir.clone(),
-            default_branch: "main".to_string(),
-            owner: String::new(),
-            repo: "manifests".to_string(),
-            platform_type: crate::core::manifest::PlatformType::GitHub,
-            platform_base_url: None,
-            project: None,
-            reference: false,
-            groups: Vec::new(),
-        };
+    if let Some(manifests_dir) = manifest_paths::resolve_manifest_repo_dir(workspace_root) {
+        let manifests_git_dir = manifests_dir.join(".git");
+        if manifests_git_dir.exists() && path_exists(&manifests_dir) {
+            println!();
+            let rel_path = manifests_dir
+                .strip_prefix(workspace_root)
+                .ok()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| manifest_paths::MAIN_SPACE_DIR.to_string());
+            // Create a minimal RepoInfo for the manifest
+            let manifest_repo_info = RepoInfo {
+                name: "manifest".to_string(),
+                url: String::new(),
+                path: rel_path,
+                absolute_path: manifests_dir.clone(),
+                default_branch: "main".to_string(),
+                owner: String::new(),
+                repo: "manifests".to_string(),
+                platform_type: crate::core::manifest::PlatformType::GitHub,
+                platform_base_url: None,
+                project: None,
+                reference: false,
+                groups: Vec::new(),
+            };
 
-        let status = get_repo_status(&manifest_repo_info);
-        let status_str = format_status(&status, verbose);
-        let main_str = format_main_comparison(&status, &manifest_repo_info.default_branch);
-        let mut manifest_table = Table::new(vec!["Repo", "Branch", "Status", "vs main"]);
-        manifest_table.add_row(vec![
-            &Output::repo_name("manifest"),
-            &Output::branch_name(&status.branch),
-            &status_str,
-            &main_str,
-        ]);
-        manifest_table.print();
+            let status = get_repo_status(&manifest_repo_info);
+            let status_str = format_status(&status, verbose);
+            let main_str = format_main_comparison(&status, &manifest_repo_info.default_branch);
+            let mut manifest_table = Table::new(vec!["Repo", "Branch", "Status", "vs main"]);
+            manifest_table.add_row(vec![
+                &Output::repo_name("manifest"),
+                &Output::branch_name(&status.branch),
+                &status_str,
+                &main_str,
+            ]);
+            manifest_table.print();
+        }
     }
 
     // Summary

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -112,10 +112,10 @@ pub async fn run_sync(
     if let Some(ref manifest_config) = manifest.manifest {
         if let Some(ref composefiles) = manifest_config.composefile {
             if !composefiles.is_empty() {
-                let manifests_dir = workspace_root.join(".gitgrip").join("manifests");
-                let gripspaces_dir = workspace_root.join(".gitgrip").join("gripspaces");
+                let manifests_dir = manifest_paths::resolve_manifest_content_dir(workspace_root);
+                let spaces_dir = manifest_paths::spaces_dir(workspace_root);
 
-                match process_composefiles(workspace_root, &manifests_dir, &gripspaces_dir, composefiles) {
+                match process_composefiles(workspace_root, &manifests_dir, &spaces_dir, composefiles) {
                     Ok(()) => {
                         if !quiet {
                             Output::success(&format!(
@@ -146,7 +146,7 @@ fn sync_gripspaces(
         _ => return Ok(manifest.clone()),
     };
 
-    let gripspaces_dir = workspace_root.join(".gitgrip").join("gripspaces");
+    let spaces_dir = manifest_paths::spaces_dir(workspace_root);
 
     if !quiet {
         Output::header(&format!("Syncing {} gripspace(s)...", gripspaces.len()));
@@ -155,7 +155,10 @@ fn sync_gripspaces(
 
     for gs_config in gripspaces {
         let name = gripspace_name(&gs_config.url);
-        let gs_path = gripspaces_dir.join(&name);
+        // Use resolve_space_name to find the actual directory (handles reserved names)
+        let dir_name = crate::core::gripspace::resolve_space_name(&gs_config.url, &spaces_dir)
+            .unwrap_or_else(|_| name.clone());
+        let gs_path = spaces_dir.join(&dir_name);
 
         if gs_path.exists() {
             match update_gripspace(&gs_path, gs_config) {
@@ -169,7 +172,7 @@ fn sync_gripspaces(
                 }
             }
         } else {
-            match ensure_gripspace(&gripspaces_dir, gs_config) {
+            match ensure_gripspace(&spaces_dir, gs_config) {
                 Ok(_) => {
                     if !quiet {
                         Output::success(&format!("gripspace '{}': cloned", name));
@@ -194,7 +197,7 @@ fn sync_gripspaces(
         manifest.clone()
     };
 
-    if let Err(e) = resolve_all_gripspaces(&mut resolved, &gripspaces_dir) {
+    if let Err(e) = resolve_all_gripspaces(&mut resolved, &spaces_dir) {
         Output::warning(&format!("Gripspace resolution failed: {}", e));
         return Ok(manifest.clone());
     }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -156,8 +156,17 @@ fn sync_gripspaces(
     for gs_config in gripspaces {
         let name = gripspace_name(&gs_config.url);
         // Use resolve_space_name to find the actual directory (handles reserved names)
-        let dir_name = crate::core::gripspace::resolve_space_name(&gs_config.url, &spaces_dir)
-            .unwrap_or_else(|_| name.clone());
+        let dir_name = match crate::core::gripspace::resolve_space_name(&gs_config.url, &spaces_dir)
+        {
+            Ok(dir_name) => dir_name,
+            Err(e) => {
+                Output::warning(&format!(
+                    "gripspace '{}': name resolution failed: {}",
+                    gs_config.url, e
+                ));
+                continue;
+            }
+        };
         let gs_path = spaces_dir.join(&dir_name);
 
         if gs_path.exists() {

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -201,7 +201,8 @@ fn sync_gripspaces(
 
     if let Err(e) = resolved.validate() {
         Output::warning(&format!(
-            "Resolved manifest validation failed after gripspace sync: {}",
+            "Resolved manifest validation failed after gripspace sync: {}. \
+Using the pre-sync manifest; check gripspace manifests/includes.",
             e
         ));
         return Ok(manifest.clone());

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -29,6 +29,17 @@ pub fn gripspace_name(url: &str) -> String {
     last.trim_end_matches(".git").to_string()
 }
 
+fn gripspace_identity(config: &GripspaceConfig) -> String {
+    let mut url = config.url.trim_end_matches('/').to_string();
+    if let Some(stripped) = url.strip_suffix(".git") {
+        url = stripped.to_string();
+    }
+    match &config.rev {
+        Some(rev) if !rev.is_empty() => format!("{}#{}", url, rev),
+        _ => url,
+    }
+}
+
 /// Ensure a gripspace is cloned locally. Returns the path to the gripspace directory.
 ///
 /// If the gripspace is already cloned, this is a no-op.
@@ -319,7 +330,8 @@ fn resolve_gripspace_recursive(
         )));
     }
 
-    if resolved.contains(&name) {
+    let resolved_key = gripspace_identity(config);
+    if resolved.contains(&resolved_key) {
         return Ok(());
     }
 
@@ -430,7 +442,7 @@ fn resolve_gripspace_recursive(
     }
 
     active_stack.remove(&name);
-    resolved.insert(name);
+    resolved.insert(resolved_key);
 
     Ok(())
 }

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -1,6 +1,6 @@
 //! Manifest parsing and validation
 //!
-//! The manifest file (manifest.yaml) defines the multi-repo workspace configuration.
+//! The workspace file (gripspace.yml) defines the multi-repo workspace configuration.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/core/manifest_paths.rs
+++ b/src/core/manifest_paths.rs
@@ -6,11 +6,20 @@
 
 use std::path::{Path, PathBuf};
 
+pub const SPACES_DIR: &str = ".gitgrip/spaces";
 pub const MAIN_SPACE_DIR: &str = ".gitgrip/spaces/main";
 pub const LOCAL_SPACE_DIR: &str = ".gitgrip/spaces/local";
 pub const LEGACY_MANIFEST_DIR: &str = ".gitgrip/manifests";
 pub const PRIMARY_FILE_NAME: &str = "gripspace.yml";
 pub const LEGACY_FILE_NAMES: [&str; 2] = ["manifest.yaml", "manifest.yml"];
+
+/// Names reserved for internal use within `.gitgrip/spaces/`.
+/// Included gripspaces that derive one of these names will be auto-suffixed.
+pub const RESERVED_SPACE_NAMES: [&str; 2] = ["main", "local"];
+
+pub fn spaces_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(SPACES_DIR)
+}
 
 pub fn main_space_dir(workspace_root: &Path) -> PathBuf {
     workspace_root.join(MAIN_SPACE_DIR)

--- a/src/core/manifest_paths.rs
+++ b/src/core/manifest_paths.rs
@@ -1,0 +1,177 @@
+//! Workspace manifest path/layout helpers.
+//!
+//! Supports both:
+//! - New layout: `.gitgrip/spaces/main/gripspace.yml`
+//! - Legacy layout: `.gitgrip/manifests/manifest.yaml`
+
+use std::path::{Path, PathBuf};
+
+pub const MAIN_SPACE_DIR: &str = ".gitgrip/spaces/main";
+pub const LOCAL_SPACE_DIR: &str = ".gitgrip/spaces/local";
+pub const LEGACY_MANIFEST_DIR: &str = ".gitgrip/manifests";
+pub const PRIMARY_FILE_NAME: &str = "gripspace.yml";
+pub const LEGACY_FILE_NAMES: [&str; 2] = ["manifest.yaml", "manifest.yml"];
+
+pub fn main_space_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(MAIN_SPACE_DIR)
+}
+
+pub fn local_space_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(LOCAL_SPACE_DIR)
+}
+
+pub fn legacy_manifest_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(LEGACY_MANIFEST_DIR)
+}
+
+pub fn default_workspace_manifest_path(workspace_root: &Path) -> PathBuf {
+    main_space_dir(workspace_root).join(PRIMARY_FILE_NAME)
+}
+
+pub fn default_local_manifest_path(workspace_root: &Path) -> PathBuf {
+    local_space_dir(workspace_root).join(PRIMARY_FILE_NAME)
+}
+
+pub fn resolve_manifest_file_in_dir(dir: &Path) -> Option<PathBuf> {
+    let primary = dir.join(PRIMARY_FILE_NAME);
+    if primary.exists() {
+        return Some(primary);
+    }
+
+    for legacy in LEGACY_FILE_NAMES {
+        let path = dir.join(legacy);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+pub fn resolve_workspace_manifest_path(workspace_root: &Path) -> Option<PathBuf> {
+    let new_dir = main_space_dir(workspace_root);
+    if let Some(path) = resolve_manifest_file_in_dir(&new_dir) {
+        return Some(path);
+    }
+
+    let legacy_dir = legacy_manifest_dir(workspace_root);
+    resolve_manifest_file_in_dir(&legacy_dir)
+}
+
+pub fn resolve_repo_manifest_path(workspace_root: &Path) -> Option<PathBuf> {
+    let repo_manifests_dir = workspace_root.join(".repo").join("manifests");
+    resolve_manifest_file_in_dir(&repo_manifests_dir)
+}
+
+pub fn resolve_manifest_repo_dir(workspace_root: &Path) -> Option<PathBuf> {
+    let new_dir = main_space_dir(workspace_root);
+    if new_dir.join(".git").exists() {
+        return Some(new_dir);
+    }
+
+    let legacy_dir = legacy_manifest_dir(workspace_root);
+    if legacy_dir.join(".git").exists() {
+        return Some(legacy_dir);
+    }
+
+    None
+}
+
+pub fn resolve_manifest_content_dir(workspace_root: &Path) -> PathBuf {
+    let new_dir = main_space_dir(workspace_root);
+    if new_dir.exists() {
+        return new_dir;
+    }
+
+    let legacy_dir = legacy_manifest_dir(workspace_root);
+    if legacy_dir.exists() {
+        return legacy_dir;
+    }
+
+    resolve_manifest_repo_dir(workspace_root).unwrap_or_else(|| main_space_dir(workspace_root))
+}
+
+pub fn resolve_manifest_path_for_update(workspace_root: &Path) -> Option<PathBuf> {
+    if let Some(path) = resolve_workspace_manifest_path(workspace_root) {
+        return Some(path);
+    }
+
+    if let Some(dir) = resolve_manifest_repo_dir(workspace_root) {
+        return Some(dir.join(PRIMARY_FILE_NAME));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolve_workspace_manifest_prefers_new_layout() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let new_dir = main_space_dir(root);
+        let legacy_dir = legacy_manifest_dir(root);
+        std::fs::create_dir_all(&new_dir).unwrap();
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        let new_path = new_dir.join(PRIMARY_FILE_NAME);
+        let legacy_path = legacy_dir.join("manifest.yaml");
+        std::fs::write(
+            &new_path,
+            "version: 1\nrepos:\n  a:\n    url: x\n    path: a\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &legacy_path,
+            "version: 1\nrepos:\n  b:\n    url: y\n    path: b\n",
+        )
+        .unwrap();
+
+        assert_eq!(resolve_workspace_manifest_path(root), Some(new_path));
+    }
+
+    #[test]
+    fn resolve_workspace_manifest_falls_back_to_legacy() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let legacy_dir = legacy_manifest_dir(root);
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        let legacy_path = legacy_dir.join("manifest.yaml");
+        std::fs::write(
+            &legacy_path,
+            "version: 1\nrepos:\n  b:\n    url: y\n    path: b\n",
+        )
+        .unwrap();
+
+        assert_eq!(resolve_workspace_manifest_path(root), Some(legacy_path));
+    }
+
+    #[test]
+    fn resolve_manifest_repo_dir_prefers_new_git_repo() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let new_dir = main_space_dir(root);
+        let legacy_dir = legacy_manifest_dir(root);
+        std::fs::create_dir_all(new_dir.join(".git")).unwrap();
+        std::fs::create_dir_all(legacy_dir.join(".git")).unwrap();
+
+        assert_eq!(resolve_manifest_repo_dir(root), Some(new_dir));
+    }
+
+    #[test]
+    fn resolve_manifest_path_for_update_uses_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let new_dir = main_space_dir(root);
+        std::fs::create_dir_all(&new_dir).unwrap();
+        let path = new_dir.join(PRIMARY_FILE_NAME);
+        std::fs::write(&path, "version: 1\nrepos:\n  a:\n    url: x\n    path: a\n").unwrap();
+
+        assert_eq!(resolve_manifest_path_for_update(root), Some(path));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod griptree;
 pub mod manifest;
+pub mod manifest_paths;
 pub mod repo;
 pub mod repo_manifest;
 pub mod state;

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::core::manifest::{Manifest, ManifestRepoConfig, PlatformType, RepoConfig};
+use crate::core::manifest_paths;
 
 /// Extended repository information with computed fields
 #[derive(Debug, Clone)]
@@ -212,7 +213,7 @@ pub fn filter_repos(
 /// in operations like sync, branch, checkout, push, and diff.
 pub fn get_manifest_repo_info(manifest: &Manifest, workspace_root: &Path) -> Option<RepoInfo> {
     let manifest_config = manifest.manifest.as_ref()?;
-    let manifests_dir = workspace_root.join(".gitgrip").join("manifests");
+    let manifests_dir = manifest_paths::resolve_manifest_repo_dir(workspace_root)?;
 
     // Only return if the manifest repo actually exists as a git repo
     if !manifests_dir.join(".git").exists() {
@@ -227,7 +228,13 @@ fn create_manifest_repo_info(
     config: &ManifestRepoConfig,
     workspace_root: &Path,
 ) -> Option<RepoInfo> {
-    let path = ".gitgrip/manifests".to_string();
+    let repo_dir = manifest_paths::resolve_manifest_repo_dir(workspace_root)
+        .unwrap_or_else(|| manifest_paths::main_space_dir(workspace_root));
+    let path = repo_dir
+        .strip_prefix(workspace_root)
+        .ok()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| manifest_paths::MAIN_SPACE_DIR.to_string());
 
     RepoInfo::from_config(
         "manifest",
@@ -385,7 +392,7 @@ mod tests {
             workspace: None,
         };
 
-        // No .gitgrip/manifests/.git directory exists
+        // No manifest repo git directory exists
         let result = get_manifest_repo_info(&manifest, temp.path());
         assert!(result.is_none());
     }
@@ -399,8 +406,8 @@ mod tests {
 
         let temp = TempDir::new().unwrap();
 
-        // Create .gitgrip/manifests/.git directory
-        let manifests_dir = temp.path().join(".gitgrip").join("manifests");
+        // Create .gitgrip/spaces/main/.git directory
+        let manifests_dir = temp.path().join(".gitgrip").join("spaces").join("main");
         fs::create_dir_all(manifests_dir.join(".git")).unwrap();
 
         let manifest = Manifest {
@@ -422,7 +429,7 @@ mod tests {
 
         let info = result.unwrap();
         assert_eq!(info.name, "manifest");
-        assert_eq!(info.path, ".gitgrip/manifests");
+        assert_eq!(info.path, ".gitgrip/spaces/main");
         assert_eq!(info.default_branch, "main");
         assert!(!info.reference);
     }

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -44,7 +44,7 @@ fn validate_gripspace_name(name: &str) -> Result<(), String> {
 ///
 /// Each composefile concatenates parts in order. Parts can come from:
 /// - A gripspace: reads from `.gitgrip/gripspaces/<name>/<src>`
-/// - The local manifest: reads from `.gitgrip/manifests/<src>`
+/// - The local manifest content directory (resolved by `manifest_paths`)
 pub fn process_composefiles(
     workspace_root: &Path,
     manifests_dir: &Path,

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -5,6 +5,41 @@
 use crate::core::manifest::ComposeFileConfig;
 use std::path::Path;
 
+fn is_windows_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+        || path.starts_with("\\\\")
+}
+
+fn validate_relative_source_path(path: &str, field: &str) -> Result<(), String> {
+    if path.is_empty() {
+        return Err(format!("Invalid {}: empty path", field));
+    }
+
+    let normalized = path.replace('\\', "/");
+    if normalized.starts_with('/') || normalized.starts_with("//") || is_windows_absolute(path) {
+        return Err(format!("Invalid {}: absolute path '{}'", field, path));
+    }
+
+    if normalized.split('/').any(|segment| segment == "..") {
+        return Err(format!("Invalid {}: path traversal '{}'", field, path));
+    }
+
+    Ok(())
+}
+
+fn validate_gripspace_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Invalid gripspace name: empty".to_string());
+    }
+
+    if name.contains("..") || name.contains('/') || name.contains('\\') {
+        return Err(format!("Invalid gripspace name: '{}'", name));
+    }
+
+    Ok(())
+}
+
 /// Process composefile entries, writing composed files to the workspace root.
 ///
 /// Each composefile concatenates parts in order. Parts can come from:
@@ -17,45 +52,35 @@ pub fn process_composefiles(
     composefiles: &[ComposeFileConfig],
 ) -> anyhow::Result<()> {
     for compose in composefiles {
-        // Validate dest doesn't escape workspace
-        if compose.dest.contains("..") || compose.dest.starts_with('/') {
-            anyhow::bail!(
-                "Composefile dest escapes workspace boundary: {}",
-                compose.dest
-            );
-        }
+        validate_relative_source_path(&compose.dest, "composefile dest")
+            .map_err(anyhow::Error::msg)?;
 
         let separator = compose.separator.as_deref().unwrap_or("\n\n");
         let mut parts_content: Vec<String> = Vec::new();
 
         for part in &compose.parts {
             let source_path = if let Some(ref gs_name) = part.gripspace {
-                // Validate gripspace name doesn't contain traversal
-                if gs_name.contains("..")
-                    || gs_name.contains('/')
-                    || gs_name.contains('\\')
-                    || gs_name.is_empty()
-                {
+                if let Err(e) = validate_gripspace_name(gs_name) {
                     eprintln!(
-                        "Warning: composefile '{}' has invalid gripspace name: '{}'",
-                        compose.dest, gs_name
+                        "Warning: composefile '{}' has invalid gripspace name: {}",
+                        compose.dest, e
                     );
                     continue;
                 }
-                if part.src.contains("..") || part.src.starts_with('/') {
+                if let Err(e) = validate_relative_source_path(&part.src, "composefile part src") {
                     eprintln!(
-                        "Warning: composefile '{}' has invalid part src: '{}'",
-                        compose.dest, part.src
+                        "Warning: composefile '{}' has invalid part src: {}",
+                        compose.dest, e
                     );
                     continue;
                 }
                 // Source from gripspace
                 gripspaces_dir.join(gs_name).join(&part.src)
             } else {
-                if part.src.contains("..") || part.src.starts_with('/') {
+                if let Err(e) = validate_relative_source_path(&part.src, "composefile part src") {
                     eprintln!(
-                        "Warning: composefile '{}' has invalid part src: '{}'",
-                        compose.dest, part.src
+                        "Warning: composefile '{}' has invalid part src: {}",
+                        compose.dest, e
                     );
                     continue;
                 }
@@ -116,21 +141,13 @@ pub fn resolve_file_source(
             let name = &rest[..colon_pos];
             let path = &rest[colon_pos + 1..];
 
-            // Validate gripspace name and path don't contain traversal
-            if name.contains("..") || name.contains('/') || name.contains('\\') || name.is_empty()
-            {
-                return Err(format!("Invalid gripspace name: '{}'", name));
-            }
-            if path.contains("..") || path.starts_with('/') || path.starts_with('\\') {
-                return Err(format!(
-                    "Invalid gripspace path: '{}' (path traversal)",
-                    path
-                ));
-            }
+            validate_gripspace_name(name)?;
+            validate_relative_source_path(path, "gripspace path")?;
 
             return Ok(gripspaces_dir.join(name).join(path));
         }
     }
+    validate_relative_source_path(src, "manifest path")?;
     Ok(repo_path.join(src))
 }
 
@@ -327,6 +344,22 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_file_source_local_path_traversal() {
+        let repo_path = Path::new("/workspace/repo");
+        let gripspaces_dir = Path::new("/workspace/.gitgrip/gripspaces");
+        let result = resolve_file_source("../outside.txt", repo_path, gripspaces_dir);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_file_source_local_windows_absolute_path() {
+        let repo_path = Path::new("/workspace/repo");
+        let gripspaces_dir = Path::new("/workspace/.gitgrip/gripspaces");
+        let result = resolve_file_source("C:\\Windows\\System32\\etc", repo_path, gripspaces_dir);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_process_composefiles_dest_path_traversal() {
         let temp = TempDir::new().unwrap();
         let workspace = temp.path();
@@ -339,6 +372,31 @@ mod tests {
 
         let composefiles = vec![ComposeFileConfig {
             dest: "../escaped.md".to_string(),
+            parts: vec![ComposeFilePart {
+                gripspace: None,
+                src: "file.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        let result =
+            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_process_composefiles_dest_windows_absolute_path() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let gripspaces_dir = workspace.join(".gitgrip").join("gripspaces");
+
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::create_dir_all(&gripspaces_dir).unwrap();
+        std::fs::write(manifests_dir.join("file.md"), "content").unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "C:\\temp\\escaped.md".to_string(),
             parts: vec![ComposeFilePart {
                 gripspace: None,
                 src: "file.md".to_string(),

--- a/tests/griptree_tests.rs
+++ b/tests/griptree_tests.rs
@@ -95,7 +95,7 @@ fn test_main_manifests_dir_path() {
     let temp = TempDir::new().unwrap();
     let workspace_root = PathBuf::from(temp.path());
 
-    let manifests_dir = workspace_root.join(".gitgrip").join("manifests");
+    let manifests_dir = workspace_root.join(".gitgrip").join("spaces").join("main");
 
     // Create the directory structure
     fs::create_dir_all(&manifests_dir).unwrap();
@@ -109,7 +109,7 @@ fn test_griptree_manifest_path() {
     let temp = TempDir::new().unwrap();
     let griptree_path = PathBuf::from(temp.path());
 
-    let griptree_manifest_dir = griptree_path.join(".gitgrip").join("manifests");
+    let griptree_manifest_dir = griptree_path.join(".gitgrip").join("spaces").join("main");
 
     // Create the directory structure
     fs::create_dir_all(&griptree_manifest_dir).unwrap();

--- a/tests/init_e2e.rs
+++ b/tests/init_e2e.rs
@@ -51,6 +51,10 @@ fn run_init_from_dirs(workspace_dir: &std::path::Path) -> std::process::Output {
         .expect("Failed to run gr init")
 }
 
+fn workspace_manifest_path(workspace: &std::path::Path) -> std::path::PathBuf {
+    workspace.join(".gitgrip/spaces/main/gripspace.yml")
+}
+
 #[test]
 fn test_init_from_dirs_discovers_repos() {
     let temp = TempDir::new().unwrap();
@@ -72,8 +76,8 @@ fn test_init_from_dirs_discovers_repos() {
     assert!(output.status.success(), "init failed: {:?}", output);
 
     // Verify manifest created
-    let manifest_path = workspace.join(".gitgrip/manifests/manifest.yaml");
-    assert!(manifest_path.exists(), "manifest.yaml not created");
+    let manifest_path = workspace_manifest_path(workspace);
+    assert!(manifest_path.exists(), "gripspace.yml not created");
 
     // Verify manifest content
     let manifest_content = fs::read_to_string(&manifest_path).unwrap();
@@ -116,8 +120,8 @@ fn test_init_from_dirs_handles_mixed_platforms() {
     );
 
     // Verify manifest created
-    let manifest_path = workspace.join(".gitgrip/manifests/manifest.yaml");
-    assert!(manifest_path.exists(), "manifest.yaml not created");
+    let manifest_path = workspace_manifest_path(workspace);
+    assert!(manifest_path.exists(), "gripspace.yml not created");
 
     // Both repos should be included
     let manifest_content = fs::read_to_string(&manifest_path).unwrap();
@@ -166,8 +170,8 @@ fn test_init_from_dirs_handles_repos_without_remotes() {
     );
 
     // Verify manifest created
-    let manifest_path = workspace.join(".gitgrip/manifests/manifest.yaml");
-    assert!(manifest_path.exists(), "manifest.yaml not created");
+    let manifest_path = workspace_manifest_path(workspace);
+    assert!(manifest_path.exists(), "gripspace.yml not created");
 
     // Local repo should be included with placeholder URL
     let manifest_content = fs::read_to_string(&manifest_path).unwrap();
@@ -212,8 +216,8 @@ fn test_init_from_dirs_detects_azure_repos() {
     );
 
     // Verify manifest created
-    let manifest_path = workspace.join(".gitgrip/manifests/manifest.yaml");
-    assert!(manifest_path.exists(), "manifest.yaml not created");
+    let manifest_path = workspace_manifest_path(workspace);
+    assert!(manifest_path.exists(), "gripspace.yml not created");
 
     // Both repos should be included
     let manifest_content = fs::read_to_string(&manifest_path).unwrap();
@@ -299,7 +303,7 @@ fn test_init_skips_hidden_directories() {
     assert!(output.status.success(), "init failed: {:?}", output);
 
     // Verify manifest only includes visible repo
-    let manifest_path = workspace.join(".gitgrip/manifests/manifest.yaml");
+    let manifest_path = workspace_manifest_path(workspace);
     let manifest_content = fs::read_to_string(&manifest_path).unwrap();
 
     assert!(

--- a/tests/test_ci.rs
+++ b/tests/test_ci.rs
@@ -7,11 +7,9 @@ use std::fs;
 
 /// Helper: append workspace CI config to the existing manifest YAML.
 fn write_ci_manifest(ws: &common::fixtures::WorkspaceFixture, ci_yaml: &str) {
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path =
+        gitgrip::core::manifest_paths::resolve_workspace_manifest_path(&ws.workspace_root)
+            .expect("workspace manifest path should resolve");
     let existing = fs::read_to_string(&manifest_path).unwrap();
     let full = format!(
         "{}\nworkspace:\n  ci:\n    pipelines:\n{}",

--- a/tests/test_edge_cases.rs
+++ b/tests/test_edge_cases.rs
@@ -133,11 +133,9 @@ fn test_branch_group_filter_json() {
 // ── CI with workspace env vars ──────────────────────────────────
 
 fn write_ci_env_manifest(ws: &common::fixtures::WorkspaceFixture, yaml: &str) {
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path =
+        gitgrip::core::manifest_paths::resolve_workspace_manifest_path(&ws.workspace_root)
+            .expect("workspace manifest path should resolve");
     let existing = fs::read_to_string(&manifest_path).unwrap();
     let full = format!("{}\nworkspace:\n{}", existing, yaml);
     fs::write(&manifest_path, full).unwrap();

--- a/tests/test_link.rs
+++ b/tests/test_link.rs
@@ -7,11 +7,9 @@ use std::fs;
 
 /// Helper: append copyfile/linkfile entries to a repo's manifest config.
 fn write_link_manifest(ws: &common::fixtures::WorkspaceFixture, repo_name: &str, link_yaml: &str) {
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path =
+        gitgrip::core::manifest_paths::resolve_workspace_manifest_path(&ws.workspace_root)
+            .expect("workspace manifest path should resolve");
     let content = fs::read_to_string(&manifest_path).unwrap();
 
     // Insert link config under the specified repo entry

--- a/tests/test_repo_commands.rs
+++ b/tests/test_repo_commands.rs
@@ -92,6 +92,17 @@ fn test_repo_add_https_url() {
         content.contains("new-repo"),
         "manifest should contain new repo"
     );
+
+    let legacy_manifest = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let legacy_content = fs::read_to_string(legacy_manifest).unwrap();
+    assert!(
+        legacy_content.contains("new-repo"),
+        "legacy manifest mirror should also contain new repo"
+    );
 }
 
 #[test]
@@ -210,6 +221,17 @@ fn test_repo_remove_from_manifest() {
     assert!(
         content.contains("  frontend:"),
         "manifest should still contain frontend"
+    );
+
+    let legacy_manifest = ws
+        .workspace_root
+        .join(".gitgrip")
+        .join("manifests")
+        .join("manifest.yaml");
+    let legacy_content = fs::read_to_string(legacy_manifest).unwrap();
+    assert!(
+        !legacy_content.contains("  backend:"),
+        "legacy manifest mirror should not contain backend repo entry"
     );
 }
 

--- a/tests/test_repo_commands.rs
+++ b/tests/test_repo_commands.rs
@@ -4,6 +4,12 @@ mod common;
 
 use common::fixtures::WorkspaceBuilder;
 use std::fs;
+use std::path::PathBuf;
+
+fn workspace_manifest_path(workspace_root: &std::path::Path) -> PathBuf {
+    gitgrip::core::manifest_paths::resolve_workspace_manifest_path(workspace_root)
+        .expect("workspace manifest path should resolve")
+}
 
 // ── repo list ──────────────────────────────────────────────────────
 
@@ -80,11 +86,7 @@ fn test_repo_add_https_url() {
     );
 
     // Verify the manifest was updated
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path = workspace_manifest_path(&ws.workspace_root);
     let content = fs::read_to_string(&manifest_path).unwrap();
     assert!(
         content.contains("new-repo"),
@@ -108,11 +110,7 @@ fn test_repo_add_ssh_url() {
         result.err()
     );
 
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path = workspace_manifest_path(&ws.workspace_root);
     let content = fs::read_to_string(&manifest_path).unwrap();
     assert!(
         content.contains("ssh-repo"),
@@ -136,11 +134,7 @@ fn test_repo_add_custom_path() {
         result.err()
     );
 
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path = workspace_manifest_path(&ws.workspace_root);
     let content = fs::read_to_string(&manifest_path).unwrap();
     assert!(
         content.contains("custom/path"),
@@ -164,11 +158,7 @@ fn test_repo_add_custom_branch() {
         result.err()
     );
 
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path = workspace_manifest_path(&ws.workspace_root);
     let content = fs::read_to_string(&manifest_path).unwrap();
     assert!(
         content.contains("develop"),
@@ -210,11 +200,7 @@ fn test_repo_remove_from_manifest() {
     );
 
     // Verify backend is no longer in manifest
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path = workspace_manifest_path(&ws.workspace_root);
     let content = fs::read_to_string(&manifest_path).unwrap();
     assert!(
         !content.contains("  backend:"),

--- a/tests/test_run_env.rs
+++ b/tests/test_run_env.rs
@@ -7,11 +7,9 @@ use std::fs;
 
 /// Helper: append workspace config with env and/or scripts to the manifest.
 fn write_workspace_manifest(ws: &common::fixtures::WorkspaceFixture, workspace_yaml: &str) {
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path =
+        gitgrip::core::manifest_paths::resolve_workspace_manifest_path(&ws.workspace_root)
+            .expect("workspace manifest path should resolve");
     let existing = fs::read_to_string(&manifest_path).unwrap();
     let full = format!("{}\nworkspace:\n{}", existing, workspace_yaml);
     fs::write(&manifest_path, full).unwrap();

--- a/tests/test_tree.rs
+++ b/tests/test_tree.rs
@@ -99,11 +99,9 @@ fn test_tree_add_writes_repo_upstreams() {
     git_helpers::push_branch(&ws.repo_path("lib"), "origin", "dev");
     git_helpers::checkout(&ws.repo_path("lib"), "main");
 
-    let manifest_path = ws
-        .workspace_root
-        .join(".gitgrip")
-        .join("manifests")
-        .join("manifest.yaml");
+    let manifest_path =
+        gitgrip::core::manifest_paths::resolve_workspace_manifest_path(&ws.workspace_root)
+            .expect("workspace manifest path should resolve");
     set_default_branch(&manifest_path, "lib", "dev");
     let manifest = ws.load_manifest();
 
@@ -160,11 +158,13 @@ fn test_tree_add_with_manifest_repo() {
         .join("feat-with-manifest");
 
     // Manifest worktree should be created in griptree
-    let tree_manifest_dir = tree_path.join(".gitgrip").join("manifests");
+    let tree_manifest_dir = tree_path.join(".gitgrip").join("spaces").join("main");
     assertions::assert_file_exists(&tree_manifest_dir);
 
-    // manifest.yaml should exist in griptree's manifest dir
-    assertions::assert_file_exists(&tree_manifest_dir.join("manifest.yaml"));
+    // A supported manifest filename should exist in the griptree manifest dir.
+    assert!(
+        gitgrip::core::manifest_paths::resolve_manifest_file_in_dir(&tree_manifest_dir).is_some()
+    );
 
     // Pointer should reference the manifest worktree
     let pointer_path = tree_path.join(".griptree");


### PR DESCRIPTION
## What this does
- Merges `feat/gripspace-layout` into `feat/gripspace-includes` via integration branch.
- Resolves the `src/cli/commands/link.rs` conflict while preserving:
  - new manifest path helpers (`.gitgrip/spaces/main/gripspace.yml`)
  - gripspace-sourced link/copy/compose behavior
- Fixes post-merge regressions in include resolution and sync behavior.

## Additional fixes included
- `sync_gripspaces` now resolves manifest path via `manifest_paths` and validates the resolved manifest before use.
- Recursive gripspace resolution now:
  - avoids false cycle positives for shared nested includes (DAGs),
  - supports `gripspace.yml` in included gripspaces (with legacy fallback),
  - reuses/ensures gripspace checkouts consistently.
- Fixes init path handling bug introduced during merge (`Option<PathBuf>` read).

## Validation
- `cargo test gripspace::tests --lib`
- `cargo test --test test_link`

This PR is intended to be merged into #270 branch (`feat/gripspace-includes`) first, then #270 can be rebased/updated for mainline review.
