### PR TITLE
feat(mcp): add stdio MCP server with full CLI tool coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,30 @@ The skill file teaches AI assistants to:
 - Create proper linked PRs across repos
 - Manage branches and sync correctly
 
+### MCP Server (Tool Calling)
+
+gitgrip can run as a stdio MCP server that exposes agent operations as tools:
+
+- `gitgrip_agent_context`
+- `gitgrip_agent_build`
+- `gitgrip_agent_test`
+- `gitgrip_agent_verify`
+- `gitgrip_agent_generate_context`
+
+Add this to your MCP client config (for example `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "gitgrip": {
+      "type": "stdio",
+      "command": "gitgrip",
+      "args": ["mcp", "server"]
+    }
+  }
+}
+```
+
 ## History
 
 This project was originally written in TypeScript and published to npm as `gitgrip`. It was rewritten in Rust for better performance and additional features.

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -117,7 +117,12 @@ impl RepoInfo {
             target,
             sync_remote,
             push_remote,
-            owner: parsed.owner,
+            owner: match &parsed.project {
+                Some(project) if platform_type == PlatformType::AzureDevOps => {
+                    format!("{}/{}", parsed.owner, project)
+                }
+                _ => parsed.owner,
+            },
             repo: parsed.repo,
             platform_type,
             platform_base_url,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 pub mod core;
 pub mod files;
 pub mod git;
+pub mod mcp;
 pub mod platform;
 pub mod telemetry;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,7 +393,7 @@ enum AgentCommands {
 
 #[derive(Subcommand)]
 enum McpCommands {
-    /// Start stdio MCP server exposing gitgrip agent tools
+    /// Start stdio MCP server exposing gitgrip tools
     Server,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,6 +309,11 @@ enum Commands {
         #[command(subcommand)]
         action: AgentCommands,
     },
+    /// MCP server operations
+    Mcp {
+        #[command(subcommand)]
+        action: McpCommands,
+    },
     /// Automated release workflow
     Release {
         /// Version to release (e.g. v0.12.4)
@@ -384,6 +389,12 @@ enum AgentCommands {
         #[arg(long)]
         dry_run: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum McpCommands {
+    /// Start stdio MCP server exposing gitgrip agent tools
+    Server,
 }
 
 #[derive(Subcommand)]
@@ -1152,6 +1163,11 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
+        Some(Commands::Mcp { action }) => match action {
+            McpCommands::Server => {
+                gitgrip::mcp::server::run_mcp_server()?;
+            }
+        },
         Some(Commands::Release {
             version,
             notes,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,3 @@
+//! MCP support for gitgrip.
+
+pub mod server;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,4 +1,4 @@
-//! stdio MCP server for gitgrip agent operations.
+//! stdio MCP server for gitgrip operations.
 
 use anyhow::Context;
 use serde::Deserialize;
@@ -78,6 +78,173 @@ struct WorkerResponse {
     request_key: String,
     response: Value,
 }
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct PassthroughArgs {
+    #[serde(default)]
+    args: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+struct CliToolSpec {
+    tool_name: &'static str,
+    command: &'static str,
+    description: &'static str,
+}
+
+const CLI_TOOL_SPECS: &[CliToolSpec] = &[
+    CliToolSpec {
+        tool_name: "gitgrip_init",
+        command: "init",
+        description: "Initialize a new workspace (`gr init ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_sync",
+        command: "sync",
+        description: "Sync all repositories (`gr sync ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_status",
+        command: "status",
+        description: "Show status of all repositories (`gr status ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_branch",
+        command: "branch",
+        description: "Create/switch branches across repos (`gr branch ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_checkout",
+        command: "checkout",
+        description: "Checkout a branch across repos (`gr checkout ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_add",
+        command: "add",
+        description: "Stage changes across repos (`gr add ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_diff",
+        command: "diff",
+        description: "Show diff across repos (`gr diff ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_commit",
+        command: "commit",
+        description: "Commit changes across repos (`gr commit ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_push",
+        command: "push",
+        description: "Push changes across repos (`gr push ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_prune",
+        command: "prune",
+        description: "Clean merged branches across repos (`gr prune ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_pr",
+        command: "pr",
+        description: "Pull request operations (`gr pr ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_tree",
+        command: "tree",
+        description: "Griptree operations (`gr tree ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_grep",
+        command: "grep",
+        description: "Search across repos (`gr grep ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_forall",
+        command: "forall",
+        description: "Run a command in each repo (`gr forall ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_rebase",
+        command: "rebase",
+        description: "Rebase branches across repos (`gr rebase ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_pull",
+        command: "pull",
+        description: "Pull latest changes across repos (`gr pull ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_link",
+        command: "link",
+        description: "Manage links (`gr link ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_run",
+        command: "run",
+        description: "Run workspace scripts (`gr run ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_env",
+        command: "env",
+        description: "Show environment variables (`gr env`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_bench",
+        command: "bench",
+        description: "Run benchmarks (`gr bench ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_repo",
+        command: "repo",
+        description: "Repository operations (`gr repo ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_group",
+        command: "group",
+        description: "Repository group operations (`gr group ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_gc",
+        command: "gc",
+        description: "Run garbage collection (`gr gc ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_cherry_pick",
+        command: "cherry-pick",
+        description: "Cherry-pick commits across repos (`gr cherry-pick ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_ci",
+        command: "ci",
+        description: "CI/CD pipeline operations (`gr ci ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_manifest",
+        command: "manifest",
+        description: "Manifest operations (`gr manifest ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_agent",
+        command: "agent",
+        description: "Agent operations (`gr agent ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_release",
+        command: "release",
+        description: "Automated release workflow (`gr release ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_completions",
+        command: "completions",
+        description: "Generate shell completions (`gr completions ...`).",
+    },
+    CliToolSpec {
+        tool_name: "gitgrip_verify",
+        command: "verify",
+        description: "Verify workspace assertions (`gr verify ...`).",
+    },
+];
 
 /// Run the gitgrip MCP server over stdio.
 pub fn run_mcp_server() -> anyhow::Result<()> {
@@ -212,6 +379,18 @@ fn handle_request(request: RpcRequest) -> Option<Value> {
             });
             Some(jsonrpc_result(id, result))
         }
+        "resources/list" => {
+            let result = json!({
+                "resources": []
+            });
+            Some(jsonrpc_result(id, result))
+        }
+        "resources/templates/list" => {
+            let result = json!({
+                "resourceTemplates": []
+            });
+            Some(jsonrpc_result(id, result))
+        }
         _ => Some(jsonrpc_error(
             id,
             -32601,
@@ -250,15 +429,15 @@ fn handle_tool_call(id: Value, params: Value, cancel_flag: Option<Arc<AtomicBool
         }
         "gitgrip_agent_build" => {
             let args: RepoArgs = parse_tool_args(parsed.arguments)?;
-            run_text_tool("build", args.repo, &["agent", "build"], cancel_flag)
+            run_text_tool("agent build", args.repo, &["agent", "build"], cancel_flag)
         }
         "gitgrip_agent_test" => {
             let args: RepoArgs = parse_tool_args(parsed.arguments)?;
-            run_text_tool("test", args.repo, &["agent", "test"], cancel_flag)
+            run_text_tool("agent test", args.repo, &["agent", "test"], cancel_flag)
         }
         "gitgrip_agent_verify" => {
             let args: RepoArgs = parse_tool_args(parsed.arguments)?;
-            run_text_tool("verify", args.repo, &["agent", "verify"], cancel_flag)
+            run_text_tool("agent verify", args.repo, &["agent", "verify"], cancel_flag)
         }
         "gitgrip_agent_generate_context" => {
             let args: GenerateContextArgs = parse_tool_args(parsed.arguments)?;
@@ -266,9 +445,14 @@ fn handle_tool_call(id: Value, params: Value, cancel_flag: Option<Arc<AtomicBool
             if args.dry_run {
                 cmd.push("--dry-run".to_string());
             }
-            run_command_tool("generate-context", &cmd, None, cancel_flag)
+            run_command_tool("agent generate-context", &cmd, None, cancel_flag)
         }
-        _ => Err(anyhow::anyhow!("Unknown tool: {}", parsed.name)),
+        name => {
+            let spec = find_cli_tool_spec(name)
+                .ok_or_else(|| anyhow::anyhow!("Unknown tool: {}", parsed.name))?;
+            let args: PassthroughArgs = parse_tool_args(parsed.arguments)?;
+            run_passthrough_tool(spec, args, cancel_flag)
+        }
     })();
 
     match tool_result {
@@ -296,7 +480,7 @@ fn run_context_tool(
 
     let out = run_context_command(&args, cancel_flag)?;
     if !out.success {
-        let text = command_failure_context("context", &out);
+        let text = command_failure_context("agent context", &out);
         return Ok(tool_text_response(
             &text,
             true,
@@ -342,7 +526,7 @@ fn run_command_tool(
     let out = run_gitgrip_command(args, cancel_flag)?;
     if out.success {
         let text = non_empty_output(&out.stdout, &out.stderr)
-            .unwrap_or_else(|| format!("gitgrip agent {label} completed successfully"));
+            .unwrap_or_else(|| format!("gitgrip {label} completed successfully"));
         Ok(tool_text_response(
             &text,
             false,
@@ -360,6 +544,16 @@ fn run_command_tool(
             out.status_code,
         ))
     }
+}
+
+fn run_passthrough_tool(
+    spec: &CliToolSpec,
+    args: PassthroughArgs,
+    cancel_flag: Option<Arc<AtomicBool>>,
+) -> anyhow::Result<Value> {
+    let mut cmd = vec![spec.command.to_string()];
+    cmd.extend(args.args);
+    run_command_tool(spec.command, &cmd, None, cancel_flag)
 }
 
 fn parse_tool_args<T: for<'de> Deserialize<'de>>(value: Value) -> anyhow::Result<T> {
@@ -598,10 +792,10 @@ fn capture_stream<R: Read>(mut reader: R, max_bytes: usize) -> anyhow::Result<(V
 
 fn command_failure(label: &str, out: &CommandOutput) -> String {
     let mut message = if out.cancelled {
-        format!("gitgrip agent {label} cancelled")
+        format!("gitgrip {label} cancelled")
     } else {
         format!(
-            "gitgrip agent {label} failed (exit code: {})",
+            "gitgrip {label} failed (exit code: {})",
             out.status_code
                 .map(|c| c.to_string())
                 .unwrap_or_else(|| "unknown".to_string())
@@ -618,10 +812,10 @@ fn command_failure(label: &str, out: &CommandOutput) -> String {
 
 fn command_failure_context(label: &str, out: &ContextCommandOutput) -> String {
     let mut message = if out.cancelled {
-        format!("gitgrip agent {label} cancelled")
+        format!("gitgrip {label} cancelled")
     } else {
         format!(
-            "gitgrip agent {label} failed (exit code: {})",
+            "gitgrip {label} failed (exit code: {})",
             out.status_code
                 .map(|c| c.to_string())
                 .unwrap_or_else(|| "unknown".to_string())
@@ -648,7 +842,7 @@ fn non_empty_output(stdout: &str, stderr: &str) -> Option<String> {
 }
 
 fn tools_definition() -> Vec<Value> {
-    vec![
+    let mut tools = vec![
         json!({
             "name": "gitgrip_agent_context",
             "description": "Get gitgrip workspace/repo agent context as structured JSON.",
@@ -719,7 +913,35 @@ fn tools_definition() -> Vec<Value> {
                 "additionalProperties": false
             }
         }),
-    ]
+    ];
+
+    let passthrough_schema = json!({
+        "type": "object",
+        "properties": {
+            "args": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "Additional CLI args to pass after the command name."
+            }
+        },
+        "additionalProperties": false
+    });
+
+    for spec in CLI_TOOL_SPECS {
+        tools.push(json!({
+            "name": spec.tool_name,
+            "description": spec.description,
+            "inputSchema": passthrough_schema
+        }));
+    }
+
+    tools
+}
+
+fn find_cli_tool_spec(name: &str) -> Option<&'static CliToolSpec> {
+    CLI_TOOL_SPECS.iter().find(|spec| spec.tool_name == name)
 }
 
 fn tool_text_response(
@@ -837,6 +1059,9 @@ mod tests {
         assert!(names.contains(&"gitgrip_agent_test".to_string()));
         assert!(names.contains(&"gitgrip_agent_verify".to_string()));
         assert!(names.contains(&"gitgrip_agent_generate_context".to_string()));
+        assert!(names.contains(&"gitgrip_sync".to_string()));
+        assert!(names.contains(&"gitgrip_pr".to_string()));
+        assert!(names.contains(&"gitgrip_manifest".to_string()));
     }
 
     #[test]
@@ -873,6 +1098,46 @@ mod tests {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
         assert!(is_error, "expected tool call to fail on unknown arguments");
+    }
+
+    #[test]
+    fn test_resources_list_returns_empty() {
+        let response = handle_request(RpcRequest {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(json!(1)),
+            method: "resources/list".to_string(),
+            params: json!({}),
+        })
+        .expect("resources/list should return a response");
+
+        assert_eq!(
+            response
+                .get("result")
+                .and_then(|r| r.get("resources"))
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn test_resources_templates_list_returns_empty() {
+        let response = handle_request(RpcRequest {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(json!(1)),
+            method: "resources/templates/list".to_string(),
+            params: json!({}),
+        })
+        .expect("resources/templates/list should return a response");
+
+        assert_eq!(
+            response
+                .get("result")
+                .and_then(|r| r.get("resourceTemplates"))
+                .and_then(|v| v.as_array())
+                .map(|a| a.len()),
+            Some(0)
+        );
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,0 +1,480 @@
+//! stdio MCP server for gitgrip agent operations.
+
+use anyhow::Context;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::process::{Command, Stdio};
+
+const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+
+#[derive(Debug, Deserialize)]
+struct RpcRequest {
+    #[allow(dead_code)]
+    jsonrpc: Option<String>,
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallParams {
+    name: String,
+    #[serde(default)]
+    arguments: Value,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct RepoArgs {
+    repo: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct GenerateContextArgs {
+    #[serde(default)]
+    dry_run: bool,
+}
+
+struct CommandOutput {
+    success: bool,
+    status_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+/// Run the gitgrip MCP server over stdio.
+pub fn run_mcp_server() -> anyhow::Result<()> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut reader = BufReader::new(stdin.lock());
+    let mut writer = BufWriter::new(stdout.lock());
+
+    while let Some(bytes) = read_frame(&mut reader)? {
+        let request: RpcRequest = match serde_json::from_slice(&bytes) {
+            Ok(req) => req,
+            Err(err) => {
+                let response = jsonrpc_error(Value::Null, -32700, &format!("Parse error: {err}"));
+                write_frame(&mut writer, &response)?;
+                continue;
+            }
+        };
+
+        let maybe_response = handle_request(request);
+        if let Some(response) = maybe_response {
+            write_frame(&mut writer, &response)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_request(request: RpcRequest) -> Option<Value> {
+    let id = request.id;
+
+    if id.is_none() {
+        return None;
+    }
+
+    let response = match request.method.as_str() {
+        "initialize" => {
+            let result = json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {
+                    "tools": {
+                        "listChanged": false
+                    }
+                },
+                "serverInfo": {
+                    "name": "gitgrip",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            });
+            Some(jsonrpc_result(id.clone().unwrap_or(Value::Null), result))
+        }
+        "notifications/initialized" => None,
+        "notifications/cancelled" => None,
+        "ping" => Some(jsonrpc_result(id.clone().unwrap_or(Value::Null), json!({}))),
+        "tools/list" => {
+            let result = json!({
+                "tools": tools_definition()
+            });
+            Some(jsonrpc_result(id.clone().unwrap_or(Value::Null), result))
+        }
+        "tools/call" => Some(handle_tool_call(
+            id.clone().unwrap_or(Value::Null),
+            request.params,
+        )),
+        _ => Some(jsonrpc_error(
+            id.clone().unwrap_or(Value::Null),
+            -32601,
+            &format!("Method not found: {}", request.method),
+        )),
+    };
+
+    response
+}
+
+fn handle_tool_call(id: Value, params: Value) -> Value {
+    let parsed: ToolCallParams = match serde_json::from_value(params) {
+        Ok(v) => v,
+        Err(err) => {
+            return jsonrpc_error(id, -32602, &format!("Invalid params for tools/call: {err}"));
+        }
+    };
+
+    let tool_result: anyhow::Result<Value> = (|| match parsed.name.as_str() {
+        "gitgrip_agent_context" => {
+            let args: RepoArgs = parse_tool_args(parsed.arguments)?;
+            run_context_tool(args.repo)
+        }
+        "gitgrip_agent_build" => {
+            let args: RepoArgs = parse_tool_args(parsed.arguments)?;
+            run_text_tool("build", args.repo, &["agent", "build"])
+        }
+        "gitgrip_agent_test" => {
+            let args: RepoArgs = parse_tool_args(parsed.arguments)?;
+            run_text_tool("test", args.repo, &["agent", "test"])
+        }
+        "gitgrip_agent_verify" => {
+            let args: RepoArgs = parse_tool_args(parsed.arguments)?;
+            run_text_tool("verify", args.repo, &["agent", "verify"])
+        }
+        "gitgrip_agent_generate_context" => {
+            let args: GenerateContextArgs = parse_tool_args(parsed.arguments)?;
+            let mut cmd = vec!["agent".to_string(), "generate-context".to_string()];
+            if args.dry_run {
+                cmd.push("--dry-run".to_string());
+            }
+            run_command_tool("generate-context", &cmd, None)
+        }
+        _ => Err(anyhow::anyhow!("Unknown tool: {}", parsed.name)),
+    })();
+
+    match tool_result {
+        Ok(result) => jsonrpc_result(id, result),
+        Err(err) => jsonrpc_result(id, tool_text_response(&err.to_string(), true, None)),
+    }
+}
+
+fn run_context_tool(repo: Option<String>) -> anyhow::Result<Value> {
+    let mut args = vec![
+        "--json".to_string(),
+        "agent".to_string(),
+        "context".to_string(),
+    ];
+    if let Some(repo) = repo {
+        args.push("--repo".to_string());
+        args.push(repo);
+    }
+
+    let out = run_gitgrip_command(&args)?;
+    if !out.success {
+        let text = command_failure("context", &out);
+        return Ok(tool_text_response(&text, true, None));
+    }
+
+    let stdout = out.stdout.trim();
+    let parsed_json: Value = serde_json::from_str(stdout).with_context(|| {
+        format!(
+            "agent context produced non-JSON output. stdout:\n{}",
+            if stdout.is_empty() { "<empty>" } else { stdout }
+        )
+    })?;
+
+    let pretty = serde_json::to_string_pretty(&parsed_json)?;
+    Ok(tool_text_response(&pretty, false, Some(parsed_json)))
+}
+
+fn run_text_tool(label: &str, repo: Option<String>, base_args: &[&str]) -> anyhow::Result<Value> {
+    let mut args: Vec<String> = base_args.iter().map(|s| s.to_string()).collect();
+    if let Some(repo) = repo {
+        args.push(repo);
+    }
+    run_command_tool(label, &args, None)
+}
+
+fn run_command_tool(
+    label: &str,
+    args: &[String],
+    structured: Option<Value>,
+) -> anyhow::Result<Value> {
+    let out = run_gitgrip_command(args)?;
+    if out.success {
+        let text = non_empty_output(&out.stdout, &out.stderr)
+            .unwrap_or_else(|| format!("gitgrip agent {label} completed successfully"));
+        Ok(tool_text_response(&text, false, structured))
+    } else {
+        let text = command_failure(label, &out);
+        Ok(tool_text_response(&text, true, structured))
+    }
+}
+
+fn parse_tool_args<T: for<'de> Deserialize<'de>>(value: Value) -> anyhow::Result<T> {
+    if value.is_null() {
+        return serde_json::from_value(json!({})).context("Failed to parse default args");
+    }
+    serde_json::from_value(value).context("Invalid tool arguments")
+}
+
+fn run_gitgrip_command(args: &[String]) -> anyhow::Result<CommandOutput> {
+    let exe = std::env::current_exe().context("Failed to locate current gitgrip executable")?;
+    let output = Command::new(exe)
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR", "0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .context("Failed to execute gitgrip subprocess")?;
+
+    Ok(CommandOutput {
+        success: output.status.success(),
+        status_code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn command_failure(label: &str, out: &CommandOutput) -> String {
+    let mut message = format!(
+        "gitgrip agent {label} failed (exit code: {})",
+        out.status_code
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+
+    if let Some(details) = non_empty_output(&out.stdout, &out.stderr) {
+        message.push('\n');
+        message.push_str(&details);
+    }
+
+    message
+}
+
+fn non_empty_output(stdout: &str, stderr: &str) -> Option<String> {
+    let s_out = stdout.trim();
+    let s_err = stderr.trim();
+    match (s_out.is_empty(), s_err.is_empty()) {
+        (true, true) => None,
+        (false, true) => Some(s_out.to_string()),
+        (true, false) => Some(s_err.to_string()),
+        (false, false) => Some(format!("{s_out}\n{s_err}")),
+    }
+}
+
+fn tools_definition() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "gitgrip_agent_context",
+            "description": "Get gitgrip workspace/repo agent context as structured JSON.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo": {
+                        "type": "string",
+                        "description": "Optional repo name to filter context output."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "gitgrip_agent_build",
+            "description": "Run agent.build command(s) defined in the gitgrip manifest.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo": {
+                        "type": "string",
+                        "description": "Optional repo name to build."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "gitgrip_agent_test",
+            "description": "Run agent.test command(s) defined in the gitgrip manifest.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo": {
+                        "type": "string",
+                        "description": "Optional repo name to test."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "gitgrip_agent_verify",
+            "description": "Run agent verification checks (build/test/lint) for configured repos.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo": {
+                        "type": "string",
+                        "description": "Optional repo name to verify."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "gitgrip_agent_generate_context",
+            "description": "Generate context files for configured AI tool targets.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "If true, preview generated files without writing."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }),
+    ]
+}
+
+fn tool_text_response(text: &str, is_error: bool, structured_content: Option<Value>) -> Value {
+    let mut result = json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text
+            }
+        ],
+        "isError": is_error
+    });
+
+    if let Some(content) = structured_content {
+        let result_map = result
+            .as_object_mut()
+            .expect("tool response object must be an object");
+        result_map.insert("structuredContent".to_string(), content);
+    }
+
+    result
+}
+
+fn jsonrpc_result(id: Value, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+}
+
+fn jsonrpc_error(id: Value, code: i64, message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message
+        }
+    })
+}
+
+fn read_frame<R: BufRead>(reader: &mut R) -> anyhow::Result<Option<Vec<u8>>> {
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader.read_line(&mut line)?;
+        if bytes_read == 0 {
+            if content_length.is_none() {
+                return Ok(None);
+            }
+            anyhow::bail!("Unexpected EOF while reading MCP headers");
+        }
+
+        let line = line.trim_end_matches(|c| c == '\r' || c == '\n');
+        if line.is_empty() {
+            break;
+        }
+
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("content-length") {
+                content_length = Some(
+                    value
+                        .trim()
+                        .parse::<usize>()
+                        .context("Invalid Content-Length header value")?,
+                );
+            }
+        }
+    }
+
+    let len = content_length.context("Missing Content-Length header")?;
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload)?;
+    Ok(Some(payload))
+}
+
+fn write_frame<W: Write>(writer: &mut W, message: &Value) -> anyhow::Result<()> {
+    let body = serde_json::to_vec(message)?;
+    write!(writer, "Content-Length: {}\r\n\r\n", body.len())?;
+    writer.write_all(&body)?;
+    writer.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tool_list_has_expected_tools() {
+        let tools = tools_definition();
+        let names: Vec<String> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(str::to_string))
+            .collect();
+
+        assert!(names.contains(&"gitgrip_agent_context".to_string()));
+        assert!(names.contains(&"gitgrip_agent_build".to_string()));
+        assert!(names.contains(&"gitgrip_agent_test".to_string()));
+        assert!(names.contains(&"gitgrip_agent_verify".to_string()));
+        assert!(names.contains(&"gitgrip_agent_generate_context".to_string()));
+    }
+
+    #[test]
+    fn test_read_frame_parses_valid_message() {
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+        let input = format!(
+            "Content-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
+            payload.len(),
+            String::from_utf8_lossy(payload)
+        );
+
+        let mut reader = BufReader::new(input.as_bytes());
+        let read = read_frame(&mut reader).unwrap().unwrap();
+        assert_eq!(read, payload);
+    }
+
+    #[test]
+    fn test_tool_call_rejects_unknown_arguments() {
+        let response = handle_tool_call(
+            json!(1),
+            json!({
+                "name": "gitgrip_agent_build",
+                "arguments": {
+                    "repo": "app",
+                    "unexpected": true
+                }
+            }),
+        );
+
+        let is_error = response
+            .get("result")
+            .and_then(|r| r.get("isError"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        assert!(is_error, "expected tool call to fail on unknown arguments");
+    }
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -12,7 +12,8 @@ use std::thread;
 use std::time::Duration;
 
 const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
-const MAX_CAPTURE_BYTES: usize = 1024 * 1024;
+const DEFAULT_MAX_CAPTURE_BYTES: usize = 1024 * 1024;
+const MAX_CAPTURE_ENV: &str = "GITGRIP_MCP_MAX_CAPTURE_BYTES";
 const CAPTURE_TRUNCATED_MSG: &str = "\n[output truncated: exceeded capture limit]";
 
 #[derive(Debug, Deserialize)]
@@ -56,6 +57,14 @@ struct CommandOutput {
     cancelled: bool,
     status_code: Option<i32>,
     stdout: String,
+    stderr: String,
+}
+
+struct ContextCommandOutput {
+    success: bool,
+    cancelled: bool,
+    status_code: Option<i32>,
+    context_json: Option<Value>,
     stderr: String,
 }
 
@@ -264,7 +273,10 @@ fn handle_tool_call(id: Value, params: Value, cancel_flag: Option<Arc<AtomicBool
 
     match tool_result {
         Ok(result) => jsonrpc_result(id, result),
-        Err(err) => jsonrpc_result(id, tool_text_response(&err.to_string(), true, None)),
+        Err(err) => jsonrpc_result(
+            id,
+            tool_text_response(&err.to_string(), true, None, false, None),
+        ),
     }
 }
 
@@ -282,22 +294,30 @@ fn run_context_tool(
         args.push(repo);
     }
 
-    let out = run_gitgrip_command(&args, cancel_flag)?;
+    let out = run_context_command(&args, cancel_flag)?;
     if !out.success {
-        let text = command_failure("context", &out);
-        return Ok(tool_text_response(&text, true, None));
+        let text = command_failure_context("context", &out);
+        return Ok(tool_text_response(
+            &text,
+            true,
+            None,
+            out.cancelled,
+            out.status_code,
+        ));
     }
 
-    let stdout = out.stdout.trim();
-    let parsed_json: Value = serde_json::from_str(stdout).with_context(|| {
-        format!(
-            "agent context produced non-JSON output. stdout:\n{}",
-            if stdout.is_empty() { "<empty>" } else { stdout }
-        )
-    })?;
+    let parsed_json = out
+        .context_json
+        .context("agent context did not produce structured JSON output")?;
 
     let pretty = serde_json::to_string_pretty(&parsed_json)?;
-    Ok(tool_text_response(&pretty, false, Some(parsed_json)))
+    Ok(tool_text_response(
+        &pretty,
+        false,
+        Some(parsed_json),
+        false,
+        out.status_code,
+    ))
 }
 
 fn run_text_tool(
@@ -323,10 +343,22 @@ fn run_command_tool(
     if out.success {
         let text = non_empty_output(&out.stdout, &out.stderr)
             .unwrap_or_else(|| format!("gitgrip agent {label} completed successfully"));
-        Ok(tool_text_response(&text, false, structured))
+        Ok(tool_text_response(
+            &text,
+            false,
+            structured,
+            false,
+            out.status_code,
+        ))
     } else {
         let text = command_failure(label, &out);
-        Ok(tool_text_response(&text, true, structured))
+        Ok(tool_text_response(
+            &text,
+            true,
+            structured,
+            out.cancelled,
+            out.status_code,
+        ))
     }
 }
 
@@ -360,31 +392,16 @@ fn run_gitgrip_command(
         .take()
         .context("Failed to capture subprocess stderr")?;
 
-    let out_thread = thread::spawn(move || capture_stream(stdout));
-    let err_thread = thread::spawn(move || capture_stream(stderr));
+    let max_capture = max_capture_bytes();
+    let out_thread = thread::spawn(move || capture_stream(stdout, max_capture));
+    let err_thread = thread::spawn(move || capture_stream(stderr, max_capture));
 
-    let mut cancelled = false;
-    let status = loop {
-        if cancel_flag
-            .as_ref()
-            .is_some_and(|f| f.load(Ordering::SeqCst))
-        {
-            cancelled = true;
-            let _ = child.kill();
-            break child
-                .wait()
-                .context("Failed waiting on cancelled subprocess")?;
-        }
+    let cancel_status = start_cancel_controller(child.id(), cancel_flag.clone());
 
-        if let Some(status) = child
-            .try_wait()
-            .context("Failed to poll subprocess status")?
-        {
-            break status;
-        }
-
-        thread::sleep(Duration::from_millis(30));
-    };
+    let status = child.wait().context("Failed waiting for subprocess")?;
+    cancel_status.done.store(true, Ordering::SeqCst);
+    let _ = cancel_status.join.join();
+    let cancelled = cancel_status.kill_sent.load(Ordering::SeqCst);
 
     let (stdout, stdout_truncated) = out_thread
         .join()
@@ -412,7 +429,148 @@ fn run_gitgrip_command(
     })
 }
 
-fn capture_stream<R: Read>(mut reader: R) -> anyhow::Result<(Vec<u8>, bool)> {
+fn run_context_command(
+    args: &[String],
+    cancel_flag: Option<Arc<AtomicBool>>,
+) -> anyhow::Result<ContextCommandOutput> {
+    let exe = std::env::current_exe().context("Failed to locate current gitgrip executable")?;
+    let mut child = Command::new(exe)
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR", "0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("Failed to execute gitgrip subprocess")?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .context("Failed to capture subprocess stdout")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("Failed to capture subprocess stderr")?;
+
+    let max_capture = max_capture_bytes();
+    let err_thread = thread::spawn(move || capture_stream(stderr, max_capture));
+    let parse_thread = thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        serde_json::from_reader::<_, Value>(&mut reader)
+    });
+
+    let cancel_status = start_cancel_controller(child.id(), cancel_flag);
+
+    let status = child.wait().context("Failed waiting for subprocess")?;
+    cancel_status.done.store(true, Ordering::SeqCst);
+    let _ = cancel_status.join.join();
+    let cancelled = cancel_status.kill_sent.load(Ordering::SeqCst);
+
+    let context_json = parse_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("stdout parser thread panicked"))?;
+
+    let (stderr, stderr_truncated) = err_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("stderr capture thread panicked"))??;
+    let mut stderr = String::from_utf8_lossy(&stderr).to_string();
+    if stderr_truncated {
+        stderr.push_str(CAPTURE_TRUNCATED_MSG);
+    }
+
+    let context_json = match context_json {
+        Ok(value) => Some(value),
+        Err(err) => {
+            if status.success() && !cancelled {
+                return Err(anyhow::anyhow!(
+                    "agent context produced non-JSON output: {err}"
+                ));
+            }
+            None
+        }
+    };
+
+    Ok(ContextCommandOutput {
+        success: status.success() && !cancelled && context_json.is_some(),
+        cancelled,
+        status_code: status.code(),
+        context_json,
+        stderr,
+    })
+}
+
+struct CancelController {
+    done: Arc<AtomicBool>,
+    kill_sent: Arc<AtomicBool>,
+    join: thread::JoinHandle<()>,
+}
+
+fn start_cancel_controller(pid: u32, cancel_flag: Option<Arc<AtomicBool>>) -> CancelController {
+    let done = Arc::new(AtomicBool::new(false));
+    let kill_sent = Arc::new(AtomicBool::new(false));
+
+    let done_clone = Arc::clone(&done);
+    let kill_clone = Arc::clone(&kill_sent);
+    let join = thread::spawn(move || {
+        let Some(flag) = cancel_flag else {
+            return;
+        };
+
+        while !done_clone.load(Ordering::SeqCst) {
+            if flag.load(Ordering::SeqCst) {
+                if kill_process(pid).is_ok() {
+                    kill_clone.store(true, Ordering::SeqCst);
+                }
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    });
+
+    CancelController {
+        done,
+        kill_sent,
+        join,
+    }
+}
+
+#[cfg(unix)]
+fn kill_process(pid: u32) -> std::io::Result<()> {
+    let pid_s = pid.to_string();
+    let status = Command::new("kill").args(["-TERM", &pid_s]).status()?;
+    if status.success() {
+        return Ok(());
+    }
+
+    let status = Command::new("kill").args(["-KILL", &pid_s]).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other("failed to kill process"))
+    }
+}
+
+#[cfg(windows)]
+fn kill_process(pid: u32) -> std::io::Result<()> {
+    let status = Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F"])
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other("failed to kill process"))
+    }
+}
+
+fn max_capture_bytes() -> usize {
+    std::env::var(MAX_CAPTURE_ENV)
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_MAX_CAPTURE_BYTES)
+}
+
+fn capture_stream<R: Read>(mut reader: R, max_bytes: usize) -> anyhow::Result<(Vec<u8>, bool)> {
     let mut out = Vec::new();
     let mut buf = [0u8; 8192];
     let mut truncated = false;
@@ -423,8 +581,8 @@ fn capture_stream<R: Read>(mut reader: R) -> anyhow::Result<(Vec<u8>, bool)> {
             break;
         }
 
-        if out.len() < MAX_CAPTURE_BYTES {
-            let remaining = MAX_CAPTURE_BYTES - out.len();
+        if out.len() < max_bytes {
+            let remaining = max_bytes - out.len();
             let keep = remaining.min(read);
             out.extend_from_slice(&buf[..keep]);
             if keep < read {
@@ -453,6 +611,26 @@ fn command_failure(label: &str, out: &CommandOutput) -> String {
     if let Some(details) = non_empty_output(&out.stdout, &out.stderr) {
         message.push('\n');
         message.push_str(&details);
+    }
+
+    message
+}
+
+fn command_failure_context(label: &str, out: &ContextCommandOutput) -> String {
+    let mut message = if out.cancelled {
+        format!("gitgrip agent {label} cancelled")
+    } else {
+        format!(
+            "gitgrip agent {label} failed (exit code: {})",
+            out.status_code
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        )
+    };
+
+    if !out.stderr.trim().is_empty() {
+        message.push('\n');
+        message.push_str(out.stderr.trim());
     }
 
     message
@@ -544,7 +722,13 @@ fn tools_definition() -> Vec<Value> {
     ]
 }
 
-fn tool_text_response(text: &str, is_error: bool, structured_content: Option<Value>) -> Value {
+fn tool_text_response(
+    text: &str,
+    is_error: bool,
+    structured_content: Option<Value>,
+    cancelled: bool,
+    status_code: Option<i32>,
+) -> Value {
     let mut result = json!({
         "content": [
             {
@@ -555,11 +739,18 @@ fn tool_text_response(text: &str, is_error: bool, structured_content: Option<Val
         "isError": is_error
     });
 
+    let result_map = result
+        .as_object_mut()
+        .expect("tool response object must be an object");
+
     if let Some(content) = structured_content {
-        let result_map = result
-            .as_object_mut()
-            .expect("tool response object must be an object");
         result_map.insert("structuredContent".to_string(), content);
+    }
+    if cancelled {
+        result_map.insert("cancelled".to_string(), Value::Bool(true));
+    }
+    if let Some(code) = status_code {
+        result_map.insert("exitCode".to_string(), Value::Number(code.into()));
     }
 
     result
@@ -686,9 +877,10 @@ mod tests {
 
     #[test]
     fn test_capture_stream_truncates() {
-        let input = vec![b'a'; MAX_CAPTURE_BYTES + 128];
-        let (captured, truncated) = capture_stream(Cursor::new(input)).unwrap();
-        assert_eq!(captured.len(), MAX_CAPTURE_BYTES);
+        let max = 1024;
+        let input = vec![b'a'; max + 128];
+        let (captured, truncated) = capture_stream(Cursor::new(input), max).unwrap();
+        assert_eq!(captured.len(), max);
         assert!(truncated);
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1010,7 +1010,7 @@ fn read_frame<R: BufRead>(reader: &mut R) -> anyhow::Result<Option<Vec<u8>>> {
             anyhow::bail!("Unexpected EOF while reading MCP headers");
         }
 
-        let line = line.trim_end_matches(|c| c == '\r' || c == '\n');
+        let line = line.trim_end_matches(['\r', '\n']);
         if line.is_empty() {
             break;
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3,10 +3,17 @@
 use anyhow::Context;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::collections::HashMap;
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::Duration;
 
 const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+const MAX_CAPTURE_BYTES: usize = 1024 * 1024;
+const CAPTURE_TRUNCATED_MSG: &str = "\n[output truncated: exceeded capture limit]";
 
 #[derive(Debug, Deserialize)]
 struct RpcRequest {
@@ -25,6 +32,12 @@ struct ToolCallParams {
     arguments: Value,
 }
 
+#[derive(Debug, Deserialize)]
+struct CancelledParams {
+    #[serde(rename = "requestId")]
+    request_id: Value,
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 struct RepoArgs {
@@ -40,31 +53,124 @@ struct GenerateContextArgs {
 
 struct CommandOutput {
     success: bool,
+    cancelled: bool,
     status_code: Option<i32>,
     stdout: String,
     stderr: String,
 }
 
+enum ReaderEvent {
+    Frame(Vec<u8>),
+    Eof,
+    Error(String),
+}
+
+struct WorkerResponse {
+    request_key: String,
+    response: Value,
+}
+
 /// Run the gitgrip MCP server over stdio.
 pub fn run_mcp_server() -> anyhow::Result<()> {
-    let stdin = io::stdin();
-    let stdout = io::stdout();
-    let mut reader = BufReader::new(stdin.lock());
-    let mut writer = BufWriter::new(stdout.lock());
+    let (reader_tx, reader_rx) = mpsc::channel::<ReaderEvent>();
+    thread::spawn(move || {
+        let stdin = io::stdin();
+        let mut reader = BufReader::new(stdin.lock());
 
-    while let Some(bytes) = read_frame(&mut reader)? {
-        let request: RpcRequest = match serde_json::from_slice(&bytes) {
-            Ok(req) => req,
-            Err(err) => {
-                let response = jsonrpc_error(Value::Null, -32700, &format!("Parse error: {err}"));
-                write_frame(&mut writer, &response)?;
-                continue;
+        loop {
+            match read_frame(&mut reader) {
+                Ok(Some(bytes)) => {
+                    if reader_tx.send(ReaderEvent::Frame(bytes)).is_err() {
+                        break;
+                    }
+                }
+                Ok(None) => {
+                    let _ = reader_tx.send(ReaderEvent::Eof);
+                    break;
+                }
+                Err(err) => {
+                    let _ = reader_tx.send(ReaderEvent::Error(err.to_string()));
+                    break;
+                }
             }
-        };
+        }
+    });
 
-        let maybe_response = handle_request(request);
-        if let Some(response) = maybe_response {
-            write_frame(&mut writer, &response)?;
+    let (worker_tx, worker_rx) = mpsc::channel::<WorkerResponse>();
+    let stdout = io::stdout();
+    let mut writer = io::BufWriter::new(stdout.lock());
+
+    let mut reader_done = false;
+    let mut cancellation_map: HashMap<String, Arc<AtomicBool>> = HashMap::new();
+
+    loop {
+        while let Ok(done) = worker_rx.try_recv() {
+            cancellation_map.remove(&done.request_key);
+            write_frame(&mut writer, &done.response)?;
+        }
+
+        if reader_done && cancellation_map.is_empty() {
+            break;
+        }
+
+        match reader_rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(ReaderEvent::Frame(bytes)) => {
+                let request: RpcRequest = match serde_json::from_slice(&bytes) {
+                    Ok(req) => req,
+                    Err(err) => {
+                        let response =
+                            jsonrpc_error(Value::Null, -32700, &format!("Parse error: {err}"));
+                        write_frame(&mut writer, &response)?;
+                        continue;
+                    }
+                };
+
+                if request.method == "notifications/cancelled" {
+                    handle_cancel_notification(request.params, &cancellation_map);
+                    continue;
+                }
+
+                let Some(id) = request.id.clone() else {
+                    continue;
+                };
+
+                if request.method == "tools/call" {
+                    let request_key = request_id_key(&id);
+                    let cancel_flag = Arc::new(AtomicBool::new(false));
+                    cancellation_map.insert(request_key.clone(), Arc::clone(&cancel_flag));
+
+                    let tx = worker_tx.clone();
+                    let params = request.params;
+                    thread::spawn(move || {
+                        let response = handle_tool_call(id, params, Some(cancel_flag));
+                        let _ = tx.send(WorkerResponse {
+                            request_key,
+                            response,
+                        });
+                    });
+                    continue;
+                }
+
+                if let Some(response) = handle_request(request) {
+                    write_frame(&mut writer, &response)?;
+                }
+            }
+            Ok(ReaderEvent::Eof) => {
+                reader_done = true;
+            }
+            Ok(ReaderEvent::Error(message)) => {
+                let response = jsonrpc_error(
+                    Value::Null,
+                    -32000,
+                    &format!("MCP server read failure: {message}"),
+                );
+                write_frame(&mut writer, &response)?;
+                reader_done = true;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                reader_done = true;
+            }
         }
     }
 
@@ -72,13 +178,9 @@ pub fn run_mcp_server() -> anyhow::Result<()> {
 }
 
 fn handle_request(request: RpcRequest) -> Option<Value> {
-    let id = request.id;
+    let id = request.id?;
 
-    if id.is_none() {
-        return None;
-    }
-
-    let response = match request.method.as_str() {
+    match request.method.as_str() {
         "initialize" => {
             let result = json!({
                 "protocolVersion": MCP_PROTOCOL_VERSION,
@@ -92,32 +194,39 @@ fn handle_request(request: RpcRequest) -> Option<Value> {
                     "version": env!("CARGO_PKG_VERSION")
                 }
             });
-            Some(jsonrpc_result(id.clone().unwrap_or(Value::Null), result))
+            Some(jsonrpc_result(id, result))
         }
-        "notifications/initialized" => None,
-        "notifications/cancelled" => None,
-        "ping" => Some(jsonrpc_result(id.clone().unwrap_or(Value::Null), json!({}))),
+        "ping" => Some(jsonrpc_result(id, json!({}))),
         "tools/list" => {
             let result = json!({
                 "tools": tools_definition()
             });
-            Some(jsonrpc_result(id.clone().unwrap_or(Value::Null), result))
+            Some(jsonrpc_result(id, result))
         }
-        "tools/call" => Some(handle_tool_call(
-            id.clone().unwrap_or(Value::Null),
-            request.params,
-        )),
         _ => Some(jsonrpc_error(
-            id.clone().unwrap_or(Value::Null),
+            id,
             -32601,
             &format!("Method not found: {}", request.method),
         )),
-    };
-
-    response
+    }
 }
 
-fn handle_tool_call(id: Value, params: Value) -> Value {
+fn handle_cancel_notification(params: Value, cancellation_map: &HashMap<String, Arc<AtomicBool>>) {
+    let Ok(parsed) = serde_json::from_value::<CancelledParams>(params) else {
+        return;
+    };
+
+    let key = request_id_key(&parsed.request_id);
+    if let Some(flag) = cancellation_map.get(&key) {
+        flag.store(true, Ordering::SeqCst);
+    }
+}
+
+fn request_id_key(id: &Value) -> String {
+    id.to_string()
+}
+
+fn handle_tool_call(id: Value, params: Value, cancel_flag: Option<Arc<AtomicBool>>) -> Value {
     let parsed: ToolCallParams = match serde_json::from_value(params) {
         Ok(v) => v,
         Err(err) => {
@@ -128,19 +237,19 @@ fn handle_tool_call(id: Value, params: Value) -> Value {
     let tool_result: anyhow::Result<Value> = (|| match parsed.name.as_str() {
         "gitgrip_agent_context" => {
             let args: RepoArgs = parse_tool_args(parsed.arguments)?;
-            run_context_tool(args.repo)
+            run_context_tool(args.repo, cancel_flag)
         }
         "gitgrip_agent_build" => {
             let args: RepoArgs = parse_tool_args(parsed.arguments)?;
-            run_text_tool("build", args.repo, &["agent", "build"])
+            run_text_tool("build", args.repo, &["agent", "build"], cancel_flag)
         }
         "gitgrip_agent_test" => {
             let args: RepoArgs = parse_tool_args(parsed.arguments)?;
-            run_text_tool("test", args.repo, &["agent", "test"])
+            run_text_tool("test", args.repo, &["agent", "test"], cancel_flag)
         }
         "gitgrip_agent_verify" => {
             let args: RepoArgs = parse_tool_args(parsed.arguments)?;
-            run_text_tool("verify", args.repo, &["agent", "verify"])
+            run_text_tool("verify", args.repo, &["agent", "verify"], cancel_flag)
         }
         "gitgrip_agent_generate_context" => {
             let args: GenerateContextArgs = parse_tool_args(parsed.arguments)?;
@@ -148,7 +257,7 @@ fn handle_tool_call(id: Value, params: Value) -> Value {
             if args.dry_run {
                 cmd.push("--dry-run".to_string());
             }
-            run_command_tool("generate-context", &cmd, None)
+            run_command_tool("generate-context", &cmd, None, cancel_flag)
         }
         _ => Err(anyhow::anyhow!("Unknown tool: {}", parsed.name)),
     })();
@@ -159,7 +268,10 @@ fn handle_tool_call(id: Value, params: Value) -> Value {
     }
 }
 
-fn run_context_tool(repo: Option<String>) -> anyhow::Result<Value> {
+fn run_context_tool(
+    repo: Option<String>,
+    cancel_flag: Option<Arc<AtomicBool>>,
+) -> anyhow::Result<Value> {
     let mut args = vec![
         "--json".to_string(),
         "agent".to_string(),
@@ -170,7 +282,7 @@ fn run_context_tool(repo: Option<String>) -> anyhow::Result<Value> {
         args.push(repo);
     }
 
-    let out = run_gitgrip_command(&args)?;
+    let out = run_gitgrip_command(&args, cancel_flag)?;
     if !out.success {
         let text = command_failure("context", &out);
         return Ok(tool_text_response(&text, true, None));
@@ -188,20 +300,26 @@ fn run_context_tool(repo: Option<String>) -> anyhow::Result<Value> {
     Ok(tool_text_response(&pretty, false, Some(parsed_json)))
 }
 
-fn run_text_tool(label: &str, repo: Option<String>, base_args: &[&str]) -> anyhow::Result<Value> {
+fn run_text_tool(
+    label: &str,
+    repo: Option<String>,
+    base_args: &[&str],
+    cancel_flag: Option<Arc<AtomicBool>>,
+) -> anyhow::Result<Value> {
     let mut args: Vec<String> = base_args.iter().map(|s| s.to_string()).collect();
     if let Some(repo) = repo {
         args.push(repo);
     }
-    run_command_tool(label, &args, None)
+    run_command_tool(label, &args, None, cancel_flag)
 }
 
 fn run_command_tool(
     label: &str,
     args: &[String],
     structured: Option<Value>,
+    cancel_flag: Option<Arc<AtomicBool>>,
 ) -> anyhow::Result<Value> {
-    let out = run_gitgrip_command(args)?;
+    let out = run_gitgrip_command(args, cancel_flag)?;
     if out.success {
         let text = non_empty_output(&out.stdout, &out.stderr)
             .unwrap_or_else(|| format!("gitgrip agent {label} completed successfully"));
@@ -219,32 +337,118 @@ fn parse_tool_args<T: for<'de> Deserialize<'de>>(value: Value) -> anyhow::Result
     serde_json::from_value(value).context("Invalid tool arguments")
 }
 
-fn run_gitgrip_command(args: &[String]) -> anyhow::Result<CommandOutput> {
+fn run_gitgrip_command(
+    args: &[String],
+    cancel_flag: Option<Arc<AtomicBool>>,
+) -> anyhow::Result<CommandOutput> {
     let exe = std::env::current_exe().context("Failed to locate current gitgrip executable")?;
-    let output = Command::new(exe)
+    let mut child = Command::new(exe)
         .args(args)
         .env("NO_COLOR", "1")
         .env("CLICOLOR", "0")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
+        .spawn()
         .context("Failed to execute gitgrip subprocess")?;
 
+    let stdout = child
+        .stdout
+        .take()
+        .context("Failed to capture subprocess stdout")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("Failed to capture subprocess stderr")?;
+
+    let out_thread = thread::spawn(move || capture_stream(stdout));
+    let err_thread = thread::spawn(move || capture_stream(stderr));
+
+    let mut cancelled = false;
+    let status = loop {
+        if cancel_flag
+            .as_ref()
+            .is_some_and(|f| f.load(Ordering::SeqCst))
+        {
+            cancelled = true;
+            let _ = child.kill();
+            break child
+                .wait()
+                .context("Failed waiting on cancelled subprocess")?;
+        }
+
+        if let Some(status) = child
+            .try_wait()
+            .context("Failed to poll subprocess status")?
+        {
+            break status;
+        }
+
+        thread::sleep(Duration::from_millis(30));
+    };
+
+    let (stdout, stdout_truncated) = out_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("stdout capture thread panicked"))??;
+    let (stderr, stderr_truncated) = err_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("stderr capture thread panicked"))??;
+
+    let mut stdout = String::from_utf8_lossy(&stdout).to_string();
+    let mut stderr = String::from_utf8_lossy(&stderr).to_string();
+
+    if stdout_truncated {
+        stdout.push_str(CAPTURE_TRUNCATED_MSG);
+    }
+    if stderr_truncated {
+        stderr.push_str(CAPTURE_TRUNCATED_MSG);
+    }
+
     Ok(CommandOutput {
-        success: output.status.success(),
-        status_code: output.status.code(),
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        success: status.success() && !cancelled,
+        cancelled,
+        status_code: status.code(),
+        stdout,
+        stderr,
     })
 }
 
+fn capture_stream<R: Read>(mut reader: R) -> anyhow::Result<(Vec<u8>, bool)> {
+    let mut out = Vec::new();
+    let mut buf = [0u8; 8192];
+    let mut truncated = false;
+
+    loop {
+        let read = reader.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+
+        if out.len() < MAX_CAPTURE_BYTES {
+            let remaining = MAX_CAPTURE_BYTES - out.len();
+            let keep = remaining.min(read);
+            out.extend_from_slice(&buf[..keep]);
+            if keep < read {
+                truncated = true;
+            }
+        } else {
+            truncated = true;
+        }
+    }
+
+    Ok((out, truncated))
+}
+
 fn command_failure(label: &str, out: &CommandOutput) -> String {
-    let mut message = format!(
-        "gitgrip agent {label} failed (exit code: {})",
-        out.status_code
-            .map(|c| c.to_string())
-            .unwrap_or_else(|| "unknown".to_string())
-    );
+    let mut message = if out.cancelled {
+        format!("gitgrip agent {label} cancelled")
+    } else {
+        format!(
+            "gitgrip agent {label} failed (exit code: {})",
+            out.status_code
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        )
+    };
 
     if let Some(details) = non_empty_output(&out.stdout, &out.stderr) {
         message.push('\n');
@@ -427,6 +631,7 @@ fn write_frame<W: Write>(writer: &mut W, message: &Value) -> anyhow::Result<()> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     #[test]
     fn test_tool_list_has_expected_tools() {
@@ -468,6 +673,7 @@ mod tests {
                     "unexpected": true
                 }
             }),
+            None,
         );
 
         let is_error = response
@@ -476,5 +682,26 @@ mod tests {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
         assert!(is_error, "expected tool call to fail on unknown arguments");
+    }
+
+    #[test]
+    fn test_capture_stream_truncates() {
+        let input = vec![b'a'; MAX_CAPTURE_BYTES + 128];
+        let (captured, truncated) = capture_stream(Cursor::new(input)).unwrap();
+        assert_eq!(captured.len(), MAX_CAPTURE_BYTES);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_cancel_notification_sets_flag() {
+        let request_id = json!(123);
+        let key = request_id_key(&request_id);
+        let flag = Arc::new(AtomicBool::new(false));
+        let mut map = HashMap::new();
+        map.insert(key, Arc::clone(&flag));
+
+        handle_cancel_notification(json!({ "requestId": 123 }), &map);
+
+        assert!(flag.load(Ordering::SeqCst));
     }
 }

--- a/src/platform/azure.rs
+++ b/src/platform/azure.rs
@@ -130,14 +130,14 @@ impl AzureDevOpsAdapter {
             self.base_url, ctx.organization, ctx.project, endpoint
         );
 
-        // Azure DevOps uses Basic auth with PAT (username can be empty)
-        let auth = STANDARD.encode(format!(":{}", token));
-
         let mut request = self
             .http_client
             .request(method, &url)
-            .header("Authorization", format!("Basic {}", auth))
-            .header("Content-Type", "application/json");
+            .header("Authorization", self.build_auth_header(&token))
+            .header("Content-Type", "application/json")
+            // Required for Azure AD tokens with Microsoft personal accounts (MSA)
+            .header("X-VSS-ForceMsaPassThrough", "true")
+            .header("X-TFS-FedAuthRedirect", "Suppress");
 
         if let Some(b) = body {
             request = request.json(&b);
@@ -176,13 +176,13 @@ impl AzureDevOpsAdapter {
             self.base_url, ctx.organization, ctx.project, endpoint
         );
 
-        let auth = STANDARD.encode(format!(":{}", token));
-
         let response = self
             .http_client
             .patch(&url)
-            .header("Authorization", format!("Basic {}", auth))
+            .header("Authorization", self.build_auth_header(&token))
             .header("Content-Type", "application/json")
+            .header("X-VSS-ForceMsaPassThrough", "true")
+            .header("X-TFS-FedAuthRedirect", "Suppress")
             .json(&body)
             .send()
             .await
@@ -198,6 +198,16 @@ impl AzureDevOpsAdapter {
         }
 
         Ok(())
+    }
+
+    /// Build auth header: Bearer for Azure AD JWT tokens, Basic for PATs.
+    fn build_auth_header(&self, token: &str) -> String {
+        if token.starts_with("eyJ") {
+            format!("Bearer {}", token)
+        } else {
+            let encoded = STANDARD.encode(format!(":{}", token));
+            format!("Basic {}", encoded)
+        }
     }
 
     /// Build PR web URL

--- a/tests/test_mcp_server.rs
+++ b/tests/test_mcp_server.rs
@@ -1,0 +1,216 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::thread;
+use std::time::Duration;
+use tempfile::TempDir;
+
+fn write_frame(stdin: &mut ChildStdin, payload: &Value) {
+    let bytes = serde_json::to_vec(payload).expect("serialize payload");
+    write!(stdin, "Content-Length: {}\r\n\r\n", bytes.len()).expect("write header");
+    stdin.write_all(&bytes).expect("write payload");
+    stdin.flush().expect("flush stdin");
+}
+
+fn read_frame(stdout: &mut BufReader<ChildStdout>) -> Value {
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let mut line = String::new();
+        let read = stdout.read_line(&mut line).expect("read frame header line");
+        assert!(read > 0, "unexpected EOF while reading frame headers");
+
+        let line = line.trim_end_matches(['\r', '\n']);
+        if line.is_empty() {
+            break;
+        }
+
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("content-length") {
+                content_length = Some(value.trim().parse::<usize>().expect("parse Content-Length"));
+            }
+        }
+    }
+
+    let len = content_length.expect("missing Content-Length");
+    let mut body = vec![0u8; len];
+    stdout.read_exact(&mut body).expect("read frame body");
+    serde_json::from_slice(&body).expect("parse JSON payload")
+}
+
+fn shutdown(mut child: Child) {
+    drop(child.stdin.take());
+
+    for _ in 0..100 {
+        if child.try_wait().expect("poll child").is_some() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn write_minimal_workspace(root: &std::path::Path) {
+    let spaces_main = root.join(".gitgrip").join("spaces").join("main");
+    fs::create_dir_all(&spaces_main).expect("create spaces/main");
+    fs::create_dir_all(root.join("app")).expect("create app dir");
+
+    let manifest = r#"version: 1
+repos:
+  app:
+    url: git@github.com:example/app.git
+    path: ./app
+    default_branch: main
+    agent:
+      build: sleep 5
+"#;
+    fs::write(spaces_main.join("gripspace.yml"), manifest).expect("write manifest");
+}
+
+#[test]
+fn test_mcp_server_initialize_list_and_call() {
+    let temp = TempDir::new().expect("create temp dir");
+    let exe = env!("CARGO_BIN_EXE_gitgrip");
+
+    let mut child = Command::new(exe)
+        .args(["mcp", "server"])
+        .current_dir(temp.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mcp server");
+
+    let mut stdin = child.stdin.take().expect("take stdin");
+    let stdout = child.stdout.take().expect("take stdout");
+    let mut reader = BufReader::new(stdout);
+
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }),
+    );
+    let initialize = read_frame(&mut reader);
+    assert_eq!(initialize["id"], json!(1));
+    assert_eq!(initialize["result"]["protocolVersion"], json!("2024-11-05"));
+
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }),
+    );
+    let tools = read_frame(&mut reader);
+    assert_eq!(tools["id"], json!(2));
+
+    let names: Vec<&str> = tools["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t.get("name").and_then(Value::as_str))
+        .collect();
+    assert!(names.contains(&"gitgrip_agent_context"));
+    assert!(names.contains(&"gitgrip_agent_build"));
+
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "gitgrip_agent_build",
+                "arguments": {}
+            }
+        }),
+    );
+    let call = read_frame(&mut reader);
+    assert_eq!(call["id"], json!(3));
+    assert_eq!(call["result"]["isError"], json!(true));
+
+    drop(stdin);
+    shutdown(child);
+}
+
+#[test]
+fn test_mcp_server_cancelled_notification_interrupts_tool_call() {
+    let temp = TempDir::new().expect("create temp dir");
+    write_minimal_workspace(temp.path());
+    let exe = env!("CARGO_BIN_EXE_gitgrip");
+
+    let mut child = Command::new(exe)
+        .args(["mcp", "server"])
+        .current_dir(temp.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mcp server");
+
+    let mut stdin = child.stdin.take().expect("take stdin");
+    let stdout = child.stdout.take().expect("take stdout");
+    let mut reader = BufReader::new(stdout);
+
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }),
+    );
+    let _ = read_frame(&mut reader);
+
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "tools/call",
+            "params": {
+                "name": "gitgrip_agent_build",
+                "arguments": {
+                    "repo": "app"
+                }
+            }
+        }),
+    );
+
+    thread::sleep(Duration::from_millis(150));
+
+    write_frame(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/cancelled",
+            "params": {
+                "requestId": 42
+            }
+        }),
+    );
+
+    let response = read_frame(&mut reader);
+    assert_eq!(response["id"], json!(42));
+    assert_eq!(response["result"]["isError"], json!(true));
+    let text = response["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        text.contains("cancelled"),
+        "expected cancellation message, got: {text}"
+    );
+
+    drop(stdin);
+    shutdown(child);
+}

--- a/tests/test_mcp_server.rs
+++ b/tests/test_mcp_server.rs
@@ -1,116 +1,161 @@
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
+use std::path::Path;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
 
-fn write_frame(stdin: &mut ChildStdin, payload: &Value) {
-    let bytes = serde_json::to_vec(payload).expect("serialize payload");
-    write!(stdin, "Content-Length: {}\r\n\r\n", bytes.len()).expect("write header");
-    stdin.write_all(&bytes).expect("write payload");
-    stdin.flush().expect("flush stdin");
+struct ServerHarness {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
 }
 
-fn read_frame(stdout: &mut BufReader<ChildStdout>) -> Value {
-    let mut content_length: Option<usize> = None;
-
-    loop {
-        let mut line = String::new();
-        let read = stdout.read_line(&mut line).expect("read frame header line");
-        assert!(read > 0, "unexpected EOF while reading frame headers");
-
-        let line = line.trim_end_matches(['\r', '\n']);
-        if line.is_empty() {
-            break;
+impl ServerHarness {
+    fn spawn(cwd: &Path, envs: &[(&str, &str)]) -> Self {
+        let exe = env!("CARGO_BIN_EXE_gitgrip");
+        let mut cmd = Command::new(exe);
+        cmd.args(["mcp", "server"]).current_dir(cwd);
+        for (k, v) in envs {
+            cmd.env(k, v);
         }
 
-        if let Some((name, value)) = line.split_once(':') {
-            if name.trim().eq_ignore_ascii_case("content-length") {
-                content_length = Some(value.trim().parse::<usize>().expect("parse Content-Length"));
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn mcp server");
+
+        let stdin = child.stdin.take().expect("take stdin");
+        let stdout = child.stdout.take().expect("take stdout");
+        Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+        }
+    }
+
+    fn send(&mut self, payload: &Value) {
+        let bytes = serde_json::to_vec(payload).expect("serialize payload");
+        write!(self.stdin, "Content-Length: {}\r\n\r\n", bytes.len()).expect("write header");
+        self.stdin.write_all(&bytes).expect("write payload");
+        self.stdin.flush().expect("flush stdin");
+    }
+
+    fn send_raw_json_frame(&mut self, raw_payload: &[u8]) {
+        write!(self.stdin, "Content-Length: {}\r\n\r\n", raw_payload.len()).expect("write header");
+        self.stdin
+            .write_all(raw_payload)
+            .expect("write raw payload");
+        self.stdin.flush().expect("flush stdin");
+    }
+
+    fn recv(&mut self) -> Value {
+        let mut content_length: Option<usize> = None;
+
+        loop {
+            let mut line = String::new();
+            let read = self
+                .stdout
+                .read_line(&mut line)
+                .expect("read frame header line");
+            assert!(read > 0, "unexpected EOF while reading frame headers");
+
+            let line = line.trim_end_matches(['\r', '\n']);
+            if line.is_empty() {
+                break;
+            }
+
+            if let Some((name, value)) = line.split_once(':') {
+                if name.trim().eq_ignore_ascii_case("content-length") {
+                    content_length =
+                        Some(value.trim().parse::<usize>().expect("parse Content-Length"));
+                }
             }
         }
+
+        let len = content_length.expect("missing Content-Length");
+        let mut body = vec![0u8; len];
+        self.stdout.read_exact(&mut body).expect("read frame body");
+        serde_json::from_slice(&body).expect("parse JSON payload")
     }
 
-    let len = content_length.expect("missing Content-Length");
-    let mut body = vec![0u8; len];
-    stdout.read_exact(&mut body).expect("read frame body");
-    serde_json::from_slice(&body).expect("parse JSON payload")
-}
+    fn initialize(&mut self) {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }));
+        let initialize = self.recv();
+        assert_eq!(initialize["id"], json!(1));
+        assert_eq!(initialize["result"]["protocolVersion"], json!("2024-11-05"));
+    }
 
-fn shutdown(mut child: Child) {
-    drop(child.stdin.take());
+    fn shutdown(mut self) {
+        drop(self.stdin);
 
-    for _ in 0..100 {
-        if child.try_wait().expect("poll child").is_some() {
-            return;
+        for _ in 0..120 {
+            if self.child.try_wait().expect("poll child").is_some() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(20));
         }
-        thread::sleep(Duration::from_millis(20));
-    }
 
-    let _ = child.kill();
-    let _ = child.wait();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
 }
 
-fn write_minimal_workspace(root: &std::path::Path) {
+fn write_workspace_with_build_commands(root: &Path, repos: &[(&str, &str)]) {
     let spaces_main = root.join(".gitgrip").join("spaces").join("main");
     fs::create_dir_all(&spaces_main).expect("create spaces/main");
-    fs::create_dir_all(root.join("app")).expect("create app dir");
 
-    let manifest = r#"version: 1
-repos:
-  app:
-    url: git@github.com:example/app.git
-    path: ./app
-    default_branch: main
-    agent:
-      build: sleep 5
-"#;
+    let mut manifest = String::from("version: 1\nrepos:\n");
+    for (name, cmd) in repos {
+        fs::create_dir_all(root.join(name)).expect("create repo dir");
+        manifest.push_str(&format!(
+            "  {name}:\n    url: git@github.com:example/{name}.git\n    path: ./{name}\n    default_branch: main\n    agent:\n      build: \"{cmd}\"\n"
+        ));
+    }
+
+    fs::write(spaces_main.join("gripspace.yml"), manifest).expect("write manifest");
+}
+
+fn write_large_context_workspace(root: &Path, repo_count: usize) {
+    let spaces_main = root.join(".gitgrip").join("spaces").join("main");
+    fs::create_dir_all(&spaces_main).expect("create spaces/main");
+
+    let long_desc = "x".repeat(320);
+    let mut manifest = String::from("version: 1\nrepos:\n");
+    for i in 0..repo_count {
+        let name = format!("repo_{i}");
+        manifest.push_str(&format!(
+            "  {name}:\n    url: git@github.com:example/{name}.git\n    path: ./{name}\n    default_branch: main\n    agent:\n      description: \"{long_desc}\"\n      build: \"echo ok\"\n"
+        ));
+    }
+
     fs::write(spaces_main.join("gripspace.yml"), manifest).expect("write manifest");
 }
 
 #[test]
 fn test_mcp_server_initialize_list_and_call() {
     let temp = TempDir::new().expect("create temp dir");
-    let exe = env!("CARGO_BIN_EXE_gitgrip");
+    let mut server = ServerHarness::spawn(temp.path(), &[]);
 
-    let mut child = Command::new(exe)
-        .args(["mcp", "server"])
-        .current_dir(temp.path())
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn mcp server");
+    server.initialize();
 
-    let mut stdin = child.stdin.take().expect("take stdin");
-    let stdout = child.stdout.take().expect("take stdout");
-    let mut reader = BufReader::new(stdout);
-
-    write_frame(
-        &mut stdin,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {}
-        }),
-    );
-    let initialize = read_frame(&mut reader);
-    assert_eq!(initialize["id"], json!(1));
-    assert_eq!(initialize["result"]["protocolVersion"], json!("2024-11-05"));
-
-    write_frame(
-        &mut stdin,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/list",
-            "params": {}
-        }),
-    );
-    let tools = read_frame(&mut reader);
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {}
+    }));
+    let tools = server.recv();
     assert_eq!(tools["id"], json!(2));
 
     let names: Vec<&str> = tools["result"]["tools"]
@@ -122,95 +167,234 @@ fn test_mcp_server_initialize_list_and_call() {
     assert!(names.contains(&"gitgrip_agent_context"));
     assert!(names.contains(&"gitgrip_agent_build"));
 
-    write_frame(
-        &mut stdin,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": 3,
-            "method": "tools/call",
-            "params": {
-                "name": "gitgrip_agent_build",
-                "arguments": {}
-            }
-        }),
-    );
-    let call = read_frame(&mut reader);
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "gitgrip_agent_build",
+            "arguments": {}
+        }
+    }));
+    let call = server.recv();
     assert_eq!(call["id"], json!(3));
     assert_eq!(call["result"]["isError"], json!(true));
 
-    drop(stdin);
-    shutdown(child);
+    server.shutdown();
 }
 
 #[test]
-fn test_mcp_server_cancelled_notification_interrupts_tool_call() {
+fn test_mcp_server_cancel_immediate_and_ping_still_works() {
     let temp = TempDir::new().expect("create temp dir");
-    write_minimal_workspace(temp.path());
-    let exe = env!("CARGO_BIN_EXE_gitgrip");
+    write_workspace_with_build_commands(temp.path(), &[("app", "sleep 2")]);
+    let mut server = ServerHarness::spawn(temp.path(), &[]);
 
-    let mut child = Command::new(exe)
-        .args(["mcp", "server"])
-        .current_dir(temp.path())
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn mcp server");
+    server.initialize();
 
-    let mut stdin = child.stdin.take().expect("take stdin");
-    let stdout = child.stdout.take().expect("take stdout");
-    let mut reader = BufReader::new(stdout);
-
-    write_frame(
-        &mut stdin,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {}
-        }),
-    );
-    let _ = read_frame(&mut reader);
-
-    write_frame(
-        &mut stdin,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": 42,
-            "method": "tools/call",
-            "params": {
-                "name": "gitgrip_agent_build",
-                "arguments": {
-                    "repo": "app"
-                }
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "tools/call",
+        "params": {
+            "name": "gitgrip_agent_build",
+            "arguments": {
+                "repo": "app"
             }
-        }),
-    );
+        }
+    }));
 
-    thread::sleep(Duration::from_millis(150));
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/cancelled",
+        "params": {
+            "requestId": 42
+        }
+    }));
 
-    write_frame(
-        &mut stdin,
-        &json!({
-            "jsonrpc": "2.0",
-            "method": "notifications/cancelled",
-            "params": {
-                "requestId": 42
-            }
-        }),
-    );
-
-    let response = read_frame(&mut reader);
+    let response = server.recv();
     assert_eq!(response["id"], json!(42));
     assert_eq!(response["result"]["isError"], json!(true));
-    let text = response["result"]["content"][0]["text"]
-        .as_str()
-        .unwrap_or_default();
+    assert_eq!(response["result"]["cancelled"], json!(true));
+
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 43,
+        "method": "ping",
+        "params": {}
+    }));
+    let ping = server.recv();
+    assert_eq!(ping["id"], json!(43));
+    assert_eq!(ping["result"], json!({}));
+
+    server.shutdown();
+}
+
+#[test]
+fn test_mcp_server_cancel_near_completion_is_safe() {
+    let temp = TempDir::new().expect("create temp dir");
+    write_workspace_with_build_commands(temp.path(), &[("app", "sleep 1")]);
+    let mut server = ServerHarness::spawn(temp.path(), &[]);
+
+    server.initialize();
+
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 50,
+        "method": "tools/call",
+        "params": {
+            "name": "gitgrip_agent_build",
+            "arguments": {
+                "repo": "app"
+            }
+        }
+    }));
+
+    thread::sleep(Duration::from_millis(900));
+
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/cancelled",
+        "params": {
+            "requestId": 50
+        }
+    }));
+
+    let response = server.recv();
+    assert_eq!(response["id"], json!(50));
+    let is_error = response["result"]["isError"].as_bool().unwrap_or(false);
+    let cancelled = response["result"]
+        .get("cancelled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
     assert!(
-        text.contains("cancelled"),
-        "expected cancellation message, got: {text}"
+        (!is_error && !cancelled) || (is_error && cancelled),
+        "near-completion cancel should be either clean success or explicit cancellation"
     );
 
-    drop(stdin);
-    shutdown(child);
+    server.shutdown();
+}
+
+#[test]
+fn test_mcp_server_malformed_json_frame_recovery() {
+    let temp = TempDir::new().expect("create temp dir");
+    let mut server = ServerHarness::spawn(temp.path(), &[]);
+
+    server.initialize();
+
+    server.send_raw_json_frame(br#"{"jsonrpc":"2.0","id":99,"method":"ping""#);
+    let parse_err = server.recv();
+    assert_eq!(parse_err["error"]["code"], json!(-32700));
+
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 100,
+        "method": "ping",
+        "params": {}
+    }));
+    let ping = server.recv();
+    assert_eq!(ping["id"], json!(100));
+    assert_eq!(ping["result"], json!({}));
+
+    server.shutdown();
+}
+
+#[test]
+fn test_mcp_server_concurrent_calls_with_one_cancelled() {
+    let temp = TempDir::new().expect("create temp dir");
+    write_workspace_with_build_commands(temp.path(), &[("slow", "sleep 3"), ("fast", "echo fast")]);
+    let mut server = ServerHarness::spawn(temp.path(), &[]);
+
+    server.initialize();
+
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 200,
+        "method": "tools/call",
+        "params": {
+            "name": "gitgrip_agent_build",
+            "arguments": {
+                "repo": "slow"
+            }
+        }
+    }));
+
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 201,
+        "method": "tools/call",
+        "params": {
+            "name": "gitgrip_agent_build",
+            "arguments": {
+                "repo": "fast"
+            }
+        }
+    }));
+
+    thread::sleep(Duration::from_millis(120));
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/cancelled",
+        "params": {
+            "requestId": 200
+        }
+    }));
+
+    let mut responses: HashMap<i64, Value> = HashMap::new();
+    for _ in 0..2 {
+        let resp = server.recv();
+        let id = resp["id"].as_i64().expect("numeric id");
+        responses.insert(id, resp);
+    }
+
+    let slow = responses.get(&200).expect("slow response present");
+    let fast = responses.get(&201).expect("fast response present");
+
+    assert_eq!(slow["result"]["isError"], json!(true));
+    assert_eq!(slow["result"]["cancelled"], json!(true));
+    assert_eq!(fast["result"]["isError"], json!(false));
+
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 202,
+        "method": "ping",
+        "params": {}
+    }));
+    let ping = server.recv();
+    assert_eq!(ping["id"], json!(202));
+
+    server.shutdown();
+}
+
+#[test]
+fn test_mcp_server_large_context_ignores_small_capture_cap() {
+    let temp = TempDir::new().expect("create temp dir");
+    write_large_context_workspace(temp.path(), 500);
+
+    // Force a very small cap to prove context does not rely on capped stdout capture.
+    let mut server =
+        ServerHarness::spawn(temp.path(), &[("GITGRIP_MCP_MAX_CAPTURE_BYTES", "2048")]);
+
+    server.initialize();
+
+    server.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 300,
+        "method": "tools/call",
+        "params": {
+            "name": "gitgrip_agent_context",
+            "arguments": {}
+        }
+    }));
+
+    let response = server.recv();
+    assert_eq!(response["id"], json!(300));
+    assert_eq!(response["result"]["isError"], json!(false));
+
+    let repos = response["result"]["structuredContent"]["repos"]
+        .as_array()
+        .expect("repos array in structured content");
+    assert_eq!(repos.len(), 500);
+
+    server.shutdown();
 }


### PR DESCRIPTION
## Summary
- Add `gitgrip mcp server` command with stdio JSON-RPC transport
- Expose agent operations as MCP tools (`context`, `build`, `test`, `verify`, `generate-context`)
- Add 30 CLI passthrough tools (`gitgrip_<command>`) covering all top-level commands (sync, status, branch, pr, commit, push, etc.)
- Add `resources/list` and `resources/templates/list` endpoints (empty arrays) for client compatibility
- Framed stdio JSON-RPC handling for initialize/ping/tools/list/tools/call
- Strict tool argument parsing with rejection of unknown fields
- Document MCP setup in README
- **Fix Azure DevOps auth**: Use Bearer auth for Azure AD JWT tokens, add MSA passthrough headers
- **Fix Azure DevOps URL resolution**: Compose owner as `org/project` for correct API URL construction

## Test plan
- [x] `cargo test` — 847 passed, 0 failed
- [x] `cargo test mcp::server` — 7 unit tests pass (tools list, resources endpoints, argument validation)
- [x] Multi-provider e2e tests — 17/19 passed across GitHub, GitLab, Azure DevOps
  - [x] Azure DevOps full PR workflow — now passing (was broken)
  - [ ] `forall` tests — 2 pre-existing failures (unrelated path resolution issue)
- [x] Direct MCP stdio probe: handshake, tools list (35 tools), tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)