### PR TITLE
feat: advance sprint-13 with gr2 repo lifecycle

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -76,4 +76,10 @@ pub enum RepoCommands {
 
     /// List registered repos
     List,
+
+    /// Remove a registered repo
+    Remove {
+        /// Logical repo name
+        name: String,
+    },
 }

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -73,4 +73,7 @@ pub enum RepoCommands {
         /// Canonical remote URL
         url: String,
     },
+
+    /// List registered repos
+    List,
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -134,6 +134,46 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 println!("Added gr2 repo '{}' -> {}", name, url);
                 Ok(())
             }
+            RepoCommands::List => {
+                let workspace_root = require_workspace_root()?;
+                let repos_root = workspace_root.join("repos");
+
+                let mut repos = Vec::new();
+                for entry in fs::read_dir(&repos_root)? {
+                    let entry = entry?;
+                    let repo_toml = entry.path().join("repo.toml");
+                    if entry.file_type()?.is_dir() && repo_toml.exists() {
+                        let content = fs::read_to_string(repo_toml)?;
+                        let fallback_name = entry.file_name().to_string_lossy().into_owned();
+                        let name = content
+                            .lines()
+                            .find_map(|line| line.strip_prefix("name = \""))
+                            .and_then(|line| line.strip_suffix('"'))
+                            .map(str::to_owned)
+                            .unwrap_or(fallback_name);
+                        let url = content
+                            .lines()
+                            .find_map(|line| line.strip_prefix("url = \""))
+                            .and_then(|line| line.strip_suffix('"'))
+                            .unwrap_or("")
+                            .to_string();
+                        repos.push((name, url));
+                    }
+                }
+
+                repos.sort_by(|a, b| a.0.cmp(&b.0));
+
+                if repos.is_empty() {
+                    println!("No gr2 repos registered.");
+                } else {
+                    println!("Repos");
+                    for (name, url) in repos {
+                        println!("- {} -> {}", name, url);
+                    }
+                }
+
+                Ok(())
+            }
         },
     }
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -174,6 +174,57 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
 
                 Ok(())
             }
+            RepoCommands::Remove { name } => {
+                let workspace_root = require_workspace_root()?;
+                let repos_root = workspace_root.join("repos");
+                let repo_root = repos_root.join(&name);
+                let repo_toml = repo_root.join("repo.toml");
+
+                if !repo_toml.exists() {
+                    anyhow::bail!("repo '{}' not found", name);
+                }
+
+                fs::remove_dir_all(&repo_root)?;
+
+                let registry_path = workspace_root.join(".grip/repos.toml");
+                if registry_path.exists() {
+                    let registry = fs::read_to_string(&registry_path)?;
+                    let kept_entries = registry
+                        .split("\n[[repo]]\n")
+                        .filter_map(|chunk| {
+                            let chunk = chunk.trim();
+                            if chunk.is_empty() {
+                                return None;
+                            }
+                            let normalized = if chunk.starts_with("[[repo]]") {
+                                chunk.to_string()
+                            } else {
+                                format!("[[repo]]\n{}", chunk)
+                            };
+                            let matches_name = normalized
+                                .lines()
+                                .find_map(|line| line.strip_prefix("name = \""))
+                                .and_then(|line| line.strip_suffix('"'))
+                                .map(|entry_name| entry_name == name)
+                                .unwrap_or(false);
+                            if matches_name {
+                                None
+                            } else {
+                                Some(normalized)
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    if kept_entries.is_empty() {
+                        fs::remove_file(&registry_path)?;
+                    } else {
+                        fs::write(&registry_path, kept_entries.join("\n\n"))?;
+                    }
+                }
+
+                println!("Removed gr2 repo '{}'", name);
+                Ok(())
+            }
         },
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -400,6 +400,81 @@ fn test_gr2_repo_add_requires_gr2_workspace() {
         ));
 }
 
+#[test]
+fn test_gr2_repo_list_shows_registered_repos() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add_app = Command::cargo_bin("gr2").unwrap();
+    add_app
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut add_docs = Command::cargo_bin("gr2").unwrap();
+    add_docs
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("docs")
+        .arg("https://github.com/synapt-dev/docs.git")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("repo")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Repos"))
+        .stdout(predicate::str::contains(
+            "- app -> https://github.com/synapt-dev/app.git",
+        ))
+        .stdout(predicate::str::contains(
+            "- docs -> https://github.com/synapt-dev/docs.git",
+        ));
+}
+
+#[test]
+fn test_gr2_repo_list_reports_empty_state() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("repo")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No gr2 repos registered."));
+}
+
+#[test]
+fn test_gr2_repo_list_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(temp.path())
+        .arg("repo")
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -475,6 +475,76 @@ fn test_gr2_repo_list_requires_gr2_workspace() {
         ));
 }
 
+#[test]
+fn test_gr2_repo_remove_deletes_registered_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let repo_root = workspace_root.join("repos/app");
+    assert!(repo_root.join("repo.toml").exists());
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("remove")
+        .arg("app")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed gr2 repo 'app'"));
+
+    assert!(!repo_root.exists());
+    assert!(!workspace_root.join(".grip/repos.toml").exists());
+}
+
+#[test]
+fn test_gr2_repo_remove_rejects_missing_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("remove")
+        .arg("app")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("repo 'app' not found"));
+}
+
+#[test]
+fn test_gr2_repo_remove_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(temp.path())
+        .arg("repo")
+        .arg("remove")
+        .arg("app")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {


### PR DESCRIPTION
## Summary
- advance `sprint-13` from `gr2 repo add` through the current repo lifecycle frontier
- pull in `gr2 repo list` and `gr2 repo remove` on top of the already-landed `gr2` workspace/team stack
- keep sprint integration moving through PRs now that direct pushes to `sprint-13` are protected

## Includes
- `grip#505` `feat: add gr2 repo list`
- `grip#507` `feat: add gr2 repo remove`

## Verification
- `cargo fmt --all --check`
- `cargo test --test cli_tests test_gr2_repo_list_shows_registered_repos -- --nocapture`
- `cargo test --test cli_tests test_gr2_repo_list_reports_empty_state -- --nocapture`
- `cargo test --test cli_tests test_gr2_repo_list_requires_gr2_workspace -- --nocapture`
- `cargo test --test cli_tests test_gr2_repo_remove_deletes_registered_repo -- --nocapture`
- `cargo test --test cli_tests test_gr2_repo_remove_rejects_missing_repo -- --nocapture`
- `cargo test --test cli_tests test_gr2_repo_remove_requires_gr2_workspace -- --nocapture