### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-02-09
+
+### Added
+- **Gripspace includes** - Composable manifest inheritance via `gripspaces:` directive (#270)
+  - Clone external gripspace repositories and merge their repos, scripts, env, hooks, linkfiles, and copyfiles into the local workspace
+  - Recursive resolution with DAG-aware cycle detection (max depth 5)
+  - Local manifest values always win on conflict
+  - `gr sync` and `gr init` resolve and clone gripspaces automatically
+  - `gr status` shows gripspace clone status with revision and dirty state
+- **Composefile support** - Generate files by concatenating parts from gripspaces and/or local manifest (`composefile:` directive)
+  - Processed on `gr sync` and `gr link --apply`
+  - Parts can reference gripspace content or local manifest content
+- **URL normalization** - SSH and HTTPS URLs to the same repo are recognized as equivalent for space reuse (`git@github.com:user/repo` ↔ `https://github.com/user/repo`)
+- **Manifest paths module** - Consistent path resolution across all commands (`manifest_paths.rs`)
+
+### Changed
+- **Unified directory layout** - `.gitgrip/spaces/` is now the single directory for all space content (gripspaces and manifest), replacing the previous split between `gripspaces/` and `spaces/`
+- Reserved space names (`main`, `local`) are auto-suffixed to avoid conflicts with the manifest space
+
+### Security
+- Gripspace name validation with allowlist (`[a-zA-Z0-9._-]`), rejecting `.`, `..`, and path traversal
+- Windows absolute path and UNC path rejection in path boundary checks
+- Gripspace manifest validation via `validate_as_gripspace()` (allows empty repos, validates all other constraints)
+- Failed clone cleanup — partial directories are removed on clone error
+- Untrusted gripspace path hardening across all validators
+
 ## [0.11.3] - 2026-02-09
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,7 @@ src/
 Workspace configuration in `.gitgrip/spaces/main/gripspace.yml`:
 - `repos`: Repository definitions with URL, path, default_branch
 - `manifest`: Self-tracking for the manifest repo itself
+- `gripspaces`: Composable includes — clone external gripspace repos and merge their repos, scripts, env, hooks, and file links
 - `workspace`: Scripts, hooks, and environment variables
 - `settings`: PR prefix, merge strategy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"

--- a/docs/MANIFEST.md
+++ b/docs/MANIFEST.md
@@ -55,6 +55,62 @@ When `manifest` is defined:
 - `gr push` pushes the manifest repo
 - `gr diff` shows manifest changes
 
+## Gripspace Includes
+
+Compose workspaces by inheriting configuration from shared gripspace repositories:
+
+```yaml
+gripspaces:
+  - url: git@github.com:org/base-workspace.git
+  - url: git@github.com:org/frontend-tools.git
+    rev: v2.0.0  # Pin to branch, tag, or commit (default: remote HEAD)
+```
+
+Gripspace repos are cloned into `.gitgrip/spaces/<name>/` and their `gripspace.yml` manifests are merged into the local workspace during `gr sync` and `gr init`.
+
+### What Gets Merged
+
+| Section | Merge Strategy |
+|---------|---------------|
+| `repos` | Gripspace repos added first, local repos override by key |
+| `scripts` | Gripspace scripts added first, local scripts override by key |
+| `env` | Gripspace env added first, local env overrides by key |
+| `hooks` | Gripspace hooks run first (deepest first), then local hooks |
+| `copyfile` | Gripspace entries added, local entries override by dest |
+| `linkfile` | Gripspace entries added, local entries override by dest |
+
+**Local values always win on conflict.**
+
+### Recursive Includes
+
+Gripspaces can include other gripspaces (max depth 5). Resolution is depth-first with DAG-aware cycle detection — the same gripspace referenced from multiple parents is only resolved once.
+
+### Composefiles
+
+Generate files by concatenating parts from gripspaces and/or the local manifest:
+
+```yaml
+manifest:
+  url: git@github.com:org/workspace.git
+  composefile:
+    - dest: CLAUDE.md
+      separator: "\n\n"  # Optional (default: "\n\n")
+      parts:
+        - gripspace: base-workspace  # Read from .gitgrip/spaces/base-workspace/
+          src: CODI.md
+        - src: LOCAL_DOCS.md         # Read from local manifest content dir
+```
+
+Composefiles are processed on every `gr sync` and `gr link --apply`.
+
+### URL Normalization
+
+SSH and HTTPS URLs to the same repository are recognized as equivalent. If a gripspace directory already exists with a matching remote (even via a different protocol), it is reused rather than creating a duplicate:
+
+```
+git@github.com:org/repo.git  ↔  https://github.com/org/repo.git
+```
+
 ## Repository Definitions
 
 Each repository is defined under `repos`:

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -196,6 +196,19 @@ gr branch feat/x
 gr pr create -t "title"
 ```
 
+## Gripspace Includes
+
+Workspaces can inherit repos, scripts, env, hooks, and file links from shared gripspace repositories:
+
+```yaml
+gripspaces:
+  - url: git@github.com:org/base-workspace.git
+  - url: git@github.com:org/tools.git
+    rev: v2.0.0  # Pin to branch/tag/commit
+```
+
+Gripspaces are cloned into `.gitgrip/spaces/<name>/` and merged during `gr sync`. Local values always win. Resolution is recursive (max depth 5) with cycle detection.
+
 ## Manifest Location
 
 The canonical workspace manifest is `.gitgrip/spaces/main/gripspace.yml` (legacy `.gitgrip/manifests/manifest.yaml` is still supported). Use `gr manifest schema` to view the schema.

--- a/docs/manifest-schema.yaml
+++ b/docs/manifest-schema.yaml
@@ -9,7 +9,7 @@ version: 1
 
 # Gripspace includes (optional)
 # Include repos, scripts, env, hooks, and linkfiles from other gripspace repositories.
-# Gripspaces are cloned into .gitgrip/gripspaces/<name>/ and their manifests are merged.
+# Gripspaces are cloned into .gitgrip/spaces/<name>/ and their manifests are merged.
 # Local manifest values always win on conflict.
 # Supports recursive includes (max depth: 5) with cycle detection.
 gripspaces:


### PR DESCRIPTION
## Summary

- Version bump 0.11.3 → 0.12.0
- Updated CHANGELOG, README, docs/MANIFEST.md, docs/SKILL.md, CLAUDE.md, and manifest-schema.yaml with gripspace includes documentation
- Fixed stale path in manifest-schema.yaml (`.gitgrip/gripspaces/` → `.gitgrip/spaces/`)

## Release: Gripspace Includes (v0.12.0)

**Added:**
- Gripspace includes (`gripspaces:` directive) for composable manifest inheritance
- Recursive gripspace resolution with cycle detection (max depth 5)
- Composefile support (`composefile:`) for generating files from gripspace parts
- URL normalization for SSH/HTTPS equivalence detection

**Changed:**
- Unified directory layout: `.gitgrip/spaces/` for all space content

**Security:**
- Gripspace name validation with character allowlist
- Windows absolute path rejection
- Failed clone cleanup (remove partial directory on error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)