### PR TITLE
feat: add claudemock — mock agent for gr spawn testing

### DIFF
--- a/scripts/claudemock
+++ b/scripts/claudemock
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# claudemock — lightweight mock agent for testing gr spawn tmux integration.
+#
+# Simulates an interactive agent session without requiring real Claude/Codex.
+# Responds to commands, stays alive until /exit or SIGTERM, and respects
+# the AGENT_NAME env var set by gr spawn.
+
+set -euo pipefail
+
+AGENT="${AGENT_NAME:-mock-agent}"
+START_TIME=$(date +%s)
+
+# Clean shutdown on SIGTERM (from gr spawn down)
+trap 'echo "[$AGENT] Received SIGTERM — shutting down."; exit 0' TERM
+
+# Banner
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  claudemock — $AGENT"
+echo "  PID: $$"
+echo "  Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Type /help for commands, /exit to quit."
+echo ""
+
+while true; do
+    # Print prompt
+    printf "[%s] > " "$AGENT"
+
+    # Read with timeout so SIGTERM can interrupt
+    if ! read -r -t 5 line 2>/dev/null; then
+        # Timeout — just loop (keeps agent alive, allows SIGTERM)
+        continue
+    fi
+
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    case "$line" in
+        /exit)
+            echo "[$AGENT] Exiting."
+            exit 0
+            ;;
+        /status)
+            NOW=$(date +%s)
+            UPTIME=$(( NOW - START_TIME ))
+            echo "[$AGENT] Agent: $AGENT"
+            echo "[$AGENT] PID: $$"
+            echo "[$AGENT] Uptime: ${UPTIME}s"
+            echo "[$AGENT] Role: ${AGENT_ROLE:-unset}"
+            echo "[$AGENT] Channel: ${SYNAPT_CHANNELS:-unset}"
+            ;;
+        /help)
+            echo "[$AGENT] Available commands:"
+            echo "  /status  — show agent name, PID, uptime"
+            echo "  /help    — show this help"
+            echo "  /exit    — clean shutdown"
+            echo "  (anything else is echoed back)"
+            ;;
+        *)
+            echo "[$AGENT] echo: $line"
+            ;;
+    esac
+done


### PR DESCRIPTION
## Summary
- Adds `scripts/claudemock` — lightweight bash script that simulates an interactive agent in tmux
- Responds to `/help`, `/status`, `/exit`, echoes arbitrary input
- Respects `AGENT_NAME`, `AGENT_ROLE`, `SYNAPT_CHANNELS` env vars from `gr spawn`
- Clean SIGTERM handling for `gr spawn down` testing
- Tests full spawn lifecycle: up, logs, attach, down, status

### agents.toml integration
```toml
[tools.mock]
binary = "scripts/claudemock"

[agents.test]
role = "Mock agent for testing"
tool = "mock"
worktree = "main"
```

## Test plan
- [x] Manual test: all commands work (`/help`, `/status`, `/exit`, echo)
- [x] SIGTERM clean shutdown
- [x] Env vars read correctly
- [ ] End-to-end with `gr spawn up/attach/logs/down`

🤖 Generated with [Claude Code](https://claude.com/claude-code)