### PR TITLE
feat: add gr2 repo add

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -37,6 +37,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: TeamCommands,
     },
+
+    /// Repo registry operations
+    Repo {
+        #[command(subcommand)]
+        command: RepoCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -54,5 +60,17 @@ pub enum TeamCommands {
     Remove {
         /// Agent workspace name
         name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RepoCommands {
+    /// Register a repo in the team workspace
+    Add {
+        /// Logical repo name
+        name: String,
+
+        /// Canonical remote URL
+        url: String,
     },
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, TeamCommands};
+use crate::args::{Commands, RepoCommands, TeamCommands};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -101,6 +101,37 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
 
                 fs::remove_dir_all(&agent_root)?;
                 println!("Removed gr2 agent workspace '{}'", name);
+                Ok(())
+            }
+        },
+        Commands::Repo { command } => match command {
+            RepoCommands::Add { name, url } => {
+                let workspace_root = require_workspace_root()?;
+                let repos_root = workspace_root.join("repos");
+                let registry_path = workspace_root.join(".grip/repos.toml");
+                let repo_dir = repos_root.join(&name);
+
+                if repo_dir.exists() {
+                    anyhow::bail!("repo '{}' already exists", name);
+                }
+
+                fs::create_dir_all(&repo_dir)?;
+                fs::write(
+                    repo_dir.join("repo.toml"),
+                    format!("name = \"{}\"\nurl = \"{}\"\n", name, url),
+                )?;
+
+                let mut entries = Vec::new();
+                if registry_path.exists() {
+                    entries.push(fs::read_to_string(&registry_path)?);
+                }
+                entries.push(format!(
+                    "[[repo]]\nname = \"{}\"\nurl = \"{}\"\n",
+                    name, url
+                ));
+                fs::write(&registry_path, entries.join("\n"))?;
+
+                println!("Added gr2 repo '{}' -> {}", name, url);
                 Ok(())
             }
         },

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -322,6 +322,84 @@ fn test_gr2_team_remove_requires_gr2_workspace() {
         ));
 }
 
+#[test]
+fn test_gr2_repo_add_registers_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Added gr2 repo 'app' -> https://github.com/synapt-dev/app.git",
+        ));
+
+    let repo_toml = std::fs::read_to_string(workspace_root.join("repos/app/repo.toml")).unwrap();
+    assert!(repo_toml.contains("name = \"app\""));
+    assert!(repo_toml.contains("url = \"https://github.com/synapt-dev/app.git\""));
+
+    let registry = std::fs::read_to_string(workspace_root.join(".grip/repos.toml")).unwrap();
+    assert!(registry.contains("[[repo]]"));
+    assert!(registry.contains("name = \"app\""));
+}
+
+#[test]
+fn test_gr2_repo_add_rejects_duplicate_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut first = Command::cargo_bin("gr2").unwrap();
+    first
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr2").unwrap();
+    duplicate
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("repo 'app' already exists"));
+}
+
+#[test]
+fn test_gr2_repo_add_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(temp.path())
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {


### PR DESCRIPTION
## Summary
- add `gr2 repo add <name> <url>` for explicit repo registration
- write repo metadata under `repos/<name>/repo.toml`
- maintain a minimal workspace repo registry at `.grip/repos.toml`

## Verification
- `cargo fmt --all --check`
- `cargo test --test cli_tests test_gr2_repo_add_registers_repo -- --nocapture`
- `cargo test --test cli_tests test_gr2_repo_add_rejects_duplicate_repo -- --nocapture`
- `cargo test --test cli_tests test_gr2_repo_add_requires_gr2_workspace -- --nocapture`

Closes #502.