### PR TITLE
feat: add checkout lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,32 @@ gr checkout add docs-only --group docs
 gr checkout add app-only --repo app
 ```
 
+#### `gr checkout list`
+
+Show the currently materialized child checkouts under
+`.grip/checkouts/`.
+
+**Examples:**
+
+```bash
+# List all materialized child checkouts
+gr checkout list
+```
+
+#### `gr checkout remove <name>`
+
+Remove a materialized child checkout under `.grip/checkouts/<name>/`.
+
+This deletes the child clone only. It does not delete the shared cache under
+`~/.grip/cache/`.
+
+**Examples:**
+
+```bash
+# Remove a disposable child checkout
+gr checkout remove sandbox
+```
+
 #### `gr branch [name]`
 
 Create a new branch across all repositories, or list existing branches. Manifest repo is always included.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -127,11 +127,11 @@ pub enum Commands {
         group: Option<Vec<String>>,
     },
     #[command(
-        after_help = "Examples:\n  gr checkout feat/login\n  gr checkout --base\n  gr checkout add sandbox\n  gr checkout add docs-only --group docs\n  gr checkout add app-only --repo app"
+        after_help = "Examples:\n  gr checkout feat/login\n  gr checkout --base\n  gr checkout add sandbox\n  gr checkout add docs-only --group docs\n  gr checkout add app-only --repo app\n  gr checkout list\n  gr checkout remove sandbox"
     )]
-    /// Checkout a branch across repos or create an independent child checkout
+    /// Checkout a branch across repos or manage independent child checkouts
     Checkout {
-        /// Branch name, or `add` to create an independent child checkout
+        /// Branch name, or `add`/`list`/`remove` for child checkout lifecycle
         name: Option<String>,
         /// Additional checkout action args (e.g. `add <name>`)
         #[arg(hide = true)]

--- a/src/cli/commands/checkout.rs
+++ b/src/cli/commands/checkout.rs
@@ -163,3 +163,35 @@ pub fn run_checkout_add(
     Output::info(&format!("Path: {}", info.path.display()));
     Ok(())
 }
+
+/// List cache-backed child checkouts.
+pub fn run_checkout_list(workspace_root: &Path) -> anyhow::Result<()> {
+    Output::header("Checkouts");
+    println!();
+
+    let checkouts = workspace_checkout::list_checkouts(workspace_root)?;
+    if checkouts.is_empty() {
+        println!("No checkouts configured.");
+        return Ok(());
+    }
+
+    for checkout in checkouts {
+        println!("{} -> {}", checkout.name, checkout.path.display());
+    }
+
+    Ok(())
+}
+
+/// Remove a cache-backed child checkout.
+pub fn run_checkout_remove(workspace_root: &Path, checkout_name: &str) -> anyhow::Result<()> {
+    Output::header(&format!("Removing checkout '{}'", checkout_name));
+    println!();
+
+    let removed = workspace_checkout::remove_checkout(workspace_root, checkout_name)?;
+    if removed {
+        Output::success(&format!("Removed checkout '{}'", checkout_name));
+        Ok(())
+    } else {
+        anyhow::bail!("Checkout '{}' not found", checkout_name);
+    }
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -120,6 +120,25 @@ pub async fn dispatch_command(
                     repo.as_deref(),
                     group.as_deref(),
                 )?;
+            } else if matches!(name.as_deref(), Some("list")) {
+                if create || base || !extra.is_empty() {
+                    anyhow::bail!("`gr checkout list` does not accept extra arguments");
+                }
+                crate::cli::commands::checkout::run_checkout_list(&ctx.workspace_root)?;
+            } else if matches!(name.as_deref(), Some("remove")) {
+                if create || base {
+                    anyhow::bail!("--create and --base are not valid with 'remove'");
+                }
+                if extra.len() > 1 {
+                    anyhow::bail!("unexpected extra arguments after checkout name");
+                }
+                let checkout_name = extra.first().ok_or_else(|| {
+                    anyhow::anyhow!("Checkout name is required: gr checkout remove <name>")
+                })?;
+                crate::cli::commands::checkout::run_checkout_remove(
+                    &ctx.workspace_root,
+                    checkout_name,
+                )?;
             } else {
                 let branch = if base {
                     let config = crate::core::griptree::GriptreeConfig::load_from_workspace(

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -861,6 +861,35 @@ fn test_checkout_list_shows_materialized_checkouts() {
 }
 
 #[test]
+fn test_checkout_list_reports_empty_state() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut list = Command::cargo_bin("gr").unwrap();
+    list.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No checkouts configured."));
+}
+
+#[test]
+fn test_checkout_list_rejects_extra_positional_args() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut list = Command::cargo_bin("gr").unwrap();
+    list.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("list")
+        .arg("extra")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`gr checkout list` does not accept extra arguments",
+        ));
+}
+
+#[test]
 fn test_checkout_remove_deletes_materialized_checkout() {
     let ws = WorkspaceBuilder::new().add_repo("app").build();
     let checkout_root = ws.workspace_root.join(".grip/checkouts/sandbox");
@@ -901,4 +930,22 @@ fn test_checkout_remove_errors_for_missing_checkout() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Checkout 'missing' not found"));
+}
+
+#[test]
+fn test_checkout_remove_rejects_extra_positional_args() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut remove = Command::cargo_bin("gr").unwrap();
+    remove
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("remove")
+        .arg("sandbox")
+        .arg("extra")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unexpected extra arguments after checkout name",
+        ));
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -553,15 +553,17 @@ fn test_checkout_help_mentions_add_mode() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Checkout a branch across repos or create an independent child checkout",
+            "Checkout a branch across repos or manage independent child checkouts",
         ))
         .stdout(predicate::str::contains(
-            "Branch name, or `add` to create an independent child checkout",
+            "Branch name, or `add`/`list`/`remove` for child checkout lifecycle",
         ))
         .stdout(predicate::str::contains("gr checkout add sandbox"))
         .stdout(predicate::str::contains(
             "gr checkout add docs-only --group docs",
-        ));
+        ))
+        .stdout(predicate::str::contains("gr checkout list"))
+        .stdout(predicate::str::contains("gr checkout remove sandbox"));
 }
 
 /// Test that `gr status` fails gracefully outside a workspace
@@ -834,4 +836,69 @@ fn test_checkout_add_rejects_duplicate_checkout_name() {
         .stderr(predicate::str::contains(
             "checkout 'sandbox' already exists",
         ));
+}
+
+#[test]
+fn test_checkout_list_shows_materialized_checkouts() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut add = Command::cargo_bin("gr").unwrap();
+    add.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr").unwrap();
+    list.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Checkouts"))
+        .stdout(predicate::str::contains("sandbox ->"));
+}
+
+#[test]
+fn test_checkout_remove_deletes_materialized_checkout() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let checkout_root = ws.workspace_root.join(".grip/checkouts/sandbox");
+
+    let mut add = Command::cargo_bin("gr").unwrap();
+    add.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .success();
+
+    assert!(checkout_root.is_dir());
+
+    let mut remove = Command::cargo_bin("gr").unwrap();
+    remove
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("remove")
+        .arg("sandbox")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed checkout 'sandbox'"));
+
+    assert!(!checkout_root.exists());
+}
+
+#[test]
+fn test_checkout_remove_errors_for_missing_checkout() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut remove = Command::cargo_bin("gr").unwrap();
+    remove
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("remove")
+        .arg("missing")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Checkout 'missing' not found"));
 }


### PR DESCRIPTION
## Summary
- add `gr checkout list` for cache-backed child checkouts
- add `gr checkout remove <name>` for child checkout cleanup
- extend checkout help text and CLI tests for the new lifecycle commands

## Testing
- cargo fmt --all
- cargo test --test cli_tests test_checkout_help_mentions_add_mode -- --nocapture
- cargo test --test cli_tests test_checkout_list_shows_materialized_checkouts -- --nocapture
- cargo test --test cli_tests test_checkout_remove_deletes_materialized_checkout -- --nocapture
- cargo test --test cli_tests test_checkout_remove_errors_for_missing_checkout -- --nocapture

Closes #488.
