### PR TITLE
chore: bump to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
IPC module, clone strategy, migration tooling, clippy fixes, gr init auto-sync.