### PR TITLE
chore: bump version to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
Version bump for release. Unblocks Sentinel's release artifacts work.