### PR TITLE
feat: add gr2 init workspace bootstrap

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -19,6 +19,16 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Initialize a new team workspace root
+    Init {
+        /// Path to create the workspace in
+        path: String,
+
+        /// Optional logical workspace name
+        #[arg(long)]
+        name: Option<String>,
+    },
+
     /// Verify the gr2 bootstrap binary is wired correctly
     Doctor,
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -1,9 +1,45 @@
 use anyhow::Result;
+use std::fs;
+use std::path::PathBuf;
 
 use crate::args::Commands;
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
+        Commands::Init { path, name } => {
+            let workspace_root = PathBuf::from(path);
+            let workspace_name = name.unwrap_or_else(|| {
+                workspace_root
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "workspace".to_string())
+            });
+
+            if workspace_root.exists() {
+                anyhow::bail!(
+                    "workspace path already exists: {}",
+                    workspace_root.display()
+                );
+            }
+
+            fs::create_dir_all(workspace_root.join(".grip"))?;
+            fs::create_dir_all(workspace_root.join("config"))?;
+            fs::create_dir_all(workspace_root.join("agents"))?;
+            fs::create_dir_all(workspace_root.join("repos"))?;
+
+            let workspace_toml = format!(
+                "version = 2\nname = \"{}\"\nlayout = \"team-workspace\"\n",
+                workspace_name
+            );
+            fs::write(workspace_root.join(".grip/workspace.toml"), workspace_toml)?;
+
+            println!(
+                "Initialized gr2 team workspace '{}' at {}",
+                workspace_name,
+                workspace_root.display()
+            );
+            Ok(())
+        }
         Commands::Doctor => {
             if verbose {
                 println!("gr2 bootstrap OK (verbose)");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -63,6 +63,48 @@ fn test_gr2_doctor() {
         .stdout(predicate::str::contains("gr2 bootstrap OK"));
 }
 
+#[test]
+fn test_gr2_init_scaffolds_team_workspace() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Initialized gr2 team workspace 'demo'",
+        ));
+
+    assert!(workspace_root.join(".grip").is_dir());
+    assert!(workspace_root.join("config").is_dir());
+    assert!(workspace_root.join("agents").is_dir());
+    assert!(workspace_root.join("repos").is_dir());
+
+    let workspace_toml =
+        std::fs::read_to_string(workspace_root.join(".grip/workspace.toml")).unwrap();
+    assert!(workspace_toml.contains("version = 2"));
+    assert!(workspace_toml.contains("name = \"demo\""));
+    assert!(workspace_toml.contains("layout = \"team-workspace\""));
+}
+
+#[test]
+fn test_gr2_init_rejects_existing_path() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+    std::fs::create_dir_all(&workspace_root).unwrap();
+
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("init")
+        .arg(&workspace_root)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("workspace path already exists"));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {


### PR DESCRIPTION
## Summary
- add a native `gr2 init <path>` flow for team workspace bootstrap
- scaffold `.grip/`, `config/`, `agents/`, and `repos/`
- write a minimal `.grip/workspace.toml` for the new model

## Verification
- `cargo fmt --all --check`
- `cargo test --test cli_tests test_gr2_init_scaffolds_team_workspace -- --nocapture`
- `cargo test --test cli_tests test_gr2_init_rejects_existing_path -- --nocapture`
- `cargo test --test cli_tests test_gr2_doctor -- --nocapture`

Closes #494.