### PR TITLE
feat: add gr2 unit registry commands

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -43,6 +43,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: RepoCommands,
     },
+
+    /// Unit registry operations
+    Unit {
+        #[command(subcommand)]
+        command: UnitCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -80,6 +86,24 @@ pub enum RepoCommands {
     /// Remove a registered repo
     Remove {
         /// Logical repo name
+        name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum UnitCommands {
+    /// Register a local unit in the workspace materialization model
+    Add {
+        /// Unit name
+        name: String,
+    },
+
+    /// List registered units
+    List,
+
+    /// Remove a registered unit
+    Remove {
+        /// Unit name
         name: String,
     },
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -229,6 +229,7 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
         Commands::Unit { command } => match command {
             UnitCommands::Add { name } => {
                 let workspace_root = require_workspace_root()?;
+                validate_unit_name(&name)?;
                 let units_root = workspace_root.join("agents");
                 let registry_path = workspace_root.join(".grip/units.toml");
                 let unit_root = units_root.join(&name);
@@ -340,4 +341,22 @@ fn require_workspace_root() -> Result<PathBuf> {
         anyhow::bail!("not in a gr2 workspace: missing .grip/workspace.toml");
     }
     Ok(workspace_root)
+}
+
+fn validate_unit_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("unit name must not be empty");
+    }
+
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+    {
+        anyhow::bail!(
+            "invalid unit name '{}': use only ASCII letters, numbers, '_' or '-'",
+            name
+        );
+    }
+
+    Ok(())
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, RepoCommands, TeamCommands};
+use crate::args::{Commands, RepoCommands, TeamCommands, UnitCommands};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -223,6 +223,110 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 }
 
                 println!("Removed gr2 repo '{}'", name);
+                Ok(())
+            }
+        },
+        Commands::Unit { command } => match command {
+            UnitCommands::Add { name } => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+                let registry_path = workspace_root.join(".grip/units.toml");
+                let unit_root = units_root.join(&name);
+
+                if unit_root.exists() {
+                    anyhow::bail!("unit '{}' already exists", name);
+                }
+
+                fs::create_dir_all(&unit_root)?;
+                fs::write(
+                    unit_root.join("unit.toml"),
+                    format!("name = \"{}\"\nkind = \"unit\"\n", name),
+                )?;
+
+                let mut entries = Vec::new();
+                if registry_path.exists() {
+                    entries.push(fs::read_to_string(&registry_path)?);
+                }
+                entries.push(format!("[[unit]]\nname = \"{}\"\nkind = \"unit\"\n", name));
+                fs::write(&registry_path, entries.join("\n"))?;
+
+                println!("Added gr2 unit '{}'", name);
+                Ok(())
+            }
+            UnitCommands::List => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+
+                let mut names = Vec::new();
+                for entry in fs::read_dir(&units_root)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_dir() && entry.path().join("unit.toml").exists() {
+                        names.push(entry.file_name().to_string_lossy().into_owned());
+                    }
+                }
+
+                names.sort();
+
+                if names.is_empty() {
+                    println!("No gr2 units registered.");
+                } else {
+                    println!("Units");
+                    for name in names {
+                        println!("- {}", name);
+                    }
+                }
+
+                Ok(())
+            }
+            UnitCommands::Remove { name } => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+                let unit_root = units_root.join(&name);
+                let unit_toml = unit_root.join("unit.toml");
+
+                if !unit_toml.exists() {
+                    anyhow::bail!("unit '{}' not found", name);
+                }
+
+                fs::remove_dir_all(&unit_root)?;
+
+                let registry_path = workspace_root.join(".grip/units.toml");
+                if registry_path.exists() {
+                    let registry = fs::read_to_string(&registry_path)?;
+                    let kept_entries = registry
+                        .split("\n[[unit]]\n")
+                        .filter_map(|chunk| {
+                            let chunk = chunk.trim();
+                            if chunk.is_empty() {
+                                return None;
+                            }
+                            let normalized = if chunk.starts_with("[[unit]]") {
+                                chunk.to_string()
+                            } else {
+                                format!("[[unit]]\n{}", chunk)
+                            };
+                            let matches_name = normalized
+                                .lines()
+                                .find_map(|line| line.strip_prefix("name = \""))
+                                .and_then(|line| line.strip_suffix('"'))
+                                .map(|entry_name| entry_name == name)
+                                .unwrap_or(false);
+                            if matches_name {
+                                None
+                            } else {
+                                Some(normalized)
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    if kept_entries.is_empty() {
+                        fs::remove_file(&registry_path)?;
+                    } else {
+                        fs::write(&registry_path, kept_entries.join("\n\n"))?;
+                    }
+                }
+
+                println!("Removed gr2 unit '{}'", name);
                 Ok(())
             }
         },

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -546,6 +546,164 @@ fn test_gr2_repo_remove_requires_gr2_workspace() {
 }
 
 #[test]
+fn test_gr2_unit_add_registers_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Added gr2 unit 'atlas'"));
+
+    let unit_toml = std::fs::read_to_string(workspace_root.join("agents/atlas/unit.toml")).unwrap();
+    assert!(unit_toml.contains("name = \"atlas\""));
+    assert!(unit_toml.contains("kind = \"unit\""));
+
+    let registry = std::fs::read_to_string(workspace_root.join(".grip/units.toml")).unwrap();
+    assert!(registry.contains("[[unit]]"));
+    assert!(registry.contains("name = \"atlas\""));
+}
+
+#[test]
+fn test_gr2_unit_add_rejects_duplicate_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut first = Command::cargo_bin("gr2").unwrap();
+    first
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr2").unwrap();
+    duplicate
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unit 'atlas' already exists"));
+}
+
+#[test]
+fn test_gr2_unit_list_shows_registered_units() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add_atlas = Command::cargo_bin("gr2").unwrap();
+    add_atlas
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut add_opus = Command::cargo_bin("gr2").unwrap();
+    add_opus
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("opus")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Units"))
+        .stdout(predicate::str::contains("- atlas"))
+        .stdout(predicate::str::contains("- opus"));
+}
+
+#[test]
+fn test_gr2_unit_list_reports_empty_state() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No gr2 units registered."));
+}
+
+#[test]
+fn test_gr2_unit_remove_deletes_registered_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let unit_root = workspace_root.join("agents/atlas");
+    assert!(unit_root.join("unit.toml").exists());
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("remove")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed gr2 unit 'atlas'"));
+
+    assert!(!unit_root.exists());
+    assert!(!workspace_root.join(".grip/units.toml").exists());
+}
+
+#[test]
+fn test_gr2_unit_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(temp.path())
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -601,6 +601,27 @@ fn test_gr2_unit_add_rejects_duplicate_unit() {
 }
 
 #[test]
+fn test_gr2_unit_add_rejects_invalid_name() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut invalid = Command::cargo_bin("gr2").unwrap();
+    invalid
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas/dev")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "invalid unit name 'atlas/dev': use only ASCII letters, numbers, '_' or '-'",
+        ));
+}
+
+#[test]
 fn test_gr2_unit_list_shows_registered_units() {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().join("demo-team");


### PR DESCRIPTION
## Summary
- add  as the next object-model slice in the clean-break CLI
- persist registered units in 
- write per-unit metadata to 
- keep the implementation narrow so  exists before we build 

## Why
The Sprint 13  road stopped at , , and . The design expects  to regain its own materialization model via units plus a plan/apply engine. This PR restores the missing  seam so the next architectural step can be  and  instead of more unrelated 
                *    *
           *    |    |
           |    |    |
      *    |    |    |
      |    \    \    \
       \    \    \    \       *
        *    *    *    *       \
         \    \    \    \      *
          \    \    \    \    /
           *----*----*----*--*
            \        |      /
             \       |     /
              *------*----*

        __ _ _ _              _
       / _` (_) |_ __ _ _ _ _(_)_ __
      | (_| | |  _/ _` | '_| | '_ \
       \__, |_|\__\__, |_| |_| .__/
       |___/      |___/      |_|
              git a grip.

  Run 'gr --help' for usage work.

## Testing
- 
running 6 tests
......
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 45 filtered out; finished in 1.18s