### PR TITLE
ci: split Windows tests into non-blocking lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --all-features
+
+  test-windows:
+    name: Test (windows-latest)
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -83,10 +98,7 @@ jobs:
       - name: Run tests
         run: cargo test --all-features
         env:
-          # Windows: link advapi32 for libgit2-sys (needed for test crates that
-          # don't go through build.rs) and increase stack to 8 MB (debug builds
-          # overflow the default 1 MB Windows stack during clap parsing)
-          RUSTFLAGS: ${{ matrix.os == 'windows-latest' && '-C link-arg=advapi32.lib -C link-arg=/STACK:8388608' || '' }}
+          RUSTFLAGS: '-C link-arg=advapi32.lib -C link-arg=/STACK:8388608'
 
   build:
     name: Build Release
@@ -149,14 +161,16 @@ jobs:
       - name: Run spawn integration tests
         run: GR=./target/debug/gr ./tests/spawn_graceful_shutdown.sh
 
-  # Summary job for branch protection - requires all other jobs to pass
+  # Summary job for branch protection - requires all jobs except Windows to pass.
+  # Windows tests run separately (test-windows) and are visible but non-blocking,
+  # since they are significantly slower and should not gate PR merges.
   ci:
     name: CI
     runs-on: ubuntu-latest
     needs: [check, fmt, clippy, test, build, bench, integration]
     if: always()
     steps:
-      - name: Check all jobs passed
+      - name: Check all required jobs passed
         run: |
           if [[ "${{ needs.check.result }}" != "success" ]] || \
              [[ "${{ needs.fmt.result }}" != "success" ]] || \
@@ -165,7 +179,7 @@ jobs:
              [[ "${{ needs.build.result }}" != "success" ]] || \
              [[ "${{ needs.bench.result }}" != "success" ]] || \
              [[ "${{ needs.integration.result }}" != "success" ]]; then
-            echo "One or more jobs failed"
+            echo "One or more required jobs failed"
             exit 1
           fi
-          echo "All jobs passed"
+          echo "All required jobs passed"


### PR DESCRIPTION
## Summary

- Split the 3-OS test matrix into required unix tests + non-blocking Windows tests
- `test` job: `[ubuntu-latest, macos-latest]` -- required, gates the `ci` summary
- `test-windows` job: runs in parallel, visible on PR but does not block merges
- No branch protection rule changes needed

## Why

Windows CI takes ~4min vs ~2min for unix and has been blocking PR merges (e.g. grip#484 waited 30+ minutes on a single Windows leg). Windows failures should be visible but not gate merges.

Closes #486.

## Test plan

- [x] Verify `ci` summary job `needs` array does not include `test-windows`
- [ ] Observe next PR: Windows shows as separate check, unix failures still block