### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.17.1] - 2026-03-12
 
 ### Added
 - **`gr issue` commands** (#239)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
## Summary

Patch release v0.17.1 with new commands and bug fixes.

### Added
- `gr issue` commands — list, create, view, close, reopen (#239)
- `gr pr edit` — update PR title/body across repos (#257)
- `gr pr create` multi-branch support — group by branch instead of erroring (#225)
- `gr pr checks` — `--repo` filter, reference repo skip, stale check dedup (#238)
- `gr pr list` and `gr pr view` commands (#202)
- `gr push` — skip repos with no unique commits on new branches (#372)

### Fixed
- `gr add` — stage files individually so one missing path doesn't block the rest (#374)

🤖 Generated with [Claude Code](https://claude.com/claude-code)