### PR TITLE
feat: bootstrap gr2 binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ path = "src/main.rs"
 name = "gitgrip"
 path = "src/main.rs"
 
+[[bin]]
+name = "gr2"
+path = "src/bin/gr2.rs"
+
 [lib]
 name = "gitgrip"
 path = "src/lib.rs"

--- a/src/bin/gr2.rs
+++ b/src/bin/gr2.rs
@@ -1,0 +1,22 @@
+//! gr2 CLI entry point
+
+use clap::Parser;
+use gitgrip::gr2::args::Cli;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    if cli.verbose {
+        tracing_subscriber::fmt()
+            .with_env_filter("gitgrip=debug")
+            .with_target(false)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+    }
+
+    gitgrip::gr2::dispatch::dispatch_command(cli.command, cli.verbose).await
+}

--- a/src/gr2/args.rs
+++ b/src/gr2/args.rs
@@ -1,0 +1,24 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "gr2",
+    about = "Clean-break gitgrip CLI for clone-backed team workspaces",
+    long_about = "gr2 is the clean-break gitgrip CLI for the new team-workspace, cache, and checkout model.",
+    version,
+    arg_required_else_help = true
+)]
+pub struct Cli {
+    /// Enable verbose logging
+    #[arg(short, long)]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Verify the gr2 bootstrap binary is wired correctly
+    Doctor,
+}

--- a/src/gr2/dispatch.rs
+++ b/src/gr2/dispatch.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+
+use crate::gr2::args::Commands;
+
+pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
+    match command {
+        Commands::Doctor => {
+            if verbose {
+                println!("gr2 bootstrap OK (verbose)");
+            } else {
+                println!("gr2 bootstrap OK");
+            }
+            Ok(())
+        }
+    }
+}

--- a/src/gr2/mod.rs
+++ b/src/gr2/mod.rs
@@ -1,0 +1,8 @@
+//! gr2 CLI namespace
+//!
+//! This is the clean-break CLI surface for the new team-workspace model.
+
+pub mod args;
+pub mod dispatch;
+
+pub use args::Cli;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 pub mod core;
 pub mod files;
 pub mod git;
+pub mod gr2;
 pub mod ipc;
 pub mod mcp;
 pub mod platform;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -32,6 +32,37 @@ fn test_version() {
         .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
+#[test]
+fn test_gr2_help() {
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "gr2 is the clean-break gitgrip CLI for the new team-workspace, cache, and checkout model.",
+        ))
+        .stdout(predicate::str::contains("doctor"))
+        .stdout(predicate::str::contains("gr2"));
+}
+
+#[test]
+fn test_gr2_version() {
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn test_gr2_doctor() {
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("gr2 bootstrap OK"));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {


### PR DESCRIPTION
## Summary
- add `gr2` as a separate Cargo binary target
- scaffold a dedicated `gr2` CLI namespace and entrypoint
- lock the clean-break binary boundary with focused help/version/doctor tests

## Verification
- `cargo fmt --all --check`
- `cargo test --test cli_tests test_gr2_help -- --nocapture`
- `cargo test --test cli_tests test_gr2_version -- --nocapture`
- `cargo test --test cli_tests test_gr2_doctor -- --nocapture`

Closes #490.