### PR TITLE
fix: P1 quality — branch JSON, git lock detection, GHE auto-merge, tests

### DIFF
--- a/src/cli/commands/branch.rs
+++ b/src/cli/commands/branch.rs
@@ -39,43 +39,136 @@ pub fn run_branch(opts: BranchOptions<'_>) -> anyhow::Result<()> {
     match opts.name {
         Some(branch_name) if opts.delete => {
             // Delete branch
-            Output::header(&format!("Deleting branch '{}'", branch_name));
-            println!();
+            #[derive(serde::Serialize)]
+            struct JsonDeleteResult {
+                repo: String,
+                branch: String,
+                action: String,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                error: Option<String>,
+            }
+
+            let mut json_results: Vec<JsonDeleteResult> = Vec::new();
+
+            if !opts.json {
+                Output::header(&format!("Deleting branch '{}'", branch_name));
+                println!();
+            }
 
             for repo in &repos {
                 if !repo.exists() {
-                    Output::warning(&format!("{}: not cloned", repo.name));
+                    if opts.json {
+                        json_results.push(JsonDeleteResult {
+                            repo: repo.name.clone(),
+                            branch: branch_name.to_string(),
+                            action: "skipped".to_string(),
+                            error: Some("not cloned".to_string()),
+                        });
+                    } else {
+                        Output::warning(&format!("{}: not cloned", repo.name));
+                    }
                     continue;
                 }
 
                 match open_repo(&repo.absolute_path) {
                     Ok(git_repo) => {
                         if !branch_exists(&git_repo, branch_name) {
-                            Output::info(&format!("{}: branch doesn't exist", repo.name));
+                            if opts.json {
+                                json_results.push(JsonDeleteResult {
+                                    repo: repo.name.clone(),
+                                    branch: branch_name.to_string(),
+                                    action: "not_found".to_string(),
+                                    error: None,
+                                });
+                            } else {
+                                Output::info(&format!("{}: branch doesn't exist", repo.name));
+                            }
                             continue;
                         }
 
                         match delete_local_branch(&git_repo, branch_name, false) {
-                            Ok(()) => Output::success(&format!("{}: deleted", repo.name)),
-                            Err(e) => Output::error(&format!("{}: {}", repo.name, e)),
+                            Ok(()) => {
+                                if opts.json {
+                                    json_results.push(JsonDeleteResult {
+                                        repo: repo.name.clone(),
+                                        branch: branch_name.to_string(),
+                                        action: "deleted".to_string(),
+                                        error: None,
+                                    });
+                                } else {
+                                    Output::success(&format!("{}: deleted", repo.name));
+                                }
+                            }
+                            Err(e) => {
+                                if opts.json {
+                                    json_results.push(JsonDeleteResult {
+                                        repo: repo.name.clone(),
+                                        branch: branch_name.to_string(),
+                                        action: "error".to_string(),
+                                        error: Some(e.to_string()),
+                                    });
+                                } else {
+                                    Output::error(&format!("{}: {}", repo.name, e));
+                                }
+                            }
                         }
                     }
-                    Err(e) => Output::error(&format!("{}: {}", repo.name, e)),
+                    Err(e) => {
+                        if opts.json {
+                            json_results.push(JsonDeleteResult {
+                                repo: repo.name.clone(),
+                                branch: branch_name.to_string(),
+                                action: "error".to_string(),
+                                error: Some(e.to_string()),
+                            });
+                        } else {
+                            Output::error(&format!("{}: {}", repo.name, e));
+                        }
+                    }
                 }
+            }
+
+            if opts.json {
+                println!("{}", serde_json::to_string_pretty(&json_results)?);
             }
         }
         Some(branch_name) if opts.move_commits => {
             // Move commits to new branch (create branch, reset current to remote, checkout new)
-            Output::header(&format!(
-                "Moving commits to branch '{}' in {} repos...",
-                branch_name,
-                repos.len()
-            ));
-            println!();
+            #[derive(serde::Serialize)]
+            struct JsonMoveResult {
+                repo: String,
+                branch: String,
+                action: String,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                from_branch: Option<String>,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                error: Option<String>,
+            }
+
+            let mut json_results: Vec<JsonMoveResult> = Vec::new();
+
+            if !opts.json {
+                Output::header(&format!(
+                    "Moving commits to branch '{}' in {} repos...",
+                    branch_name,
+                    repos.len()
+                ));
+                println!();
+            }
 
             for repo in &repos {
                 if !repo.exists() {
-                    Output::warning(&format!("{}: not cloned", repo.name));
+                    if opts.json {
+                        json_results.push(JsonMoveResult {
+                            repo: repo.name.clone(),
+                            branch: branch_name.to_string(),
+                            action: "skipped".to_string(),
+                            from_branch: None,
+                            error: Some("not cloned".to_string()),
+                        });
+                    } else {
+                        Output::warning(&format!("{}: not cloned", repo.name));
+                    }
                     continue;
                 }
 
@@ -84,19 +177,42 @@ pub fn run_branch(opts: BranchOptions<'_>) -> anyhow::Result<()> {
                         let current = match get_current_branch(&git_repo) {
                             Ok(b) => b,
                             Err(e) => {
-                                Output::error(&format!(
-                                    "{}: failed to get current branch - {}",
-                                    repo.name, e
-                                ));
+                                if opts.json {
+                                    json_results.push(JsonMoveResult {
+                                        repo: repo.name.clone(),
+                                        branch: branch_name.to_string(),
+                                        action: "error".to_string(),
+                                        from_branch: None,
+                                        error: Some(format!(
+                                            "failed to get current branch - {}",
+                                            e
+                                        )),
+                                    });
+                                } else {
+                                    Output::error(&format!(
+                                        "{}: failed to get current branch - {}",
+                                        repo.name, e
+                                    ));
+                                }
                                 continue;
                             }
                         };
 
                         if branch_exists(&git_repo, branch_name) {
-                            Output::error(&format!(
-                                "{}: branch '{}' already exists",
-                                repo.name, branch_name
-                            ));
+                            if opts.json {
+                                json_results.push(JsonMoveResult {
+                                    repo: repo.name.clone(),
+                                    branch: branch_name.to_string(),
+                                    action: "error".to_string(),
+                                    from_branch: Some(current),
+                                    error: Some(format!("branch '{}' already exists", branch_name)),
+                                });
+                            } else {
+                                Output::error(&format!(
+                                    "{}: branch '{}' already exists",
+                                    repo.name, branch_name
+                                ));
+                            }
                             continue;
                         }
 
@@ -104,29 +220,59 @@ pub fn run_branch(opts: BranchOptions<'_>) -> anyhow::Result<()> {
                         let head = match git_repo.head() {
                             Ok(h) => h,
                             Err(e) => {
-                                Output::error(&format!(
-                                    "{}: failed to get HEAD - {}",
-                                    repo.name, e
-                                ));
+                                if opts.json {
+                                    json_results.push(JsonMoveResult {
+                                        repo: repo.name.clone(),
+                                        branch: branch_name.to_string(),
+                                        action: "error".to_string(),
+                                        from_branch: Some(current),
+                                        error: Some(format!("failed to get HEAD - {}", e)),
+                                    });
+                                } else {
+                                    Output::error(&format!(
+                                        "{}: failed to get HEAD - {}",
+                                        repo.name, e
+                                    ));
+                                }
                                 continue;
                             }
                         };
                         let head_commit = match head.peel_to_commit() {
                             Ok(c) => c,
                             Err(e) => {
-                                Output::error(&format!(
-                                    "{}: failed to get HEAD commit - {}",
-                                    repo.name, e
-                                ));
+                                if opts.json {
+                                    json_results.push(JsonMoveResult {
+                                        repo: repo.name.clone(),
+                                        branch: branch_name.to_string(),
+                                        action: "error".to_string(),
+                                        from_branch: Some(current),
+                                        error: Some(format!("failed to get HEAD commit - {}", e)),
+                                    });
+                                } else {
+                                    Output::error(&format!(
+                                        "{}: failed to get HEAD commit - {}",
+                                        repo.name, e
+                                    ));
+                                }
                                 continue;
                             }
                         };
 
                         if let Err(e) = git_repo.branch(branch_name, &head_commit, false) {
-                            Output::error(&format!(
-                                "{}: failed to create branch - {}",
-                                repo.name, e
-                            ));
+                            if opts.json {
+                                json_results.push(JsonMoveResult {
+                                    repo: repo.name.clone(),
+                                    branch: branch_name.to_string(),
+                                    action: "error".to_string(),
+                                    from_branch: Some(current),
+                                    error: Some(format!("failed to create branch - {}", e)),
+                                });
+                            } else {
+                                Output::error(&format!(
+                                    "{}: failed to create branch - {}",
+                                    repo.name, e
+                                ));
+                            }
                             continue;
                         }
 
@@ -136,18 +282,44 @@ pub fn run_branch(opts: BranchOptions<'_>) -> anyhow::Result<()> {
                             Ok(obj) => match obj.peel_to_commit() {
                                 Ok(c) => c,
                                 Err(e) => {
-                                    Output::error(&format!(
-                                        "{}: failed to find remote commit - {}",
-                                        repo.name, e
-                                    ));
+                                    if opts.json {
+                                        json_results.push(JsonMoveResult {
+                                            repo: repo.name.clone(),
+                                            branch: branch_name.to_string(),
+                                            action: "error".to_string(),
+                                            from_branch: Some(current),
+                                            error: Some(format!(
+                                                "failed to find remote commit - {}",
+                                                e
+                                            )),
+                                        });
+                                    } else {
+                                        Output::error(&format!(
+                                            "{}: failed to find remote commit - {}",
+                                            repo.name, e
+                                        ));
+                                    }
                                     continue;
                                 }
                             },
                             Err(e) => {
-                                Output::error(&format!(
-                                    "{}: no remote tracking branch origin/{} - {}",
-                                    repo.name, current, e
-                                ));
+                                if opts.json {
+                                    json_results.push(JsonMoveResult {
+                                        repo: repo.name.clone(),
+                                        branch: branch_name.to_string(),
+                                        action: "error".to_string(),
+                                        from_branch: Some(current.clone()),
+                                        error: Some(format!(
+                                            "no remote tracking branch origin/{} - {}",
+                                            current, e
+                                        )),
+                                    });
+                                } else {
+                                    Output::error(&format!(
+                                        "{}: no remote tracking branch origin/{} - {}",
+                                        repo.name, current, e
+                                    ));
+                                }
                                 continue;
                             }
                         };
@@ -155,83 +327,210 @@ pub fn run_branch(opts: BranchOptions<'_>) -> anyhow::Result<()> {
                         if let Err(e) =
                             git_repo.reset(remote_commit.as_object(), git2::ResetType::Hard, None)
                         {
-                            Output::error(&format!(
-                                "{}: failed to reset to origin/{} - {}",
-                                repo.name, current, e
-                            ));
+                            if opts.json {
+                                json_results.push(JsonMoveResult {
+                                    repo: repo.name.clone(),
+                                    branch: branch_name.to_string(),
+                                    action: "error".to_string(),
+                                    from_branch: Some(current.clone()),
+                                    error: Some(format!(
+                                        "failed to reset to origin/{} - {}",
+                                        current, e
+                                    )),
+                                });
+                            } else {
+                                Output::error(&format!(
+                                    "{}: failed to reset to origin/{} - {}",
+                                    repo.name, current, e
+                                ));
+                            }
                             continue;
                         }
 
                         // Checkout the new branch
                         if let Err(e) = git_repo.set_head(&format!("refs/heads/{}", branch_name)) {
-                            Output::error(&format!(
-                                "{}: failed to checkout new branch - {}",
-                                repo.name, e
-                            ));
+                            if opts.json {
+                                json_results.push(JsonMoveResult {
+                                    repo: repo.name.clone(),
+                                    branch: branch_name.to_string(),
+                                    action: "error".to_string(),
+                                    from_branch: Some(current),
+                                    error: Some(format!("failed to checkout new branch - {}", e)),
+                                });
+                            } else {
+                                Output::error(&format!(
+                                    "{}: failed to checkout new branch - {}",
+                                    repo.name, e
+                                ));
+                            }
                             continue;
                         }
 
                         if let Err(e) = git_repo
                             .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
                         {
-                            Output::error(&format!(
-                                "{}: failed to update working tree - {}",
-                                repo.name, e
-                            ));
+                            if opts.json {
+                                json_results.push(JsonMoveResult {
+                                    repo: repo.name.clone(),
+                                    branch: branch_name.to_string(),
+                                    action: "error".to_string(),
+                                    from_branch: Some(current),
+                                    error: Some(format!("failed to update working tree - {}", e)),
+                                });
+                            } else {
+                                Output::error(&format!(
+                                    "{}: failed to update working tree - {}",
+                                    repo.name, e
+                                ));
+                            }
                             continue;
                         }
 
-                        Output::success(&format!(
-                            "{}: moved commits from {} to {}",
-                            repo.name, current, branch_name
-                        ));
+                        if opts.json {
+                            json_results.push(JsonMoveResult {
+                                repo: repo.name.clone(),
+                                branch: branch_name.to_string(),
+                                action: "moved".to_string(),
+                                from_branch: Some(current.clone()),
+                                error: None,
+                            });
+                        } else {
+                            Output::success(&format!(
+                                "{}: moved commits from {} to {}",
+                                repo.name, current, branch_name
+                            ));
+                        }
                     }
-                    Err(e) => Output::error(&format!("{}: {}", repo.name, e)),
+                    Err(e) => {
+                        if opts.json {
+                            json_results.push(JsonMoveResult {
+                                repo: repo.name.clone(),
+                                branch: branch_name.to_string(),
+                                action: "error".to_string(),
+                                from_branch: None,
+                                error: Some(e.to_string()),
+                            });
+                        } else {
+                            Output::error(&format!("{}: {}", repo.name, e));
+                        }
+                    }
                 }
             }
 
-            println!();
-            println!(
-                "Commits moved to branch: {}",
-                Output::branch_name(branch_name)
-            );
+            if opts.json {
+                println!("{}", serde_json::to_string_pretty(&json_results)?);
+            } else {
+                println!();
+                println!(
+                    "Commits moved to branch: {}",
+                    Output::branch_name(branch_name)
+                );
+            }
         }
         Some(branch_name) => {
             // Create branch
-            Output::header(&format!(
-                "Creating branch '{}' in {} repos...",
-                branch_name,
-                repos.len()
-            ));
-            println!();
+            #[derive(serde::Serialize)]
+            struct JsonCreateResult {
+                repo: String,
+                branch: String,
+                action: String,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                error: Option<String>,
+            }
+
+            let mut json_results: Vec<JsonCreateResult> = Vec::new();
+
+            if !opts.json {
+                Output::header(&format!(
+                    "Creating branch '{}' in {} repos...",
+                    branch_name,
+                    repos.len()
+                ));
+                println!();
+            }
 
             for repo in &repos {
                 if !repo.exists() {
-                    Output::warning(&format!("{}: not cloned", repo.name));
+                    if opts.json {
+                        json_results.push(JsonCreateResult {
+                            repo: repo.name.clone(),
+                            branch: branch_name.to_string(),
+                            action: "skipped".to_string(),
+                            error: Some("not cloned".to_string()),
+                        });
+                    } else {
+                        Output::warning(&format!("{}: not cloned", repo.name));
+                    }
                     continue;
                 }
 
                 match open_repo(&repo.absolute_path) {
                     Ok(git_repo) => {
                         if branch_exists(&git_repo, branch_name) {
-                            Output::info(&format!("{}: already exists", repo.name));
+                            if opts.json {
+                                json_results.push(JsonCreateResult {
+                                    repo: repo.name.clone(),
+                                    branch: branch_name.to_string(),
+                                    action: "already_exists".to_string(),
+                                    error: None,
+                                });
+                            } else {
+                                Output::info(&format!("{}: already exists", repo.name));
+                            }
                             continue;
                         }
 
                         match create_and_checkout_branch(&git_repo, branch_name) {
-                            Ok(()) => Output::success(&format!("{}: created", repo.name)),
-                            Err(e) => Output::error(&format!("{}: {}", repo.name, e)),
+                            Ok(()) => {
+                                if opts.json {
+                                    json_results.push(JsonCreateResult {
+                                        repo: repo.name.clone(),
+                                        branch: branch_name.to_string(),
+                                        action: "created".to_string(),
+                                        error: None,
+                                    });
+                                } else {
+                                    Output::success(&format!("{}: created", repo.name));
+                                }
+                            }
+                            Err(e) => {
+                                if opts.json {
+                                    json_results.push(JsonCreateResult {
+                                        repo: repo.name.clone(),
+                                        branch: branch_name.to_string(),
+                                        action: "error".to_string(),
+                                        error: Some(e.to_string()),
+                                    });
+                                } else {
+                                    Output::error(&format!("{}: {}", repo.name, e));
+                                }
+                            }
                         }
                     }
-                    Err(e) => Output::error(&format!("{}: {}", repo.name, e)),
+                    Err(e) => {
+                        if opts.json {
+                            json_results.push(JsonCreateResult {
+                                repo: repo.name.clone(),
+                                branch: branch_name.to_string(),
+                                action: "error".to_string(),
+                                error: Some(e.to_string()),
+                            });
+                        } else {
+                            Output::error(&format!("{}: {}", repo.name, e));
+                        }
+                    }
                 }
             }
 
-            println!();
-            println!(
-                "All repos now on branch: {}",
-                Output::branch_name(branch_name)
-            );
+            if opts.json {
+                println!("{}", serde_json::to_string_pretty(&json_results)?);
+            } else {
+                println!();
+                println!(
+                    "All repos now on branch: {}",
+                    Output::branch_name(branch_name)
+                );
+            }
         }
         None => {
             if opts.json {


### PR DESCRIPTION
## Summary
- Implement JSON output for `branch` create, delete, and move-commits operations (was broken — flag existed but no output code)
- Add `git_lock_exists()` and `wait_for_git_lock()` with exponential backoff in `src/git/mod.rs`
- Fix GHE auto-merge: extract hostname from `base_url` and pass `--hostname` to `gh` CLI
- Add 26 new unit tests for previously untested modules: cherry_pick.rs, gc.rs, griptree.rs, git lock detection

## Files changed
- `src/cli/commands/branch.rs` — JSON output for create/delete/move-commits
- `src/git/mod.rs` — `RepositoryLocked` error, `git_lock_exists()`, `wait_for_git_lock()`, tests
- `src/platform/github.rs` — GHE hostname extraction for auto-merge
- `src/git/cherry_pick.rs` — 6 new unit tests
- `src/git/gc.rs` — 7 new unit tests
- `src/core/griptree.rs` — 9 new unit tests (save/load, pointer, find_in_ancestors)

## Test plan
- [x] `cargo clippy --all-features` passes clean (with CI allow flags)
- [x] `cargo fmt --all --check` passes clean
- [x] All 362 unit tests pass (26 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)