### PR TITLE
style: format sprint-9 ceremony branch

### DIFF
--- a/src/cli/commands/cache.rs
+++ b/src/cli/commands/cache.rs
@@ -34,8 +34,7 @@ pub fn run_cache(
                 .map(|r| (r.name.as_str(), r.url.as_str()))
                 .collect();
 
-            let count =
-                workspace_cache::bootstrap_all(workspace_root, repo_pairs.into_iter())?;
+            let count = workspace_cache::bootstrap_all(workspace_root, repo_pairs.into_iter())?;
 
             if !quiet {
                 if count > 0 {

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -5,8 +5,8 @@
 pub mod add;
 pub mod agent;
 pub mod bench;
-pub mod cache;
 pub mod branch;
+pub mod cache;
 pub mod channel;
 pub mod checkout;
 pub mod cherry_pick;

--- a/src/core/workspace_cache.rs
+++ b/src/core/workspace_cache.rs
@@ -46,8 +46,7 @@ pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Res
     }
 
     let mut cmd = Command::new("git");
-    cmd.args(["clone", "--bare", url])
-        .arg(&path);
+    cmd.args(["clone", "--bare", url]).arg(&path);
     log_cmd(&cmd);
 
     let output = cmd
@@ -73,11 +72,7 @@ pub fn update_cache(workspace_root: &Path, repo_name: &str) -> Result<()> {
     let path = cache_path(workspace_root, repo_name);
 
     if !cache_exists(workspace_root, repo_name) {
-        anyhow::bail!(
-            "cache does not exist for {}: {}",
-            repo_name,
-            path.display()
-        );
+        anyhow::bail!("cache does not exist for {}: {}", repo_name, path.display());
     }
 
     let mut cmd = Command::new("git");

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -34,10 +34,7 @@ pub struct CheckoutRepo {
 
 /// Resolve the checkout root: `<workspace_root>/.grip/checkouts/<name>/`
 pub fn checkout_path(workspace_root: &Path, name: &str) -> PathBuf {
-    workspace_root
-        .join(".grip")
-        .join(CHECKOUTS_DIR)
-        .join(name)
+    workspace_root.join(".grip").join(CHECKOUTS_DIR).join(name)
 }
 
 /// Check whether a checkout exists.
@@ -129,14 +126,7 @@ pub fn create_checkout<'a>(
     let mut checkout_repos = Vec::new();
 
     for (name, url, path) in repos {
-        let target = materialize_repo(
-            workspace_root,
-            checkout_name,
-            name,
-            url,
-            path,
-            branch,
-        )?;
+        let target = materialize_repo(workspace_root, checkout_name, name, url, path, branch)?;
         checkout_repos.push(CheckoutRepo {
             name: name.to_string(),
             path: target,
@@ -266,8 +256,7 @@ mod tests {
         // Create workspace and bootstrap cache
         fs::create_dir_all(&workspace).expect("mkdir workspace");
         let url = remote_path.to_string_lossy().to_string();
-        workspace_cache::bootstrap_cache(&workspace, "testrepo", &url)
-            .expect("bootstrap cache");
+        workspace_cache::bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap cache");
 
         (workspace, remote_path)
     }
@@ -335,15 +324,8 @@ mod tests {
         let (workspace, remote) = setup_cached_workspace(tmp.path());
 
         let url = remote.to_string_lossy().to_string();
-        let target = materialize_repo(
-            &workspace,
-            "ref-test",
-            "testrepo",
-            &url,
-            "testrepo",
-            None,
-        )
-        .expect("materialize");
+        let target = materialize_repo(&workspace, "ref-test", "testrepo", &url, "testrepo", None)
+            .expect("materialize");
 
         // Check alternates file exists (proves --reference was used)
         let alternates = target.join(".git/objects/info/alternates");


### PR DESCRIPTION
## Summary\n- apply rustfmt to the sprint-9 ceremony branch changes\n- fix the failing Format check on #481 without changing behavior\n\n## Testing\n- cargo fmt --all --check