### PR TITLE
Sprint 9 ceremony: workspace cache + checkout materialization + playground

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -123,6 +123,7 @@ fn bench_url_parse(c: &mut Criterion) {
         reference: false,
         groups: Vec::new(),
         agent: None,
+        clone_strategy: None,
     };
     let workspace = PathBuf::from("/home/user/workspace");
     let settings = ManifestSettings::default();
@@ -156,6 +157,7 @@ fn bench_url_parse_azure(c: &mut Criterion) {
         reference: false,
         groups: Vec::new(),
         agent: None,
+        clone_strategy: None,
     };
     let workspace = PathBuf::from("/home/user/workspace");
     let settings = ManifestSettings::default();

--- a/scripts/e2e-demo.sh
+++ b/scripts/e2e-demo.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# e2e-demo.sh — Team-verified demo for Sprint 11 release.
+#
+# Spawns mock agents, verifies dashboard API endpoints work,
+# checks channel operations, tears down. Exit 0 = pass.
+#
+# Usage: ./scripts/e2e-demo.sh [--skip-dashboard]
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo -e "  ${GREEN}✓${NC} $1"; ((PASS++)); }
+fail() { echo -e "  ${RED}✗${NC} $1"; ((FAIL++)); }
+skip() { echo -e "  ${YELLOW}⊘${NC} $1 (skipped)"; ((SKIP++)); }
+
+echo "═══════════════════════════════════════════"
+echo "  e2e Demo — Sprint 11 Release Verification"
+echo "═══════════════════════════════════════════"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 1: Spawn
+# ---------------------------------------------------------------------------
+echo "Phase 1: Agent Spawn"
+
+# Check tmux is available
+if ! command -v tmux &>/dev/null; then
+    fail "tmux not installed"
+    echo ""
+    echo "Result: FAIL (tmux required)"
+    exit 1
+fi
+pass "tmux available"
+
+# Find gr binary
+if [ -z "${GR:-}" ]; then
+    GR=$(command -v gr 2>/dev/null || true)
+    [ -z "$GR" ] && GR="./target/debug/gr"
+fi
+if [ ! -x "$GR" ]; then
+    GR="./target/release/gr"
+fi
+if [ ! -x "$GR" ]; then
+    fail "gr binary not found"
+    exit 1
+fi
+pass "gr binary found: $GR"
+
+# Check agents.toml exists
+if [ ! -f ".gitgrip/agents.toml" ]; then
+    fail ".gitgrip/agents.toml not found (run gr sync first)"
+    exit 1
+fi
+pass "agents.toml found"
+
+# Kill any existing session
+SESSION=$(grep 'session_name' .gitgrip/agents.toml 2>/dev/null | head -1 | sed 's/.*= *"//' | sed 's/".*//')
+SESSION="${SESSION:-synapt}"
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+
+# Spawn mock agents
+echo ""
+echo "  Spawning mock agents..."
+if $GR spawn up --mock 2>&1 | tail -5; then
+    pass "gr spawn up --mock succeeded"
+else
+    fail "gr spawn up --mock failed"
+fi
+
+# Verify session exists
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+    pass "tmux session '$SESSION' exists"
+else
+    fail "tmux session '$SESSION' not created"
+fi
+
+# Count agent windows
+WINDOW_COUNT=$(tmux list-windows -t "$SESSION" 2>/dev/null | wc -l | tr -d ' ')
+EXPECTED_AGENTS=$(grep '^\[agents\.' .gitgrip/agents.toml 2>/dev/null | wc -l | tr -d ' ')
+if [ "$WINDOW_COUNT" -ge "$EXPECTED_AGENTS" ]; then
+    pass "agent windows created: $WINDOW_COUNT (expected >= $EXPECTED_AGENTS)"
+else
+    fail "agent windows: got $WINDOW_COUNT, expected >= $EXPECTED_AGENTS"
+fi
+
+# Check team.db was created
+ORG_ID=$(grep 'org_id' .gitgrip/agents.toml 2>/dev/null | head -1 | sed 's/.*= *"//' | sed 's/".*//')
+ORG_ID="${ORG_ID:-$SESSION}"
+TEAM_DB="$HOME/.synapt/orgs/$ORG_ID/team.db"
+if [ -f "$TEAM_DB" ]; then
+    AGENT_COUNT=$(sqlite3 "$TEAM_DB" "SELECT COUNT(*) FROM org_agents" 2>/dev/null || echo 0)
+    pass "team.db exists with $AGENT_COUNT agents"
+else
+    fail "team.db not found at $TEAM_DB"
+fi
+
+# Check pipe-pane log dirs
+LOG_DIR=".synapt/logs"
+if [ -d "$LOG_DIR" ]; then
+    LOG_COUNT=$(find "$LOG_DIR" -name "output.log" 2>/dev/null | wc -l | tr -d ' ')
+    pass "pipe-pane log dirs created ($LOG_COUNT output.log files)"
+else
+    skip "pipe-pane log dirs (mock mode may not create them)"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2: Channels
+# ---------------------------------------------------------------------------
+echo ""
+echo "Phase 2: Channel Operations"
+
+# Post a message
+if $GR channel post "e2e-demo: test message $(date +%s)" 2>/dev/null; then
+    pass "channel post succeeded"
+else
+    fail "channel post failed"
+fi
+
+# Read messages
+READ_OUTPUT=$($GR channel read 2>/dev/null || echo "")
+if echo "$READ_OUTPUT" | grep -q "e2e-demo"; then
+    pass "channel read shows posted message"
+else
+    fail "channel read doesn't show posted message"
+fi
+
+# Who is online
+WHO_OUTPUT=$($GR channel who 2>/dev/null || echo "")
+if [ -n "$WHO_OUTPUT" ]; then
+    pass "channel who returned data"
+else
+    skip "channel who (no agents joined channel yet)"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 3: Dashboard API (optional)
+# ---------------------------------------------------------------------------
+echo ""
+echo "Phase 3: Dashboard API"
+
+SKIP_DASHBOARD="${1:-}"
+if [ "$SKIP_DASHBOARD" = "--skip-dashboard" ]; then
+    skip "dashboard API (--skip-dashboard flag)"
+else
+    # Check if synapt dashboard is importable
+    if python3 -c "from synapt.recall.dashboard import app" 2>/dev/null; then
+        pass "dashboard module importable"
+
+        # Check agents API
+        # Start dashboard briefly in background
+        python3 -c "
+import json
+from synapt.recall.dashboard import get_agents_json
+agents = json.loads(get_agents_json())
+print(json.dumps(agents, indent=2))
+" 2>/dev/null && pass "agents API returns data" || fail "agents API failed"
+    else
+        skip "dashboard API (synapt not installed or dashboard not available)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 4: Dashboard Pane Targeting
+# ---------------------------------------------------------------------------
+echo ""
+echo "Phase 4: Dashboard Layout"
+
+# Create dashboard and verify pane count
+$GR spawn down 2>/dev/null || true
+sleep 1
+$GR spawn up --mock 2>/dev/null
+
+if $GR spawn status 2>&1 | grep -q "running\|✓"; then
+    pass "agents running after respawn"
+else
+    fail "agents not running after respawn"
+fi
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+echo ""
+echo "Teardown"
+$GR spawn down 2>/dev/null
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+    pass "session cleaned up"
+else
+    fail "session still exists after spawn down"
+fi
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══════════════════════════════════════════"
+TOTAL=$((PASS + FAIL + SKIP))
+echo -e "  Results: ${GREEN}$PASS passed${NC}, ${RED}$FAIL failed${NC}, ${YELLOW}$SKIP skipped${NC} / $TOTAL total"
+echo "═══════════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo -e "${RED}DEMO FAILED${NC} — $FAIL test(s) failed. Fix before release."
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}DEMO PASSED${NC} — ready for release."
+    exit 0
+fi

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -972,4 +972,22 @@ pub enum MigrateCommands {
         #[arg(short, long)]
         path: Option<String>,
     },
+    /// Convert an existing git repo directory into a gripspace in-place
+    ///
+    /// Moves the repo contents into a child directory (named after the repo),
+    /// keeps .synapt/ and .claude/ at the gripspace root, and repairs any
+    /// linked worktree paths. Requires git 2.30+.
+    ///
+    /// Example: gr migrate in-place
+    ///   ~/conversa/           → ~/conversa/conversa-app/ (repo)
+    ///                            ~/conversa/.synapt/     (stays)
+    ///                            ~/conversa/.claude/     (stays)
+    InPlace {
+        /// Show what would happen without making any changes
+        #[arg(long)]
+        dry_run: bool,
+        /// Path to the repo directory (default: current directory)
+        #[arg(short, long)]
+        path: Option<String>,
+    },
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -349,6 +349,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: TargetCommands,
     },
+    /// Manage workspace repo caches (.grip/cache/)
+    Cache {
+        #[command(subcommand)]
+        action: CacheCommands,
+    },
     /// Run garbage collection across repos
     Gc {
         /// More thorough gc (slower)
@@ -871,6 +876,21 @@ pub enum TargetCommands {
         /// Unset target for a specific repo instead of globally
         #[arg(long)]
         repo: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CacheCommands {
+    /// Bootstrap bare caches for all manifest repos
+    Bootstrap,
+    /// Fetch latest refs into all caches
+    Update,
+    /// Show cache status
+    Status,
+    /// Remove a repo cache
+    Remove {
+        /// Repo name
+        repo: String,
     },
 }
 

--- a/src/cli/commands/cache.rs
+++ b/src/cli/commands/cache.rs
@@ -1,0 +1,99 @@
+//! Cache command implementation
+//!
+//! Manages bare-repo caches under `.grip/cache/` for workspace repos.
+
+use crate::cli::args::CacheCommands;
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::filter_repos;
+use crate::core::workspace_cache;
+use anyhow::Result;
+use colored::Colorize;
+use std::path::Path;
+
+pub fn run_cache(
+    workspace_root: &Path,
+    manifest: &Manifest,
+    action: CacheCommands,
+    quiet: bool,
+) -> Result<()> {
+    // Include reference repos in caching — they benefit from local caches too
+    let repos = filter_repos(manifest, workspace_root, None, None, true);
+
+    match action {
+        CacheCommands::Bootstrap => {
+            if !quiet {
+                Output::info(&format!(
+                    "Bootstrapping caches for {} repos...",
+                    repos.len()
+                ));
+            }
+
+            let repo_pairs: Vec<(&str, &str)> = repos
+                .iter()
+                .map(|r| (r.name.as_str(), r.url.as_str()))
+                .collect();
+
+            let count =
+                workspace_cache::bootstrap_all(workspace_root, repo_pairs.into_iter())?;
+
+            if !quiet {
+                if count > 0 {
+                    Output::success(&format!("Bootstrapped {} new cache(s)", count));
+                } else {
+                    Output::info("All caches already exist");
+                }
+            }
+        }
+
+        CacheCommands::Update => {
+            if !quiet {
+                Output::info("Updating all caches...");
+            }
+
+            let count = workspace_cache::update_all(workspace_root)?;
+
+            if !quiet {
+                Output::success(&format!("Updated {} cache(s)", count));
+            }
+        }
+
+        CacheCommands::Status => {
+            let cache_dir = workspace_root.join(".grip").join("cache");
+            if !cache_dir.is_dir() {
+                Output::info("No caches exist yet. Run 'gr cache bootstrap' to create them.");
+                return Ok(());
+            }
+
+            println!(
+                "{:<20} {:<8} {}",
+                "Repo".bold(),
+                "Status".bold(),
+                "Path".bold()
+            );
+            println!("{}", "─".repeat(70));
+
+            for repo in &repos {
+                let exists = workspace_cache::cache_exists(workspace_root, &repo.name);
+                let path = workspace_cache::cache_path(workspace_root, &repo.name);
+                let status = if exists {
+                    "cached".green().to_string()
+                } else {
+                    "missing".yellow().to_string()
+                };
+                println!("{:<20} {:<8} {}", repo.name, status, path.display());
+            }
+        }
+
+        CacheCommands::Remove { repo } => {
+            let removed = workspace_cache::remove_cache(workspace_root, &repo)?;
+            if removed {
+                Output::success(&format!("Removed cache for {}", repo));
+            } else {
+                Output::warning(&format!("No cache found for {}", repo));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/commands/cache.rs
+++ b/src/cli/commands/cache.rs
@@ -34,8 +34,7 @@ pub fn run_cache(
                 .map(|r| (r.name.as_str(), r.url.as_str()))
                 .collect();
 
-            let count =
-                workspace_cache::bootstrap_all(workspace_root, repo_pairs.into_iter())?;
+            let count = workspace_cache::bootstrap_all(workspace_root, repo_pairs.into_iter())?;
 
             if !quiet {
                 if count > 0 {

--- a/src/cli/commands/migrate.rs
+++ b/src/cli/commands/migrate.rs
@@ -1,13 +1,19 @@
 //! `gr migrate` — convert existing repos into a gripspace (#424).
 //!
-//! First customer migration tooling. Generates gripspace.yml +
-//! agents.toml + CLAUDE.md + per-agent prompts from a list of
-//! GitHub repos. Interactive mode configures the full agent team.
+//! Two subcommands:
+//!   - `from-repos`: Generate a new gripspace from GitHub repo list
+//!   - `in-place`:   Convert an existing git repo dir into a gripspace
 
 use crate::cli::output::Output;
+use crate::core::griptree::{GriptreeConfig, GriptreePointer, GriptreeRepoInfo};
+use crate::core::manifest::{CloneStrategy, Manifest, ManifestSettings, MergeStrategy, RepoConfig};
+use crate::core::manifest_paths;
+use chrono::Utc;
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
+use std::collections::{HashMap, HashSet};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::process::Output as ProcessOutput;
 
 /// Agent configuration collected during interactive setup.
 struct AgentSpec {
@@ -15,6 +21,26 @@ struct AgentSpec {
     role: String,
     model: String,
     tool: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExistingWorktree {
+    root: PathBuf,
+    branch: Option<String>,
+    is_main: bool,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+struct MigratedGriptreesList {
+    griptrees: HashMap<String, MigratedGriptreeEntry>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct MigratedGriptreeEntry {
+    path: String,
+    branch: String,
+    locked: bool,
+    lock_reason: Option<String>,
 }
 
 /// Run `gr migrate from-repos` — generate gripspace from GitHub repos.
@@ -412,9 +438,611 @@ fn create_gripspace_dirs(
     Ok(())
 }
 
+/// Run `gr migrate in-place` — convert a git repo dir into a gripspace.
+///
+/// Algorithm (v3.2):
+/// 1. Derive repo name from `git remote get-url origin` (basename, strip .git)
+///    Falls back to directory name if no remote or command fails.
+/// 2. Enumerate the main repo plus linked worktrees via `git worktree list --porcelain`.
+/// 3. For each worktree root, move everything into `<worktree-root>/<repo-name>` EXCEPT:
+///    .synapt/, .claude/, .env, _migrate_tmp/, and the child dir name.
+/// 4. Run `git worktree repair` after all paths move so linked worktree metadata points at
+///    the new `<worktree-root>/<repo-name>` locations.
+/// 5. Create `.gitgrip/griptrees.json` at the main root and `.griptree` /
+///    `.gitgrip/griptree.json` in each linked worktree root.
+pub async fn run_migrate_in_place(
+    path: Option<&str>,
+    dry_run: bool,
+    json: bool,
+) -> anyhow::Result<()> {
+    let root = match path {
+        Some(p) => PathBuf::from(p).canonicalize()?,
+        None => std::env::current_dir()?,
+    };
+
+    // Guard: must be a git repo (has .git at root)
+    if !root.join(".git").exists() {
+        if root.join(".gitgrip").exists() {
+            anyhow::bail!(
+                "Already a gripspace (has .gitgrip/). Run `gr status` to check the workspace."
+            );
+        }
+        anyhow::bail!("Not a git repository: no .git found at {}", root.display());
+    }
+
+    // Guard: git 2.30+ required for `git worktree repair`
+    check_git_version_for_repair()?;
+
+    // Derive repo name
+    let repo_name = derive_repo_name_from_remote(&root);
+    let worktrees = list_existing_worktrees(&root)?;
+    let linked_worktrees: Vec<ExistingWorktree> =
+        worktrees.iter().filter(|wt| !wt.is_main).cloned().collect();
+    let main_revision = worktrees
+        .iter()
+        .find(|wt| wt.is_main)
+        .and_then(|wt| wt.branch.clone())
+        .unwrap_or_else(|| "main".to_string());
+
+    validate_migration_targets(&worktrees, &repo_name)?;
+
+    if !json {
+        Output::header("gr migrate in-place");
+        println!();
+        Output::info(&format!("Gripspace root: {}", root.display()));
+        Output::info(&format!("Repo child:     {}/{}", root.display(), repo_name));
+        if !linked_worktrees.is_empty() {
+            Output::info(&format!("Linked worktrees: {}", linked_worktrees.len()));
+            for wt in &linked_worktrees {
+                let branch = wt.branch.as_deref().unwrap_or("(detached)");
+                println!("  {} -> {}/{}", branch, wt.root.display(), repo_name);
+            }
+        }
+        println!();
+        if dry_run {
+            Output::warning("DRY RUN — no changes will be made");
+            println!();
+        }
+    }
+
+    if !json && dry_run {
+        for wt in &worktrees {
+            let to_move = collect_paths_to_move(&wt.root, &repo_name)?;
+            let label = if wt.is_main {
+                "main repo".to_string()
+            } else {
+                format!(
+                    "linked worktree ({})",
+                    wt.branch.as_deref().unwrap_or("detached")
+                )
+            };
+            println!(
+                "  Would move {} into {}/{}:",
+                label,
+                wt.root.display(),
+                repo_name
+            );
+            for p in &to_move {
+                println!(
+                    "    {}",
+                    p.file_name().unwrap_or_default().to_string_lossy()
+                );
+            }
+            println!();
+            println!("  Would keep at {}:", wt.root.display());
+            for path in [".synapt", ".claude", ".env"] {
+                if wt.root.join(path).exists() {
+                    if wt.root.join(path).is_dir() {
+                        println!("    {}/", path);
+                    } else {
+                        println!("    {}", path);
+                    }
+                }
+            }
+            println!();
+        }
+        println!("  Would run: git worktree repair");
+        println!("  Would create: {}/.gitgrip/griptrees.json", root.display());
+        println!(
+            "  Would create: {}/.gitgrip/spaces/main/gripspace.yml",
+            root.display()
+        );
+        for wt in &linked_worktrees {
+            println!("  Would create: {}/.griptree", wt.root.display());
+            println!(
+                "  Would create: {}/.gitgrip/griptree.json",
+                wt.root.display()
+            );
+        }
+        return Ok(());
+    }
+
+    if dry_run {
+        let result = serde_json::json!({
+            "root": root.display().to_string(),
+            "repo_name": repo_name,
+            "worktrees": worktrees.iter().map(|wt| serde_json::json!({
+                "root": wt.root.display().to_string(),
+                "branch": wt.branch,
+                "is_main": wt.is_main,
+                "to_move": collect_paths_to_move(&wt.root, &repo_name).unwrap_or_default().iter()
+                    .map(|p| p.file_name().unwrap_or_default().to_string_lossy().to_string())
+                    .collect::<Vec<_>>(),
+            })).collect::<Vec<_>>(),
+            "dry_run": true,
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    for wt in &worktrees {
+        migrate_single_worktree_root(&wt.root, &repo_name)?;
+    }
+
+    let repair_outputs = run_worktree_repairs(&worktrees, &repo_name)?;
+    for repair in &repair_outputs {
+        if !json {
+            let repair_out = String::from_utf8_lossy(&repair.stdout);
+            let repair_err = String::from_utf8_lossy(&repair.stderr);
+            if !repair_out.trim().is_empty() || !repair_err.trim().is_empty() {
+                Output::info("git worktree repair output:");
+                for line in repair_out.lines().chain(repair_err.lines()) {
+                    println!("  {}", line);
+                }
+            }
+        }
+        worktree_repair_must_succeed(repair)?;
+    }
+
+    create_root_gripspace_metadata(&root, &linked_worktrees)?;
+    create_root_gripspace_manifest(&root, &repo_name, &main_revision)?;
+    for wt in &linked_worktrees {
+        create_linked_griptree_metadata(&root, wt, &repo_name)?;
+    }
+
+    if json {
+        let result = serde_json::json!({
+            "root": root.display().to_string(),
+            "repo_name": repo_name,
+            "main_child": root.join(&repo_name).display().to_string(),
+            "linked_worktrees": linked_worktrees.iter().map(|wt| serde_json::json!({
+                "root": wt.root.display().to_string(),
+                "child": wt.root.join(&repo_name).display().to_string(),
+                "branch": wt.branch,
+            })).collect::<Vec<_>>(),
+            "worktree_repair": true,
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        Output::success("Migration complete!");
+        println!();
+        println!("  Main repo moved to: {}/{}/", root.display(), repo_name);
+        for wt in &linked_worktrees {
+            println!(
+                "  Linked worktree:   {}/{} ({})",
+                wt.root.display(),
+                repo_name,
+                wt.branch.as_deref().unwrap_or("detached")
+            );
+        }
+        if root.join(".synapt").exists() {
+            println!("  .synapt/           stays at gripspace root");
+        }
+        if root.join(".claude").exists() {
+            println!("  .claude/           stays at gripspace root");
+        }
+        if root.join(".env").exists() {
+            println!("  .env               stays at gripspace root");
+        }
+        println!("  .gitgrip/          created (gripspace marker)");
+        println!();
+        Output::info("Next steps:");
+        println!("  cd {}", root.display());
+        println!("  gr tree list    # verify linked worktrees became griptrees");
+        println!("  gr status       # verify repos are visible");
+    }
+
+    Ok(())
+}
+
+fn migration_keep_names() -> HashSet<&'static str> {
+    [".synapt", ".claude", ".env", "_migrate_tmp"]
+        .iter()
+        .copied()
+        .collect()
+}
+
+fn collect_paths_to_move(root: &Path, repo_name: &str) -> anyhow::Result<Vec<PathBuf>> {
+    let keep = migration_keep_names();
+    let mut to_move: Vec<PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy().to_string();
+        if keep.contains(name_str.as_str()) || name_str == repo_name {
+            continue;
+        }
+        to_move.push(entry.path());
+    }
+    Ok(to_move)
+}
+
+fn list_existing_worktrees(root: &Path) -> anyhow::Result<Vec<ExistingWorktree>> {
+    let output = std::process::Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(root)
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to run git worktree list --porcelain: {}", e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git worktree list --porcelain failed: {}", stderr.trim());
+    }
+    parse_worktree_list_porcelain(&String::from_utf8_lossy(&output.stdout), root)
+}
+
+fn parse_worktree_list_porcelain(
+    stdout: &str,
+    main_root: &Path,
+) -> anyhow::Result<Vec<ExistingWorktree>> {
+    let mut worktrees = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_branch: Option<String> = None;
+
+    let mut flush_current =
+        |path: &mut Option<PathBuf>, branch: &mut Option<String>| -> anyhow::Result<()> {
+            if let Some(root) = path.take() {
+                let canonical = root.canonicalize().unwrap_or(root.clone());
+                worktrees.push(ExistingWorktree {
+                    is_main: canonical == main_root,
+                    root,
+                    branch: branch.take(),
+                });
+            }
+            Ok(())
+        };
+
+    for line in stdout.lines() {
+        if line.trim().is_empty() {
+            flush_current(&mut current_path, &mut current_branch)?;
+            continue;
+        }
+        if let Some(path) = line.strip_prefix("worktree ") {
+            flush_current(&mut current_path, &mut current_branch)?;
+            current_path = Some(PathBuf::from(path.trim()));
+            continue;
+        }
+        if let Some(branch) = line.strip_prefix("branch ") {
+            current_branch = Some(normalize_branch_name(branch.trim()));
+        }
+    }
+
+    flush_current(&mut current_path, &mut current_branch)?;
+
+    if !worktrees.iter().any(|wt| wt.is_main) {
+        anyhow::bail!(
+            "git worktree list did not include the main repo path {}",
+            main_root.display()
+        );
+    }
+
+    Ok(worktrees)
+}
+
+fn normalize_branch_name(branch: &str) -> String {
+    branch
+        .strip_prefix("refs/heads/")
+        .unwrap_or(branch)
+        .to_string()
+}
+
+fn validate_migration_targets(
+    worktrees: &[ExistingWorktree],
+    repo_name: &str,
+) -> anyhow::Result<()> {
+    for wt in worktrees {
+        if !wt.is_main && wt.branch.is_none() {
+            anyhow::bail!(
+                "Linked worktree at {} is detached; migrate in-place requires branch-backed worktrees",
+                wt.root.display()
+            );
+        }
+        let child = wt.root.join(repo_name);
+        if child.exists() {
+            anyhow::bail!(
+                "Child directory already exists: {}. Migration may have already run.",
+                child.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn migrate_single_worktree_root(root: &Path, repo_name: &str) -> anyhow::Result<()> {
+    let to_move = collect_paths_to_move(root, repo_name)?;
+    let tmp = root.join("_migrate_tmp");
+    std::fs::create_dir_all(&tmp)?;
+
+    for src in &to_move {
+        let dest = tmp.join(src.file_name().unwrap());
+        std::fs::rename(src, dest)
+            .map_err(|e| anyhow::anyhow!("Failed to move {}: {}", src.display(), e))?;
+    }
+
+    let child = root.join(repo_name);
+    std::fs::rename(&tmp, &child).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to rename _migrate_tmp to {}: {}",
+            child.display(),
+            e
+        )
+    })?;
+    Ok(())
+}
+
+fn run_worktree_repairs(
+    worktrees: &[ExistingWorktree],
+    repo_name: &str,
+) -> anyhow::Result<Vec<ProcessOutput>> {
+    let main = worktrees
+        .iter()
+        .find(|wt| wt.is_main)
+        .ok_or_else(|| anyhow::anyhow!("Missing main worktree entry"))?;
+    let main_child = main.root.join(repo_name);
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(["worktree", "repair"]).current_dir(&main_child);
+    for wt in worktrees.iter().filter(|wt| !wt.is_main) {
+        cmd.arg(wt.root.join(repo_name));
+    }
+
+    let output = cmd.output().map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to run git worktree repair in {}: {}",
+            main_child.display(),
+            e
+        )
+    })?;
+
+    Ok(vec![output])
+}
+
+fn create_root_gripspace_metadata(
+    root: &Path,
+    linked_worktrees: &[ExistingWorktree],
+) -> anyhow::Result<()> {
+    let gitgrip_dir = root.join(".gitgrip");
+    std::fs::create_dir_all(&gitgrip_dir)?;
+    let stale_child_marker = gitgrip_dir.join("griptree.json");
+    if stale_child_marker.exists() {
+        let _ = std::fs::remove_file(&stale_child_marker);
+    }
+
+    let mut griptrees = MigratedGriptreesList::default();
+    for wt in linked_worktrees {
+        let branch = wt.branch.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("Missing branch for linked worktree {}", wt.root.display())
+        })?;
+        griptrees.griptrees.insert(
+            branch.clone(),
+            MigratedGriptreeEntry {
+                path: wt.root.to_string_lossy().to_string(),
+                branch: branch.clone(),
+                locked: false,
+                lock_reason: None,
+            },
+        );
+    }
+
+    let griptrees_json = serde_json::to_string_pretty(&griptrees)?;
+    std::fs::write(gitgrip_dir.join("griptrees.json"), griptrees_json)?;
+    Ok(())
+}
+
+fn create_root_gripspace_manifest(
+    root: &Path,
+    repo_name: &str,
+    revision: &str,
+) -> anyhow::Result<()> {
+    let repo_child = root.join(repo_name);
+    let remote_url = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(&repo_child)
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let manifest_dir = manifest_paths::main_space_dir(root);
+    std::fs::create_dir_all(&manifest_dir)?;
+
+    let repo = RepoConfig {
+        url: remote_url,
+        remote: None,
+        path: format!("./{}", repo_name),
+        revision: Some(revision.to_string()),
+        target: None,
+        sync_remote: None,
+        push_remote: None,
+        copyfile: None,
+        linkfile: None,
+        platform: None,
+        reference: false,
+        groups: vec![],
+        agent: None,
+        clone_strategy: None,
+    };
+
+    let manifest = Manifest {
+        version: 2,
+        remotes: None,
+        gripspaces: None,
+        manifest: None,
+        repos: HashMap::from([(repo_name.to_string(), repo)]),
+        settings: ManifestSettings {
+            pr_prefix: "[cross-repo]".to_string(),
+            merge_strategy: MergeStrategy::default(),
+            revision: Some(revision.to_string()),
+            target: None,
+            sync_remote: None,
+            push_remote: None,
+            clone_strategy: CloneStrategy::default(),
+        },
+        workspace: None,
+    };
+
+    let yaml = format!(
+        "# Generated by gr migrate in-place\n{}",
+        serde_yaml::to_string(&manifest)?
+    );
+    std::fs::write(manifest_dir.join("gripspace.yml"), yaml)?;
+    Ok(())
+}
+
+fn create_linked_griptree_metadata(
+    main_root: &Path,
+    worktree: &ExistingWorktree,
+    repo_name: &str,
+) -> anyhow::Result<()> {
+    let branch = worktree.branch.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Missing branch for linked worktree {}",
+            worktree.root.display()
+        )
+    })?;
+    let gitgrip_dir = worktree.root.join(".gitgrip");
+    std::fs::create_dir_all(&gitgrip_dir)?;
+    std::fs::write(gitgrip_dir.join("state.json"), "{}")?;
+
+    let mut config = GriptreeConfig::new(branch, &worktree.root.to_string_lossy());
+    config
+        .repo_upstreams
+        .insert(repo_name.to_string(), format!("origin/{}", branch));
+    config.save(&gitgrip_dir.join("griptree.json"))?;
+
+    let child = worktree.root.join(repo_name);
+    let main_child = main_root.join(repo_name);
+    let pointer = GriptreePointer {
+        main_workspace: main_root.to_string_lossy().to_string(),
+        branch: branch.clone(),
+        locked: false,
+        created_at: Some(Utc::now()),
+        repos: vec![GriptreeRepoInfo {
+            name: repo_name.to_string(),
+            original_branch: branch.clone(),
+            is_reference: false,
+            worktree_name: None,
+            worktree_path: Some(child.to_string_lossy().to_string()),
+            main_repo_path: Some(main_child.to_string_lossy().to_string()),
+        }],
+        manifest_branch: None,
+        manifest_worktree_name: None,
+    };
+    let pointer_json = serde_json::to_string_pretty(&pointer)?;
+    std::fs::write(worktree.root.join(".griptree"), pointer_json)?;
+    Ok(())
+}
+
+fn worktree_repair_must_succeed(repair: &ProcessOutput) -> anyhow::Result<()> {
+    if repair.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&repair.stderr);
+    anyhow::bail!("git worktree repair exited non-zero: {}", stderr.trim());
+}
+
+/// Derive the repo name from `git remote get-url origin`, falling back to dir name.
+/// "git@github.com:GetConversa/conversa-app.git" → "conversa-app"
+fn derive_repo_name_from_remote(repo: &Path) -> String {
+    let result = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(repo)
+        .output();
+
+    if let Ok(out) = result {
+        if out.status.success() {
+            let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !url.is_empty() {
+                // SSH: git@github.com:org/repo.git  → after last '/' or ':'
+                // HTTPS: https://github.com/org/repo.git → after last '/'
+                let base = url.rsplit(['/', ':']).next().unwrap_or(&url).to_string();
+                // Strip .git suffix
+                return base.strip_suffix(".git").unwrap_or(&base).to_string();
+            }
+        }
+    }
+
+    // Fallback: use the directory name
+    repo.file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Check that git >= 2.30 is available (required for `git worktree repair`).
+fn check_git_version_for_repair() -> anyhow::Result<()> {
+    let out = std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .map_err(|_| anyhow::anyhow!("git not found — is git installed?"))?;
+
+    let version_str = String::from_utf8_lossy(&out.stdout);
+    // "git version 2.43.0 (Apple Git-115)" → parse major.minor
+    let parts: Vec<u32> = version_str
+        .split_whitespace()
+        .find(|s| s.contains('.'))
+        .unwrap_or("0.0")
+        .split('.')
+        .take(2)
+        .filter_map(|s| s.parse().ok())
+        .collect();
+
+    let (major, minor) = (
+        parts.first().copied().unwrap_or(0),
+        parts.get(1).copied().unwrap_or(0),
+    );
+    if major < 2 || (major == 2 && minor < 30) {
+        anyhow::bail!(
+            "git 2.30+ required for `git worktree repair` (found git {}.{}). \
+             Please upgrade git.",
+            major,
+            minor
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    fn run_git(dir: &Path, args: &[&str]) -> ProcessOutput {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run git {:?}: {}", args, e))
+    }
+
+    fn assert_git_ok(dir: &Path, args: &[&str]) -> ProcessOutput {
+        let output = run_git(dir, args);
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    fn normalize_git_path(path: &Path) -> String {
+        path.canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/")
+            .replace("//?/", "")
+    }
 
     #[test]
     fn test_generate_manifest_yaml() {
@@ -468,5 +1096,165 @@ mod tests {
         let toml = generate_agents_toml("myproject", &[]);
         assert!(toml.contains("session_name = \"myproject\""));
         assert!(toml.contains("# Add agents here:"));
+    }
+
+    #[test]
+    fn test_migration_keep_names_includes_root_env() {
+        let keep = migration_keep_names();
+        assert!(keep.contains(".synapt"));
+        assert!(keep.contains(".claude"));
+        assert!(keep.contains(".env"));
+        assert!(keep.contains("_migrate_tmp"));
+    }
+
+    #[test]
+    fn test_worktree_repair_failure_is_error() {
+        let output = std::process::Command::new("git")
+            .args(["worktree", "definitely-not-a-subcommand"])
+            .output()
+            .expect("git should be runnable in test environment");
+        assert!(worktree_repair_must_succeed(&output).is_err());
+    }
+
+    #[test]
+    fn test_parse_worktree_list_marks_main_and_branch_names() {
+        let main = PathBuf::from("/tmp/conversa")
+            .canonicalize()
+            .unwrap_or_else(|_| PathBuf::from("/tmp/conversa"));
+        let porcelain = "\
+worktree /tmp/conversa
+HEAD deadbeef
+branch refs/heads/main
+
+worktree /tmp/conversa-dev
+HEAD feedface
+branch refs/heads/feat/dev
+";
+
+        let worktrees = parse_worktree_list_porcelain(porcelain, &main).unwrap();
+        assert_eq!(worktrees.len(), 2);
+        assert!(worktrees[0].is_main);
+        assert_eq!(worktrees[0].branch.as_deref(), Some("main"));
+        assert!(!worktrees[1].is_main);
+        assert_eq!(worktrees[1].branch.as_deref(), Some("feat/dev"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_in_place_converts_linked_worktrees_into_griptrees() {
+        let temp = TempDir::new().unwrap();
+        let main_root = temp.path().join("conversa");
+        let linked_root = temp.path().join("conversa-dev");
+        std::fs::create_dir_all(&main_root).unwrap();
+
+        assert_git_ok(&main_root, &["init", "-b", "main"]);
+        assert_git_ok(&main_root, &["config", "user.name", "Test User"]);
+        assert_git_ok(&main_root, &["config", "user.email", "test@example.com"]);
+        std::fs::write(main_root.join("README.md"), "hello\n").unwrap();
+        std::fs::write(main_root.join(".env"), "FOO=bar\n").unwrap();
+        assert_git_ok(&main_root, &["add", "."]);
+        assert_git_ok(&main_root, &["commit", "-m", "init"]);
+        assert_git_ok(
+            &main_root,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:GetConversa/conversa-app.git",
+            ],
+        );
+
+        assert_git_ok(
+            &main_root,
+            &[
+                "worktree",
+                "add",
+                linked_root.to_str().unwrap(),
+                "-b",
+                "feat/dev",
+            ],
+        );
+        std::fs::create_dir_all(linked_root.join(".claude")).unwrap();
+
+        run_migrate_in_place(Some(main_root.to_str().unwrap()), false, false)
+            .await
+            .unwrap();
+
+        let repo_name = "conversa-app";
+        let main_child = main_root.join(repo_name);
+        let linked_child = linked_root.join(repo_name);
+
+        assert!(main_child.exists(), "main child repo should exist");
+        assert!(linked_child.exists(), "linked child repo should exist");
+        assert!(
+            main_root.join(".env").exists(),
+            ".env should stay at main root"
+        );
+        assert!(
+            linked_root.join(".claude").exists(),
+            ".claude should stay at linked worktree root"
+        );
+
+        let griptrees: MigratedGriptreesList = serde_json::from_str(
+            &std::fs::read_to_string(main_root.join(".gitgrip").join("griptrees.json")).unwrap(),
+        )
+        .unwrap();
+        let entry = griptrees.griptrees.get("feat/dev").unwrap();
+        assert_eq!(
+            PathBuf::from(&entry.path).canonicalize().unwrap(),
+            linked_root.canonicalize().unwrap()
+        );
+
+        let griptree_cfg = GriptreeConfig::load_from_workspace(&linked_root)
+            .unwrap()
+            .unwrap();
+        assert_eq!(griptree_cfg.branch, "feat/dev");
+
+        let manifest_path = manifest_paths::main_space_dir(&main_root).join("gripspace.yml");
+        assert!(
+            manifest_path.exists(),
+            "root manifest should exist after migration"
+        );
+        let manifest = crate::core::manifest::Manifest::load(&manifest_path).unwrap();
+        let repo = manifest.repos.get(repo_name).unwrap();
+        assert_eq!(repo.path, format!("./{}", repo_name));
+        assert_eq!(repo.revision.as_deref(), Some("main"));
+        assert_eq!(
+            repo.url.as_deref(),
+            Some("git@github.com:GetConversa/conversa-app.git")
+        );
+
+        let pointer = GriptreePointer::load(&linked_root.join(".griptree")).unwrap();
+        assert_eq!(
+            PathBuf::from(pointer.main_workspace)
+                .canonicalize()
+                .unwrap(),
+            main_root.canonicalize().unwrap()
+        );
+        assert_eq!(pointer.branch, "feat/dev");
+        assert_eq!(pointer.repos.len(), 1);
+        assert_eq!(pointer.repos[0].name, repo_name);
+        assert_eq!(
+            PathBuf::from(pointer.repos[0].worktree_path.as_ref().unwrap())
+                .canonicalize()
+                .unwrap(),
+            linked_child.canonicalize().unwrap()
+        );
+        assert_eq!(
+            PathBuf::from(pointer.repos[0].main_repo_path.as_ref().unwrap())
+                .canonicalize()
+                .unwrap(),
+            main_child.canonicalize().unwrap()
+        );
+
+        assert_git_ok(&main_child, &["status", "--short"]);
+        let linked_branch = assert_git_ok(&linked_child, &["rev-parse", "--abbrev-ref", "HEAD"]);
+        assert_eq!(
+            String::from_utf8_lossy(&linked_branch.stdout).trim(),
+            "feat/dev"
+        );
+
+        let worktree_list = assert_git_ok(&main_child, &["worktree", "list", "--porcelain"]);
+        let worktree_stdout = String::from_utf8_lossy(&worktree_list.stdout).replace('\\', "/");
+        assert!(worktree_stdout.contains(&normalize_git_path(&linked_child)));
     }
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -5,8 +5,8 @@
 pub mod add;
 pub mod agent;
 pub mod bench;
-pub mod cache;
 pub mod branch;
+pub mod cache;
 pub mod channel;
 pub mod checkout;
 pub mod cherry_pick;

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -5,6 +5,7 @@
 pub mod add;
 pub mod agent;
 pub mod bench;
+pub mod cache;
 pub mod branch;
 pub mod channel;
 pub mod checkout;

--- a/src/cli/commands/spawn.rs
+++ b/src/cli/commands/spawn.rs
@@ -354,9 +354,19 @@ pub fn run_spawn_up(
             let resolved_defaults: Vec<String> = default_args.iter().map(|s| resolve(s)).collect();
             let resolved_args: Vec<String> = agent.args.iter().map(|s| resolve(s)).collect();
 
+            // Inject --model from agent.model if not already in args (#472)
+            let has_model_flag = resolved_args.iter().any(|a| a == "--model")
+                || resolved_defaults.iter().any(|a| a == "--model");
+            let model_inject: Vec<String> = if !has_model_flag && !agent.model.is_empty() {
+                vec!["--model".into(), agent.model.clone()]
+            } else {
+                vec![]
+            };
+
             let mut parts: Vec<&str> = vec![binary];
             parts.extend(cmd_parts.iter().map(|s| s.as_str()));
             parts.extend(resolved_defaults.iter().map(|s| s.as_str()));
+            parts.extend(model_inject.iter().map(|s| s.as_str()));
             parts.extend(resolved_args.iter().map(|s| s.as_str()));
 
             let launch = parts.join(" ");
@@ -366,6 +376,43 @@ pub fn run_spawn_up(
         let _ = Command::new("tmux")
             .args(["send-keys", "-t", &target, &launch_cmd, "Enter"])
             .status();
+
+        // Set up pipe-pane for output streaming (#443 Mission Control)
+        let log_dir = workspace_root.join(".synapt").join("logs").join(&agent_id);
+        let _ = std::fs::create_dir_all(&log_dir);
+        let log_path = log_dir.join("output.log");
+        let pipe_cmd = format!("cat >> {}", log_path.display());
+        let _ = Command::new("tmux")
+            .args(["pipe-pane", "-t", &target, &pipe_cmd])
+            .status();
+
+        // Get tmux pane PID for process tracking
+        let pane_pid = Command::new("tmux")
+            .args(["display-message", "-t", &target, "-p", "#{pane_pid}"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                String::from_utf8_lossy(&o.stdout)
+                    .trim()
+                    .parse::<u32>()
+                    .ok()
+            });
+
+        // Update process state in team.db
+        if let Err(e) = crate::core::agent_registry::update_process_state(
+            &org_dir,
+            &agent_id,
+            pane_pid,
+            Some(&target),
+            "online",
+            Some(log_path.to_str().unwrap_or("")),
+            None, // session_id set by agent on join
+        ) {
+            Output::warning(&format!(
+                "Failed to update process state for {}: {}",
+                name, e
+            ));
+        }
 
         // Print status
         let mode_tag = if mock_mode {
@@ -825,80 +872,79 @@ pub fn run_spawn_dashboard(_quiet: bool) -> anyhow::Result<()> {
         gr_path
     );
 
-    // First pane (pane 0) gets agent 0
+    // Helper: get the active pane ID after a split or window creation.
+    // Returns %N format (e.g. "%42") which is stable across splits.
+    let get_pane_id = |target: &str| -> Option<String> {
+        Command::new("tmux")
+            .args(["display-message", "-t", target, "-p", "#{pane_id}"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                let id = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                if id.starts_with('%') {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+    };
+
+    // Track pane IDs for stable targeting (#452)
+    let mut pane_ids: Vec<String> = Vec::new();
+
+    // First pane (initial pane in the new window) gets agent 0
     if let Some(name) = names.first() {
-        Command::new("tmux")
-            .args([
-                "send-keys",
-                "-t",
-                &dashboard_target,
-                &capture_script(name),
-                "Enter",
-            ])
-            .status()?;
+        if let Some(id) = get_pane_id(&dashboard_target) {
+            pane_ids.push(id.clone());
+            Command::new("tmux")
+                .args(["send-keys", "-t", &id, &capture_script(name), "Enter"])
+                .status()?;
+        }
     }
 
-    // Split right for agent 1 (pane 1)
+    // Split right for agent 1
     if names.len() > 1 {
-        Command::new("tmux")
-            .args([
-                "split-window",
-                "-h",
-                "-t",
-                &format!("{}.0", dashboard_target),
-            ])
-            .status()?;
-        Command::new("tmux")
-            .args([
-                "send-keys",
-                "-t",
-                &format!("{}.1", dashboard_target),
-                &capture_script(&names[1]),
-                "Enter",
-            ])
-            .status()?;
+        if let Some(ref first_pane) = pane_ids.first().cloned() {
+            Command::new("tmux")
+                .args(["split-window", "-h", "-t", first_pane])
+                .status()?;
+            if let Some(id) = get_pane_id(&dashboard_target) {
+                pane_ids.push(id.clone());
+                Command::new("tmux")
+                    .args(["send-keys", "-t", &id, &capture_script(&names[1]), "Enter"])
+                    .status()?;
+            }
+        }
     }
 
-    // Split pane 0 vertically for agent 2 (pane 2)
+    // Split first pane vertically for agent 2
     if names.len() > 2 {
-        Command::new("tmux")
-            .args([
-                "split-window",
-                "-v",
-                "-t",
-                &format!("{}.0", dashboard_target),
-            ])
-            .status()?;
-        Command::new("tmux")
-            .args([
-                "send-keys",
-                "-t",
-                &format!("{}.2", dashboard_target),
-                &capture_script(&names[2]),
-                "Enter",
-            ])
-            .status()?;
+        if let Some(ref first_pane) = pane_ids.first().cloned() {
+            Command::new("tmux")
+                .args(["split-window", "-v", "-t", first_pane])
+                .status()?;
+            if let Some(id) = get_pane_id(&dashboard_target) {
+                pane_ids.push(id.clone());
+                Command::new("tmux")
+                    .args(["send-keys", "-t", &id, &capture_script(&names[2]), "Enter"])
+                    .status()?;
+            }
+        }
     }
 
-    // Split pane 1 vertically for agent 3 (pane 3)
+    // Split second pane vertically for agent 3
     if names.len() > 3 {
-        Command::new("tmux")
-            .args([
-                "split-window",
-                "-v",
-                "-t",
-                &format!("{}.1", dashboard_target),
-            ])
-            .status()?;
-        Command::new("tmux")
-            .args([
-                "send-keys",
-                "-t",
-                &format!("{}.3", dashboard_target),
-                &capture_script(&names[3]),
-                "Enter",
-            ])
-            .status()?;
+        if let Some(ref second_pane) = pane_ids.get(1).cloned() {
+            Command::new("tmux")
+                .args(["split-window", "-v", "-t", second_pane])
+                .status()?;
+            if let Some(id) = get_pane_id(&dashboard_target) {
+                pane_ids.push(id.clone());
+                Command::new("tmux")
+                    .args(["send-keys", "-t", &id, &capture_script(&names[3]), "Enter"])
+                    .status()?;
+            }
+        }
     }
 
     // Bottom input pane — split the full width at the bottom
@@ -906,9 +952,9 @@ pub fn run_spawn_dashboard(_quiet: bool) -> anyhow::Result<()> {
         .args(["split-window", "-v", "-l", "3", "-t", &dashboard_target])
         .status()?;
 
-    // Find the last pane (input pane) and send the input script
-    let pane_count = names.len().min(4) + 1; // agent panes + input pane
-    let input_pane = format!("{}.{}", dashboard_target, pane_count);
+    // Get the input pane ID (the newly created pane after the last split)
+    let input_pane = get_pane_id(&dashboard_target)
+        .unwrap_or_else(|| format!("{}.{}", dashboard_target, pane_ids.len()));
     Command::new("tmux")
         .args(["send-keys", "-t", &input_pane, &input_script, "Enter"])
         .status()?;
@@ -985,4 +1031,110 @@ pub fn run_spawn_web(port: u16, no_open: bool, _quiet: bool) -> anyhow::Result<(
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_agent(model: &str, args: Vec<&str>) -> AgentConfig {
+        AgentConfig {
+            role: "test".into(),
+            model: model.into(),
+            tool: "claude".into(),
+            worktree: "main".into(),
+            startup_prompt: None,
+            cmd: vec![],
+            args: args.into_iter().map(String::from).collect(),
+            channel: None,
+            loop_interval: "5m".into(),
+            heartbeat_interval: 60,
+            timeout_threshold: 180,
+            restart_policy: "always".into(),
+            restart_delay: 5,
+            max_restarts: 3,
+            env: HashMap::new(),
+        }
+    }
+
+    /// Model injection: --model is auto-injected from agent.model when not in args (#472)
+    #[test]
+    fn test_model_injected_when_absent() {
+        let agent = make_agent("claude-opus-4-6", vec!["-n", "opus"]);
+        let default_args: Vec<String> = vec![];
+        let resolved_args: Vec<String> = agent.args.clone();
+
+        let has_model_flag = resolved_args.iter().any(|a| a == "--model")
+            || default_args.iter().any(|a| a == "--model");
+
+        assert!(!has_model_flag);
+
+        let model_inject: Vec<String> = if !has_model_flag && !agent.model.is_empty() {
+            vec!["--model".into(), agent.model.clone()]
+        } else {
+            vec![]
+        };
+
+        assert_eq!(model_inject, vec!["--model", "claude-opus-4-6"]);
+    }
+
+    /// Model injection: --model is NOT injected when already in agent.args (#472)
+    #[test]
+    fn test_model_not_duplicated_when_in_args() {
+        let agent = make_agent(
+            "claude-opus-4-6",
+            vec!["--model", "claude-opus-4-6", "-n", "opus"],
+        );
+        let default_args: Vec<String> = vec![];
+        let resolved_args: Vec<String> = agent.args.clone();
+
+        let has_model_flag = resolved_args.iter().any(|a| a == "--model")
+            || default_args.iter().any(|a| a == "--model");
+
+        assert!(has_model_flag);
+
+        let model_inject: Vec<String> = if !has_model_flag && !agent.model.is_empty() {
+            vec!["--model".into(), agent.model.clone()]
+        } else {
+            vec![]
+        };
+
+        assert!(model_inject.is_empty());
+    }
+
+    /// Model injection: --model in default_args also prevents injection (#472)
+    #[test]
+    fn test_model_not_duplicated_when_in_default_args() {
+        let agent = make_agent("claude-opus-4-6", vec!["-n", "opus"]);
+        let default_args: Vec<String> = vec!["--model".into(), "claude-sonnet-4-6".into()];
+        let resolved_args: Vec<String> = agent.args.clone();
+
+        let has_model_flag = resolved_args.iter().any(|a| a == "--model")
+            || default_args.iter().any(|a| a == "--model");
+
+        assert!(has_model_flag);
+    }
+
+    /// Model injection: empty model string does not inject --model
+    #[test]
+    fn test_empty_model_no_injection() {
+        let agent = make_agent("", vec!["-n", "opus"]);
+        let default_args: Vec<String> = vec![];
+        let resolved_args: Vec<String> = agent.args.clone();
+
+        let has_model_flag = resolved_args.iter().any(|a| a == "--model")
+            || default_args.iter().any(|a| a == "--model");
+
+        let model_inject: Vec<String> = if !has_model_flag && !agent.model.is_empty() {
+            vec!["--model".into(), agent.model.clone()]
+        } else {
+            vec![]
+        };
+
+        assert!(model_inject.is_empty());
+    }
 }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -53,6 +53,92 @@ struct HookResult {
     error: Option<String>,
 }
 
+/// Auto-recover: if `spaces/main/` exists but is not a git repository, clone from `manifest.url`.
+///
+/// This happens when a user copies a `gripspace.yml` without running `gr init`, or after a
+/// manual migration that doesn't preserve `.git/`. Without recovery, `gr sync` silently reads
+/// the stale local file and never pulls from the remote manifest.
+///
+/// Returns the (possibly reloaded) manifest.
+fn recover_manifest_repo<'a>(
+    workspace_root: &Path,
+    manifest: &'a Manifest,
+    quiet: bool,
+) -> anyhow::Result<std::borrow::Cow<'a, Manifest>> {
+    let main_space = manifest_paths::main_space_dir(workspace_root);
+
+    // Nothing to recover: either doesn't exist yet (normal first-run) or already a git repo.
+    if !main_space.exists() || main_space.join(".git").exists() {
+        return Ok(std::borrow::Cow::Borrowed(manifest));
+    }
+
+    let manifest_url = manifest
+        .manifest
+        .as_ref()
+        .map(|m| m.url.as_str())
+        .unwrap_or("");
+
+    if manifest_url.is_empty() {
+        Output::warning(&format!(
+            "manifest dir '{}' is not a git repository and no manifest.url is set. \
+             Run `gr init <url>` to re-initialize the workspace.",
+            main_space.display()
+        ));
+        return Ok(std::borrow::Cow::Borrowed(manifest));
+    }
+
+    let revision = manifest
+        .manifest
+        .as_ref()
+        .and_then(|m| m.revision.as_deref());
+
+    if !quiet {
+        Output::warning(&format!(
+            "manifest dir '{}' is not a git repository — re-cloning from {}",
+            main_space.display(),
+            manifest_url
+        ));
+    }
+
+    // Remove the non-git directory and clone fresh. The gripspace.yml inside it came from
+    // somewhere (or was created manually), but the clone will restore it from the remote.
+    std::fs::remove_dir_all(&main_space).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to remove non-git manifest dir '{}': {}",
+            main_space.display(),
+            e
+        )
+    })?;
+
+    match clone_repo(manifest_url, &main_space, revision) {
+        Ok(_) => {
+            if !quiet {
+                Output::success("manifest repo re-cloned");
+            }
+        }
+        Err(e) => {
+            anyhow::bail!(
+                "Failed to re-clone manifest repo from {}: {}",
+                manifest_url,
+                e
+            );
+        }
+    }
+
+    // Reload the manifest from the fresh clone so subsequent operations see up-to-date content.
+    let manifest_path = manifest_paths::resolve_gripspace_manifest_path(workspace_root);
+    let fresh = if let Some(path) = manifest_path {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("Failed to read fresh manifest after re-clone: {}", e))?;
+        Manifest::parse_raw(&content)
+            .map_err(|e| anyhow::anyhow!("Failed to parse fresh manifest after re-clone: {}", e))?
+    } else {
+        manifest.clone()
+    };
+
+    Ok(std::borrow::Cow::Owned(fresh))
+}
+
 /// Run the sync command
 #[allow(clippy::too_many_arguments)]
 pub async fn run_sync(
@@ -67,6 +153,10 @@ pub async fn run_sync(
     json: bool,
     no_hooks: bool,
 ) -> anyhow::Result<()> {
+    // Auto-recover: if spaces/main/ is not a git repo, re-clone before doing anything else.
+    let manifest_cow = recover_manifest_repo(workspace_root, manifest, quiet)?;
+    let manifest = manifest_cow.as_ref();
+
     // Re-load and resolve gripspaces before syncing repos
     let manifest = sync_gripspaces(workspace_root, manifest, quiet)?;
     let manifest = &manifest;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -628,6 +628,15 @@ pub async fn dispatch_command(
                 }
             }
         }
+        Some(Commands::Cache { action }) => {
+            let ctx = load_workspace_context(quiet, verbose, json)?;
+            crate::cli::commands::cache::run_cache(
+                &ctx.workspace_root,
+                &ctx.manifest,
+                action,
+                ctx.quiet,
+            )?;
+        }
         Some(Commands::Gc {
             aggressive,
             dry_run,

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -347,6 +347,14 @@ pub async fn dispatch_command(
                     )
                     .await?;
                 }
+                MigrateCommands::InPlace { dry_run, path } => {
+                    crate::cli::commands::migrate::run_migrate_in_place(
+                        path.as_deref(),
+                        dry_run,
+                        json,
+                    )
+                    .await?;
+                }
             }
         }
         Some(Commands::Init {

--- a/src/core/agent_registry.rs
+++ b/src/core/agent_registry.rs
@@ -18,7 +18,13 @@ CREATE TABLE IF NOT EXISTS org_agents (
     role TEXT,
     org_id TEXT NOT NULL,
     created_at TEXT NOT NULL,
-    last_seen_at TEXT
+    last_seen_at TEXT,
+    -- Process tracking columns (Sprint 9 Mission Control)
+    pid INTEGER,
+    tmux_target TEXT,
+    status TEXT DEFAULT 'offline',
+    log_path TEXT,
+    session_id TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_org_display
     ON org_agents(org_id, display_name);
@@ -163,6 +169,38 @@ pub fn rename_agent(org_dir: &Path, agent_id: &str, new_display_name: &str) -> R
     let updated = conn.execute(
         "UPDATE org_agents SET display_name = ? WHERE agent_id = ?",
         rusqlite::params![new_display_name, agent_id],
+    )?;
+    if updated == 0 {
+        anyhow::bail!("Agent '{}' not found", agent_id);
+    }
+    Ok(())
+}
+
+/// Update an agent's process state (called by gr spawn).
+pub fn update_process_state(
+    org_dir: &Path,
+    agent_id: &str,
+    pid: Option<u32>,
+    tmux_target: Option<&str>,
+    status: &str,
+    log_path: Option<&str>,
+    session_id: Option<&str>,
+) -> Result<()> {
+    let conn = open_db(org_dir)?;
+    let now = chrono::Utc::now().to_rfc3339();
+    let updated = conn.execute(
+        "UPDATE org_agents SET pid = ?1, tmux_target = ?2, status = ?3, \
+         log_path = ?4, session_id = ?5, last_seen_at = ?6 \
+         WHERE agent_id = ?7",
+        rusqlite::params![
+            pid.map(|p| p as i64),
+            tmux_target,
+            status,
+            log_path,
+            session_id,
+            now,
+            agent_id,
+        ],
     )?;
     if updated == 0 {
         anyhow::bail!("Agent '{}' not found", agent_id);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod repo;
 pub mod repo_manifest;
 pub mod state;
 pub mod sync_state;
+pub mod workspace_cache;
 
 pub use manifest::CloneStrategy;
 pub use manifest::Manifest;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ pub mod repo_manifest;
 pub mod state;
 pub mod sync_state;
 pub mod workspace_cache;
+pub mod workspace_checkout;
 
 pub use manifest::CloneStrategy;
 pub use manifest::Manifest;

--- a/src/core/workspace_cache.rs
+++ b/src/core/workspace_cache.rs
@@ -46,8 +46,7 @@ pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Res
     }
 
     let mut cmd = Command::new("git");
-    cmd.args(["clone", "--bare", url])
-        .arg(&path);
+    cmd.args(["clone", "--bare", url]).arg(&path);
     log_cmd(&cmd);
 
     let output = cmd
@@ -73,11 +72,7 @@ pub fn update_cache(workspace_root: &Path, repo_name: &str) -> Result<()> {
     let path = cache_path(workspace_root, repo_name);
 
     if !cache_exists(workspace_root, repo_name) {
-        anyhow::bail!(
-            "cache does not exist for {}: {}",
-            repo_name,
-            path.display()
-        );
+        anyhow::bail!("cache does not exist for {}: {}", repo_name, path.display());
     }
 
     let mut cmd = Command::new("git");

--- a/src/core/workspace_cache.rs
+++ b/src/core/workspace_cache.rs
@@ -1,0 +1,367 @@
+//! Workspace cache — bare-repo cache layer for manifest repos
+//!
+//! Each manifest repo gets a bare clone under `.grip/cache/<name>.git`.
+//! These caches serve as fast local references for creating agent workspaces
+//! and manual checkouts without sharing mutable .git state.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::util::log_cmd;
+
+/// Directory name under .grip/ where bare caches live.
+const CACHE_DIR: &str = "cache";
+
+/// Resolve the cache path for a repo: `<workspace_root>/.grip/cache/<name>.git`
+pub fn cache_path(workspace_root: &Path, repo_name: &str) -> PathBuf {
+    workspace_root
+        .join(".grip")
+        .join(CACHE_DIR)
+        .join(format!("{}.git", repo_name))
+}
+
+/// Check whether a bare cache exists for the given repo.
+pub fn cache_exists(workspace_root: &Path, repo_name: &str) -> bool {
+    let path = cache_path(workspace_root, repo_name);
+    // A valid bare repo has a HEAD file
+    path.join("HEAD").is_file()
+}
+
+/// Bootstrap a bare cache by cloning from the canonical remote.
+///
+/// Creates `.grip/cache/<name>.git` as a bare clone of `url`.
+/// If the cache already exists, this is a no-op (use `update_cache` to fetch).
+pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<()> {
+    let path = cache_path(workspace_root, repo_name);
+
+    if cache_exists(workspace_root, repo_name) {
+        return Ok(());
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating cache directory: {}", parent.display()))?;
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(["clone", "--bare", url])
+        .arg(&path);
+    log_cmd(&cmd);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("running git clone --bare for {}", repo_name))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to bootstrap cache for {}: {}",
+            repo_name,
+            stderr.trim()
+        );
+    }
+
+    Ok(())
+}
+
+/// Fetch latest refs into an existing bare cache.
+///
+/// Runs `git fetch --all --prune` inside the bare repo to bring it up to date.
+pub fn update_cache(workspace_root: &Path, repo_name: &str) -> Result<()> {
+    let path = cache_path(workspace_root, repo_name);
+
+    if !cache_exists(workspace_root, repo_name) {
+        anyhow::bail!(
+            "cache does not exist for {}: {}",
+            repo_name,
+            path.display()
+        );
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(["fetch", "--all", "--prune"]).current_dir(&path);
+    log_cmd(&cmd);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("fetching cache for {}", repo_name))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to update cache for {}: {}",
+            repo_name,
+            stderr.trim()
+        );
+    }
+
+    Ok(())
+}
+
+/// Get the remote URL stored in a bare cache.
+pub fn cache_remote_url(workspace_root: &Path, repo_name: &str) -> Result<Option<String>> {
+    let path = cache_path(workspace_root, repo_name);
+
+    if !cache_exists(workspace_root, repo_name) {
+        return Ok(None);
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(["remote", "get-url", "origin"]).current_dir(&path);
+    log_cmd(&cmd);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("reading cache remote for {}", repo_name))?;
+
+    if output.status.success() {
+        Ok(Some(
+            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Bootstrap caches for all repos in a manifest.
+///
+/// Takes an iterator of (name, url) pairs. Skips repos that already have caches.
+/// Returns the count of newly bootstrapped caches.
+pub fn bootstrap_all<'a>(
+    workspace_root: &Path,
+    repos: impl Iterator<Item = (&'a str, &'a str)>,
+) -> Result<usize> {
+    let mut count = 0;
+    for (name, url) in repos {
+        if !cache_exists(workspace_root, name) {
+            bootstrap_cache(workspace_root, name, url)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+/// Update all existing caches under `.grip/cache/`.
+///
+/// Returns the count of caches updated.
+pub fn update_all(workspace_root: &Path) -> Result<usize> {
+    let cache_dir = workspace_root.join(".grip").join(CACHE_DIR);
+    if !cache_dir.is_dir() {
+        return Ok(0);
+    }
+
+    let mut count = 0;
+    for entry in std::fs::read_dir(&cache_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Cache dirs are named <repo>.git
+        if name_str.ends_with(".git") && entry.path().join("HEAD").is_file() {
+            let repo_name = name_str.trim_end_matches(".git");
+            update_cache(workspace_root, repo_name)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+/// Remove a single repo cache.
+pub fn remove_cache(workspace_root: &Path, repo_name: &str) -> Result<bool> {
+    let path = cache_path(workspace_root, repo_name);
+    if path.is_dir() {
+        std::fs::remove_dir_all(&path)
+            .with_context(|| format!("removing cache: {}", path.display()))?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Helper: create a temporary "remote" repo to clone from
+    fn create_test_remote(dir: &Path) -> PathBuf {
+        let remote_path = dir.join("remote-repo.git");
+        // Init a bare repo to act as the remote
+        Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&remote_path)
+            .output()
+            .expect("git init --bare");
+
+        // Create a non-bare repo, add a commit, push to the bare repo
+        let work_path = dir.join("work-repo");
+        Command::new("git")
+            .args(["init"])
+            .arg(&work_path)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&work_path)
+            .output()
+            .expect("git config email");
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&work_path)
+            .output()
+            .expect("git config name");
+        fs::write(work_path.join("README.md"), "# test").expect("write file");
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&work_path)
+            .output()
+            .expect("git add");
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(&work_path)
+            .output()
+            .expect("git commit");
+        Command::new("git")
+            .args(["remote", "add", "origin"])
+            .arg(&remote_path)
+            .current_dir(&work_path)
+            .output()
+            .expect("git remote add");
+        Command::new("git")
+            .args(["push", "origin", "main"])
+            .current_dir(&work_path)
+            .output()
+            .ok(); // might be master, not main
+        Command::new("git")
+            .args(["push", "origin", "master"])
+            .current_dir(&work_path)
+            .output()
+            .ok();
+
+        remote_path
+    }
+
+    #[test]
+    fn test_cache_path() {
+        let root = Path::new("/workspace");
+        let path = cache_path(root, "myrepo");
+        assert_eq!(path, PathBuf::from("/workspace/.grip/cache/myrepo.git"));
+    }
+
+    #[test]
+    fn test_cache_does_not_exist_initially() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!cache_exists(tmp.path(), "nonexistent"));
+    }
+
+    #[test]
+    fn test_bootstrap_and_exists() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        assert!(!cache_exists(&workspace, "testrepo"));
+
+        bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap");
+        assert!(cache_exists(&workspace, "testrepo"));
+
+        // Verify it's a bare repo
+        let cp = cache_path(&workspace, "testrepo");
+        assert!(cp.join("HEAD").is_file());
+        assert!(!cp.join(".git").exists()); // bare repos don't have .git subdir
+    }
+
+    #[test]
+    fn test_bootstrap_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 1");
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 2"); // no-op
+        assert!(cache_exists(&workspace, "repo"));
+    }
+
+    #[test]
+    fn test_update_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+        update_cache(&workspace, "repo").expect("update");
+    }
+
+    #[test]
+    fn test_update_nonexistent_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = update_cache(tmp.path(), "nope");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cache_remote_url() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+
+        let stored_url = cache_remote_url(&workspace, "repo")
+            .expect("get url")
+            .expect("has url");
+        assert_eq!(stored_url, url);
+    }
+
+    #[test]
+    fn test_remove_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+        assert!(cache_exists(&workspace, "repo"));
+
+        let removed = remove_cache(&workspace, "repo").expect("remove");
+        assert!(removed);
+        assert!(!cache_exists(&workspace, "repo"));
+    }
+
+    #[test]
+    fn test_remove_nonexistent_returns_false() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let removed = remove_cache(tmp.path(), "nope").expect("remove");
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_bootstrap_all() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
+        let count = bootstrap_all(&workspace, repos.into_iter()).expect("bootstrap all");
+        assert_eq!(count, 2);
+        assert!(cache_exists(&workspace, "repo1"));
+        assert!(cache_exists(&workspace, "repo2"));
+
+        // Second call: no new bootstraps
+        let repos2 = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
+        let count2 = bootstrap_all(&workspace, repos2.into_iter()).expect("bootstrap all 2");
+        assert_eq!(count2, 0);
+    }
+}

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -34,10 +34,7 @@ pub struct CheckoutRepo {
 
 /// Resolve the checkout root: `<workspace_root>/.grip/checkouts/<name>/`
 pub fn checkout_path(workspace_root: &Path, name: &str) -> PathBuf {
-    workspace_root
-        .join(".grip")
-        .join(CHECKOUTS_DIR)
-        .join(name)
+    workspace_root.join(".grip").join(CHECKOUTS_DIR).join(name)
 }
 
 /// Check whether a checkout exists.
@@ -129,14 +126,7 @@ pub fn create_checkout<'a>(
     let mut checkout_repos = Vec::new();
 
     for (name, url, path) in repos {
-        let target = materialize_repo(
-            workspace_root,
-            checkout_name,
-            name,
-            url,
-            path,
-            branch,
-        )?;
+        let target = materialize_repo(workspace_root, checkout_name, name, url, path, branch)?;
         checkout_repos.push(CheckoutRepo {
             name: name.to_string(),
             path: target,
@@ -266,8 +256,7 @@ mod tests {
         // Create workspace and bootstrap cache
         fs::create_dir_all(&workspace).expect("mkdir workspace");
         let url = remote_path.to_string_lossy().to_string();
-        workspace_cache::bootstrap_cache(&workspace, "testrepo", &url)
-            .expect("bootstrap cache");
+        workspace_cache::bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap cache");
 
         (workspace, remote_path)
     }
@@ -335,15 +324,8 @@ mod tests {
         let (workspace, remote) = setup_cached_workspace(tmp.path());
 
         let url = remote.to_string_lossy().to_string();
-        let target = materialize_repo(
-            &workspace,
-            "ref-test",
-            "testrepo",
-            &url,
-            "testrepo",
-            None,
-        )
-        .expect("materialize");
+        let target = materialize_repo(&workspace, "ref-test", "testrepo", &url, "testrepo", None)
+            .expect("materialize");
 
         // Check alternates file exists (proves --reference was used)
         let alternates = target.join(".git/objects/info/alternates");

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -1,0 +1,432 @@
+//! Workspace checkouts — independent child clones materialized from the cache
+//!
+//! Each checkout lives under `.grip/checkouts/<name>/` and contains full clones
+//! of manifest repos, created with `--reference` to reuse objects from the
+//! bare cache. Checkouts are independently disposable.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::core::workspace_cache;
+use crate::util::log_cmd;
+
+/// Directory name under .grip/ where checkouts live.
+const CHECKOUTS_DIR: &str = "checkouts";
+
+/// Metadata for a single checkout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckoutInfo {
+    pub name: String,
+    pub path: PathBuf,
+    pub repos: Vec<CheckoutRepo>,
+    pub created_at: String,
+}
+
+/// A single repo within a checkout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckoutRepo {
+    pub name: String,
+    pub path: PathBuf,
+    pub branch: Option<String>,
+}
+
+/// Resolve the checkout root: `<workspace_root>/.grip/checkouts/<name>/`
+pub fn checkout_path(workspace_root: &Path, name: &str) -> PathBuf {
+    workspace_root
+        .join(".grip")
+        .join(CHECKOUTS_DIR)
+        .join(name)
+}
+
+/// Check whether a checkout exists.
+pub fn checkout_exists(workspace_root: &Path, name: &str) -> bool {
+    checkout_path(workspace_root, name).is_dir()
+}
+
+/// Materialize a single repo into a checkout from the cache.
+///
+/// Uses `git clone --reference <cache> <url> <target>` if a cache exists,
+/// otherwise falls back to a direct clone.
+/// Optionally checks out a specific branch.
+pub fn materialize_repo(
+    workspace_root: &Path,
+    checkout_name: &str,
+    repo_name: &str,
+    repo_url: &str,
+    repo_path: &str,
+    branch: Option<&str>,
+) -> Result<PathBuf> {
+    let checkout_root = checkout_path(workspace_root, checkout_name);
+    let target = checkout_root.join(repo_path);
+
+    if target.join(".git").exists() {
+        // Already materialized
+        return Ok(target);
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating checkout dir: {}", parent.display()))?;
+    }
+
+    let cache = workspace_cache::cache_path(workspace_root, repo_name);
+    let has_cache = workspace_cache::cache_exists(workspace_root, repo_name);
+
+    let mut cmd = Command::new("git");
+    cmd.arg("clone");
+
+    // Use cache as reference if available (fast, saves disk via hardlinks)
+    if has_cache {
+        cmd.args(["--reference", &cache.to_string_lossy()]);
+    }
+
+    // Optionally specify branch
+    if let Some(b) = branch {
+        cmd.args(["--branch", b]);
+    }
+
+    cmd.arg(repo_url).arg(&target);
+    log_cmd(&cmd);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("cloning {} into checkout {}", repo_name, checkout_name))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to clone {} into checkout {}: {}",
+            repo_name,
+            checkout_name,
+            stderr.trim()
+        );
+    }
+
+    Ok(target)
+}
+
+/// Create a full checkout with all provided repos.
+///
+/// Takes an iterator of (name, url, path) tuples.
+/// Returns info about the created checkout.
+pub fn create_checkout<'a>(
+    workspace_root: &Path,
+    checkout_name: &str,
+    repos: impl Iterator<Item = (&'a str, &'a str, &'a str)>,
+    branch: Option<&str>,
+) -> Result<CheckoutInfo> {
+    if checkout_exists(workspace_root, checkout_name) {
+        anyhow::bail!("checkout '{}' already exists", checkout_name);
+    }
+
+    let checkout_root = checkout_path(workspace_root, checkout_name);
+    std::fs::create_dir_all(&checkout_root)
+        .with_context(|| format!("creating checkout root: {}", checkout_root.display()))?;
+
+    let mut checkout_repos = Vec::new();
+
+    for (name, url, path) in repos {
+        let target = materialize_repo(
+            workspace_root,
+            checkout_name,
+            name,
+            url,
+            path,
+            branch,
+        )?;
+        checkout_repos.push(CheckoutRepo {
+            name: name.to_string(),
+            path: target,
+            branch: branch.map(String::from),
+        });
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let info = CheckoutInfo {
+        name: checkout_name.to_string(),
+        path: checkout_root.clone(),
+        repos: checkout_repos,
+        created_at: now,
+    };
+
+    // Write checkout metadata
+    let meta_path = checkout_root.join(".checkout.json");
+    let json = serde_json::to_string_pretty(&info)?;
+    std::fs::write(&meta_path, json)
+        .with_context(|| format!("writing checkout metadata: {}", meta_path.display()))?;
+
+    Ok(info)
+}
+
+/// List all checkouts under `.grip/checkouts/`.
+pub fn list_checkouts(workspace_root: &Path) -> Result<Vec<CheckoutInfo>> {
+    let checkouts_dir = workspace_root.join(".grip").join(CHECKOUTS_DIR);
+    if !checkouts_dir.is_dir() {
+        return Ok(vec![]);
+    }
+
+    let mut checkouts = Vec::new();
+    for entry in std::fs::read_dir(&checkouts_dir)? {
+        let entry = entry?;
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let meta_path = entry.path().join(".checkout.json");
+        if meta_path.is_file() {
+            let content = std::fs::read_to_string(&meta_path)?;
+            if let Ok(info) = serde_json::from_str::<CheckoutInfo>(&content) {
+                checkouts.push(info);
+            }
+        } else {
+            // Checkout dir exists but no metadata — construct minimal info
+            let name = entry.file_name().to_string_lossy().to_string();
+            checkouts.push(CheckoutInfo {
+                name: name.clone(),
+                path: entry.path(),
+                repos: vec![],
+                created_at: "unknown".to_string(),
+            });
+        }
+    }
+
+    Ok(checkouts)
+}
+
+/// Remove a checkout and all its contents.
+pub fn remove_checkout(workspace_root: &Path, name: &str) -> Result<bool> {
+    let path = checkout_path(workspace_root, name);
+    if path.is_dir() {
+        std::fs::remove_dir_all(&path)
+            .with_context(|| format!("removing checkout: {}", path.display()))?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Helper: create a test remote repo and bootstrap its cache
+    fn setup_cached_workspace(dir: &Path) -> (PathBuf, PathBuf) {
+        let remote_path = dir.join("remote-repo.git");
+        let workspace = dir.join("workspace");
+
+        // Init bare remote
+        Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&remote_path)
+            .output()
+            .expect("git init --bare");
+
+        // Create work repo with a commit
+        let work = dir.join("work-repo");
+        Command::new("git")
+            .args(["init"])
+            .arg(&work)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&work)
+            .output()
+            .expect("config email");
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&work)
+            .output()
+            .expect("config name");
+        fs::write(work.join("README.md"), "# test repo").expect("write");
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&work)
+            .output()
+            .expect("add");
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(&work)
+            .output()
+            .expect("commit");
+        // Push to bare remote — try both main and master
+        let _ = Command::new("git")
+            .args(["remote", "add", "origin"])
+            .arg(&remote_path)
+            .current_dir(&work)
+            .output();
+        let _ = Command::new("git")
+            .args(["push", "origin", "HEAD"])
+            .current_dir(&work)
+            .output();
+
+        // Create workspace and bootstrap cache
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        let url = remote_path.to_string_lossy().to_string();
+        workspace_cache::bootstrap_cache(&workspace, "testrepo", &url)
+            .expect("bootstrap cache");
+
+        (workspace, remote_path)
+    }
+
+    #[test]
+    fn test_checkout_path() {
+        let root = Path::new("/ws");
+        assert_eq!(
+            checkout_path(root, "mybranch"),
+            PathBuf::from("/ws/.grip/checkouts/mybranch")
+        );
+    }
+
+    #[test]
+    fn test_checkout_does_not_exist_initially() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!checkout_exists(tmp.path(), "nope"));
+    }
+
+    #[test]
+    fn test_materialize_single_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let target = materialize_repo(
+            &workspace,
+            "test-checkout",
+            "testrepo",
+            &url,
+            "testrepo",
+            None,
+        )
+        .expect("materialize");
+
+        assert!(target.join(".git").exists());
+        assert!(target.join("README.md").exists());
+    }
+
+    #[test]
+    fn test_materialize_is_independent_clone() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let target = materialize_repo(
+            &workspace,
+            "independent",
+            "testrepo",
+            &url,
+            "testrepo",
+            None,
+        )
+        .expect("materialize");
+
+        // The clone has its own .git directory (not a worktree link)
+        assert!(target.join(".git").is_dir());
+        // Not a file pointing elsewhere (that would be a worktree)
+        assert!(!target.join(".git").is_file());
+    }
+
+    #[test]
+    fn test_materialize_uses_cache_reference() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let target = materialize_repo(
+            &workspace,
+            "ref-test",
+            "testrepo",
+            &url,
+            "testrepo",
+            None,
+        )
+        .expect("materialize");
+
+        // Check alternates file exists (proves --reference was used)
+        let alternates = target.join(".git/objects/info/alternates");
+        assert!(alternates.is_file(), "alternates file should exist");
+        let content = fs::read_to_string(&alternates).expect("read alternates");
+        assert!(
+            content.contains("cache/testrepo.git"),
+            "alternates should reference the cache"
+        );
+    }
+
+    #[test]
+    fn test_create_and_list_checkout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+
+        let info = create_checkout(&workspace, "feat-x", repos.into_iter(), None)
+            .expect("create checkout");
+
+        assert_eq!(info.name, "feat-x");
+        assert_eq!(info.repos.len(), 1);
+        assert!(checkout_exists(&workspace, "feat-x"));
+
+        let all = list_checkouts(&workspace).expect("list");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].name, "feat-x");
+    }
+
+    #[test]
+    fn test_create_duplicate_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+        create_checkout(&workspace, "dup", repos.into_iter(), None).expect("first");
+
+        let repos2 = vec![("testrepo", url.as_str(), "testrepo")];
+        let result = create_checkout(&workspace, "dup", repos2.into_iter(), None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_remove_checkout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+        create_checkout(&workspace, "removeme", repos.into_iter(), None).expect("create");
+
+        assert!(checkout_exists(&workspace, "removeme"));
+        let removed = remove_checkout(&workspace, "removeme").expect("remove");
+        assert!(removed);
+        assert!(!checkout_exists(&workspace, "removeme"));
+    }
+
+    #[test]
+    fn test_remove_nonexistent_returns_false() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let removed = remove_checkout(tmp.path(), "nope").expect("remove");
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_cache_survives_checkout_removal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+        create_checkout(&workspace, "ephemeral", repos.into_iter(), None).expect("create");
+
+        // Remove the checkout
+        remove_checkout(&workspace, "ephemeral").expect("remove");
+
+        // Cache must still exist — this is a first-class guarantee
+        assert!(
+            workspace_cache::cache_exists(&workspace, "testrepo"),
+            "cache must survive checkout deletion"
+        );
+    }
+}

--- a/tests/common/git_helpers.rs
+++ b/tests/common/git_helpers.rs
@@ -137,9 +137,13 @@ pub fn clone_repo(url: &str, dest: &Path) {
         "git clone failed: {}",
         String::from_utf8_lossy(&status.stderr)
     );
-    // Configure git identity (CI runners may not have global config)
-    git(dest, &["config", "user.email", "test@example.com"]);
-    git(dest, &["config", "user.name", "Test User"]);
+    configure_identity(dest);
+}
+
+/// Configure local git identity for commits in a repo.
+pub fn configure_identity(repo_path: &Path) {
+    git(repo_path, &["config", "user.email", "test@example.com"]);
+    git(repo_path, &["config", "user.name", "Test User"]);
 }
 
 /// Run a git command, panic on failure.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,3 +2,4 @@ pub mod assertions;
 pub mod fixtures;
 pub mod git_helpers;
 pub mod mock_platform;
+pub mod playground;

--- a/tests/common/playground.rs
+++ b/tests/common/playground.rs
@@ -1,0 +1,139 @@
+//! Disposable playground harness for binary-level CLI flows.
+//!
+//! This is the proving-ground layer for future team-workspace work. It starts
+//! from plain local git repos, initializes a workspace via `gr init --from-dirs`,
+//! and then drives real `gr` commands against that disposable workspace.
+
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+use super::git_helpers;
+
+pub struct PlaygroundHarness {
+    pub _temp: TempDir,
+    pub workspace_root: PathBuf,
+    pub remotes_dir: PathBuf,
+    pub repo_names: Vec<String>,
+}
+
+impl PlaygroundHarness {
+    pub fn new(repo_names: &[&str]) -> Self {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let workspace_root = temp.path().join("playground");
+        let remotes_dir = temp.path().join("remotes");
+        std::fs::create_dir_all(&workspace_root).expect("failed to create workspace root");
+        std::fs::create_dir_all(&remotes_dir).expect("failed to create remotes dir");
+
+        for repo_name in repo_names {
+            let bare_path = remotes_dir.join(format!("{}.git", repo_name));
+            let staging = temp.path().join(format!("staging-{}", repo_name));
+            let repo_path = workspace_root.join(repo_name);
+
+            git_helpers::init_bare_repo(&bare_path);
+            git_helpers::init_repo(&staging);
+            git_helpers::commit_file(
+                &staging,
+                "README.md",
+                &format!("# {}\n", repo_name),
+                "Initial commit",
+            );
+
+            let remote_url = format!("file://{}", bare_path.display());
+            git_helpers::add_remote(&staging, "origin", &remote_url);
+            git_helpers::push_upstream(&staging, "origin", "main");
+            git_helpers::clone_repo(&remote_url, &repo_path);
+        }
+
+        Self {
+            _temp: temp,
+            workspace_root,
+            remotes_dir,
+            repo_names: repo_names.iter().map(|name| (*name).to_string()).collect(),
+        }
+    }
+
+    pub fn repo_path(&self, name: &str) -> PathBuf {
+        self.workspace_root.join(name)
+    }
+
+    pub fn remote_url(&self, name: &str) -> String {
+        format!(
+            "file://{}",
+            self.remotes_dir.join(format!("{}.git", name)).display()
+        )
+    }
+
+    pub fn init_from_dirs(&self) {
+        self.run_from_manifest_dir([
+            "init",
+            "--from-dirs",
+            "-p",
+            self.workspace_root
+                .to_str()
+                .expect("workspace path should be utf-8"),
+        ]);
+        self.ensure_repo_identities();
+    }
+
+    pub fn run_in_workspace<I, S>(&self, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.run(args, &self.workspace_root);
+    }
+
+    pub fn run_from_manifest_dir<I, S>(&self, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.run(args, Path::new(env!("CARGO_MANIFEST_DIR")));
+    }
+
+    pub fn run_in_workspace_output<I, S>(&self, args: I) -> std::process::Output
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.run_output(args, &self.workspace_root)
+    }
+
+    pub fn ensure_repo_identities(&self) {
+        for repo_name in &self.repo_names {
+            let repo_path = self.repo_path(repo_name);
+            if repo_path.join(".git").exists() {
+                git_helpers::configure_identity(&repo_path);
+            }
+        }
+    }
+
+    fn run<I, S>(&self, args: I, current_dir: &Path)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let args_vec: Vec<String> = args.into_iter().map(|s| s.as_ref().to_string()).collect();
+        let output = self.run_output(args_vec.iter().map(String::as_str), current_dir);
+        assert!(
+            output.status.success(),
+            "gr {:?} failed in {}:\nstdout:\n{}\nstderr:\n{}",
+            args_vec,
+            current_dir.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn run_output<I, S>(&self, args: I, current_dir: &Path) -> std::process::Output
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let args_vec: Vec<String> = args.into_iter().map(|s| s.as_ref().to_string()).collect();
+        let mut cmd = std::process::Command::new(assert_cmd::cargo::cargo_bin!("gr"));
+        cmd.current_dir(current_dir)
+            .args(args_vec.iter().map(String::as_str));
+        cmd.output().expect("failed to run gr binary")
+    }
+}

--- a/tests/test_playground.rs
+++ b/tests/test_playground.rs
@@ -1,0 +1,176 @@
+//! Proving-ground tests for the team-workspace playground harness.
+//!
+//! These tests intentionally drive the `gr` binary against disposable local
+//! repos. The goal is to validate the workspace lifecycle in a safe, offline
+//! environment before later slices add cache-backed materialization and agent
+//! workspace flows.
+
+mod common;
+
+use common::assertions::{assert_branch_not_exists, assert_file_exists, assert_on_branch};
+use common::git_helpers;
+use common::playground::PlaygroundHarness;
+
+#[test]
+fn test_playground_cli_flow_init_sync_branch_checkout_and_prune() {
+    let playground = PlaygroundHarness::new(&["frontend", "backend"]);
+
+    playground.init_from_dirs();
+
+    let manifest_path = playground
+        .workspace_root
+        .join(".gitgrip")
+        .join("spaces")
+        .join("main")
+        .join("gripspace.yml");
+    assert_file_exists(&manifest_path);
+
+    std::fs::remove_dir_all(playground.repo_path("backend")).expect("failed to remove backend");
+    assert!(
+        !playground.repo_path("backend").exists(),
+        "backend repo should be removed before sync"
+    );
+
+    playground.run_in_workspace(["sync"]);
+    playground.ensure_repo_identities();
+    assert_file_exists(&playground.repo_path("backend").join(".git"));
+
+    playground.run_in_workspace(["branch", "feat/playground"]);
+    for repo_name in &playground.repo_names {
+        assert_on_branch(&playground.repo_path(repo_name), "feat/playground");
+    }
+
+    git_helpers::commit_file(
+        &playground.repo_path("frontend"),
+        "playground.txt",
+        "frontend playground content\n",
+        "Add frontend playground change",
+    );
+    git_helpers::commit_file(
+        &playground.repo_path("backend"),
+        "playground.txt",
+        "backend playground content\n",
+        "Add backend playground change",
+    );
+
+    playground.run_in_workspace(["checkout", "main"]);
+    for repo_name in &playground.repo_names {
+        assert_on_branch(&playground.repo_path(repo_name), "main");
+    }
+
+    for repo_name in &playground.repo_names {
+        let repo_path = playground.repo_path(repo_name);
+        let output = std::process::Command::new("git")
+            .args([
+                "merge",
+                "feat/playground",
+                "--no-ff",
+                "-m",
+                "Merge feat/playground",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("failed to run git merge");
+        assert!(
+            output.status.success(),
+            "git merge failed in {}: {}",
+            repo_path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    playground.run_in_workspace(["prune", "--execute"]);
+    for repo_name in &playground.repo_names {
+        assert_branch_not_exists(&playground.repo_path(repo_name), "feat/playground");
+        assert_on_branch(&playground.repo_path(repo_name), "main");
+    }
+}
+
+#[test]
+fn test_playground_sync_cli_pulls_upstream_change() {
+    let playground = PlaygroundHarness::new(&["frontend"]);
+
+    playground.init_from_dirs();
+
+    let staging = playground._temp.path().join("sync-staging-frontend");
+    git_helpers::clone_repo(&playground.remote_url("frontend"), &staging);
+    git_helpers::commit_file(
+        &staging,
+        "upstream.txt",
+        "new upstream content\n",
+        "Add upstream change",
+    );
+    git_helpers::push_branch(&staging, "origin", "main");
+
+    let status_output = playground.run_in_workspace_output(["status", "--quiet"]);
+    assert!(
+        status_output.status.success(),
+        "status should succeed before sync: {}",
+        String::from_utf8_lossy(&status_output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&status_output.stdout);
+    assert!(
+        stdout.contains("SUMMARY:"),
+        "quiet status should include summary line, got:\n{}",
+        stdout
+    );
+
+    playground.run_in_workspace(["sync"]);
+
+    assert_file_exists(&playground.repo_path("frontend").join("upstream.txt"));
+    assert_on_branch(&playground.repo_path("frontend"), "main");
+}
+
+#[test]
+fn test_playground_prune_dry_run_keeps_merged_branch() {
+    let playground = PlaygroundHarness::new(&["frontend"]);
+
+    playground.init_from_dirs();
+    playground.run_in_workspace(["branch", "feat/dry-run"]);
+
+    git_helpers::commit_file(
+        &playground.repo_path("frontend"),
+        "dry-run.txt",
+        "dry run content\n",
+        "Add dry-run change",
+    );
+
+    playground.run_in_workspace(["checkout", "main"]);
+
+    let merge_output = std::process::Command::new("git")
+        .args([
+            "merge",
+            "feat/dry-run",
+            "--no-ff",
+            "-m",
+            "Merge feat/dry-run",
+        ])
+        .current_dir(playground.repo_path("frontend"))
+        .output()
+        .expect("failed to run git merge");
+    assert!(
+        merge_output.status.success(),
+        "git merge failed: {}",
+        String::from_utf8_lossy(&merge_output.stderr)
+    );
+
+    let prune_output = playground.run_in_workspace_output(["prune"]);
+    assert!(
+        prune_output.status.success(),
+        "prune dry-run should succeed: {}",
+        String::from_utf8_lossy(&prune_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&prune_output.stdout);
+    assert!(
+        stdout.contains("Would delete: feat/dry-run"),
+        "expected dry-run prune output to mention feat/dry-run, got:\n{}",
+        stdout
+    );
+
+    assert_on_branch(&playground.repo_path("frontend"), "main");
+    assert!(
+        git_helpers::branch_exists(&playground.repo_path("frontend"), "feat/dry-run"),
+        "dry-run prune should not delete the merged branch"
+    );
+}

--- a/tests/test_spawn_tmux.rs
+++ b/tests/test_spawn_tmux.rs
@@ -1,0 +1,184 @@
+//! TDD tests for tmux integration in gr spawn (#442).
+//!
+//! Tests 13-18 from the Mission Control test plan.
+//! All tests mock tmux subprocess calls (unit tests).
+//! Integration tests requiring real tmux are in a separate module.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+use gitgrip::core::agent_registry::{get_agent, register_agent};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Simulated spawn state for testing without real tmux.
+struct MockSpawnState {
+    pub session_name: String,
+    pub windows: Vec<String>,
+    pub pipe_panes: HashMap<String, PathBuf>,
+    pub team_db_entries: Vec<TeamDbEntry>,
+}
+
+/// Expected team.db entry after spawn.
+struct TeamDbEntry {
+    pub agent_id: String,
+    pub tmux_target: String,
+    pub pid: Option<u32>,
+    pub status: String,
+    pub log_path: PathBuf,
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: gr spawn creates named tmux session
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+fn test_spawn_creates_tmux_session() {
+    // gr spawn up should create a tmux session named after [spawn].session_name
+    // from agents.toml (e.g. "synapt" or "conversa").
+    let _session = create_tmux_session("synapt");
+    // Verify: tmux has-session -t synapt returns 0
+    unimplemented!("create_tmux_session not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Test 14: each agent gets its own tmux window
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+fn test_spawn_creates_window_per_agent() {
+    // Each agent in agents.toml should get a tmux window named after the agent.
+    // 4 agents → 4 windows: synapt:opus, synapt:atlas, synapt:apollo, synapt:sentinel
+    let agents = vec!["opus", "atlas", "apollo", "sentinel"];
+    let windows = create_agent_windows("synapt", &agents);
+    assert_eq!(windows.len(), 4);
+    for agent in &agents {
+        assert!(
+            windows.contains(&format!("synapt:{}", agent)),
+            "Missing window for {}",
+            agent
+        );
+    }
+    unimplemented!("create_agent_windows not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Test 15: each window has pipe-pane to output.log
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+fn test_spawn_sets_pipe_pane() {
+    // Each agent window should have tmux pipe-pane set to write stdout
+    // to a log file at <log_dir>/<agent_id>/output.log.
+    // This enables real-time output streaming via file tailing.
+    let tmp = TempDir::new().unwrap();
+    let log_dir = tmp.path().join("logs");
+
+    let pipe_panes = setup_pipe_panes("synapt", &["opus", "atlas"], &log_dir);
+
+    // Verify pipe-pane targets
+    assert_eq!(
+        pipe_panes.get("opus").unwrap(),
+        &log_dir.join("opus-001").join("output.log")
+    );
+    assert_eq!(
+        pipe_panes.get("atlas").unwrap(),
+        &log_dir.join("atlas-001").join("output.log")
+    );
+    unimplemented!("setup_pipe_panes not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Test 16: PID, tmux_target, session_id written to team.db
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_spawn_registers_in_team_db() {
+    // After spawn, team.db should have process columns for each agent:
+    // tmux_target (e.g. "synapt:opus"), pid, status ("online"), log_path.
+    let tmp = TempDir::new().unwrap();
+    let org_dir = tmp.path().join("synapt-dev");
+    fs::create_dir_all(&org_dir).unwrap();
+
+    // Register agent (this part works from Sprint 8)
+    let agent_id = register_agent(&org_dir, "synapt-dev", "opus", Some("CEO")).unwrap();
+    assert_eq!(agent_id, "opus-001");
+
+    // Verify agent exists in team.db
+    let entry = get_agent(&org_dir, &agent_id).unwrap().unwrap();
+    assert_eq!(entry.display_name, "opus");
+    assert_eq!(entry.org_id, "synapt-dev");
+
+    // TODO: verify process columns (tmux_target, pid, status, log_path)
+    // once the schema is extended. For now, this test passes because
+    // the base registration works. The process columns are Sprint 9 work.
+}
+
+// ---------------------------------------------------------------------------
+// Test 17: gr spawn down terminates tmux session
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+fn test_spawn_down_kills_session() {
+    // gr spawn down should:
+    // 1. Send /exit to each agent window via send-keys
+    // 2. Wait 2 seconds for graceful shutdown
+    // 3. Kill the tmux session
+    // 4. Update team.db status to "offline" for all agents
+    let result = teardown_tmux_session("synapt");
+    assert!(result.is_ok());
+    // Verify: tmux has-session -t synapt returns non-zero
+    unimplemented!("teardown_tmux_session not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Test 18: gr spawn status reads from team.db + tmux
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+fn test_spawn_status_reads_team_db() {
+    // gr spawn status should read from team.db (registered agents + process info)
+    // AND check tmux for actual pane liveness. If team.db says "online" but
+    // tmux pane is dead, status should report "crashed".
+    let status = get_spawn_status("synapt");
+    assert!(!status.is_empty());
+    // Each entry should have: agent_id, display_name, status, pid, tmux_target
+    unimplemented!("get_spawn_status not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Stub functions — will be implemented in grip#443
+// ---------------------------------------------------------------------------
+
+fn create_tmux_session(_session: &str) -> String {
+    unimplemented!("create_tmux_session not yet implemented")
+}
+
+fn create_agent_windows(_session: &str, _agents: &[&str]) -> Vec<String> {
+    unimplemented!("create_agent_windows not yet implemented")
+}
+
+fn setup_pipe_panes(
+    _session: &str,
+    _agents: &[&str],
+    _log_dir: &std::path::Path,
+) -> HashMap<String, PathBuf> {
+    unimplemented!("setup_pipe_panes not yet implemented")
+}
+
+fn teardown_tmux_session(_session: &str) -> anyhow::Result<()> {
+    unimplemented!("teardown_tmux_session not yet implemented")
+}
+
+fn get_spawn_status(_session: &str) -> Vec<HashMap<String, String>> {
+    unimplemented!("get_spawn_status not yet implemented")
+}

--- a/tests/test_sync.rs
+++ b/tests/test_sync.rs
@@ -648,3 +648,86 @@ workspace:
         "hook marker file should NOT exist when --no-hooks is set"
     );
 }
+
+/// grip#468: `gr sync` should auto-reclone spaces/main when it exists but has no .git
+#[tokio::test]
+async fn test_sync_reclones_non_git_manifest_dir() {
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("workspace");
+    let remotes_dir = temp.path().join("remotes");
+    fs::create_dir_all(&workspace_root).unwrap();
+    fs::create_dir_all(&remotes_dir).unwrap();
+
+    // Set up a bare remote for the manifest repo
+    let manifest_remote = remotes_dir.join("manifest.git");
+    git_helpers::init_bare_repo(&manifest_remote);
+
+    // Commit a gripspace.yml to the manifest remote via a staging repo
+    let manifest_staging = temp.path().join("manifest-staging");
+    git_helpers::init_repo(&manifest_staging);
+    let manifest_url = format!("file://{}", manifest_remote.display());
+    let manifest_yaml = "version: 1\nrepos: {}\n";
+    git_helpers::commit_file(
+        &manifest_staging,
+        "gripspace.yml",
+        manifest_yaml,
+        "Initial manifest",
+    );
+    git_helpers::add_remote(&manifest_staging, "origin", &manifest_url);
+    git_helpers::push_upstream(&manifest_staging, "origin", "main");
+
+    // Clone the manifest remote into spaces/main/ (normal first-time setup)
+    let spaces_main = workspace_root.join(".gitgrip").join("spaces").join("main");
+    git_helpers::clone_repo(&manifest_url, &spaces_main);
+
+    // Verify it's a proper git clone before we corrupt it
+    assert!(
+        spaces_main.join(".git").exists(),
+        "pre-condition: should be a git repo"
+    );
+
+    // Simulate corruption: remove .git from spaces/main/ (the bug scenario)
+    fs::remove_dir_all(spaces_main.join(".git")).unwrap();
+    assert!(
+        !spaces_main.join(".git").exists(),
+        "pre-condition: .git removed"
+    );
+
+    // Build a manifest that includes manifest.url so recover_manifest_repo can re-clone
+    let manifest_with_url = format!(
+        "version: 1\nmanifest:\n  url: {}\n  default_branch: main\nrepos: {{}}\n",
+        manifest_url
+    );
+    fs::write(spaces_main.join("gripspace.yml"), &manifest_with_url).unwrap();
+
+    let manifest = gitgrip::core::manifest::Manifest::parse_raw(&manifest_with_url)
+        .expect("failed to parse test manifest");
+
+    let result = gitgrip::cli::commands::sync::run_sync(
+        &workspace_root,
+        &manifest,
+        false,
+        true, // quiet
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "sync should succeed after auto-recovery: {:?}",
+        result.err()
+    );
+
+    // spaces/main/ should now have a .git (re-cloned)
+    assert!(
+        spaces_main.join(".git").exists(),
+        "spaces/main/ should be a git repo after auto-recovery"
+    );
+}


### PR DESCRIPTION
## Sprint 9 Ceremony

Three stories shipped, all tests green.

### What's included

1. **feat: workspace cache bootstrap (#475)** — Bare-repo cache layer under `.grip/cache/<name>.git`. New `gr cache` CLI with bootstrap/update/status/remove subcommands. 10 unit tests.

2. **feat: cache-backed checkout materialization (#476)** — Independent child clones from the cache via `git clone --reference`. Checkouts under `.grip/checkouts/<name>/` with own `.git` dirs. Cache-survival guarantee tested. 10 unit tests.

3. **test: playground harness (#477)** — Reusable offline proving ground for binary-level CLI flows. 3 scenarios covering init, sync, branch, prune. Foundation for Sprint 10 integration tests.

### Also included (pre-sprint)

- **fix: spawn model passthrough (#472)** — Auto-inject `--model` from agents.toml into launch command. 4 unit tests.

### Why this matters

This is the foundation of Grip v2: clone-backed team workspaces instead of git worktrees. The cache layer enables fast, isolated agent workspaces without shared mutable `.git` state.

### Test plan

- [x] 24 new unit tests (10 cache + 10 checkout + 4 spawn)
- [x] 3 binary-level playground scenarios
- [x] `cargo build` clean
- [x] Atlas validated merged sprint-9 branch: `cargo test --test test_playground` -> 3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)