### PR TITLE
feat: enforce gr branch in gripspaces (#405)

### DIFF
--- a/scripts/enforce-gr-branch.sh
+++ b/scripts/enforce-gr-branch.sh
@@ -17,7 +17,7 @@ INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('command',''))" 2>/dev/null || echo "")
 
 # Check for raw git branch creation commands
-if echo "$COMMAND" | grep -qE '^\s*git\s+(checkout\s+-b|branch\s+[^-])'; then
+if echo "$COMMAND" | grep -qE '^\s*git\s+(checkout\s+-b|switch\s+-c|branch\s+[^-])'; then
     # Check if we're in a gripspace (look for .gitgrip dir upward)
     DIR="${PWD}"
     IN_GRIPSPACE=false
@@ -33,7 +33,8 @@ if echo "$COMMAND" | grep -qE '^\s*git\s+(checkout\s+-b|branch\s+[^-])'; then
         echo "WARNING: Use 'gr branch' instead of raw git branch commands in a gripspace." >&2
         echo "Raw git creates the branch in only one repo. 'gr branch' creates it across all repos." >&2
         echo "" >&2
-        echo "Suggested: gr branch $(echo "$COMMAND" | sed -E 's/.*git (checkout -b|branch) //')" >&2
+        BRANCH_NAME=$(echo "$COMMAND" | sed -E 's/.*git (checkout -b|switch -c|branch) //')
+        echo "Suggested: gr branch $BRANCH_NAME" >&2
         exit 2
     fi
 fi

--- a/scripts/enforce-gr-branch.sh
+++ b/scripts/enforce-gr-branch.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Pre-tool-use hook: warn when 'git checkout -b' or 'git branch' is used
+# inside a gripspace. Agents should use 'gr branch' instead.
+#
+# Install as a PreToolUse hook for Bash in settings.json:
+#   {"matcher": "Bash", "hooks": [{"type": "command", "command": "path/to/enforce-gr-branch.sh"}]}
+#
+# The hook reads the tool input from stdin as JSON.
+# Exit 0 = allow, exit 2 = block with message on stderr.
+
+set -e
+
+# Read the tool input JSON from stdin
+INPUT=$(cat)
+
+# Extract the command from the JSON
+COMMAND=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('command',''))" 2>/dev/null || echo "")
+
+# Check for raw git branch creation commands
+if echo "$COMMAND" | grep -qE '^\s*git\s+(checkout\s+-b|branch\s+[^-])'; then
+    # Check if we're in a gripspace (look for .gitgrip dir upward)
+    DIR="${PWD}"
+    IN_GRIPSPACE=false
+    while [ "$DIR" != "/" ]; do
+        if [ -d "$DIR/.gitgrip" ]; then
+            IN_GRIPSPACE=true
+            break
+        fi
+        DIR=$(dirname "$DIR")
+    done
+
+    if [ "$IN_GRIPSPACE" = true ]; then
+        echo "WARNING: Use 'gr branch' instead of raw git branch commands in a gripspace." >&2
+        echo "Raw git creates the branch in only one repo. 'gr branch' creates it across all repos." >&2
+        echo "" >&2
+        echo "Suggested: gr branch $(echo "$COMMAND" | sed -E 's/.*git (checkout -b|branch) //')" >&2
+        exit 2
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- New `scripts/enforce-gr-branch.sh` — PreToolUse hook for Claude Code
- Detects `git checkout -b` and `git branch <name>` when inside a gripspace (`.gitgrip` dir)
- Blocks with exit 2 and suggests the equivalent `gr branch` command
- Safe commands like `git branch -a` (listing) pass through

## Installation
Add to `settings.json` under `hooks.PreToolUse`:
```json
{"matcher": "Bash", "hooks": [{"type": "command", "command": "gitgrip/scripts/enforce-gr-branch.sh"}]}
```

## Test plan
- [x] `git checkout -b feat/x` in gripspace → blocked with suggestion
- [x] `git status` → passes through
- [x] `git branch -a` (listing) → passes through
- [x] Outside gripspace → passes through

🤖 Generated with [Claude Code](https://claude.com/claude-code)