### PR TITLE
feat: add gr pr list and gr pr view commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MCP stdio server** for agent tool access (#335)
   - CLI passthrough tools and resource endpoints
   - Cancellation support and bounded output capture
+- **`gr pr list` and `gr pr view` commands** (#202)
+  - `gr pr list` — list PRs across all repos with `--state`, `--repo`, `--limit` filters
+  - `gr pr view [number]` — view PR details, reviews, and body (auto-detects from current branch)
+  - `list_pull_requests` platform trait method with GitHub implementation
 
 - **`gr pr checks` improvements** (#238)
   - `--repo` flag to filter checks to a specific repository

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -5,6 +5,15 @@ use clap_complete::Shell;
 
 use crate::platform::MergeMethod;
 
+/// Filter for listing pull requests
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum PrStateFilter {
+    Open,
+    Closed,
+    Merged,
+    All,
+}
+
 #[derive(Parser)]
 #[command(name = "gr")]
 #[command(author, version, about = "Multi-repo workflow tool", long_about = None)]
@@ -612,6 +621,26 @@ pub enum PrCommands {
         /// Show stat summary only
         #[arg(long)]
         stat: bool,
+    },
+    /// List pull requests
+    List {
+        /// Filter by state
+        #[arg(long, value_enum, default_value = "open")]
+        state: PrStateFilter,
+        /// Filter to a specific repo
+        #[arg(long)]
+        repo: Option<String>,
+        /// Maximum number of PRs per repo
+        #[arg(long, default_value = "30", value_parser = clap::value_parser!(u32).range(1..=100))]
+        limit: u32,
+    },
+    /// View pull request details
+    View {
+        /// PR number (omit to find PR for current branch)
+        number: Option<u64>,
+        /// Filter to a specific repo
+        #[arg(long)]
+        repo: Option<String>,
     },
 }
 

--- a/src/cli/commands/pr/list.rs
+++ b/src/cli/commands/pr/list.rs
@@ -1,0 +1,139 @@
+//! PR list command implementation
+
+use crate::cli::args::PrStateFilter;
+use crate::cli::output::{Output, Table};
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::path_exists;
+use crate::platform::get_platform_adapter;
+use crate::platform::types::{PRListFilter, PRState};
+use std::path::Path;
+
+/// Run the PR list command
+pub async fn run_pr_list(
+    workspace_root: &Path,
+    manifest: &Manifest,
+    state: PrStateFilter,
+    repo_filter: Option<&str>,
+    limit: u32,
+    json_output: bool,
+) -> anyhow::Result<()> {
+    let filter_state = match state {
+        PrStateFilter::Open => Some(PRState::Open),
+        PrStateFilter::Closed => Some(PRState::Closed),
+        PrStateFilter::Merged => Some(PRState::Merged),
+        PrStateFilter::All => None,
+    };
+
+    if !json_output {
+        let state_label = match state {
+            PrStateFilter::Open => "open",
+            PrStateFilter::Closed => "closed",
+            PrStateFilter::Merged => "merged",
+            PrStateFilter::All => "all",
+        };
+        Output::header(&format!("Pull Requests ({})", state_label));
+        println!();
+    }
+
+    let repos: Vec<RepoInfo> = manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| {
+            RepoInfo::from_config(
+                name,
+                config,
+                workspace_root,
+                &manifest.settings,
+                manifest.remotes.as_ref(),
+            )
+        })
+        .filter(|r| !r.reference)
+        .filter(|r| repo_filter.map(|f| r.name == f).unwrap_or(true))
+        .collect();
+
+    if let Some(name) = repo_filter {
+        if repos.is_empty() {
+            anyhow::bail!("Repository '{}' not found in manifest", name);
+        }
+    }
+
+    #[derive(serde::Serialize)]
+    struct PRListEntry {
+        repo: String,
+        number: u64,
+        title: String,
+        state: String,
+        head: String,
+        base: String,
+        url: String,
+    }
+
+    let mut all_prs: Vec<PRListEntry> = Vec::new();
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        let platform = get_platform_adapter(repo.platform_type, repo.platform_base_url.as_deref());
+
+        let filter = PRListFilter {
+            state: filter_state,
+            limit: Some(limit),
+        };
+
+        match platform
+            .list_pull_requests(&repo.owner, &repo.repo, &filter)
+            .await
+        {
+            Ok(prs) => {
+                for pr in prs {
+                    all_prs.push(PRListEntry {
+                        repo: repo.name.clone(),
+                        number: pr.number,
+                        title: pr.title,
+                        state: pr.state.to_string(),
+                        head: pr.head.ref_name,
+                        base: pr.base.ref_name,
+                        url: pr.url,
+                    });
+                }
+            }
+            Err(e) => {
+                if !json_output {
+                    Output::error(&format!("{}: {}", repo.name, e));
+                }
+            }
+        }
+    }
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&all_prs)?);
+        return Ok(());
+    }
+
+    if all_prs.is_empty() {
+        println!("No pull requests found.");
+        return Ok(());
+    }
+
+    let mut table = Table::new(vec!["Repo", "PR#", "Title", "State", "Branch"]);
+
+    for pr in &all_prs {
+        table.add_row(vec![
+            &pr.repo,
+            &format!("#{}", pr.number),
+            &pr.title,
+            &pr.state,
+            &pr.head,
+        ]);
+    }
+
+    table.print();
+
+    println!();
+    println!("{} pull request(s)", all_prs.len());
+
+    Ok(())
+}

--- a/src/cli/commands/pr/mod.rs
+++ b/src/cli/commands/pr/mod.rs
@@ -6,12 +6,16 @@ mod checks;
 mod create;
 mod diff;
 mod edit;
+mod list;
 mod merge;
 mod status;
+mod view;
 
 pub use checks::run_pr_checks;
 pub use create::run_pr_create;
 pub use diff::run_pr_diff;
 pub use edit::run_pr_edit;
+pub use list::run_pr_list;
 pub use merge::{run_pr_merge, MergeOptions};
 pub use status::run_pr_status;
+pub use view::{run_pr_view, PRViewOptions};

--- a/src/cli/commands/pr/view.rs
+++ b/src/cli/commands/pr/view.rs
@@ -1,0 +1,192 @@
+//! PR view command implementation
+
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::RepoInfo;
+use crate::git::path_exists;
+use crate::platform::get_platform_adapter;
+use std::path::Path;
+
+/// Options for the PR view command
+pub struct PRViewOptions<'a> {
+    pub workspace_root: &'a Path,
+    pub manifest: &'a Manifest,
+    pub number: Option<u64>,
+    pub repo_filter: Option<&'a str>,
+    pub json_output: bool,
+}
+
+/// Run the PR view command
+pub async fn run_pr_view(opts: PRViewOptions<'_>) -> anyhow::Result<()> {
+    let repos: Vec<RepoInfo> = opts
+        .manifest
+        .repos
+        .iter()
+        .filter_map(|(name, config)| {
+            RepoInfo::from_config(
+                name,
+                config,
+                opts.workspace_root,
+                &opts.manifest.settings,
+                opts.manifest.remotes.as_ref(),
+            )
+        })
+        .filter(|r| !r.reference)
+        .filter(|r| opts.repo_filter.map(|f| r.name == f).unwrap_or(true))
+        .collect();
+
+    if let Some(name) = opts.repo_filter {
+        if repos.is_empty() {
+            anyhow::bail!("Repository '{}' not found in manifest", name);
+        }
+    }
+
+    // If no PR number is given, find PRs for the current branch
+    let number = opts.number;
+
+    #[derive(serde::Serialize)]
+    struct PRViewInfo {
+        repo: String,
+        number: u64,
+        title: String,
+        state: String,
+        merged: bool,
+        head: String,
+        base: String,
+        body: String,
+        url: String,
+        mergeable: Option<bool>,
+        reviews: Vec<ReviewInfo>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct ReviewInfo {
+        user: String,
+        state: String,
+    }
+
+    let mut all_views: Vec<PRViewInfo> = Vec::new();
+
+    for repo in &repos {
+        if !path_exists(&repo.absolute_path) {
+            continue;
+        }
+
+        let platform = get_platform_adapter(repo.platform_type, repo.platform_base_url.as_deref());
+
+        let pr_number = if let Some(n) = number {
+            n
+        } else {
+            // Find PR by current branch
+            let git_repo = match crate::git::open_repo(&repo.absolute_path) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            let branch = match crate::git::get_current_branch(&git_repo) {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            if branch == repo.target_branch() {
+                continue;
+            }
+            match platform
+                .find_pr_by_branch(&repo.owner, &repo.repo, &branch)
+                .await
+            {
+                Ok(Some(pr)) => pr.number,
+                Ok(None) => {
+                    if !opts.json_output {
+                        Output::info(&format!(
+                            "{}: no open PR for branch '{}'",
+                            repo.name, branch
+                        ));
+                    }
+                    continue;
+                }
+                Err(e) => {
+                    if !opts.json_output {
+                        Output::error(&format!("{}: {}", repo.name, e));
+                    }
+                    continue;
+                }
+            }
+        };
+
+        match platform
+            .get_pull_request(&repo.owner, &repo.repo, pr_number)
+            .await
+        {
+            Ok(pr) => {
+                let reviews = platform
+                    .get_pull_request_reviews(&repo.owner, &repo.repo, pr_number)
+                    .await
+                    .unwrap_or_default();
+
+                if !opts.json_output {
+                    let state_str = if pr.merged {
+                        "merged"
+                    } else {
+                        &pr.state.to_string()
+                    };
+
+                    println!("=== {} #{} ===", repo.name, pr.number);
+                    println!("Title:     {}", pr.title);
+                    println!("State:     {}", state_str);
+                    println!("Branch:    {} -> {}", pr.head.ref_name, pr.base.ref_name);
+                    println!("URL:       {}", pr.url);
+
+                    if let Some(mergeable) = pr.mergeable {
+                        println!("Mergeable: {}", if mergeable { "yes" } else { "no" });
+                    }
+
+                    if !reviews.is_empty() {
+                        println!("Reviews:");
+                        for review in &reviews {
+                            println!("  {} ({})", review.user, review.state);
+                        }
+                    }
+
+                    if !pr.body.is_empty() {
+                        println!();
+                        println!("{}", pr.body);
+                    }
+
+                    println!();
+                }
+
+                all_views.push(PRViewInfo {
+                    repo: repo.name.clone(),
+                    number: pr.number,
+                    title: pr.title,
+                    state: pr.state.to_string(),
+                    merged: pr.merged,
+                    head: pr.head.ref_name,
+                    base: pr.base.ref_name,
+                    body: pr.body,
+                    url: pr.url,
+                    mergeable: pr.mergeable,
+                    reviews: reviews
+                        .into_iter()
+                        .map(|r| ReviewInfo {
+                            user: r.user,
+                            state: r.state,
+                        })
+                        .collect(),
+                });
+            }
+            Err(e) => {
+                if !opts.json_output {
+                    Output::error(&format!("{}: {}", repo.name, e));
+                }
+            }
+        }
+    }
+
+    if opts.json_output {
+        println!("{}", serde_json::to_string_pretty(&all_views)?);
+    } else if all_views.is_empty() {
+        println!("No pull request found.");
+    }
+
+    Ok(())
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -292,6 +292,29 @@ pub async fn dispatch_command(
                     crate::cli::commands::pr::run_pr_diff(&ctx.workspace_root, &ctx.manifest, stat)
                         .await?;
                 }
+                PrCommands::List { state, repo, limit } => {
+                    crate::cli::commands::pr::run_pr_list(
+                        &ctx.workspace_root,
+                        &ctx.manifest,
+                        state,
+                        repo.as_deref(),
+                        limit,
+                        ctx.json,
+                    )
+                    .await?;
+                }
+                PrCommands::View { number, repo } => {
+                    crate::cli::commands::pr::run_pr_view(
+                        crate::cli::commands::pr::PRViewOptions {
+                            workspace_root: &ctx.workspace_root,
+                            manifest: &ctx.manifest,
+                            number,
+                            repo_filter: repo.as_deref(),
+                            json_output: ctx.json,
+                        },
+                    )
+                    .await?;
+                }
             }
         }
         Some(Commands::Init {

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -541,6 +541,74 @@ impl HostingPlatform for GitHubAdapter {
         }
     }
 
+    async fn list_pull_requests(
+        &self,
+        owner: &str,
+        repo: &str,
+        filter: &PRListFilter,
+    ) -> Result<Vec<PullRequest>, PlatformError> {
+        let client = self.get_client().await?;
+
+        let state = match filter.state {
+            Some(PRState::Open) => octocrab::params::State::Open,
+            Some(PRState::Closed) | Some(PRState::Merged) => octocrab::params::State::Closed,
+            None => octocrab::params::State::All,
+        };
+
+        // GitHub API max per_page is 100; clamp to u8 for octocrab
+        let limit = filter.limit.unwrap_or(30).min(100) as u8;
+
+        let prs = client
+            .pulls(owner, repo)
+            .list()
+            .state(state)
+            .per_page(limit)
+            .send()
+            .await
+            .map_err(|e| PlatformError::ApiError(format!("Failed to list PRs: {}", e)))?;
+
+        let mut result: Vec<PullRequest> = Vec::new();
+        for pr in &prs.items {
+            let pr_state = if pr.merged_at.is_some() {
+                PRState::Merged
+            } else {
+                match pr.state {
+                    Some(octocrab::models::IssueState::Open) => PRState::Open,
+                    Some(octocrab::models::IssueState::Closed) => PRState::Closed,
+                    _ => PRState::Open,
+                }
+            };
+
+            // If filtering for merged, skip non-merged closed PRs
+            if filter.state == Some(PRState::Merged) && pr.merged_at.is_none() {
+                continue;
+            }
+
+            result.push(PullRequest {
+                number: pr.number,
+                url: pr
+                    .html_url
+                    .as_ref()
+                    .map(|u| u.to_string())
+                    .unwrap_or_default(),
+                title: pr.title.clone().unwrap_or_default(),
+                body: pr.body.clone().unwrap_or_default(),
+                state: pr_state,
+                merged: pr.merged_at.is_some(),
+                mergeable: pr.mergeable,
+                head: PRHead {
+                    ref_name: pr.head.ref_field.clone(),
+                    sha: pr.head.sha.clone(),
+                },
+                base: PRBase {
+                    ref_name: pr.base.ref_field.clone(),
+                },
+            });
+        }
+
+        Ok(result)
+    }
+
     async fn is_pull_request_approved(
         &self,
         owner: &str,

--- a/src/platform/traits.rs
+++ b/src/platform/traits.rs
@@ -124,6 +124,18 @@ pub trait HostingPlatform: Send + Sync {
         branch: &str,
     ) -> Result<Option<PRCreateResult>, PlatformError>;
 
+    /// List pull requests for a repository
+    async fn list_pull_requests(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _filter: &PRListFilter,
+    ) -> Result<Vec<PullRequest>, PlatformError> {
+        Err(PlatformError::ApiError(
+            "Listing pull requests is not supported on this platform".to_string(),
+        ))
+    }
+
     /// Check if PR is approved
     async fn is_pull_request_approved(
         &self,

--- a/src/platform/types.rs
+++ b/src/platform/types.rs
@@ -106,6 +106,15 @@ pub struct PRMergeOptions {
     pub delete_branch: Option<bool>,
 }
 
+/// Filter options for listing PRs
+#[derive(Debug, Clone, Default)]
+pub struct PRListFilter {
+    /// Filter by state (default: open)
+    pub state: Option<PRState>,
+    /// Maximum number of PRs to return
+    pub limit: Option<u32>,
+}
+
 /// Result of creating a PR
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PRCreateResult {

--- a/tests/test_pr_list_view.rs
+++ b/tests/test_pr_list_view.rs
@@ -1,0 +1,203 @@
+//! Integration tests for pr list and pr view commands.
+//!
+//! These test the basic flow: repos on default branch are handled,
+//! reference repos are filtered, and the commands handle API errors gracefully.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+
+// ── pr list ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_pr_list_all_on_default_branch() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let manifest = ws.load_manifest();
+
+    // list_pull_requests calls platform API which fails for file:// URLs,
+    // but the command should handle errors gracefully
+    let result = gitgrip::cli::commands::pr::run_pr_list(
+        &ws.workspace_root,
+        &manifest,
+        gitgrip::cli::args::PrStateFilter::Open,
+        None,
+        30,
+        true, // json
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "pr list should handle API errors: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn test_pr_list_repo_filter_not_found() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::pr::run_pr_list(
+        &ws.workspace_root,
+        &manifest,
+        gitgrip::cli::args::PrStateFilter::Open,
+        Some("nonexistent"),
+        30,
+        true,
+    )
+    .await;
+
+    assert!(result.is_err(), "should error for unknown repo");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("not found"),
+        "error should mention 'not found': {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_pr_list_skips_reference_repos() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_reference_repo("docs")
+        .build();
+    let manifest = ws.load_manifest();
+
+    let result = gitgrip::cli::commands::pr::run_pr_list(
+        &ws.workspace_root,
+        &manifest,
+        gitgrip::cli::args::PrStateFilter::Open,
+        None,
+        30,
+        true,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "pr list should skip reference repos: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn test_pr_list_skips_non_git_repo() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    std::fs::remove_dir_all(ws.repo_path("app").join(".git")).unwrap();
+
+    let result = gitgrip::cli::commands::pr::run_pr_list(
+        &ws.workspace_root,
+        &manifest,
+        gitgrip::cli::args::PrStateFilter::Open,
+        None,
+        30,
+        true,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "pr list should skip non-git repos: {:?}",
+        result.err()
+    );
+}
+
+// ── pr view ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_pr_view_all_on_default_branch() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let manifest = ws.load_manifest();
+
+    let result =
+        gitgrip::cli::commands::pr::run_pr_view(gitgrip::cli::commands::pr::PRViewOptions {
+            workspace_root: &ws.workspace_root,
+            manifest: &manifest,
+            number: None,
+            repo_filter: None,
+            json_output: true,
+        })
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "pr view should succeed when all on default branch: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn test_pr_view_repo_filter_not_found() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let result =
+        gitgrip::cli::commands::pr::run_pr_view(gitgrip::cli::commands::pr::PRViewOptions {
+            workspace_root: &ws.workspace_root,
+            manifest: &manifest,
+            number: Some(1),
+            repo_filter: Some("nonexistent"),
+            json_output: true,
+        })
+        .await;
+
+    assert!(result.is_err(), "should error for unknown repo");
+}
+
+#[tokio::test]
+async fn test_pr_view_skips_non_git_repo() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    std::fs::remove_dir_all(ws.repo_path("app").join(".git")).unwrap();
+
+    let result =
+        gitgrip::cli::commands::pr::run_pr_view(gitgrip::cli::commands::pr::PRViewOptions {
+            workspace_root: &ws.workspace_root,
+            manifest: &manifest,
+            number: None,
+            repo_filter: None,
+            json_output: true,
+        })
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "pr view should skip non-git repos: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn test_pr_view_skips_reference_repos() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_reference_repo("docs")
+        .build();
+    let manifest = ws.load_manifest();
+
+    let result =
+        gitgrip::cli::commands::pr::run_pr_view(gitgrip::cli::commands::pr::PRViewOptions {
+            workspace_root: &ws.workspace_root,
+            manifest: &manifest,
+            number: None,
+            repo_filter: None,
+            json_output: true,
+        })
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "pr view should skip reference repos: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
## Summary

Closes #202

- **`gr pr list`** — List pull requests across all workspace repos
  - `--state open|closed|merged|all` filter (uses clap `ValueEnum` for proper help/validation)
  - `--repo <name>` filter to a specific repo
  - `--limit <n>` max PRs per repo (1-100)
  - Table output in human mode, JSON array in `--json` mode
- **`gr pr view [number]`** — View PR details with reviews
  - Auto-detects PR from current branch when no number is given
  - Shows title, state, branch, URL, mergeable status, reviews, and body
  - `--repo <name>` filter for explicit PR number lookups
- **Platform trait**: `list_pull_requests` method with GitHub implementation
- **Types**: `PRListFilter` struct, `PrStateFilter` CLI enum
- Reference repos filtered from both commands
- 8 integration tests covering error handling, filtering, and edge cases

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --lib` — all 565 tests pass
- [x] `cargo test --test test_pr_list_view` — all 8 integration tests pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --lib` — no new warnings
- [ ] CI passes on all platforms
- [ ] Manual test: `gr pr list` in a workspace with open PRs
- [ ] Manual test: `gr pr view` on a feature branch with an open PR
- [ ] Manual test: `gr pr list --state all --repo gitgrip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)