### PR TITLE
feat: add gr target command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ cargo bench                # Run benchmarks
 **Main Branch (`main`)**
 - Production-ready code
 - Protected with PR requirements
-- All PRs must target `main`
+- PRs target `main` by default (configurable via `gr target`)
 - Use `gr sync` to stay current (not `git pull`)
 
 **Feature Branches (`feat/*`, `fix/*`, `chore/*`)**
@@ -32,23 +32,57 @@ cargo bench                # Run benchmarks
 ### Standard Workflow
 
 ```bash
-# Start new work
+# 1. Start new work
 gr sync                              # Pull latest from all repos
 gr status                            # Verify clean state
+gr target list                       # Check current PR target (should be main)
 gr branch feat/my-feature            # Create branch across repos
 
-# Make changes...
+# 2. Develop
 gr diff                              # Review changes
 gr add .                             # Stage changes across repos
 gr commit -m "feat: description"     # Commit across repos
 gr push -u                           # Push with upstream tracking
 
-# Create PR
+# 3. Create PR
 gr pr create -t "feat: description" --push
 
-# After PR merged
+# 4. Merge (after review + CI)
+gr pr merge                          # Merge all PRs
+
+# 5. Cleanup
 gr sync                              # Pull latest and cleanup
 gr checkout main                     # Switch back to main
+```
+
+### Epic Branch Workflow
+
+For large features spanning multiple PRs, use `gr target` to redirect PRs to an epic branch:
+
+```bash
+# 1. Setup epic
+gr sync && gr checkout main
+gr branch epic/big-feature           # Create epic branch
+gr push -u                           # Push epic branch
+
+# 2. Set target to epic branch
+gr target set epic/big-feature       # All PRs now target the epic
+
+# 3. Work on sub-features (repeat as needed)
+gr branch feat/sub-feature-1
+# ... make changes, commit, push ...
+gr pr create -t "feat: sub-feature-1" --push
+gr pr merge
+gr checkout epic/big-feature && gr sync
+
+# 4. When epic is complete, reset target and merge epic → main
+gr target set main                   # PRs target main again
+gr checkout epic/big-feature
+gr pr create -t "epic: big feature" --push
+gr pr merge
+
+# 5. Cleanup
+gr sync && gr checkout main
 ```
 
 ### IMPORTANT: Never Use Raw Git
@@ -291,6 +325,11 @@ All commands use `gr` (or `gitgrip`):
 - `gr group list` - List all groups and their repos
   - `gr group add <group> <repos...>` - Add repos to a group
   - `gr group remove <group> <repos...>` - Remove repos from a group
+- `gr target list` - Show current PR target branches
+  - `gr target set <branch>` - Set global PR target branch
+  - `gr target set <branch> --repo <name>` - Set target for a specific repo
+  - `gr target unset` - Unset global target (falls back to revision)
+  - `gr target unset --repo <name>` - Unset per-repo target (falls back to global)
 - `gr grep <pattern>` - Search across all repos using git grep
   - `gr grep -i` - Case insensitive search
   - `gr grep --parallel` - Concurrent search

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -29,5 +29,6 @@ pub mod repo;
 pub mod run;
 pub mod status;
 pub mod sync;
+pub mod target;
 pub mod tree;
 pub mod verify;

--- a/src/cli/commands/pr/create.rs
+++ b/src/cli/commands/pr/create.rs
@@ -157,7 +157,13 @@ pub async fn run_pr_create(
 
         Output::subheader("Repositories that would create PRs:");
         for repo in &repos_with_changes {
-            println!("  - {} ({}/{})", repo.name, repo.owner, repo.repo);
+            println!(
+                "  - {} ({}/{}) → {}",
+                repo.name,
+                repo.owner,
+                repo.repo,
+                repo.target_branch()
+            );
         }
         println!();
         Output::warning("Run without --dry-run to actually create the PRs.");

--- a/src/cli/commands/pr/status.rs
+++ b/src/cli/commands/pr/status.rs
@@ -15,6 +15,15 @@ pub async fn run_pr_status(
 ) -> anyhow::Result<()> {
     if !json_output {
         Output::header("Pull Request Status");
+        let effective_target = manifest
+            .settings
+            .target
+            .as_deref()
+            .or(manifest.settings.revision.as_deref())
+            .unwrap_or("main");
+        if effective_target != "main" {
+            Output::info(&format!("Target: {}", effective_target));
+        }
         println!();
     }
 

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -40,6 +40,18 @@ pub fn run_status(
     Output::header("Repository Status");
     println!();
 
+    // Show current target if not default
+    let effective_target = manifest
+        .settings
+        .target
+        .as_deref()
+        .or(manifest.settings.revision.as_deref())
+        .unwrap_or("main");
+    if effective_target != "main" {
+        Output::info(&format!("Target: {}", effective_target));
+        println!();
+    }
+
     // Get all repo info (include reference repos for display)
     let repos: Vec<RepoInfo> = filter_repos(manifest, workspace_root, None, group_filter, true);
 

--- a/src/cli/commands/target.rs
+++ b/src/cli/commands/target.rs
@@ -1,0 +1,228 @@
+//! Target command implementation
+//!
+//! View and set the PR target branch (base branch) globally or per-repo.
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::manifest_paths;
+use crate::core::repo::RepoInfo;
+use serde_yaml::Value;
+use std::path::PathBuf;
+
+/// Show current target branches for all repos
+pub fn run_target_list(workspace_root: &PathBuf, manifest: &Manifest) -> anyhow::Result<()> {
+    Output::header("Target Branches");
+    println!();
+
+    let global_target = manifest.settings.target.as_deref();
+    let global_revision = manifest.settings.revision.as_deref();
+
+    println!(
+        "  Global target: {}",
+        if let Some(t) = global_target {
+            Output::repo_name(t).to_string()
+        } else {
+            "(not set)".to_string()
+        }
+    );
+    if let Some(rev) = global_revision {
+        println!("  Global revision: {}", rev);
+    }
+    println!();
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| {
+            RepoInfo::from_config(
+                name,
+                config,
+                workspace_root,
+                &manifest.settings,
+                manifest.remotes.as_ref(),
+            )
+        })
+        .collect();
+
+    // Find repos with per-repo target overrides
+    let mut has_overrides = false;
+    for (name, config) in &manifest.repos {
+        if config.target.is_some() {
+            if !has_overrides {
+                Output::subheader("Per-repo overrides:");
+                has_overrides = true;
+            }
+            println!(
+                "  {}: {}",
+                name,
+                config.target.as_deref().unwrap_or("(none)")
+            );
+        }
+    }
+    if has_overrides {
+        println!();
+    }
+
+    Output::subheader("Effective targets:");
+    for repo in &repos {
+        println!("  {}: {}", repo.name, repo.target_branch());
+    }
+    println!();
+
+    Ok(())
+}
+
+/// Set the global target branch
+pub fn run_target_set(workspace_root: &PathBuf, branch: &str) -> anyhow::Result<()> {
+    let manifest_path = find_manifest_path(workspace_root)?;
+    let content = std::fs::read_to_string(&manifest_path)?;
+    let mut manifest: Value = serde_yaml::from_str(&content)?;
+
+    let settings = manifest
+        .get_mut("settings")
+        .and_then(|s| s.as_mapping_mut());
+
+    match settings {
+        Some(settings_map) => {
+            settings_map.insert(
+                Value::String("target".to_string()),
+                Value::String(branch.to_string()),
+            );
+        }
+        None => {
+            // Create settings section
+            let mut settings_map = serde_yaml::Mapping::new();
+            settings_map.insert(
+                Value::String("target".to_string()),
+                Value::String(branch.to_string()),
+            );
+            manifest
+                .as_mapping_mut()
+                .ok_or_else(|| anyhow::anyhow!("Manifest root is not a mapping"))?
+                .insert(
+                    Value::String("settings".to_string()),
+                    Value::Mapping(settings_map),
+                );
+        }
+    }
+
+    let yaml = serde_yaml::to_string(&manifest)?;
+    std::fs::write(&manifest_path, &yaml)?;
+    manifest_paths::sync_legacy_mirror_if_present(workspace_root, &manifest_path, &yaml)?;
+
+    Output::success(&format!("Global target set to '{}'", branch));
+    Ok(())
+}
+
+/// Set the target branch for a specific repo
+pub fn run_target_set_repo(
+    workspace_root: &PathBuf,
+    repo_name: &str,
+    branch: &str,
+) -> anyhow::Result<()> {
+    let manifest_path = find_manifest_path(workspace_root)?;
+    let content = std::fs::read_to_string(&manifest_path)?;
+    let mut manifest: Value = serde_yaml::from_str(&content)?;
+
+    // Verify repo exists in resolved manifest
+    let resolved = Manifest::load(&manifest_path)?;
+    if !resolved.repos.contains_key(repo_name) {
+        anyhow::bail!("Repository '{}' not found in workspace", repo_name);
+    }
+
+    let repos_section = manifest
+        .get_mut("repos")
+        .ok_or_else(|| anyhow::anyhow!("No 'repos' section found in manifest"))?
+        .as_mapping_mut()
+        .ok_or_else(|| anyhow::anyhow!("'repos' is not a mapping"))?;
+
+    let repo_key = Value::String(repo_name.to_string());
+    let repo_entry = repos_section
+        .get_mut(&repo_key)
+        .ok_or_else(|| anyhow::anyhow!("Repository '{}' not found in local manifest", repo_name))?
+        .as_mapping_mut()
+        .ok_or_else(|| anyhow::anyhow!("Repository '{}' is not a mapping", repo_name))?;
+
+    repo_entry.insert(
+        Value::String("target".to_string()),
+        Value::String(branch.to_string()),
+    );
+
+    let yaml = serde_yaml::to_string(&manifest)?;
+    std::fs::write(&manifest_path, &yaml)?;
+    manifest_paths::sync_legacy_mirror_if_present(workspace_root, &manifest_path, &yaml)?;
+
+    Output::success(&format!("{}: target set to '{}'", repo_name, branch));
+    Ok(())
+}
+
+/// Unset the global target (falls back to revision)
+pub fn run_target_unset(workspace_root: &PathBuf) -> anyhow::Result<()> {
+    let manifest_path = find_manifest_path(workspace_root)?;
+    let content = std::fs::read_to_string(&manifest_path)?;
+    let mut manifest: Value = serde_yaml::from_str(&content)?;
+
+    if let Some(settings) = manifest
+        .get_mut("settings")
+        .and_then(|s| s.as_mapping_mut())
+    {
+        settings.remove(Value::String("target".to_string()));
+    }
+
+    let yaml = serde_yaml::to_string(&manifest)?;
+    std::fs::write(&manifest_path, &yaml)?;
+    manifest_paths::sync_legacy_mirror_if_present(workspace_root, &manifest_path, &yaml)?;
+
+    Output::success("Global target unset (will fall back to revision)");
+    Ok(())
+}
+
+/// Unset the target for a specific repo (falls back to global)
+pub fn run_target_unset_repo(workspace_root: &PathBuf, repo_name: &str) -> anyhow::Result<()> {
+    let manifest_path = find_manifest_path(workspace_root)?;
+    let content = std::fs::read_to_string(&manifest_path)?;
+    let mut manifest: Value = serde_yaml::from_str(&content)?;
+
+    // Verify repo exists
+    let resolved = Manifest::load(&manifest_path)?;
+    if !resolved.repos.contains_key(repo_name) {
+        anyhow::bail!("Repository '{}' not found in workspace", repo_name);
+    }
+
+    let repos_section = manifest
+        .get_mut("repos")
+        .ok_or_else(|| anyhow::anyhow!("No 'repos' section found in manifest"))?
+        .as_mapping_mut()
+        .ok_or_else(|| anyhow::anyhow!("'repos' is not a mapping"))?;
+
+    let repo_key = Value::String(repo_name.to_string());
+    if let Some(repo_entry) = repos_section
+        .get_mut(&repo_key)
+        .and_then(|v| v.as_mapping_mut())
+    {
+        repo_entry.remove(Value::String("target".to_string()));
+    }
+
+    let yaml = serde_yaml::to_string(&manifest)?;
+    std::fs::write(&manifest_path, &yaml)?;
+    manifest_paths::sync_legacy_mirror_if_present(workspace_root, &manifest_path, &yaml)?;
+
+    Output::success(&format!(
+        "{}: target unset (will fall back to global)",
+        repo_name
+    ));
+    Ok(())
+}
+
+fn find_manifest_path(workspace_root: &PathBuf) -> anyhow::Result<PathBuf> {
+    if let Some(path) = manifest_paths::resolve_gripspace_manifest_path(workspace_root) {
+        return Ok(path);
+    }
+    if let Some(path) = manifest_paths::resolve_repo_manifest_path(workspace_root) {
+        return Ok(path);
+    }
+
+    anyhow::bail!(
+        "No workspace manifest found in .gitgrip/spaces/main, .gitgrip/manifests, or .repo/manifests"
+    )
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,11 @@ enum Commands {
         #[command(subcommand)]
         action: GroupCommands,
     },
+    /// View or set the PR target branch (base branch)
+    Target {
+        #[command(subcommand)]
+        action: TargetCommands,
+    },
     /// Run garbage collection across repos
     Gc {
         /// More thorough gc (slower)
@@ -530,6 +535,26 @@ enum GroupCommands {
     Create {
         /// Group name
         name: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum TargetCommands {
+    /// Show current target branches for all repos
+    List,
+    /// Set the global target branch
+    Set {
+        /// Branch name
+        branch: String,
+        /// Set target for a specific repo instead of globally
+        #[arg(long)]
+        repo: Option<String>,
+    },
+    /// Unset the target (fall back to revision/default)
+    Unset {
+        /// Unset target for a specific repo instead of globally
+        #[arg(long)]
+        repo: Option<String>,
     },
 }
 
@@ -1050,6 +1075,43 @@ async fn main() -> anyhow::Result<()> {
                 }
                 GroupCommands::Create { name } => {
                     gitgrip::cli::commands::group::run_group_create(&ctx.workspace_root, &name)?;
+                }
+            }
+        }
+        Some(Commands::Target { action }) => {
+            let ctx = load_workspace_context(cli_quiet, cli_verbose, cli_json)?;
+            match action {
+                TargetCommands::List => {
+                    gitgrip::cli::commands::target::run_target_list(
+                        &ctx.workspace_root,
+                        &ctx.manifest,
+                    )?;
+                }
+                TargetCommands::Set { branch, repo } => {
+                    if let Some(repo_name) = repo {
+                        gitgrip::cli::commands::target::run_target_set_repo(
+                            &ctx.workspace_root,
+                            &repo_name,
+                            &branch,
+                        )?;
+                    } else {
+                        gitgrip::cli::commands::target::run_target_set(
+                            &ctx.workspace_root,
+                            &branch,
+                        )?;
+                    }
+                }
+                TargetCommands::Unset { repo } => {
+                    if let Some(repo_name) = repo {
+                        gitgrip::cli::commands::target::run_target_unset_repo(
+                            &ctx.workspace_root,
+                            &repo_name,
+                        )?;
+                    } else {
+                        gitgrip::cli::commands::target::run_target_unset(
+                            &ctx.workspace_root,
+                        )?;
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1108,9 +1108,7 @@ async fn main() -> anyhow::Result<()> {
                             &repo_name,
                         )?;
                     } else {
-                        gitgrip::cli::commands::target::run_target_unset(
-                            &ctx.workspace_root,
-                        )?;
+                        gitgrip::cli::commands::target::run_target_unset(&ctx.workspace_root)?;
                     }
                 }
             }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -240,6 +240,11 @@ const CLI_TOOL_SPECS: &[CliToolSpec] = &[
         description: "Generate shell completions (`gr completions ...`).",
     },
     CliToolSpec {
+        tool_name: "gitgrip_target",
+        command: "target",
+        description: "View or set PR target branch (`gr target ...`).",
+    },
+    CliToolSpec {
         tool_name: "gitgrip_verify",
         command: "verify",
         description: "Verify workspace assertions (`gr verify ...`).",


### PR DESCRIPTION
## Summary

- New `gr target` command to view and set PR base branches (globally or per-repo)
- `gr status`, `gr pr status`, and `gr pr create --dry-run` now surface the current target when non-default
- CLAUDE.md updated with epic branch workflow documentation and `gr target` in commands list
- MCP server updated with `gitgrip_target` passthrough tool

## Subcommands

| Command | Effect |
|---------|--------|
| `gr target list` | Show global target, per-repo overrides, and effective targets |
| `gr target set <branch>` | Set `settings.target` in manifest |
| `gr target set <branch> --repo <name>` | Set `repos.<name>.target` in manifest |
| `gr target unset` | Remove global target (falls back to revision) |
| `gr target unset --repo <name>` | Remove per-repo target (falls back to global) |

## Test plan

- [x] `gr target list` shows current targets
- [x] `gr target set main` updates manifest
- [x] `gr target set develop --repo gitgrip` sets per-repo override
- [x] `gr target unset --repo gitgrip` removes per-repo override
- [x] Clippy clean with CI flags
- [x] All tests pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)