### PR TITLE
feat: gr init auto-syncs repos and applies links

### DIFF
--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -265,21 +265,14 @@ fn run_init_from_url(url: Option<&str>, path: Option<&str>) -> anyhow::Result<()
             }
 
             // Resolve URL from config or remotes
-            let url = config
-                .url
-                .clone()
-                .or_else(|| {
-                    config.remote.as_ref().and_then(|remote_name| {
-                        manifest
-                            .remotes
-                            .as_ref()?
-                            .get(remote_name)
-                            .map(|rc| {
-                                let base = rc.fetch.trim_end_matches('/');
-                                format!("{}/{}.git", base, name)
-                            })
+            let url = config.url.clone().or_else(|| {
+                config.remote.as_ref().and_then(|remote_name| {
+                    manifest.remotes.as_ref()?.get(remote_name).map(|rc| {
+                        let base = rc.fetch.trim_end_matches('/');
+                        format!("{}/{}.git", base, name)
                     })
-                });
+                })
+            });
 
             let url = match url {
                 Some(u) if !u.is_empty() => u,
@@ -308,11 +301,7 @@ fn run_init_from_url(url: Option<&str>, path: Option<&str>) -> anyhow::Result<()
         if failed.is_empty() {
             spinner.finish_with_message(format!("All {} repositories cloned", cloned));
         } else {
-            spinner.finish_with_message(format!(
-                "{} cloned, {} failed",
-                cloned,
-                failed.len()
-            ));
+            spinner.finish_with_message(format!("{} cloned, {} failed", cloned, failed.len()));
             for (name, err) in &failed {
                 Output::warning(&format!("  {} - {}", name, err));
             }

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -735,7 +735,8 @@ mod tests {
                 platform: None,
                 reference: false,
                 groups: Vec::new(),
-                agent: None, clone_strategy: None,
+                agent: None,
+                clone_strategy: None,
             },
         );
 
@@ -930,7 +931,8 @@ mod tests {
                 platform: None,
                 reference: false,
                 groups: Vec::new(),
-                agent: None, clone_strategy: None,
+                agent: None,
+                clone_strategy: None,
             },
         );
 

--- a/src/cli/commands/pr/review.rs
+++ b/src/cli/commands/pr/review.rs
@@ -81,14 +81,10 @@ pub async fn run_pr_review(
             .await
         {
             Ok(Some(pr)) => {
-                let spinner = Output::spinner(&format!(
-                    "Reviewing {} PR #{}...",
-                    repo.name, pr.number
-                ));
+                let spinner =
+                    Output::spinner(&format!("Reviewing {} PR #{}...", repo.name, pr.number));
                 match platform
-                    .create_pull_request_review(
-                        &repo.owner, &repo.repo, pr.number, event, body,
-                    )
+                    .create_pull_request_review(&repo.owner, &repo.repo, pr.number, event, body)
                     .await
                 {
                     Ok(()) => {

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -1047,7 +1047,8 @@ version = "0.2.0"
                 project: None,
                 reference: false,
                 groups: vec![],
-                agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+                agent: None,
+                clone_strategy: crate::core::manifest::CloneStrategy::Clone,
             },
             RepoInfo {
                 name: "backend".to_string(),
@@ -1065,7 +1066,8 @@ version = "0.2.0"
                 project: None,
                 reference: false,
                 groups: vec![],
-                agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+                agent: None,
+                clone_strategy: crate::core::manifest::CloneStrategy::Clone,
             },
         ];
 
@@ -1092,7 +1094,8 @@ version = "0.2.0"
                 project: None,
                 reference: true,
                 groups: vec![],
-                agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+                agent: None,
+                clone_strategy: crate::core::manifest::CloneStrategy::Clone,
             },
             RepoInfo {
                 name: "main-repo".to_string(),
@@ -1110,7 +1113,8 @@ version = "0.2.0"
                 project: None,
                 reference: false,
                 groups: vec![],
-                agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+                agent: None,
+                clone_strategy: crate::core::manifest::CloneStrategy::Clone,
             },
         ];
 
@@ -1152,7 +1156,8 @@ version = "0.2.0"
             project: None,
             reference: false,
             groups: vec![],
-            agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+            agent: None,
+            clone_strategy: crate::core::manifest::CloneStrategy::Clone,
         }];
 
         let files = detect_version_files(&dir.path().to_path_buf(), &repos);
@@ -1184,7 +1189,8 @@ version = "0.2.0"
             project: None,
             reference: true,
             groups: vec![],
-            agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+            agent: None,
+            clone_strategy: crate::core::manifest::CloneStrategy::Clone,
         }];
 
         let files = detect_version_files(&dir.path().to_path_buf(), &repos);

--- a/src/cli/commands/tree.rs
+++ b/src/cli/commands/tree.rs
@@ -393,9 +393,7 @@ pub fn run_tree_list(workspace_root: &Path) -> anyhow::Result<()> {
     // Auto-repair stale child marker in root workspace (#402)
     let stale_child_marker = griptrees_root.join(".gitgrip").join("griptree.json");
     if config_path.exists() && stale_child_marker.exists() {
-        eprintln!(
-            "Repaired: removed stale .gitgrip/griptree.json from root workspace"
-        );
+        eprintln!("Repaired: removed stale .gitgrip/griptree.json from root workspace");
         let _ = std::fs::remove_file(&stale_child_marker);
     }
 
@@ -1095,7 +1093,10 @@ mod tests {
         let griptree_path = gitgrip_dir.join("griptree.json");
         std::fs::write(&griptree_path, r#"{"branch":"old","path":"."}"#).unwrap();
 
-        assert!(griptree_path.exists(), "child marker should exist before repair");
+        assert!(
+            griptree_path.exists(),
+            "child marker should exist before repair"
+        );
 
         // run_tree_list would clean this up, but requires full workspace setup.
         // Test the repair logic directly:

--- a/src/cli/commands/verify.rs
+++ b/src/cli/commands/verify.rs
@@ -333,7 +333,8 @@ mod tests {
             project: None,
             reference: false,
             groups: Vec::new(),
-            agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+            agent: None,
+            clone_strategy: crate::core::manifest::CloneStrategy::Clone,
         }
     }
 

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -945,7 +945,8 @@ repos:
                         platform: None,
                         reference: false,
                         groups: Vec::new(),
-                        agent: None, clone_strategy: None,
+                        agent: None,
+                        clone_strategy: None,
                     },
                 );
                 m
@@ -1009,7 +1010,8 @@ repos:
                         platform: None,
                         reference: false,
                         groups: Vec::new(),
-                        agent: None, clone_strategy: None,
+                        agent: None,
+                        clone_strategy: None,
                     },
                 );
                 m
@@ -1090,7 +1092,8 @@ repos:
                         platform: None,
                         reference: false,
                         groups: vec!["local-group".to_string()],
-                        agent: None, clone_strategy: None,
+                        agent: None,
+                        clone_strategy: None,
                     },
                 );
                 m

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -572,8 +572,7 @@ impl Manifest {
         if repo.reference {
             return CloneStrategy::Clone;
         }
-        repo.clone_strategy
-            .unwrap_or(self.settings.clone_strategy)
+        repo.clone_strategy.unwrap_or(self.settings.clone_strategy)
     }
 
     /// Validate the manifest

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -135,9 +135,7 @@ impl RepoInfo {
             clone_strategy: if config.reference {
                 CloneStrategy::Clone
             } else {
-                config
-                    .clone_strategy
-                    .unwrap_or(settings.clone_strategy)
+                config.clone_strategy.unwrap_or(settings.clone_strategy)
             },
         })
     }
@@ -631,7 +629,8 @@ mod tests {
                 platform: None,
                 reference: false,
                 groups: vec![],
-                agent: None, clone_strategy: None,
+                agent: None,
+                clone_strategy: None,
             },
         );
         repos.insert(
@@ -649,7 +648,8 @@ mod tests {
                 platform: None,
                 reference: false,
                 groups: vec![],
-                agent: None, clone_strategy: None,
+                agent: None,
+                clone_strategy: None,
             },
         );
 
@@ -698,7 +698,8 @@ mod tests {
                 platform: None,
                 reference: true,
                 groups: vec![],
-                agent: None, clone_strategy: None,
+                agent: None,
+                clone_strategy: None,
             },
         );
         repos.insert(
@@ -716,7 +717,8 @@ mod tests {
                 platform: None,
                 reference: false,
                 groups: vec![],
-                agent: None, clone_strategy: None,
+                agent: None,
+                clone_strategy: None,
             },
         );
 
@@ -762,7 +764,8 @@ mod tests {
                 platform: None,
                 reference: false,
                 groups: vec!["web".to_string()],
-                agent: None, clone_strategy: None,
+                agent: None,
+                clone_strategy: None,
             },
         );
         repos.insert(
@@ -780,7 +783,8 @@ mod tests {
                 platform: None,
                 reference: false,
                 groups: vec!["api".to_string()],
-                agent: None, clone_strategy: None,
+                agent: None,
+                clone_strategy: None,
             },
         );
 
@@ -827,7 +831,8 @@ mod tests {
             platform: None,
             reference: false,
             groups: vec![],
-            agent: None, clone_strategy: None,
+            agent: None,
+            clone_strategy: None,
         };
         let settings = ManifestSettings::default();
         let info =
@@ -849,7 +854,8 @@ mod tests {
             platform: None,
             reference: false,
             groups: vec![],
-            agent: None, clone_strategy: None,
+            agent: None,
+            clone_strategy: None,
         };
         let settings = ManifestSettings {
             revision: Some("master".to_string()),
@@ -887,7 +893,8 @@ mod tests {
             platform: None,
             reference: false,
             groups: vec![],
-            agent: None, clone_strategy: None,
+            agent: None,
+            clone_strategy: None,
         };
 
         // No target → falls back to revision
@@ -955,7 +962,8 @@ mod tests {
             platform: None,
             reference: false,
             groups: vec![],
-            agent: None, clone_strategy: None,
+            agent: None,
+            clone_strategy: None,
         };
 
         // Defaults to "origin"
@@ -1029,7 +1037,8 @@ mod tests {
             platform: None,
             reference: false,
             groups: vec![],
-            agent: None, clone_strategy: None,
+            agent: None,
+            clone_strategy: None,
         };
         let settings = ManifestSettings::default();
         let info = RepoInfo::from_config(

--- a/src/core/sync_state.rs
+++ b/src/core/sync_state.rs
@@ -172,7 +172,8 @@ mod tests {
             project: None,
             reference: false,
             groups: vec![],
-            agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+            agent: None,
+            clone_strategy: crate::core::manifest::CloneStrategy::Clone,
         }];
 
         let snapshot = SyncSnapshot::capture(workspace.path(), &repos).unwrap();
@@ -216,7 +217,8 @@ mod tests {
             project: None,
             reference: false,
             groups: vec![],
-            agent: None, clone_strategy: crate::core::manifest::CloneStrategy::Clone,
+            agent: None,
+            clone_strategy: crate::core::manifest::CloneStrategy::Clone,
         }];
 
         let snapshot = SyncSnapshot::capture(workspace.path(), &repos).unwrap();


### PR DESCRIPTION
## Summary
- gr init <manifest-url> now automatically clones all repos from the manifest after cloning the manifest itself
- Applies linkfiles and copyfiles from repo configs
- Reports per-repo clone success/failure with clear error messages
- Changes 'Next steps' from 'gr sync' to 'gr status' since repos are already cloned

Closes the gr init gap where users had to manually cd + gr sync after init.

## Verification
- cargo check clean
- cargo test --lib -> 588 passed