### PR TITLE
feat: wire up rate limiting across platform adapters

### DIFF
--- a/src/platform/azure.rs
+++ b/src/platform/azure.rs
@@ -6,7 +6,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::env;
 
-use super::http::create_http_client;
+use super::http::{check_response_rate_limit, create_http_client};
 use super::traits::{HostingPlatform, PlatformError};
 use super::types::*;
 use crate::core::manifest::PlatformType;
@@ -137,6 +137,8 @@ impl AzureDevOpsAdapter {
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
+        check_response_rate_limit(response.headers(), "Azure DevOps").await;
+
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
@@ -176,6 +178,8 @@ impl AzureDevOpsAdapter {
             .send()
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        check_response_rate_limit(response.headers(), "Azure DevOps").await;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -5,7 +5,7 @@ use octocrab::Octocrab;
 use std::env;
 use std::time::Duration;
 
-use super::http::create_http_client;
+use super::http::{check_response_rate_limit, create_http_client};
 use super::traits::{HostingPlatform, PlatformError};
 use super::types::*;
 use crate::core::manifest::PlatformType;
@@ -16,9 +16,6 @@ const CONNECT_TIMEOUT_SECS: u64 = 10;
 const READ_TIMEOUT_SECS: u64 = 30;
 /// Default write timeout in seconds
 const WRITE_TIMEOUT_SECS: u64 = 30;
-
-#[allow(unused_imports)]
-use super::rate_limit::{check_rate_limit_warning, parse_github_rate_limits};
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::metrics::GLOBAL_METRICS;
@@ -258,6 +255,8 @@ impl HostingPlatform for GitHubAdapter {
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
+        check_response_rate_limit(response.headers(), "GitHub").await;
+
         let status = response.status().as_u16();
         let body_text = response.text().await.unwrap_or_default();
 
@@ -347,6 +346,8 @@ impl HostingPlatform for GitHubAdapter {
             .send()
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        check_response_rate_limit(response.headers(), "GitHub").await;
 
         match response.status().as_u16() {
             202 => Ok(true),
@@ -532,6 +533,8 @@ impl HostingPlatform for GitHubAdapter {
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
+        check_response_rate_limit(response.headers(), "GitHub").await;
+
         if response.status().is_success() {
             #[derive(serde::Deserialize)]
             struct CheckRunsResponse {
@@ -604,6 +607,8 @@ impl HostingPlatform for GitHubAdapter {
             .send()
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        check_response_rate_limit(response.headers(), "GitHub").await;
 
         if !response.status().is_success() {
             return Err(PlatformError::ApiError(format!(
@@ -691,6 +696,8 @@ impl HostingPlatform for GitHubAdapter {
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
+        check_response_rate_limit(response.headers(), "GitHub").await;
+
         if !response.status().is_success() {
             return Err(PlatformError::ApiError(format!(
                 "Failed to get diff: {}",
@@ -767,6 +774,8 @@ impl HostingPlatform for GitHubAdapter {
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
+        check_response_rate_limit(user_response.headers(), "GitHub").await;
+
         #[derive(serde::Deserialize)]
         struct User {
             login: String,
@@ -808,6 +817,8 @@ impl HostingPlatform for GitHubAdapter {
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
+        check_response_rate_limit(response.headers(), "GitHub").await;
+
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
@@ -845,6 +856,8 @@ impl HostingPlatform for GitHubAdapter {
             .send()
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        check_response_rate_limit(response.headers(), "GitHub").await;
 
         if response.status() == 404 {
             return Err(PlatformError::NotFound(format!(
@@ -908,6 +921,8 @@ impl HostingPlatform for GitHubAdapter {
             .send()
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        check_response_rate_limit(response.headers(), "GitHub").await;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/src/platform/gitlab.rs
+++ b/src/platform/gitlab.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::env;
 
-use super::http::create_http_client;
+use super::http::{check_response_rate_limit, create_http_client};
 use super::traits::{HostingPlatform, PlatformError};
 use super::types::*;
 use crate::core::manifest::PlatformType;
@@ -131,6 +131,8 @@ impl GitLabAdapter {
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
+        check_response_rate_limit(response.headers(), "GitLab").await;
+
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().await.unwrap_or_default();
@@ -169,6 +171,8 @@ impl GitLabAdapter {
             .send()
             .await
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
+
+        check_response_rate_limit(response.headers(), "GitLab").await;
 
         if !response.status().is_success() {
             let status = response.status();

--- a/src/platform/http.rs
+++ b/src/platform/http.rs
@@ -1,8 +1,14 @@
 //! Shared HTTP utilities for platform adapters
 
+use reqwest::header::HeaderMap;
 use reqwest::Client;
 use std::time::Duration;
 use tracing::debug;
+
+use super::rate_limit::{
+    check_rate_limit_warning, parse_azure_rate_limits, parse_github_rate_limits,
+    parse_gitlab_rate_limits, wait_for_rate_limit,
+};
 
 /// Default connection timeout in seconds
 const CONNECT_TIMEOUT_SECS: u64 = 10;
@@ -25,4 +31,21 @@ pub fn create_http_client() -> Client {
             );
             Client::new()
         })
+}
+
+/// Check rate limit headers from an API response and warn if approaching limits.
+///
+/// Call this after `.send().await` on any platform API request. If rate limited,
+/// waits for the reset window before returning.
+pub async fn check_response_rate_limit(headers: &HeaderMap, platform: &str) {
+    let info = match platform {
+        "GitHub" => parse_github_rate_limits(headers),
+        "GitLab" => parse_gitlab_rate_limits(headers),
+        "Azure DevOps" => parse_azure_rate_limits(headers),
+        _ => return,
+    };
+    check_rate_limit_warning(&info, platform);
+    if info.is_rate_limited() {
+        wait_for_rate_limit(&info).await;
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `check_response_rate_limit()` shared helper to `platform/http.rs` that parses response headers and warns when approaching rate limits or waits when rate limited
- Wires into Azure DevOps (`api_request`, `api_patch`), GitLab (`api_request`, `api_put`), and all GitHub raw reqwest API calls (9 call sites)
- Removes `#[allow(unused_imports)]` from github.rs — rate_limit imports are now actively used

## Test plan
- [x] `cargo build` — clean
- [x] `cargo clippy --all-features` — 0 new warnings
- [x] `cargo test` — all 19 rate_limit tests pass, 0 failures across all suites
- [x] `cargo fmt` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)