### PR TITLE
docs: codify spawn intent-claim workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,15 @@ All git operations must go through `gr`. There is no exception.
 
 **CRITICAL: GitHub checks must pass before merging.** If checks are pending, wait. If checks fail, fix the issues first.
 
+### Spawn Coordination Process
+
+For multi-agent work coordinated through `gr spawn` and `#dev`, use this workflow to prevent duplicate execution:
+
+1. Post `intent` in `#dev` before starting any shared demo, review, merge, benchmark run, or other team-visible action.
+2. Claim the task in-channel before executing it.
+3. If another agent already claimed it, coordinate instead of racing.
+4. If you skip intent/claim by mistake, correct the channel state immediately after and do not repeat it.
+
 **Feature completeness checklist:**
 - [ ] New command registered in `src/main.rs`
 - [ ] Types added to appropriate module if needed

--- a/agents.toml
+++ b/agents.toml
@@ -8,6 +8,8 @@ session_name = "synapt"             # tmux session name
 channel = "dev"                     # default channel all agents join
 auto_journal = true                 # agents read recall_journal on startup
 mock_launch = true                  # Phase 1: echo instead of real agents
+# Coordination rule: post intent in #dev, then claim before shared execution.
+# Use this for demos, reviews, merges, eval runs, and other team-visible actions.
 
 [agents.opus]
 role = "CEO / product design — release framing, product decisions, team coordination"


### PR DESCRIPTION
## Summary\n- add the intent -> claim workflow to the gitgrip development guide\n- mirror the rule in the sample agents.toml spawn config comments\n- make duplicate-prevention explicit for demos, reviews, merges, and eval runs\n\n## Why\nThe mock spawn demo worked end-to-end, but the team had to correct an intent/claim miss afterward. This makes the coordination workflow part of the reusable gitgrip documentation and sample config instead of relying on channel memory alone.