### PR TITLE
refactor: extract shared HTTP client for platform adapters

### DIFF
--- a/src/platform/azure.rs
+++ b/src/platform/azure.rs
@@ -5,17 +5,12 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::env;
-use std::time::Duration;
 
+use super::http::create_http_client;
 use super::traits::{HostingPlatform, PlatformError};
 use super::types::*;
 use crate::core::manifest::PlatformType;
 use tracing::debug;
-
-/// Default connection timeout in seconds
-const CONNECT_TIMEOUT_SECS: u64 = 10;
-/// Default request timeout in seconds
-const REQUEST_TIMEOUT_SECS: u64 = 30;
 
 /// Azure DevOps context parsed from URL
 #[derive(Debug, Clone)]
@@ -84,15 +79,9 @@ pub struct AzureDevOpsAdapter {
 impl AzureDevOpsAdapter {
     /// Create a new Azure DevOps adapter
     pub fn new(base_url: Option<&str>) -> Self {
-        let http_client = Client::builder()
-            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
-            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-            .build()
-            .unwrap_or_else(|_| Client::new());
-
         Self {
             base_url: base_url.unwrap_or("https://dev.azure.com").to_string(),
-            http_client,
+            http_client: create_http_client(),
         }
     }
 

--- a/src/platform/bitbucket.rs
+++ b/src/platform/bitbucket.rs
@@ -4,16 +4,11 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde::Deserialize;
 use std::env;
-use std::time::Duration;
 
+use super::http::create_http_client;
 use super::traits::{HostingPlatform, LinkedPRRef, PlatformError};
 use super::types::*;
 use crate::core::manifest::PlatformType;
-
-/// Default connection timeout in seconds
-const CONNECT_TIMEOUT_SECS: u64 = 10;
-/// Default request timeout in seconds
-const REQUEST_TIMEOUT_SECS: u64 = 30;
 
 /// Bitbucket API adapter
 pub struct BitbucketAdapter {
@@ -35,11 +30,7 @@ impl BitbucketAdapter {
 
     /// Create a configured HTTP client with timeouts
     fn http_client() -> Client {
-        Client::builder()
-            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
-            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-            .build()
-            .unwrap_or_else(|_| Client::new())
+        create_http_client()
     }
 }
 

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -5,6 +5,7 @@ use octocrab::Octocrab;
 use std::env;
 use std::time::Duration;
 
+use super::http::create_http_client;
 use super::traits::{HostingPlatform, PlatformError};
 use super::types::*;
 use crate::core::manifest::PlatformType;
@@ -44,17 +45,7 @@ impl GitHubAdapter {
 
     /// Create a configured HTTP client with timeouts
     fn http_client() -> reqwest::Client {
-        reqwest::Client::builder()
-            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
-            .timeout(Duration::from_secs(READ_TIMEOUT_SECS))
-            .build()
-            .unwrap_or_else(|err| {
-                debug!(
-                    error = %err,
-                    "Failed to build HTTP client with timeouts; falling back to default client"
-                );
-                reqwest::Client::new()
-            })
+        create_http_client()
     }
 
     /// Get configured Octocrab instance with proper timeouts

--- a/src/platform/gitlab.rs
+++ b/src/platform/gitlab.rs
@@ -4,17 +4,12 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::env;
-use std::time::Duration;
 
+use super::http::create_http_client;
 use super::traits::{HostingPlatform, PlatformError};
 use super::types::*;
 use crate::core::manifest::PlatformType;
 use tracing::debug;
-
-/// Default connection timeout in seconds
-const CONNECT_TIMEOUT_SECS: u64 = 10;
-/// Default request timeout in seconds
-const REQUEST_TIMEOUT_SECS: u64 = 30;
 
 /// GitLab merge request response
 #[derive(Debug, Deserialize)]
@@ -63,15 +58,9 @@ pub struct GitLabAdapter {
 impl GitLabAdapter {
     /// Create a new GitLab adapter
     pub fn new(base_url: Option<&str>) -> Self {
-        let http_client = Client::builder()
-            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
-            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-            .build()
-            .unwrap_or_else(|_| Client::new());
-
         Self {
             base_url: base_url.unwrap_or("https://gitlab.com").to_string(),
-            http_client,
+            http_client: create_http_client(),
         }
     }
 

--- a/src/platform/http.rs
+++ b/src/platform/http.rs
@@ -1,0 +1,28 @@
+//! Shared HTTP utilities for platform adapters
+
+use reqwest::Client;
+use std::time::Duration;
+use tracing::debug;
+
+/// Default connection timeout in seconds
+const CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Default request timeout in seconds
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Create a configured HTTP client with standard timeouts.
+///
+/// All platform adapters should use this to ensure consistent timeout behavior.
+/// Falls back to a default client if the builder fails.
+pub fn create_http_client() -> Client {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .build()
+        .unwrap_or_else(|err| {
+            debug!(
+                error = %err,
+                "Failed to build HTTP client with timeouts; falling back to default client"
+            );
+            Client::new()
+        })
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,10 +7,12 @@ pub mod bitbucket;
 pub mod capabilities;
 pub mod github;
 pub mod gitlab;
+pub mod http;
 pub mod rate_limit;
 pub mod traits;
 pub mod types;
 
+pub use http::create_http_client;
 pub use traits::HostingPlatform;
 pub use types::{
     AllowedMergeMethods, CheckState, CheckStatusDetails, MergeMethod, PRBase, PRCreateResult,


### PR DESCRIPTION
## Summary
- Extract duplicated HTTP client creation from 4 platform adapters into shared `platform/http.rs`
- All adapters used identical `Client::builder()` with 10s connect / 30s request timeouts
- Single source of truth for timeout configuration

## Test plan
- [x] `cargo build` — clean, no warnings
- [x] `cargo test --lib` — 528/528 pass
- [x] No behavior changes — same timeouts, same fallback logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)