### PR TITLE
feat: add cache-backed checkout creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ gr sync
 | `gr branch [name]` | Create or list branches |
 | `gr checkout <branch>` | Checkout branch across repos |
 | `gr checkout -b <branch>` | Create and checkout branch in one command |
+| `gr checkout add <name>` | Create an independent child checkout from cached repos |
 | `gr add [files]` | Stage changes across repos |
 | `gr diff` | Show diff across repos |
 | `gr commit -m "msg"` | Commit across repos |
@@ -231,6 +232,33 @@ Checkout a branch across all repos. Can also create branches with the `-b` flag.
 |--------|-------------|
 | `-b` | Create branch if it doesn't exist |
 | `--base` | Checkout the griptree base branch (griptree workspaces only) |
+
+#### `gr checkout add <name>`
+
+Create an independent child checkout under `.grip/checkouts/<name>/` using the
+workspace cache as an accelerator.
+
+Unlike `gr tree add`, this creates normal child clones with their own `.git`
+directories. The checkout keeps the canonical remote URL as `origin`; the cache
+is only used to speed up materialization.
+
+| Option | Description |
+|--------|-------------|
+| `--repo <name>` | Only materialize specific repos |
+| `--group <name>` | Only materialize repos in a group |
+
+**Examples:**
+
+```bash
+# Materialize all repos into an independent child checkout
+gr checkout add sandbox
+
+# Materialize only the docs group
+gr checkout add docs-only --group docs
+
+# Materialize just one repo
+gr checkout add app-only --repo app
+```
 
 #### `gr branch [name]`
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -126,9 +126,12 @@ pub enum Commands {
         #[arg(long, value_delimiter = ',')]
         group: Option<Vec<String>>,
     },
-    /// Checkout a branch across repos
+    #[command(
+        after_help = "Examples:\n  gr checkout feat/login\n  gr checkout --base\n  gr checkout add sandbox\n  gr checkout add docs-only --group docs\n  gr checkout add app-only --repo app"
+    )]
+    /// Checkout a branch across repos or create an independent child checkout
     Checkout {
-        /// Branch name
+        /// Branch name, or `add` to create an independent child checkout
         name: Option<String>,
         /// Additional checkout action args (e.g. `add <name>`)
         #[arg(hide = true)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -349,7 +349,7 @@ pub enum Commands {
         #[command(subcommand)]
         action: TargetCommands,
     },
-    /// Manage workspace repo caches (.grip/cache/)
+    /// Manage machine-level repo caches (~/.grip/cache/ by default)
     Cache {
         #[command(subcommand)]
         action: CacheCommands,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -130,6 +130,9 @@ pub enum Commands {
     Checkout {
         /// Branch name
         name: Option<String>,
+        /// Additional checkout action args (e.g. `add <name>`)
+        #[arg(hide = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        extra: Vec<String>,
         /// Create branch if it doesn't exist
         #[arg(short = 'b', long)]
         create: bool,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -131,7 +131,7 @@ pub enum Commands {
         /// Branch name
         name: Option<String>,
         /// Additional checkout action args (e.g. `add <name>`)
-        #[arg(hide = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        #[arg(hide = true)]
         extra: Vec<String>,
         /// Create branch if it doesn't exist
         #[arg(short = 'b', long)]

--- a/src/cli/commands/cache.rs
+++ b/src/cli/commands/cache.rs
@@ -1,6 +1,6 @@
 //! Cache command implementation
 //!
-//! Manages bare-repo caches under `.grip/cache/` for workspace repos.
+//! Manages bare-repo caches under the machine-level cache root for workspace repos.
 
 use crate::cli::args::CacheCommands;
 use crate::cli::output::Output;
@@ -50,7 +50,12 @@ pub fn run_cache(
                 Output::info("Updating all caches...");
             }
 
-            let count = workspace_cache::update_all(workspace_root)?;
+            let repo_pairs: Vec<(&str, &str)> = repos
+                .iter()
+                .map(|r| (r.name.as_str(), r.url.as_str()))
+                .collect();
+
+            let count = workspace_cache::update_all(workspace_root, repo_pairs.into_iter())?;
 
             if !quiet {
                 Output::success(&format!("Updated {} cache(s)", count));
@@ -58,12 +63,6 @@ pub fn run_cache(
         }
 
         CacheCommands::Status => {
-            let cache_dir = workspace_root.join(".grip").join("cache");
-            if !cache_dir.is_dir() {
-                Output::info("No caches exist yet. Run 'gr cache bootstrap' to create them.");
-                return Ok(());
-            }
-
             println!(
                 "{:<20} {:<8} {}",
                 "Repo".bold(),
@@ -73,8 +72,9 @@ pub fn run_cache(
             println!("{}", "─".repeat(70));
 
             for repo in &repos {
-                let exists = workspace_cache::cache_exists(workspace_root, &repo.name);
-                let path = workspace_cache::cache_path(workspace_root, &repo.name);
+                let exists = workspace_cache::cache_exists(workspace_root, &repo.name, &repo.url)?;
+                let path =
+                    workspace_cache::resolve_cache_path(workspace_root, &repo.name, &repo.url)?;
                 let status = if exists {
                     "cached".green().to_string()
                 } else {
@@ -85,7 +85,11 @@ pub fn run_cache(
         }
 
         CacheCommands::Remove { repo } => {
-            let removed = workspace_cache::remove_cache(workspace_root, &repo)?;
+            let Some(repo_info) = repos.iter().find(|r| r.name == repo) else {
+                anyhow::bail!("repo '{}' is not in this manifest", repo);
+            };
+            let removed =
+                workspace_cache::remove_cache(workspace_root, &repo_info.name, &repo_info.url)?;
             if removed {
                 Output::success(&format!("Removed cache for {}", repo));
             } else {

--- a/src/cli/commands/checkout.rs
+++ b/src/cli/commands/checkout.rs
@@ -3,6 +3,7 @@
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
 use crate::core::repo::{filter_repos, get_manifest_repo_info, RepoInfo};
+use crate::core::workspace_checkout;
 use crate::git::{
     branch::{branch_exists, checkout_branch, create_and_checkout_branch},
     open_repo,
@@ -111,5 +112,54 @@ pub fn run_checkout(
         Output::branch_name(branch_name)
     );
 
+    Ok(())
+}
+
+/// Materialize an independent child checkout from cached repos.
+///
+/// This reserves `gr checkout add <name>` while preserving the existing
+/// `gr checkout <branch>` behavior for cross-repo branch switching.
+pub fn run_checkout_add(
+    workspace_root: &Path,
+    manifest: &Manifest,
+    checkout_name: &str,
+    repos_filter: Option<&[String]>,
+    group_filter: Option<&[String]>,
+) -> anyhow::Result<()> {
+    let mut repos: Vec<RepoInfo> =
+        filter_repos(manifest, workspace_root, repos_filter, group_filter, false);
+
+    let include_manifest = match repos_filter {
+        None => true,
+        Some(filter) => filter.iter().any(|r| r == "manifest"),
+    };
+    if include_manifest {
+        if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
+            repos.push(manifest_repo);
+        }
+    }
+
+    if repos.is_empty() {
+        anyhow::bail!("no repos matched checkout filters");
+    }
+
+    let repo_specs: Vec<(&str, &str, &str)> = repos
+        .iter()
+        .map(|repo| (repo.name.as_str(), repo.url.as_str(), repo.path.as_str()))
+        .collect();
+
+    let info = workspace_checkout::create_checkout(
+        workspace_root,
+        checkout_name,
+        repo_specs.into_iter(),
+        None,
+    )?;
+
+    Output::success(&format!(
+        "Created checkout '{}' with {} repo(s)",
+        info.name,
+        info.repos.len()
+    ));
+    Output::info(&format!("Path: {}", info.path.display()));
     Ok(())
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -102,6 +102,13 @@ pub async fn dispatch_command(
             let ctx = load_workspace_context(quiet, verbose, json)?;
 
             if matches!(name.as_deref(), Some("add")) {
+                // `add` is reserved for checkout materialization, not branch switching.
+                if create || base {
+                    anyhow::bail!("--create and --base are not valid with 'add'");
+                }
+                if extra.len() > 1 {
+                    anyhow::bail!("unexpected extra arguments after checkout name");
+                }
                 let checkout_name = extra.first().ok_or_else(|| {
                     anyhow::anyhow!("Checkout name is required: gr checkout add <name>")
                 })?;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -93,30 +93,46 @@ pub async fn dispatch_command(
         }
         Some(Commands::Checkout {
             name,
+            extra,
             create,
             base,
             repo,
             group,
         }) => {
             let ctx = load_workspace_context(quiet, verbose, json)?;
-            let branch = if base {
-                let config = crate::core::griptree::GriptreeConfig::load_from_workspace(
-                    &ctx.workspace_root,
-                )?
-                .ok_or_else(|| anyhow::anyhow!("Not in a griptree workspace"))?;
-                config.branch
-            } else {
-                name.ok_or_else(|| anyhow::anyhow!("Branch name is required"))?
-            };
 
-            crate::cli::commands::checkout::run_checkout(
-                &ctx.workspace_root,
-                &ctx.manifest,
-                &branch,
-                create,
-                repo.as_deref(),
-                group.as_deref(),
-            )?;
+            if matches!(name.as_deref(), Some("add")) {
+                let checkout_name = extra.first().ok_or_else(|| {
+                    anyhow::anyhow!("Checkout name is required: gr checkout add <name>")
+                })?;
+
+                crate::cli::commands::checkout::run_checkout_add(
+                    &ctx.workspace_root,
+                    &ctx.manifest,
+                    checkout_name,
+                    repo.as_deref(),
+                    group.as_deref(),
+                )?;
+            } else {
+                let branch = if base {
+                    let config = crate::core::griptree::GriptreeConfig::load_from_workspace(
+                        &ctx.workspace_root,
+                    )?
+                    .ok_or_else(|| anyhow::anyhow!("Not in a griptree workspace"))?;
+                    config.branch
+                } else {
+                    name.ok_or_else(|| anyhow::anyhow!("Branch name is required"))?
+                };
+
+                crate::cli::commands::checkout::run_checkout(
+                    &ctx.workspace_root,
+                    &ctx.manifest,
+                    &branch,
+                    create,
+                    repo.as_deref(),
+                    group.as_deref(),
+                )?;
+            }
         }
         Some(Commands::Add { files, repo, group }) => {
             let ctx = load_workspace_context(quiet, verbose, json)?;

--- a/src/core/workspace_cache.rs
+++ b/src/core/workspace_cache.rs
@@ -1,45 +1,139 @@
 //! Workspace cache — bare-repo cache layer for manifest repos
 //!
-//! Each manifest repo gets a bare clone under `.grip/cache/<name>.git`.
-//! These caches serve as fast local references for creating agent workspaces
-//! and manual checkouts without sharing mutable .git state.
+//! Caches now live at a machine-level root by default (`~/.grip/cache/`),
+//! keyed by normalized remote URL rather than workspace-local repo name.
+//! This lets multiple workspaces reuse the same object store without sharing
+//! mutable `.git` state between checkouts.
 
 use anyhow::{Context, Result};
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::util::log_cmd;
 
-/// Directory name under .grip/ where bare caches live.
+const CACHE_ENV_VAR: &str = "GRIP_CACHE_DIR";
+const GRIP_DIR: &str = ".grip";
 const CACHE_DIR: &str = "cache";
 
-/// Resolve the cache path for a repo: `<workspace_root>/.grip/cache/<name>.git`
-pub fn cache_path(workspace_root: &Path, repo_name: &str) -> PathBuf {
+fn home_dir() -> Result<PathBuf> {
+    if let Some(home) = env::var_os("HOME") {
+        return Ok(PathBuf::from(home));
+    }
+    if let Some(profile) = env::var_os("USERPROFILE") {
+        return Ok(PathBuf::from(profile));
+    }
+    anyhow::bail!("could not resolve home directory for global cache root")
+}
+
+/// Resolve the machine-level cache root.
+pub fn cache_root() -> Result<PathBuf> {
+    if let Some(override_dir) = env::var_os(CACHE_ENV_VAR) {
+        return Ok(PathBuf::from(override_dir));
+    }
+    Ok(home_dir()?.join(GRIP_DIR).join(CACHE_DIR))
+}
+
+fn legacy_cache_path(workspace_root: &Path, repo_name: &str) -> PathBuf {
     workspace_root
-        .join(".grip")
+        .join(GRIP_DIR)
         .join(CACHE_DIR)
         .join(format!("{}.git", repo_name))
 }
 
-/// Check whether a bare cache exists for the given repo.
-pub fn cache_exists(workspace_root: &Path, repo_name: &str) -> bool {
-    let path = cache_path(workspace_root, repo_name);
-    // A valid bare repo has a HEAD file
+fn normalize_git_url(url: &str) -> String {
+    let trimmed = url.trim().trim_end_matches('/').trim_end_matches(".git");
+
+    if !trimmed.contains("://") {
+        if let Some((user_host, path)) = trimmed.split_once(':') {
+            let host = user_host.rsplit('@').next().unwrap_or(user_host);
+            if !host.is_empty() && !path.is_empty() {
+                return format!(
+                    "{}:{}",
+                    host.to_ascii_lowercase(),
+                    path.trim_start_matches('/')
+                );
+            }
+        }
+    }
+
+    if let Some((_, rest)) = trimmed.split_once("://") {
+        if let Some((host_user, path)) = rest.split_once('/') {
+            let host = host_user.rsplit('@').next().unwrap_or(host_user);
+            if !host.is_empty() && !path.is_empty() {
+                return format!(
+                    "{}:{}",
+                    host.to_ascii_lowercase(),
+                    path.trim_start_matches('/')
+                );
+            }
+        }
+    }
+
+    trimmed.to_string()
+}
+
+/// Stable filesystem-safe cache key derived from a normalized remote URL.
+pub fn cache_key(url: &str) -> String {
+    let normalized = normalize_git_url(url);
+    let mut key = String::with_capacity(normalized.len());
+    let mut last_was_sep = false;
+
+    for ch in normalized.chars() {
+        if ch.is_ascii_alphanumeric() {
+            key.push(ch.to_ascii_lowercase());
+            last_was_sep = false;
+        } else if !last_was_sep {
+            key.push('_');
+            last_was_sep = true;
+        }
+    }
+
+    key.trim_matches('_').to_string()
+}
+
+/// Resolve the primary global cache path for a repo URL.
+pub fn cache_path(url: &str) -> Result<PathBuf> {
+    Ok(cache_root()?.join(format!("{}.git", cache_key(url))))
+}
+
+fn cache_is_valid(path: &Path) -> bool {
     path.join("HEAD").is_file()
 }
 
-/// Bootstrap a bare cache by cloning from the canonical remote.
-///
-/// Creates `.grip/cache/<name>.git` as a bare clone of `url`.
-/// If the cache already exists, this is a no-op (use `update_cache` to fetch).
-pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<()> {
-    let path = cache_path(workspace_root, repo_name);
+/// Resolve the cache path to use, preferring the global cache but falling back
+/// to an existing legacy workspace-local cache.
+pub fn resolve_cache_path(workspace_root: &Path, repo_name: &str, url: &str) -> Result<PathBuf> {
+    let global = cache_path(url)?;
+    if cache_is_valid(&global) {
+        return Ok(global);
+    }
 
-    if cache_exists(workspace_root, repo_name) {
+    let legacy = legacy_cache_path(workspace_root, repo_name);
+    if cache_is_valid(&legacy) {
+        return Ok(legacy);
+    }
+
+    Ok(global)
+}
+
+/// Check whether a cache exists for the given repo.
+pub fn cache_exists(workspace_root: &Path, repo_name: &str, url: &str) -> Result<bool> {
+    Ok(cache_is_valid(&resolve_cache_path(
+        workspace_root,
+        repo_name,
+        url,
+    )?))
+}
+
+/// Bootstrap a bare cache by cloning from the canonical remote.
+pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<()> {
+    let existing = resolve_cache_path(workspace_root, repo_name, url)?;
+    if cache_is_valid(&existing) {
         return Ok(());
     }
 
-    // Ensure parent directory exists
+    let path = cache_path(url)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating cache directory: {}", parent.display()))?;
@@ -66,12 +160,10 @@ pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Res
 }
 
 /// Fetch latest refs into an existing bare cache.
-///
-/// Runs `git fetch --all --prune` inside the bare repo to bring it up to date.
-pub fn update_cache(workspace_root: &Path, repo_name: &str) -> Result<()> {
-    let path = cache_path(workspace_root, repo_name);
+pub fn update_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<()> {
+    let path = resolve_cache_path(workspace_root, repo_name, url)?;
 
-    if !cache_exists(workspace_root, repo_name) {
+    if !cache_is_valid(&path) {
         anyhow::bail!("cache does not exist for {}: {}", repo_name, path.display());
     }
 
@@ -96,10 +188,14 @@ pub fn update_cache(workspace_root: &Path, repo_name: &str) -> Result<()> {
 }
 
 /// Get the remote URL stored in a bare cache.
-pub fn cache_remote_url(workspace_root: &Path, repo_name: &str) -> Result<Option<String>> {
-    let path = cache_path(workspace_root, repo_name);
+pub fn cache_remote_url(
+    workspace_root: &Path,
+    repo_name: &str,
+    url: &str,
+) -> Result<Option<String>> {
+    let path = resolve_cache_path(workspace_root, repo_name, url)?;
 
-    if !cache_exists(workspace_root, repo_name) {
+    if !cache_is_valid(&path) {
         return Ok(None);
     }
 
@@ -121,16 +217,13 @@ pub fn cache_remote_url(workspace_root: &Path, repo_name: &str) -> Result<Option
 }
 
 /// Bootstrap caches for all repos in a manifest.
-///
-/// Takes an iterator of (name, url) pairs. Skips repos that already have caches.
-/// Returns the count of newly bootstrapped caches.
 pub fn bootstrap_all<'a>(
     workspace_root: &Path,
     repos: impl Iterator<Item = (&'a str, &'a str)>,
 ) -> Result<usize> {
     let mut count = 0;
     for (name, url) in repos {
-        if !cache_exists(workspace_root, name) {
+        if !cache_exists(workspace_root, name, url)? {
             bootstrap_cache(workspace_root, name, url)?;
             count += 1;
         }
@@ -138,24 +231,15 @@ pub fn bootstrap_all<'a>(
     Ok(count)
 }
 
-/// Update all existing caches under `.grip/cache/`.
-///
-/// Returns the count of caches updated.
-pub fn update_all(workspace_root: &Path) -> Result<usize> {
-    let cache_dir = workspace_root.join(".grip").join(CACHE_DIR);
-    if !cache_dir.is_dir() {
-        return Ok(0);
-    }
-
+/// Update all caches for repos in the current manifest.
+pub fn update_all<'a>(
+    workspace_root: &Path,
+    repos: impl Iterator<Item = (&'a str, &'a str)>,
+) -> Result<usize> {
     let mut count = 0;
-    for entry in std::fs::read_dir(&cache_dir)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        // Cache dirs are named <repo>.git
-        if name_str.ends_with(".git") && entry.path().join("HEAD").is_file() {
-            let repo_name = name_str.trim_end_matches(".git");
-            update_cache(workspace_root, repo_name)?;
+    for (name, url) in repos {
+        if cache_exists(workspace_root, name, url)? {
+            update_cache(workspace_root, name, url)?;
             count += 1;
         }
     }
@@ -163,8 +247,8 @@ pub fn update_all(workspace_root: &Path) -> Result<usize> {
 }
 
 /// Remove a single repo cache.
-pub fn remove_cache(workspace_root: &Path, repo_name: &str) -> Result<bool> {
-    let path = cache_path(workspace_root, repo_name);
+pub fn remove_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<bool> {
+    let path = resolve_cache_path(workspace_root, repo_name, url)?;
     if path.is_dir() {
         std::fs::remove_dir_all(&path)
             .with_context(|| format!("removing cache: {}", path.display()))?;
@@ -177,19 +261,34 @@ pub fn remove_cache(workspace_root: &Path, repo_name: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use once_cell::sync::Lazy;
     use std::fs;
+    use std::sync::Mutex;
 
-    /// Helper: create a temporary "remote" repo to clone from
+    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn with_cache_dir<T>(cache_dir: &Path, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = env::var_os(CACHE_ENV_VAR);
+        env::set_var(CACHE_ENV_VAR, cache_dir);
+        let result = f();
+        match previous {
+            Some(value) => env::set_var(CACHE_ENV_VAR, value),
+            None => env::remove_var(CACHE_ENV_VAR),
+        }
+        result
+    }
+
     fn create_test_remote(dir: &Path) -> PathBuf {
         let remote_path = dir.join("remote-repo.git");
-        // Init a bare repo to act as the remote
         Command::new("git")
             .args(["init", "--bare"])
             .arg(&remote_path)
             .output()
             .expect("git init --bare");
 
-        // Create a non-bare repo, add a commit, push to the bare repo
         let work_path = dir.join("work-repo");
         Command::new("git")
             .args(["init"])
@@ -227,7 +326,7 @@ mod tests {
             .args(["push", "origin", "main"])
             .current_dir(&work_path)
             .output()
-            .ok(); // might be master, not main
+            .ok();
         Command::new("git")
             .args(["push", "origin", "master"])
             .current_dir(&work_path)
@@ -238,16 +337,37 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_path() {
-        let root = Path::new("/workspace");
-        let path = cache_path(root, "myrepo");
-        assert_eq!(path, PathBuf::from("/workspace/.grip/cache/myrepo.git"));
+    fn test_cache_key_normalizes_remote_url_forms() {
+        let ssh = cache_key("git@github.com:OpenAI/myrepo.git");
+        let https = cache_key("https://github.com/OpenAI/myrepo.git");
+        assert_eq!(ssh, "github_com_openai_myrepo");
+        assert_eq!(ssh, https);
+    }
+
+    #[test]
+    fn test_cache_path_uses_global_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let path = cache_path("git@github.com:OpenAI/myrepo.git").expect("cache path");
+            assert_eq!(path, cache_dir.join("github_com_openai_myrepo.git"));
+        });
     }
 
     #[test]
     fn test_cache_does_not_exist_initially() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        assert!(!cache_exists(tmp.path(), "nonexistent"));
+        let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        with_cache_dir(&cache_dir, || {
+            assert!(!cache_exists(
+                &workspace,
+                "nonexistent",
+                "git@github.com:user/nonexistent.git"
+            )
+            .expect("cache exists"));
+        });
     }
 
     #[test]
@@ -255,18 +375,20 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        assert!(!cache_exists(&workspace, "testrepo"));
+        with_cache_dir(&cache_dir, || {
+            assert!(!cache_exists(&workspace, "testrepo", &url).expect("cache exists before"));
 
-        bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap");
-        assert!(cache_exists(&workspace, "testrepo"));
+            bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap");
+            assert!(cache_exists(&workspace, "testrepo", &url).expect("cache exists after"));
 
-        // Verify it's a bare repo
-        let cp = cache_path(&workspace, "testrepo");
-        assert!(cp.join("HEAD").is_file());
-        assert!(!cp.join(".git").exists()); // bare repos don't have .git subdir
+            let cp = cache_path(&url).expect("cache path");
+            assert!(cp.join("HEAD").is_file());
+            assert!(!cp.join(".git").exists());
+        });
     }
 
     #[test]
@@ -274,12 +396,15 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 1");
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 2"); // no-op
-        assert!(cache_exists(&workspace, "repo"));
+        with_cache_dir(&cache_dir, || {
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 1");
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 2");
+            assert!(cache_exists(&workspace, "repo", &url).expect("cache exists"));
+        });
     }
 
     #[test]
@@ -287,18 +412,26 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
-        update_cache(&workspace, "repo").expect("update");
+        with_cache_dir(&cache_dir, || {
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+            update_cache(&workspace, "repo", &url).expect("update");
+        });
     }
 
     #[test]
     fn test_update_nonexistent_fails() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let result = update_cache(tmp.path(), "nope");
-        assert!(result.is_err());
+        let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        with_cache_dir(&cache_dir, || {
+            let result = update_cache(&workspace, "nope", "git@github.com:user/nope.git");
+            assert!(result.is_err());
+        });
     }
 
     #[test]
@@ -306,15 +439,18 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+        with_cache_dir(&cache_dir, || {
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
 
-        let stored_url = cache_remote_url(&workspace, "repo")
-            .expect("get url")
-            .expect("has url");
-        assert_eq!(stored_url, url);
+            let stored_url = cache_remote_url(&workspace, "repo", &url)
+                .expect("get url")
+                .expect("has url");
+            assert_eq!(stored_url, url);
+        });
     }
 
     #[test]
@@ -322,22 +458,31 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
-        assert!(cache_exists(&workspace, "repo"));
+        with_cache_dir(&cache_dir, || {
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+            assert!(cache_exists(&workspace, "repo", &url).expect("cache exists"));
 
-        let removed = remove_cache(&workspace, "repo").expect("remove");
-        assert!(removed);
-        assert!(!cache_exists(&workspace, "repo"));
+            let removed = remove_cache(&workspace, "repo", &url).expect("remove");
+            assert!(removed);
+            assert!(!cache_exists(&workspace, "repo", &url).expect("cache removed"));
+        });
     }
 
     #[test]
     fn test_remove_nonexistent_returns_false() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let removed = remove_cache(tmp.path(), "nope").expect("remove");
-        assert!(!removed);
+        let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        with_cache_dir(&cache_dir, || {
+            let removed =
+                remove_cache(&workspace, "nope", "git@github.com:user/nope.git").expect("remove");
+            assert!(!removed);
+        });
     }
 
     #[test]
@@ -345,18 +490,33 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        let repos = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
-        let count = bootstrap_all(&workspace, repos.into_iter()).expect("bootstrap all");
-        assert_eq!(count, 2);
-        assert!(cache_exists(&workspace, "repo1"));
-        assert!(cache_exists(&workspace, "repo2"));
+        with_cache_dir(&cache_dir, || {
+            let repos = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
+            let count = bootstrap_all(&workspace, repos.into_iter()).expect("bootstrap all");
+            assert_eq!(count, 1);
+            assert!(cache_exists(&workspace, "repo1", &url).expect("repo1 cached"));
+            assert!(cache_exists(&workspace, "repo2", &url).expect("repo2 cached"));
 
-        // Second call: no new bootstraps
-        let repos2 = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
-        let count2 = bootstrap_all(&workspace, repos2.into_iter()).expect("bootstrap all 2");
-        assert_eq!(count2, 0);
+            let repos2 = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
+            let count2 = bootstrap_all(&workspace, repos2.into_iter()).expect("bootstrap all 2");
+            assert_eq!(count2, 0);
+        });
+    }
+
+    #[test]
+    fn test_resolve_cache_path_falls_back_to_legacy_workspace_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let legacy = workspace.join(".grip/cache/repo.git");
+        fs::create_dir_all(&legacy).expect("mkdir legacy cache");
+        fs::write(legacy.join("HEAD"), "ref: refs/heads/main\n").expect("write head");
+
+        let resolved = resolve_cache_path(&workspace, "repo", "git@github.com:org/repo.git")
+            .expect("resolve path");
+        assert_eq!(resolved, legacy);
     }
 }

--- a/src/core/workspace_cache.rs
+++ b/src/core/workspace_cache.rs
@@ -259,16 +259,20 @@ pub fn remove_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+pub(crate) mod test_support {
     use once_cell::sync::Lazy;
-    use std::fs;
     use std::sync::Mutex;
 
-    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+    pub(crate) static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
 
     fn with_cache_dir<T>(cache_dir: &Path, f: impl FnOnce() -> T) -> T {
-        let _guard = ENV_LOCK
+        let _guard = test_support::ENV_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let previous = env::var_os(CACHE_ENV_VAR);

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -69,8 +69,8 @@ pub fn materialize_repo(
             .with_context(|| format!("creating checkout dir: {}", parent.display()))?;
     }
 
-    let cache = workspace_cache::cache_path(workspace_root, repo_name);
-    let has_cache = workspace_cache::cache_exists(workspace_root, repo_name);
+    let cache = workspace_cache::resolve_cache_path(workspace_root, repo_name, repo_url)?;
+    let has_cache = workspace_cache::cache_exists(workspace_root, repo_name, repo_url)?;
 
     let mut cmd = Command::new("git");
     cmd.arg("clone");
@@ -200,7 +200,25 @@ pub fn remove_checkout(workspace_root: &Path, name: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use once_cell::sync::Lazy;
     use std::fs;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn with_cache_dir<T>(cache_dir: &Path, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::var_os("GRIP_CACHE_DIR");
+        std::env::set_var("GRIP_CACHE_DIR", cache_dir);
+        let result = f();
+        match previous {
+            Some(value) => std::env::set_var("GRIP_CACHE_DIR", value),
+            None => std::env::remove_var("GRIP_CACHE_DIR"),
+        }
+        result
+    }
 
     /// Helper: create a test remote repo and bootstrap its cache
     fn setup_cached_workspace(dir: &Path) -> (PathBuf, PathBuf) {
@@ -279,111 +297,127 @@ mod tests {
     #[test]
     fn test_materialize_single_repo() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let target = materialize_repo(
-            &workspace,
-            "test-checkout",
-            "testrepo",
-            &url,
-            "testrepo",
-            None,
-        )
-        .expect("materialize");
+            let url = remote.to_string_lossy().to_string();
+            let target = materialize_repo(
+                &workspace,
+                "test-checkout",
+                "testrepo",
+                &url,
+                "testrepo",
+                None,
+            )
+            .expect("materialize");
 
-        assert!(target.join(".git").exists());
-        assert!(target.join("README.md").exists());
+            assert!(target.join(".git").exists());
+            assert!(target.join("README.md").exists());
+        });
     }
 
     #[test]
     fn test_materialize_is_independent_clone() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let target = materialize_repo(
-            &workspace,
-            "independent",
-            "testrepo",
-            &url,
-            "testrepo",
-            None,
-        )
-        .expect("materialize");
+            let url = remote.to_string_lossy().to_string();
+            let target = materialize_repo(
+                &workspace,
+                "independent",
+                "testrepo",
+                &url,
+                "testrepo",
+                None,
+            )
+            .expect("materialize");
 
-        // The clone has its own .git directory (not a worktree link)
-        assert!(target.join(".git").is_dir());
-        // Not a file pointing elsewhere (that would be a worktree)
-        assert!(!target.join(".git").is_file());
+            assert!(target.join(".git").is_dir());
+            assert!(!target.join(".git").is_file());
+        });
     }
 
     #[test]
     fn test_materialize_uses_cache_reference() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let target = materialize_repo(&workspace, "ref-test", "testrepo", &url, "testrepo", None)
-            .expect("materialize");
+            let url = remote.to_string_lossy().to_string();
+            let target =
+                materialize_repo(&workspace, "ref-test", "testrepo", &url, "testrepo", None)
+                    .expect("materialize");
 
-        // Check alternates file exists (proves --reference was used)
-        let alternates = target.join(".git/objects/info/alternates");
-        assert!(alternates.is_file(), "alternates file should exist");
-        let content = fs::read_to_string(&alternates).expect("read alternates");
-        assert!(
-            content.contains("cache/testrepo.git"),
-            "alternates should reference the cache"
-        );
+            let alternates = target.join(".git/objects/info/alternates");
+            assert!(alternates.is_file(), "alternates file should exist");
+            let content = fs::read_to_string(&alternates).expect("read alternates");
+            assert!(
+                content.contains(&workspace_cache::cache_key(&url)),
+                "alternates should reference the global cache path"
+            );
+        });
     }
 
     #[test]
     fn test_create_and_list_checkout() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            let url = remote.to_string_lossy().to_string();
+            let repos = vec![("testrepo", url.as_str(), "testrepo")];
 
-        let info = create_checkout(&workspace, "feat-x", repos.into_iter(), None)
-            .expect("create checkout");
+            let info = create_checkout(&workspace, "feat-x", repos.into_iter(), None)
+                .expect("create checkout");
 
-        assert_eq!(info.name, "feat-x");
-        assert_eq!(info.repos.len(), 1);
-        assert!(checkout_exists(&workspace, "feat-x"));
+            assert_eq!(info.name, "feat-x");
+            assert_eq!(info.repos.len(), 1);
+            assert!(checkout_exists(&workspace, "feat-x"));
 
-        let all = list_checkouts(&workspace).expect("list");
-        assert_eq!(all.len(), 1);
-        assert_eq!(all[0].name, "feat-x");
+            let all = list_checkouts(&workspace).expect("list");
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].name, "feat-x");
+        });
     }
 
     #[test]
     fn test_create_duplicate_fails() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let repos = vec![("testrepo", url.as_str(), "testrepo")];
-        create_checkout(&workspace, "dup", repos.into_iter(), None).expect("first");
+            let url = remote.to_string_lossy().to_string();
+            let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            create_checkout(&workspace, "dup", repos.into_iter(), None).expect("first");
 
-        let repos2 = vec![("testrepo", url.as_str(), "testrepo")];
-        let result = create_checkout(&workspace, "dup", repos2.into_iter(), None);
-        assert!(result.is_err());
+            let repos2 = vec![("testrepo", url.as_str(), "testrepo")];
+            let result = create_checkout(&workspace, "dup", repos2.into_iter(), None);
+            assert!(result.is_err());
+        });
     }
 
     #[test]
     fn test_remove_checkout() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let repos = vec![("testrepo", url.as_str(), "testrepo")];
-        create_checkout(&workspace, "removeme", repos.into_iter(), None).expect("create");
+            let url = remote.to_string_lossy().to_string();
+            let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            create_checkout(&workspace, "removeme", repos.into_iter(), None).expect("create");
 
-        assert!(checkout_exists(&workspace, "removeme"));
-        let removed = remove_checkout(&workspace, "removeme").expect("remove");
-        assert!(removed);
-        assert!(!checkout_exists(&workspace, "removeme"));
+            assert!(checkout_exists(&workspace, "removeme"));
+            let removed = remove_checkout(&workspace, "removeme").expect("remove");
+            assert!(removed);
+            assert!(!checkout_exists(&workspace, "removeme"));
+        });
     }
 
     #[test]
@@ -396,19 +430,20 @@ mod tests {
     #[test]
     fn test_cache_survives_checkout_removal() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let repos = vec![("testrepo", url.as_str(), "testrepo")];
-        create_checkout(&workspace, "ephemeral", repos.into_iter(), None).expect("create");
+            let url = remote.to_string_lossy().to_string();
+            let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            create_checkout(&workspace, "ephemeral", repos.into_iter(), None).expect("create");
 
-        // Remove the checkout
-        remove_checkout(&workspace, "ephemeral").expect("remove");
+            remove_checkout(&workspace, "ephemeral").expect("remove");
 
-        // Cache must still exist — this is a first-class guarantee
-        assert!(
-            workspace_cache::cache_exists(&workspace, "testrepo"),
-            "cache must survive checkout deletion"
-        );
+            assert!(
+                workspace_cache::cache_exists(&workspace, "testrepo", &url).expect("cache exists"),
+                "cache must survive checkout deletion"
+            );
+        });
     }
 }

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -200,14 +200,11 @@ pub fn remove_checkout(workspace_root: &Path, name: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use once_cell::sync::Lazy;
+    use crate::core::workspace_cache::test_support;
     use std::fs;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     fn with_cache_dir<T>(cache_dir: &Path, f: impl FnOnce() -> T) -> T {
-        let _guard = ENV_LOCK
+        let _guard = test_support::ENV_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let previous = std::env::var_os("GRIP_CACHE_DIR");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -709,3 +709,36 @@ fn test_checkout_add_respects_group_filter() {
     assert!(checkout_root.join("docs/.git").is_dir());
     assert!(!checkout_root.join("app").exists());
 }
+
+#[test]
+fn test_checkout_add_requires_name() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Checkout name is required: gr checkout add <name>",
+        ));
+}
+
+#[test]
+fn test_checkout_add_errors_when_filters_match_no_repos() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("empty")
+        .arg("--repo")
+        .arg("missing")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no repos matched checkout filters",
+        ));
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -626,3 +626,33 @@ fn test_checkout_base_uses_griptree_config() {
         "feat/base"
     );
 }
+
+#[test]
+fn test_checkout_add_materializes_independent_child_checkout() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_repo("lib")
+        .build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created checkout 'sandbox'"));
+
+    let checkout_root = ws.workspace_root.join(".grip/checkouts/sandbox");
+    let app_checkout = checkout_root.join("app");
+    assert!(app_checkout.join(".git").is_dir());
+    assert!(!app_checkout.join(".git").is_file());
+
+    let origin = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(&app_checkout)
+        .output()
+        .expect("git remote get-url");
+    let origin = String::from_utf8_lossy(&origin.stdout).trim().to_string();
+    assert_eq!(origin, ws.remote_url("app"));
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -645,8 +645,11 @@ fn test_checkout_add_materializes_independent_child_checkout() {
 
     let checkout_root = ws.workspace_root.join(".grip/checkouts/sandbox");
     let app_checkout = checkout_root.join("app");
+    let lib_checkout = checkout_root.join("lib");
     assert!(app_checkout.join(".git").is_dir());
     assert!(!app_checkout.join(".git").is_file());
+    assert!(lib_checkout.join(".git").is_dir());
+    assert!(!lib_checkout.join(".git").is_file());
 
     let origin = std::process::Command::new("git")
         .args(["remote", "get-url", "origin"])
@@ -655,4 +658,54 @@ fn test_checkout_add_materializes_independent_child_checkout() {
         .expect("git remote get-url");
     let origin = String::from_utf8_lossy(&origin.stdout).trim().to_string();
     assert_eq!(origin, ws.remote_url("app"));
+}
+
+#[test]
+fn test_checkout_add_respects_repo_filter() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_repo("lib")
+        .build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("app-only")
+        .arg("--repo")
+        .arg("app")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Created checkout 'app-only' with 1 repo(s)",
+        ));
+
+    let checkout_root = ws.workspace_root.join(".grip/checkouts/app-only");
+    assert!(checkout_root.join("app/.git").is_dir());
+    assert!(!checkout_root.join("lib").exists());
+}
+
+#[test]
+fn test_checkout_add_respects_group_filter() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_groups("app", vec!["product"])
+        .add_repo_with_groups("docs", vec!["docs"])
+        .build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("docs-only")
+        .arg("--group")
+        .arg("docs")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Created checkout 'docs-only' with 1 repo(s)",
+        ));
+
+    let checkout_root = ws.workspace_root.join(".grip/checkouts/docs-only");
+    assert!(checkout_root.join("docs/.git").is_dir());
+    assert!(!checkout_root.join("app").exists());
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -761,3 +761,77 @@ fn test_checkout_add_errors_when_filters_match_no_repos() {
             "no repos matched checkout filters",
         ));
 }
+
+#[test]
+fn test_checkout_add_rejects_create_and_base_flags() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut create_cmd = Command::cargo_bin("gr").unwrap();
+    create_cmd
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .arg("--create")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--create and --base are not valid with 'add'",
+        ));
+
+    let mut base_cmd = Command::cargo_bin("gr").unwrap();
+    base_cmd
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .arg("--base")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--create and --base are not valid with 'add'",
+        ));
+}
+
+#[test]
+fn test_checkout_add_rejects_extra_positional_args() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .arg("extra")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unexpected extra arguments after checkout name",
+        ));
+}
+
+#[test]
+fn test_checkout_add_rejects_duplicate_checkout_name() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut first = Command::cargo_bin("gr").unwrap();
+    first
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr").unwrap();
+    duplicate
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "checkout 'sandbox' already exists",
+        ));
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -545,6 +545,25 @@ fn test_gr2_repo_remove_requires_gr2_workspace() {
         ));
 }
 
+#[test]
+fn test_checkout_help_mentions_add_mode() {
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.arg("checkout")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Checkout a branch across repos or create an independent child checkout",
+        ))
+        .stdout(predicate::str::contains(
+            "Branch name, or `add` to create an independent child checkout",
+        ))
+        .stdout(predicate::str::contains("gr checkout add sandbox"))
+        .stdout(predicate::str::contains(
+            "gr checkout add docs-only --group docs",
+        ));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {


### PR DESCRIPTION
## Summary
- add a user-facing `gr checkout add <name>` path for independent child checkouts
- preserve the existing `gr checkout <branch>` branch-switching behavior
- wire the new action into `workspace_checkout::create_checkout()`

## Notes
- stacked on `grip#484` / `feat/global-cache-root`
- part of `grip#476`

## Verification
- `cargo test --test cli_tests test_checkout_add_materializes_independent_child_checkout -- --nocapture`
- `cargo test --test test_checkout -- --nocapture`
- `cargo fmt --all --check`
