### PR TITLE
feat: pipe-pane output streaming + process tracking (#443)

### DIFF
--- a/src/cli/commands/spawn.rs
+++ b/src/cli/commands/spawn.rs
@@ -367,6 +367,43 @@ pub fn run_spawn_up(
             .args(["send-keys", "-t", &target, &launch_cmd, "Enter"])
             .status();
 
+        // Set up pipe-pane for output streaming (#443 Mission Control)
+        let log_dir = workspace_root.join(".synapt").join("logs").join(&agent_id);
+        let _ = std::fs::create_dir_all(&log_dir);
+        let log_path = log_dir.join("output.log");
+        let pipe_cmd = format!("cat >> {}", log_path.display());
+        let _ = Command::new("tmux")
+            .args(["pipe-pane", "-t", &target, &pipe_cmd])
+            .status();
+
+        // Get tmux pane PID for process tracking
+        let pane_pid = Command::new("tmux")
+            .args(["display-message", "-t", &target, "-p", "#{pane_pid}"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                String::from_utf8_lossy(&o.stdout)
+                    .trim()
+                    .parse::<u32>()
+                    .ok()
+            });
+
+        // Update process state in team.db
+        if let Err(e) = crate::core::agent_registry::update_process_state(
+            &org_dir,
+            &agent_id,
+            pane_pid,
+            Some(&target),
+            "online",
+            Some(log_path.to_str().unwrap_or("")),
+            None, // session_id set by agent on join
+        ) {
+            Output::warning(&format!(
+                "Failed to update process state for {}: {}",
+                name, e
+            ));
+        }
+
         // Print status
         let mode_tag = if mock_mode {
             " [mock]".dimmed().to_string()

--- a/src/core/agent_registry.rs
+++ b/src/core/agent_registry.rs
@@ -18,7 +18,13 @@ CREATE TABLE IF NOT EXISTS org_agents (
     role TEXT,
     org_id TEXT NOT NULL,
     created_at TEXT NOT NULL,
-    last_seen_at TEXT
+    last_seen_at TEXT,
+    -- Process tracking columns (Sprint 9 Mission Control)
+    pid INTEGER,
+    tmux_target TEXT,
+    status TEXT DEFAULT 'offline',
+    log_path TEXT,
+    session_id TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_org_display
     ON org_agents(org_id, display_name);
@@ -163,6 +169,38 @@ pub fn rename_agent(org_dir: &Path, agent_id: &str, new_display_name: &str) -> R
     let updated = conn.execute(
         "UPDATE org_agents SET display_name = ? WHERE agent_id = ?",
         rusqlite::params![new_display_name, agent_id],
+    )?;
+    if updated == 0 {
+        anyhow::bail!("Agent '{}' not found", agent_id);
+    }
+    Ok(())
+}
+
+/// Update an agent's process state (called by gr spawn).
+pub fn update_process_state(
+    org_dir: &Path,
+    agent_id: &str,
+    pid: Option<u32>,
+    tmux_target: Option<&str>,
+    status: &str,
+    log_path: Option<&str>,
+    session_id: Option<&str>,
+) -> Result<()> {
+    let conn = open_db(org_dir)?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let updated = conn.execute(
+        "UPDATE org_agents SET pid = ?1, tmux_target = ?2, status = ?3, \
+         log_path = ?4, session_id = ?5, last_seen_at = ?6 \
+         WHERE agent_id = ?7",
+        rusqlite::params![
+            pid.map(|p| p as i64),
+            tmux_target,
+            status,
+            log_path,
+            session_id,
+            now,
+            agent_id,
+        ],
     )?;
     if updated == 0 {
         anyhow::bail!("Agent '{}' not found", agent_id);


### PR DESCRIPTION
## Summary
gr spawn up now sets up pipe-pane per agent for real-time output streaming and writes process state to team.db.

Changes:
- `tmux pipe-pane` per agent window → output.log for SSE streaming
- Log directories at `.synapt/logs/<agent_id>/`
- Pane PID via `tmux display-message`
- team.db schema extended: pid, tmux_target, status, log_path, session_id
- `update_process_state()` function for process tracking

Enables: dashboard reads agent state from team.db, tails output.log for SSE.

## Test plan
- [x] `cargo build` — compiles clean
- [x] All 8 registry tests pass (schema migration is additive)
- [x] TDD tests from #442 define the verification criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)