### PR TITLE
feat: add gr2 team add

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -31,4 +31,19 @@ pub enum Commands {
 
     /// Verify the gr2 bootstrap binary is wired correctly
     Doctor,
+
+    /// Team workspace operations
+    Team {
+        #[command(subcommand)]
+        command: TeamCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TeamCommands {
+    /// Register an agent workspace under agents/
+    Add {
+        /// Agent workspace name
+        name: String,
+    },
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::Commands;
+use crate::args::{Commands, TeamCommands};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -48,5 +48,28 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
             }
             Ok(())
         }
+        Commands::Team { command } => match command {
+            TeamCommands::Add { name } => {
+                let workspace_root = std::env::current_dir()?;
+                let workspace_toml = workspace_root.join(".grip/workspace.toml");
+                if !workspace_toml.exists() {
+                    anyhow::bail!("not in a gr2 workspace: missing .grip/workspace.toml");
+                }
+
+                let agent_root = workspace_root.join("agents").join(&name);
+                if agent_root.exists() {
+                    anyhow::bail!("agent '{}' already exists", name);
+                }
+
+                fs::create_dir_all(&agent_root)?;
+                fs::write(
+                    agent_root.join("agent.toml"),
+                    format!("name = \"{}\"\nkind = \"agent-workspace\"\n", name),
+                )?;
+
+                println!("Added gr2 agent workspace '{}'", name);
+                Ok(())
+            }
+        },
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -105,6 +105,82 @@ fn test_gr2_init_rejects_existing_path() {
         .stderr(predicate::str::contains("workspace path already exists"));
 }
 
+#[test]
+fn test_gr2_team_add_registers_agent_workspace() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut team_add = Command::cargo_bin("gr2").unwrap();
+    team_add
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Added gr2 agent workspace 'atlas'",
+        ));
+
+    let agent_toml =
+        std::fs::read_to_string(workspace_root.join("agents/atlas/agent.toml")).unwrap();
+    assert!(agent_toml.contains("name = \"atlas\""));
+    assert!(agent_toml.contains("kind = \"agent-workspace\""));
+}
+
+#[test]
+fn test_gr2_team_add_rejects_duplicate_agent() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut first = Command::cargo_bin("gr2").unwrap();
+    first
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr2").unwrap();
+    duplicate
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("agent 'atlas' already exists"));
+}
+
+#[test]
+fn test_gr2_team_add_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut team_add = Command::cargo_bin("gr2").unwrap();
+    team_add
+        .current_dir(temp.path())
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {


### PR DESCRIPTION
## Summary
- add `gr2 team add <name>` for explicit agent workspace registration
- create `agents/<name>/agent.toml` inside an initialized gr2 workspace
- fail cleanly outside a gr2 workspace and on duplicate names

## Verification
- `cargo fmt --all --check`
- `cargo test --test cli_tests test_gr2_team_add_registers_agent_workspace -- --nocapture`
- `cargo test --test cli_tests test_gr2_team_add_rejects_duplicate_agent -- --nocapture`
- `cargo test --test cli_tests test_gr2_team_add_requires_gr2_workspace -- --nocapture`

Closes #496.