### PR TITLE
fix: add --all flag to forall e2e tests

### DIFF
--- a/tests/multi_provider_e2e.rs
+++ b/tests/multi_provider_e2e.rs
@@ -1119,7 +1119,10 @@ mod forall_tests {
         assert!(output.status.success());
 
         // Run forall to show remote URLs (--all to include repos without changes)
-        let output = run_gr_in_dir(&["forall", "--all", "-c", "git remote get-url origin"], workspace);
+        let output = run_gr_in_dir(
+            &["forall", "--all", "-c", "git remote get-url origin"],
+            workspace,
+        );
         assert!(output.status.success());
 
         let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Summary
- Fix 2 failing forall e2e tests by adding `--all` flag — `forall` defaults to `changed_only=true`, skipping freshly cloned repos with no local modifications
- Fix stale run command in doc comment (`-- --ignored multi_provider` → `--test multi_provider_e2e -- --ignored`)

## Test plan
- [x] `cargo test --features integration-tests --test multi_provider_e2e -- --ignored` — 19/19 pass (previously 17/19)
- [x] `cargo build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)