### PR TITLE
feat: add gr2 workspace spec commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/gr2/Cargo.toml
+++ b/gr2/Cargo.toml
@@ -11,3 +11,5 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -49,6 +49,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: UnitCommands,
     },
+
+    /// Declarative workspace spec operations
+    Spec {
+        #[command(subcommand)]
+        command: SpecCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -106,4 +112,13 @@ pub enum UnitCommands {
         /// Unit name
         name: String,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SpecCommands {
+    /// Print the current workspace spec
+    Show,
+
+    /// Validate the current workspace spec against the filesystem
+    Validate,
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, RepoCommands, TeamCommands, UnitCommands};
+use crate::args::{Commands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
+use crate::spec::{
+    read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec,
+};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -328,6 +331,32 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 }
 
                 println!("Removed gr2 unit '{}'", name);
+                Ok(())
+            }
+        },
+        Commands::Spec { command } => match command {
+            SpecCommands::Show => {
+                let workspace_root = require_workspace_root()?;
+                let spec_path = workspace_spec_path(&workspace_root);
+                let spec = if spec_path.exists() {
+                    read_workspace_spec(&workspace_root)?
+                } else {
+                    let spec = WorkspaceSpec::from_workspace(&workspace_root)?;
+                    write_workspace_spec(&workspace_root, &spec)?;
+                    spec
+                };
+
+                println!("{}", toml::to_string_pretty(&spec)?);
+                Ok(())
+            }
+            SpecCommands::Validate => {
+                let workspace_root = require_workspace_root()?;
+                let spec = read_workspace_spec(&workspace_root)?;
+                spec.validate(&workspace_root)?;
+                println!(
+                    "Workspace spec is valid: {}",
+                    workspace_spec_path(&workspace_root).display()
+                );
                 Ok(())
             }
         },

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -4,3 +4,4 @@
 
 pub mod args;
 pub mod dispatch;
+pub mod spec;

--- a/gr2/src/spec.rs
+++ b/gr2/src/spec.rs
@@ -1,0 +1,223 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const WORKSPACE_SPEC_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceSpec {
+    pub schema_version: u32,
+    pub workspace_name: String,
+    pub cache: CacheSpec,
+    #[serde(default)]
+    pub repos: Vec<RepoSpec>,
+    #[serde(default)]
+    pub units: Vec<UnitSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CacheSpec {
+    pub root: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoSpec {
+    pub name: String,
+    pub path: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UnitSpec {
+    pub name: String,
+    pub path: String,
+    #[serde(default)]
+    pub repos: Vec<String>,
+}
+
+impl WorkspaceSpec {
+    pub fn from_workspace(workspace_root: &Path) -> Result<Self> {
+        let workspace_name = read_workspace_name(workspace_root)?;
+        let repos = read_registered_repos(workspace_root)?;
+        let units = read_registered_units(workspace_root)?;
+
+        Ok(Self {
+            schema_version: WORKSPACE_SPEC_VERSION,
+            workspace_name,
+            cache: CacheSpec {
+                root: ".grip/cache".to_string(),
+            },
+            repos,
+            units,
+        })
+    }
+
+    pub fn validate(&self, workspace_root: &Path) -> Result<()> {
+        if self.schema_version != WORKSPACE_SPEC_VERSION {
+            anyhow::bail!(
+                "unsupported workspace spec schema_version {}: expected {}",
+                self.schema_version,
+                WORKSPACE_SPEC_VERSION
+            );
+        }
+
+        if self.workspace_name.trim().is_empty() {
+            anyhow::bail!("workspace spec workspace_name must not be empty");
+        }
+
+        let mut repo_names = HashSet::new();
+        for repo in &self.repos {
+            if !repo_names.insert(repo.name.clone()) {
+                anyhow::bail!("workspace spec contains duplicate repo '{}'", repo.name);
+            }
+
+            if repo.path.trim().is_empty() || repo.url.trim().is_empty() {
+                anyhow::bail!("repo '{}' must include non-empty path and url", repo.name);
+            }
+
+            let repo_root = workspace_root.join(&repo.path);
+            if !repo_root.join("repo.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec repo '{}' is missing repo metadata at {}",
+                    repo.name,
+                    repo_root.join("repo.toml").display()
+                );
+            }
+        }
+
+        let mut unit_names = HashSet::new();
+        for unit in &self.units {
+            if !unit_names.insert(unit.name.clone()) {
+                anyhow::bail!("workspace spec contains duplicate unit '{}'", unit.name);
+            }
+
+            if unit.path.trim().is_empty() {
+                anyhow::bail!("unit '{}' must include a non-empty path", unit.name);
+            }
+
+            let unit_root = workspace_root.join(&unit.path);
+            if !unit_root.join("unit.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec unit '{}' is missing unit metadata at {}",
+                    unit.name,
+                    unit_root.join("unit.toml").display()
+                );
+            }
+
+            for repo_name in &unit.repos {
+                if !repo_names.contains(repo_name) {
+                    anyhow::bail!(
+                        "unit '{}' references missing repo '{}'",
+                        unit.name,
+                        repo_name
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn write_workspace_spec(workspace_root: &Path, spec: &WorkspaceSpec) -> Result<PathBuf> {
+    let spec_path = workspace_spec_path(workspace_root);
+    let content = toml::to_string_pretty(spec).context("serialize workspace spec")?;
+    fs::write(&spec_path, content).with_context(|| {
+        format!("write workspace spec to {}", spec_path.display())
+    })?;
+    Ok(spec_path)
+}
+
+pub fn read_workspace_spec(workspace_root: &Path) -> Result<WorkspaceSpec> {
+    let spec_path = workspace_spec_path(workspace_root);
+    let content = fs::read_to_string(&spec_path)
+        .with_context(|| format!("read workspace spec from {}", spec_path.display()))?;
+    toml::from_str(&content).context("parse workspace spec")
+}
+
+pub fn workspace_spec_path(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".grip/workspace_spec.toml")
+}
+
+fn read_workspace_name(workspace_root: &Path) -> Result<String> {
+    let workspace_toml = fs::read_to_string(workspace_root.join(".grip/workspace.toml"))
+        .context("read .grip/workspace.toml")?;
+    workspace_toml
+        .lines()
+        .find_map(|line| line.strip_prefix("name = \""))
+        .and_then(|line| line.strip_suffix('"'))
+        .map(str::to_owned)
+        .context("workspace name missing from .grip/workspace.toml")
+}
+
+fn read_registered_repos(workspace_root: &Path) -> Result<Vec<RepoSpec>> {
+    let repos_root = workspace_root.join("repos");
+    let mut repos = Vec::new();
+
+    for entry in fs::read_dir(&repos_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let repo_root = entry.path();
+        let repo_toml = repo_root.join("repo.toml");
+        if !repo_toml.exists() {
+            continue;
+        }
+
+        let content = fs::read_to_string(&repo_toml)?;
+        let fallback_name = entry.file_name().to_string_lossy().into_owned();
+        let name = content
+            .lines()
+            .find_map(|line| line.strip_prefix("name = \""))
+            .and_then(|line| line.strip_suffix('"'))
+            .map(str::to_owned)
+            .unwrap_or(fallback_name.clone());
+        let url = content
+            .lines()
+            .find_map(|line| line.strip_prefix("url = \""))
+            .and_then(|line| line.strip_suffix('"'))
+            .unwrap_or("")
+            .to_string();
+
+        repos.push(RepoSpec {
+            name,
+            path: format!("repos/{}", fallback_name),
+            url,
+        });
+    }
+
+    repos.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(repos)
+}
+
+fn read_registered_units(workspace_root: &Path) -> Result<Vec<UnitSpec>> {
+    let units_root = workspace_root.join("agents");
+    let mut units = Vec::new();
+
+    for entry in fs::read_dir(&units_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let unit_root = entry.path();
+        let unit_toml = unit_root.join("unit.toml");
+        if !unit_toml.exists() {
+            continue;
+        }
+
+        let fallback_name = entry.file_name().to_string_lossy().into_owned();
+        units.push(UnitSpec {
+            name: fallback_name.clone(),
+            path: format!("agents/{}", fallback_name),
+            repos: Vec::new(),
+        });
+    }
+
+    units.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(units)
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -725,6 +725,148 @@ fn test_gr2_unit_requires_gr2_workspace() {
 }
 
 #[test]
+fn test_gr2_spec_show_round_trips_workspace_spec() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("schema_version = 1"))
+        .stdout(predicate::str::contains("workspace_name = \"demo\""))
+        .stdout(predicate::str::contains("name = \"app\""))
+        .stdout(predicate::str::contains("name = \"atlas\""));
+
+    let spec = std::fs::read_to_string(workspace_root.join(".grip/workspace_spec.toml")).unwrap();
+    assert!(spec.contains("schema_version = 1"));
+    assert!(spec.contains("workspace_name = \"demo\""));
+    assert!(spec.contains("path = \"repos/app\""));
+    assert!(spec.contains("path = \"agents/atlas\""));
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Workspace spec is valid"));
+}
+
+#[test]
+fn test_gr2_spec_validate_detects_missing_repo_metadata() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    std::fs::remove_file(workspace_root.join("repos/app/repo.toml")).unwrap();
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "workspace spec repo 'app' is missing repo metadata",
+        ));
+}
+
+#[test]
+fn test_gr2_spec_validate_detects_conflicting_unit_names() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    let spec_path = workspace_root.join(".grip/workspace_spec.toml");
+    let spec = std::fs::read_to_string(&spec_path).unwrap();
+    let conflicting = format!(
+        "{}\n[[units]]\nname = \"atlas\"\npath = \"agents/atlas-copy\"\nrepos = []\n",
+        spec.trim_end()
+    );
+    std::fs::write(&spec_path, conflicting).unwrap();
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "workspace spec contains duplicate unit 'atlas'",
+        ));
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")


### PR DESCRIPTION
## Summary
- add a versioned `WorkspaceSpec` seam for the clean-break `gr2` model
- persist the generated spec at `.grip/workspace_spec.toml`
- add `gr2 spec show` and `gr2 spec validate` as the first contract-facing commands

## Scope
This is the first `#515` slice, not the full plan/apply engine. It makes the desired workspace state explicit and testable so `gr2 plan` can consume it next.

## Included
- `gr2/src/spec.rs` with versioned spec structs and validation
- `gr2 spec show` to generate/print the current spec
- `gr2 spec validate` to check the spec against the filesystem
- CLI tests for round-trip generation, missing repo detection, and conflicting unit names

## Verification
- `cargo test --test cli_tests test_gr2_spec --quiet`

Closes #515.