### PR TITLE
fix: replace risky .unwrap() calls with safe alternatives

### DIFF
--- a/src/cli/commands/bench.rs
+++ b/src/cli/commands/bench.rs
@@ -154,7 +154,7 @@ fn calculate_stats(durations: &[f64]) -> (f64, f64, f64, f64, f64, f64) {
     }
 
     let mut sorted = durations.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     let n = sorted.len();
     let min = sorted[0];

--- a/src/cli/commands/run.rs
+++ b/src/cli/commands/run.rs
@@ -45,7 +45,9 @@ pub fn run_run(
         return Ok(());
     }
 
-    let name = script_name.unwrap();
+    let Some(name) = script_name else {
+        return Ok(());
+    };
 
     // Find the script
     let script = scripts.and_then(|s| s.get(name)).ok_or_else(|| {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -71,7 +71,7 @@ impl Output {
         pb.set_style(
             ProgressStyle::default_spinner()
                 .template("{spinner:.cyan} {msg}")
-                .unwrap()
+                .expect("static spinner template is valid")
                 .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"),
         );
         pb.set_message(message.to_string());
@@ -85,7 +85,7 @@ impl Output {
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("{msg} [{bar:40.cyan/blue}] {pos}/{len}")
-                .unwrap()
+                .expect("static progress bar template is valid")
                 .progress_chars("█▓░"),
         );
         pb.set_message(message.to_string());

--- a/src/util/retry.rs
+++ b/src/util/retry.rs
@@ -50,7 +50,7 @@ fn rand_float() -> f64 {
     use std::time::SystemTime;
     let nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or(std::time::Duration::ZERO)
         .subsec_nanos();
     (nanos % 1000) as f64 / 1000.0
 }

--- a/src/util/timing.rs
+++ b/src/util/timing.rs
@@ -209,7 +209,7 @@ where
     }
 
     // Sort for percentile calculations
-    durations.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    durations.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     let min = durations[0];
     let max = durations[durations.len() - 1];
@@ -259,7 +259,7 @@ where
     }
 
     // Sort for percentile calculations
-    durations.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    durations.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     let min = durations[0];
     let max = durations[durations.len() - 1];


### PR DESCRIPTION
## Summary
- Replace 7 risky `.unwrap()` calls in production code with safe alternatives
- `retry.rs`: `duration_since(UNIX_EPOCH)` fallback to `Duration::ZERO`
- `timing.rs` + `bench.rs`: f64 `partial_cmp` with `unwrap_or(Ordering::Equal)` for NaN safety
- `output.rs`: static template `.unwrap()` → `.expect()` with descriptive message
- `run.rs`: `script_name.unwrap()` → `let-else` pattern

Closes #354

## Test plan
- [x] 565 lib tests pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)