### PR TITLE
fix: Azure pr diff auth + --no-delete-branch flag

### DIFF
--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -22,6 +22,7 @@ pub async fn run_pr_merge(
     json: bool,
     wait: bool,
     timeout: u64,
+    delete_branch: bool,
 ) -> anyhow::Result<()> {
     if !json {
         Output::header("Merging pull requests...");
@@ -439,7 +440,7 @@ pub async fn run_pr_merge(
                 &pr.repo,
                 pr.pr_number,
                 Some(merge_method),
-                true, // delete branch
+                delete_branch,
             )
             .await;
 
@@ -491,7 +492,7 @@ pub async fn run_pr_merge(
                                 &pr.repo,
                                 pr.pr_number,
                                 Some(merge_method),
-                                true,
+                                delete_branch,
                             )
                             .await
                         {

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -623,6 +623,7 @@ pub async fn run_release(opts: ReleaseOptions<'_>) -> anyhow::Result<()> {
                 opts.json,
                 true, // wait
                 opts.timeout,
+                true, // delete_branch
             )
             .await?;
             steps.push(StepResultJson::ok("ci"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,6 +444,9 @@ enum PrCommands {
         /// Timeout in seconds for --wait (default: 600)
         #[arg(long, default_value = "600")]
         timeout: u64,
+        /// Don't delete the source branch after merging
+        #[arg(long)]
+        no_delete_branch: bool,
     },
     /// Check CI status
     Checks,
@@ -817,6 +820,7 @@ async fn main() -> anyhow::Result<()> {
                     auto,
                     wait,
                     timeout,
+                    no_delete_branch,
                 } => {
                     gitgrip::cli::commands::pr::run_pr_merge(
                         &ctx.workspace_root,
@@ -828,6 +832,7 @@ async fn main() -> anyhow::Result<()> {
                         ctx.json,
                         wait,
                         timeout,
+                        !no_delete_branch,
                     )
                     .await?;
                 }

--- a/src/platform/azure.rs
+++ b/src/platform/azure.rs
@@ -655,31 +655,11 @@ impl HostingPlatform for AzureDevOpsAdapter {
         pull_number: u64,
     ) -> Result<String, PlatformError> {
         let ctx = self.parse_context(owner, repo);
-        let token = self.get_token().await?;
 
-        // Azure DevOps doesn't have a direct diff endpoint, so we get the commits
-        // and generate a diff URL or message
-        let url = format!(
-            "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/commits?api-version=7.0",
-            self.base_url, ctx.organization, ctx.project, ctx.repository, pull_number
+        let endpoint = format!(
+            "/git/repositories/{}/pullRequests/{}/commits",
+            ctx.repository, pull_number
         );
-
-        let auth = STANDARD.encode(format!(":{}", token));
-
-        let response = self
-            .http_client
-            .get(&url)
-            .header("Authorization", format!("Basic {}", auth))
-            .send()
-            .await
-            .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
-
-        if !response.status().is_success() {
-            return Err(PlatformError::ApiError(format!(
-                "Failed to get PR commits: {}",
-                response.status()
-            )));
-        }
 
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
@@ -693,10 +673,9 @@ impl HostingPlatform for AzureDevOpsAdapter {
             value: Vec<CommitInfo>,
         }
 
-        let commits: CommitsResponse = response
-            .json()
-            .await
-            .map_err(|e| PlatformError::ParseError(e.to_string()))?;
+        let commits: CommitsResponse = self
+            .api_request(reqwest::Method::GET, &ctx, &endpoint, None::<()>)
+            .await?;
 
         // Build a summary of commits
         let mut diff = String::new();
@@ -845,12 +824,12 @@ impl HostingPlatform for AzureDevOpsAdapter {
             self.base_url, ctx.organization, ctx.project, repo_info.id
         );
 
-        let auth = STANDARD.encode(format!(":{}", token));
-
         let response = self
             .http_client
             .delete(&url)
-            .header("Authorization", format!("Basic {}", auth))
+            .header("Authorization", self.build_auth_header(&token))
+            .header("X-VSS-ForceMsaPassThrough", "true")
+            .header("X-TFS-FedAuthRedirect", "Suppress")
             .send()
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -39,6 +39,7 @@ async fn test_pr_merge_no_open_prs() {
         false, // json
         false, // wait
         600,   // timeout
+        true,  // delete_branch
     )
     .await;
 
@@ -85,6 +86,7 @@ async fn test_pr_merge_skip_default_branch() {
         false, // json
         false, // wait
         600,   // timeout
+        true,  // delete_branch
     )
     .await;
 
@@ -125,6 +127,7 @@ async fn test_pr_merge_skip_reference_repos() {
         false, // json
         false, // wait
         600,   // timeout
+        true,  // delete_branch
     )
     .await;
 
@@ -164,6 +167,7 @@ async fn test_pr_merge_mixed_repos_all_skipped() {
         false, // json
         false, // wait
         600,   // timeout
+        true,  // delete_branch
     )
     .await;
 
@@ -222,6 +226,7 @@ async fn test_pr_merge_force_bypasses_checks() {
         false, // json
         false, // wait
         600,   // timeout
+        true,  // delete_branch
     )
     .await;
 
@@ -286,6 +291,7 @@ async fn test_pr_merge_branch_behind_suggests_update() {
         false, // json
         false, // wait
         600,   // timeout
+        true,  // delete_branch
     )
     .await;
 


### PR DESCRIPTION
## Summary
- **Azure DevOps pr diff 403 fix**: Refactored `get_pull_request_diff` to use the `api_request` helper instead of building auth headers manually. The manual approach always used Basic auth, but `az` CLI returns JWT tokens that need Bearer auth. Also added missing MSA passthrough headers. Same fix applied to `delete_repository`.
- **`--no-delete-branch` flag**: Added `gr pr merge --no-delete-branch` to keep the source branch after merging (useful for epic branches). Default behavior (delete after merge) is unchanged.

Fixes #340, #342

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy` passes with CI configuration
- [x] All Azure platform tests pass (13/13)
- [x] All PR merge tests pass (6/6 + 1 ignored)
- [x] Code reviewed for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)