### PR TITLE
fix: gr add stages files individually to avoid partial failures (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`gr push` skip repos with no unique commits** (#372)
   - New branches with no unique commits are skipped instead of causing push errors
 
+### Fixed
+- **`gr add` partial staging** (#374)
+  - Stage files individually so one missing path doesn't block the rest
+  - Warn instead of error when a pathspec doesn't match in a repo
+
 ## [0.17.0] - 2026-03-11
 
 ### Added

--- a/src/cli/commands/add.rs
+++ b/src/cli/commands/add.rs
@@ -103,25 +103,36 @@ fn stage_files(repo: &Repository, _repo_path: &Path, files: &[String]) -> anyhow
         return Ok(0);
     }
 
-    // Build git add command
-    let mut args = vec!["add"];
-
     if files.len() == 1 && files[0] == "." {
-        args.push("-A"); // Add all changes including deletions
-    } else {
-        for file in files {
-            args.push(file);
+        // Add all changes including deletions
+        let mut cmd = Command::new("git");
+        cmd.args(["add", "-A"]).current_dir(repo_dir);
+        log_cmd(&cmd);
+        let output = cmd.output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git add failed: {}", stderr.trim());
         }
-    }
+    } else {
+        // Stage files individually so one missing file doesn't block the rest
+        for file in files {
+            let mut cmd = Command::new("git");
+            cmd.args(["add", file]).current_dir(repo_dir);
+            log_cmd(&cmd);
+            let output = cmd.output()?;
 
-    let mut cmd = Command::new("git");
-    cmd.args(&args).current_dir(repo_dir);
-    log_cmd(&cmd);
-    let output = cmd.output()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git add failed: {}", stderr);
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                // "pathspec did not match" is expected when a file doesn't exist
+                // in this repo — warn instead of failing
+                if stderr.contains("did not match any files") {
+                    Output::warning(&format!("{}: skipped (not in this repo)", file));
+                } else {
+                    Output::error(&format!("git add {}: {}", file, stderr));
+                }
+            }
+        }
     }
 
     // Count what was actually staged


### PR DESCRIPTION
## Summary

Closes #374.

When `gr add` is given specific file paths, it now stages each file individually instead of passing them all to a single `git add` invocation. Files that don't match a pathspec in a repo produce a warning instead of failing the entire operation.

**Before:** `gr add foo.txt bar.txt` would fail entirely if `foo.txt` didn't exist, even though `bar.txt` could have been staged.

**After:** `bar.txt` gets staged, `foo.txt` shows a warning: `foo.txt: skipped (not in this repo)`.

The `gr add .` (stage all) path is unchanged — it still uses `git add -A`.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib` — 577 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)