### PR TITLE
chore: bump version to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
Version bump for Sprint 7 release. IPC module, clone strategy, migration tooling, 38 clippy fixes, PR review command, squash auto-detect.