### PR TITLE
feat: add gr2 team list

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -46,4 +46,7 @@ pub enum TeamCommands {
         /// Agent workspace name
         name: String,
     },
+
+    /// List registered agent workspaces
+    List,
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -50,11 +50,7 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
         }
         Commands::Team { command } => match command {
             TeamCommands::Add { name } => {
-                let workspace_root = std::env::current_dir()?;
-                let workspace_toml = workspace_root.join(".grip/workspace.toml");
-                if !workspace_toml.exists() {
-                    anyhow::bail!("not in a gr2 workspace: missing .grip/workspace.toml");
-                }
+                let workspace_root = require_workspace_root()?;
 
                 let agent_root = workspace_root.join("agents").join(&name);
                 if agent_root.exists() {
@@ -70,6 +66,40 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 println!("Added gr2 agent workspace '{}'", name);
                 Ok(())
             }
+            TeamCommands::List => {
+                let workspace_root = require_workspace_root()?;
+                let agents_root = workspace_root.join("agents");
+
+                let mut names = Vec::new();
+                for entry in fs::read_dir(&agents_root)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_dir() && entry.path().join("agent.toml").exists() {
+                        names.push(entry.file_name().to_string_lossy().into_owned());
+                    }
+                }
+
+                names.sort();
+
+                if names.is_empty() {
+                    println!("No gr2 agent workspaces registered.");
+                } else {
+                    println!("Agent workspaces");
+                    for name in names {
+                        println!("- {}", name);
+                    }
+                }
+
+                Ok(())
+            }
         },
     }
+}
+
+fn require_workspace_root() -> Result<PathBuf> {
+    let workspace_root = std::env::current_dir()?;
+    let workspace_toml = workspace_root.join(".grip/workspace.toml");
+    if !workspace_toml.exists() {
+        anyhow::bail!("not in a gr2 workspace: missing .grip/workspace.toml");
+    }
+    Ok(workspace_root)
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -181,6 +181,77 @@ fn test_gr2_team_add_requires_gr2_workspace() {
         ));
 }
 
+#[test]
+fn test_gr2_team_list_shows_registered_agents() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add_atlas = Command::cargo_bin("gr2").unwrap();
+    add_atlas
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut add_opus = Command::cargo_bin("gr2").unwrap();
+    add_opus
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("opus")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("team")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Agent workspaces"))
+        .stdout(predicate::str::contains("- atlas"))
+        .stdout(predicate::str::contains("- opus"));
+}
+
+#[test]
+fn test_gr2_team_list_reports_empty_state() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("team")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No gr2 agent workspaces registered.",
+        ));
+}
+
+#[test]
+fn test_gr2_team_list_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(temp.path())
+        .arg("team")
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {


### PR DESCRIPTION
## Summary
- add `gr2 team list` for registered agent workspaces
- surface agents from `agents/*/agent.toml`
- provide clear empty-state and workspace validation behavior

## Verification
- `cargo fmt --all --check`
- `cargo test --test cli_tests test_gr2_team_list_shows_registered_agents -- --nocapture`
- `cargo test --test cli_tests test_gr2_team_list_reports_empty_state -- --nocapture`
- `cargo test --test cli_tests test_gr2_team_list_requires_gr2_workspace -- --nocapture`

Closes #498.