### PR TITLE
fix: benchmark CI (missing clone_strategy in bench literals)

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -123,6 +123,7 @@ fn bench_url_parse(c: &mut Criterion) {
         reference: false,
         groups: Vec::new(),
         agent: None,
+        clone_strategy: None,
     };
     let workspace = PathBuf::from("/home/user/workspace");
     let settings = ManifestSettings::default();
@@ -156,6 +157,7 @@ fn bench_url_parse_azure(c: &mut Criterion) {
         reference: false,
         groups: Vec::new(),
         agent: None,
+        clone_strategy: None,
     };
     let workspace = PathBuf::from("/home/user/workspace");
     let settings = ManifestSettings::default();


### PR DESCRIPTION
Two RepoConfig struct literals in benches/benchmarks.rs missing the clone_strategy field added in a recent sprint. Fixes Benchmarks CI job red since Sprint 9. 2-line change.