### PR TITLE
fix: auto-reclone spaces/main when not a git repo (grip#468)

### DIFF
--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -128,12 +128,10 @@ fn recover_manifest_repo<'a>(
     // Reload the manifest from the fresh clone so subsequent operations see up-to-date content.
     let manifest_path = manifest_paths::resolve_gripspace_manifest_path(workspace_root);
     let fresh = if let Some(path) = manifest_path {
-        let content = std::fs::read_to_string(&path).map_err(|e| {
-            anyhow::anyhow!("Failed to read fresh manifest after re-clone: {}", e)
-        })?;
-        Manifest::parse_raw(&content).map_err(|e| {
-            anyhow::anyhow!("Failed to parse fresh manifest after re-clone: {}", e)
-        })?
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("Failed to read fresh manifest after re-clone: {}", e))?;
+        Manifest::parse_raw(&content)
+            .map_err(|e| anyhow::anyhow!("Failed to parse fresh manifest after re-clone: {}", e))?
     } else {
         manifest.clone()
     };

--- a/tests/test_sync.rs
+++ b/tests/test_sync.rs
@@ -683,11 +683,17 @@ async fn test_sync_reclones_non_git_manifest_dir() {
     git_helpers::clone_repo(&manifest_url, &spaces_main);
 
     // Verify it's a proper git clone before we corrupt it
-    assert!(spaces_main.join(".git").exists(), "pre-condition: should be a git repo");
+    assert!(
+        spaces_main.join(".git").exists(),
+        "pre-condition: should be a git repo"
+    );
 
     // Simulate corruption: remove .git from spaces/main/ (the bug scenario)
     fs::remove_dir_all(spaces_main.join(".git")).unwrap();
-    assert!(!spaces_main.join(".git").exists(), "pre-condition: .git removed");
+    assert!(
+        !spaces_main.join(".git").exists(),
+        "pre-condition: .git removed"
+    );
 
     // Build a manifest that includes manifest.url so recover_manifest_repo can re-clone
     let manifest_with_url = format!(
@@ -713,7 +719,11 @@ async fn test_sync_reclones_non_git_manifest_dir() {
     )
     .await;
 
-    assert!(result.is_ok(), "sync should succeed after auto-recovery: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "sync should succeed after auto-recovery: {:?}",
+        result.err()
+    );
 
     // spaces/main/ should now have a .git (re-cloned)
     assert!(


### PR DESCRIPTION
## Summary

- Detects when `spaces/main/` exists but has no `.git` directory (stale copy from migration, missing `gr init`, or corrupted workspace)
- Auto-reclones from `manifest.url` at the start of `gr sync` before any repo syncing
- Reloads the manifest from the fresh clone so downstream operations see up-to-date content
- Warns clearly when `manifest.url` is not set (can't auto-recover, tells user to run `gr init`)

## Test plan

- [x] New test `test_sync_reclones_non_git_manifest_dir`: clones manifest remote, removes `.git` to simulate corruption, verifies `run_sync` re-clones and leaves `spaces/main/` as a valid git repo
- [x] All 18 sync tests pass
- [x] `cargo build` clean

Closes grip#468

🤖 Generated with [Claude Code](https://claude.com/claude-code)