### PR TITLE
feat: add gr2 execution planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --all-features
+
+  test-windows:
+    name: Test (windows-latest)
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -83,10 +98,7 @@ jobs:
       - name: Run tests
         run: cargo test --all-features
         env:
-          # Windows: link advapi32 for libgit2-sys (needed for test crates that
-          # don't go through build.rs) and increase stack to 8 MB (debug builds
-          # overflow the default 1 MB Windows stack during clap parsing)
-          RUSTFLAGS: ${{ matrix.os == 'windows-latest' && '-C link-arg=advapi32.lib -C link-arg=/STACK:8388608' || '' }}
+          RUSTFLAGS: '-C link-arg=advapi32.lib -C link-arg=/STACK:8388608'
 
   build:
     name: Build Release
@@ -149,14 +161,16 @@ jobs:
       - name: Run spawn integration tests
         run: GR=./target/debug/gr ./tests/spawn_graceful_shutdown.sh
 
-  # Summary job for branch protection - requires all other jobs to pass
+  # Summary job for branch protection - requires all jobs except Windows to pass.
+  # Windows tests run separately (test-windows) and are visible but non-blocking,
+  # since they are significantly slower and should not gate PR merges.
   ci:
     name: CI
     runs-on: ubuntu-latest
     needs: [check, fmt, clippy, test, build, bench, integration]
     if: always()
     steps:
-      - name: Check all jobs passed
+      - name: Check all required jobs passed
         run: |
           if [[ "${{ needs.check.result }}" != "success" ]] || \
              [[ "${{ needs.fmt.result }}" != "success" ]] || \
@@ -165,7 +179,7 @@ jobs:
              [[ "${{ needs.build.result }}" != "success" ]] || \
              [[ "${{ needs.bench.result }}" != "success" ]] || \
              [[ "${{ needs.integration.result }}" != "success" ]]; then
-            echo "One or more jobs failed"
+            echo "One or more required jobs failed"
             exit 1
           fi
-          echo "All jobs passed"
+          echo "All required jobs passed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "futures",
  "git2",
  "gix",
+ "gr2-cli",
  "indicatif",
  "octocrab",
  "once_cell",
@@ -1584,6 +1585,14 @@ dependencies = [
  "gix-object",
  "gix-path",
  "gix-validate 0.9.4",
+]
+
+[[package]]
+name = "gr2-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 keywords = ["git", "monorepo", "workflow", "multi-repo", "cli"]
 categories = ["development-tools", "command-line-utilities"]
 
+[workspace]
+members = ["gr2"]
+
 [[bin]]
 name = "gr"
 path = "src/main.rs"
@@ -20,6 +23,10 @@ path = "src/main.rs"
 [[bin]]
 name = "gitgrip"
 path = "src/main.rs"
+
+[[bin]]
+name = "gr2"
+path = "src/bin/gr2.rs"
 
 [lib]
 name = "gitgrip"
@@ -40,6 +47,7 @@ release-logs = ["tracing/release_max_level_info"]
 max-perf = ["tracing/max_level_off"]
 
 [dependencies]
+gr2_cli = { package = "gr2-cli", path = "gr2" }
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "time", "net", "io-util", "sync"] }
 uuid = { version = "1", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -291,6 +291,32 @@ gr checkout add docs-only --group docs
 gr checkout add app-only --repo app
 ```
 
+#### `gr checkout list`
+
+Show the currently materialized child checkouts under
+`.grip/checkouts/`.
+
+**Examples:**
+
+```bash
+# List all materialized child checkouts
+gr checkout list
+```
+
+#### `gr checkout remove <name>`
+
+Remove a materialized child checkout under `.grip/checkouts/<name>/`.
+
+This deletes the child clone only. It does not delete the shared cache under
+`~/.grip/cache/`.
+
+**Examples:**
+
+```bash
+# Remove a disposable child checkout
+gr checkout remove sandbox
+```
+
 #### `gr branch [name]`
 
 Create a new branch across all repositories, or list existing branches. Manifest repo is always included.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ gr sync
 | `gr branch [name]` | Create or list branches |
 | `gr checkout <branch>` | Checkout branch across repos |
 | `gr checkout -b <branch>` | Create and checkout branch in one command |
+| `gr checkout add <name>` | Create an independent child checkout from cached repos |
 | `gr add [files]` | Stage changes across repos |
 | `gr diff` | Show diff across repos |
 | `gr commit -m "msg"` | Commit across repos |
@@ -262,6 +263,33 @@ Checkout a branch across all repos. Can also create branches with the `-b` flag.
 |--------|-------------|
 | `-b` | Create branch if it doesn't exist |
 | `--base` | Checkout the griptree base branch (griptree workspaces only) |
+
+#### `gr checkout add <name>`
+
+Create an independent child checkout under `.grip/checkouts/<name>/` using the
+workspace cache as an accelerator.
+
+Unlike `gr tree add`, this creates normal child clones with their own `.git`
+directories. The checkout keeps the canonical remote URL as `origin`; the cache
+is only used to speed up materialization.
+
+| Option | Description |
+|--------|-------------|
+| `--repo <name>` | Only materialize specific repos |
+| `--group <name>` | Only materialize repos in a group |
+
+**Examples:**
+
+```bash
+# Materialize all repos into an independent child checkout
+gr checkout add sandbox
+
+# Materialize only the docs group
+gr checkout add docs-only --group docs
+
+# Materialize just one repo
+gr checkout add app-only --repo app
+```
 
 #### `gr branch [name]`
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ gr sync
 | `gr link` | Manage file links |
 | `gr run <script>` | Run workspace scripts |
 | `gr env` | Show environment variables |
+| `gr cache status` | Show machine-level cache state for workspace repos |
+| `gr cache bootstrap` | Materialize missing machine-level repo caches |
+| `gr cache update` | Fetch updates into existing machine-level repo caches |
 | `gr bench` | Run performance benchmarks |
 | `gr completions <shell>` | Generate shell completions |
 
@@ -222,6 +225,34 @@ Pull latest changes from the manifest and all repositories. Syncs in parallel by
 #### `gr status`
 
 Show status of all repositories including branch, changes, and sync state.
+
+#### `gr cache <subcommand>`
+
+Manage the machine-level bare-repo cache used by workspace repos.
+
+By default caches live under `~/.grip/cache/`, keyed by canonical repo identity.
+You can override the cache root with `GRIP_CACHE_DIR` when you need a custom or
+isolated cache location.
+
+| Subcommand | Description |
+|-----------|-------------|
+| `gr cache status` | Show whether each workspace repo has a cache and where it lives |
+| `gr cache bootstrap` | Create missing caches without touching existing ones |
+| `gr cache update` | Fetch updates into existing caches |
+| `gr cache remove <repo>` | Remove one repo cache explicitly |
+
+**Examples:**
+
+```bash
+# See where caches are currently resolved
+gr cache status
+
+# Create missing caches before materializing child checkouts
+gr cache bootstrap
+
+# Use a custom cache root for an isolated environment
+GRIP_CACHE_DIR=/tmp/grip-cache gr cache status
+```
 
 #### `gr checkout <branch>`
 

--- a/gr2/Cargo.toml
+++ b/gr2/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gr2-cli"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "gr2_cli"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }

--- a/gr2/Cargo.toml
+++ b/gr2/Cargo.toml
@@ -11,3 +11,5 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -55,6 +55,13 @@ pub enum Commands {
         #[command(subcommand)]
         command: SpecCommands,
     },
+
+    /// Diff the workspace spec into an execution plan
+    Plan {
+        /// Pre-approve plans with more than 3 operations
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -49,6 +49,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: UnitCommands,
     },
+
+    /// Declarative workspace spec operations
+    Spec {
+        #[command(subcommand)]
+        command: SpecCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -106,4 +112,13 @@ pub enum UnitCommands {
         /// Unit name
         name: String,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SpecCommands {
+    /// Print the current workspace spec
+    Show,
+
+    /// Validate the current workspace spec against the filesystem
+    Validate,
 }

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -43,6 +43,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: RepoCommands,
     },
+
+    /// Unit registry operations
+    Unit {
+        #[command(subcommand)]
+        command: UnitCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -80,6 +86,24 @@ pub enum RepoCommands {
     /// Remove a registered repo
     Remove {
         /// Logical repo name
+        name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum UnitCommands {
+    /// Register a local unit in the workspace materialization model
+    Add {
+        /// Unit name
+        name: String,
+    },
+
+    /// List registered units
+    List,
+
+    /// Remove a registered unit
+    Remove {
+        /// Unit name
         name: String,
     },
 }

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -1,0 +1,85 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "gr2",
+    about = "Clean-break gitgrip CLI for clone-backed team workspaces",
+    long_about = "gr2 is the clean-break gitgrip CLI for the new team-workspace, cache, and checkout model.",
+    version,
+    arg_required_else_help = true
+)]
+pub struct Cli {
+    /// Enable verbose logging
+    #[arg(short, long)]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Initialize a new team workspace root
+    Init {
+        /// Path to create the workspace in
+        path: String,
+
+        /// Optional logical workspace name
+        #[arg(long)]
+        name: Option<String>,
+    },
+
+    /// Verify the gr2 bootstrap binary is wired correctly
+    Doctor,
+
+    /// Team workspace operations
+    Team {
+        #[command(subcommand)]
+        command: TeamCommands,
+    },
+
+    /// Repo registry operations
+    Repo {
+        #[command(subcommand)]
+        command: RepoCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TeamCommands {
+    /// Register an agent workspace under agents/
+    Add {
+        /// Agent workspace name
+        name: String,
+    },
+
+    /// List registered agent workspaces
+    List,
+
+    /// Remove a registered agent workspace
+    Remove {
+        /// Agent workspace name
+        name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RepoCommands {
+    /// Register a repo in the team workspace
+    Add {
+        /// Logical repo name
+        name: String,
+
+        /// Canonical remote URL
+        url: String,
+    },
+
+    /// List registered repos
+    List,
+
+    /// Remove a registered repo
+    Remove {
+        /// Logical repo name
+        name: String,
+    },
+}

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -361,10 +361,16 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
         },
         Commands::Plan { yes } => {
             let workspace_root = require_workspace_root()?;
-            let (_spec, plan) = ExecutionPlan::from_workspace_spec(&workspace_root)?;
-            let guard_report = plan.guard_for_apply(&workspace_root, yes)?;
+            let build = ExecutionPlan::from_workspace_spec(&workspace_root)?;
+            let guard_report = build.plan.guard_for_apply(&workspace_root, yes)?;
 
-            println!("{}", plan.render_table());
+            if build.generated_spec {
+                println!(
+                    "Generated workspace spec at {} from current workspace state.",
+                    workspace_spec_path(&workspace_root).display()
+                );
+            }
+            println!("{}", build.plan.render_table());
             for warning in guard_report.warnings {
                 println!("warning: {}", warning);
             }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -229,6 +229,7 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
         Commands::Unit { command } => match command {
             UnitCommands::Add { name } => {
                 let workspace_root = require_workspace_root()?;
+                validate_unit_name(&name)?;
                 let units_root = workspace_root.join("agents");
                 let registry_path = workspace_root.join(".grip/units.toml");
                 let unit_root = units_root.join(&name);
@@ -340,4 +341,22 @@ fn require_workspace_root() -> Result<PathBuf> {
         anyhow::bail!("not in a gr2 workspace: missing .grip/workspace.toml");
     }
     Ok(workspace_root)
+}
+
+fn validate_unit_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("unit name must not be empty");
+    }
+
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+    {
+        anyhow::bail!(
+            "invalid unit name '{}': use only ASCII letters, numbers, '_' or '-'",
+            name
+        );
+    }
+
+    Ok(())
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -1,0 +1,239 @@
+use anyhow::Result;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::args::{Commands, RepoCommands, TeamCommands};
+
+pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
+    match command {
+        Commands::Init { path, name } => {
+            let workspace_root = PathBuf::from(path);
+            let workspace_name = name.unwrap_or_else(|| {
+                workspace_root
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "workspace".to_string())
+            });
+
+            if workspace_root.exists() {
+                anyhow::bail!(
+                    "workspace path already exists: {}",
+                    workspace_root.display()
+                );
+            }
+
+            fs::create_dir_all(workspace_root.join(".grip"))?;
+            fs::create_dir_all(workspace_root.join("config"))?;
+            fs::create_dir_all(workspace_root.join("agents"))?;
+            fs::create_dir_all(workspace_root.join("repos"))?;
+
+            let workspace_toml = format!(
+                "version = 2\nname = \"{}\"\nlayout = \"team-workspace\"\n",
+                workspace_name
+            );
+            fs::write(workspace_root.join(".grip/workspace.toml"), workspace_toml)?;
+
+            println!(
+                "Initialized gr2 team workspace '{}' at {}",
+                workspace_name,
+                workspace_root.display()
+            );
+            Ok(())
+        }
+        Commands::Doctor => {
+            if verbose {
+                println!("gr2 bootstrap OK (verbose)");
+            } else {
+                println!("gr2 bootstrap OK");
+            }
+            Ok(())
+        }
+        Commands::Team { command } => match command {
+            TeamCommands::Add { name } => {
+                let workspace_root = require_workspace_root()?;
+
+                let agent_root = workspace_root.join("agents").join(&name);
+                if agent_root.exists() {
+                    anyhow::bail!("agent '{}' already exists", name);
+                }
+
+                fs::create_dir_all(&agent_root)?;
+                fs::write(
+                    agent_root.join("agent.toml"),
+                    format!("name = \"{}\"\nkind = \"agent-workspace\"\n", name),
+                )?;
+
+                println!("Added gr2 agent workspace '{}'", name);
+                Ok(())
+            }
+            TeamCommands::List => {
+                let workspace_root = require_workspace_root()?;
+                let agents_root = workspace_root.join("agents");
+
+                let mut names = Vec::new();
+                for entry in fs::read_dir(&agents_root)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_dir() && entry.path().join("agent.toml").exists() {
+                        names.push(entry.file_name().to_string_lossy().into_owned());
+                    }
+                }
+
+                names.sort();
+
+                if names.is_empty() {
+                    println!("No gr2 agent workspaces registered.");
+                } else {
+                    println!("Agent workspaces");
+                    for name in names {
+                        println!("- {}", name);
+                    }
+                }
+
+                Ok(())
+            }
+            TeamCommands::Remove { name } => {
+                let workspace_root = require_workspace_root()?;
+                let agent_root = workspace_root.join("agents").join(&name);
+
+                if !agent_root.join("agent.toml").exists() {
+                    anyhow::bail!("agent '{}' not found", name);
+                }
+
+                fs::remove_dir_all(&agent_root)?;
+                println!("Removed gr2 agent workspace '{}'", name);
+                Ok(())
+            }
+        },
+        Commands::Repo { command } => match command {
+            RepoCommands::Add { name, url } => {
+                let workspace_root = require_workspace_root()?;
+                let repos_root = workspace_root.join("repos");
+                let registry_path = workspace_root.join(".grip/repos.toml");
+                let repo_dir = repos_root.join(&name);
+
+                if repo_dir.exists() {
+                    anyhow::bail!("repo '{}' already exists", name);
+                }
+
+                fs::create_dir_all(&repo_dir)?;
+                fs::write(
+                    repo_dir.join("repo.toml"),
+                    format!("name = \"{}\"\nurl = \"{}\"\n", name, url),
+                )?;
+
+                let mut entries = Vec::new();
+                if registry_path.exists() {
+                    entries.push(fs::read_to_string(&registry_path)?);
+                }
+                entries.push(format!(
+                    "[[repo]]\nname = \"{}\"\nurl = \"{}\"\n",
+                    name, url
+                ));
+                fs::write(&registry_path, entries.join("\n"))?;
+
+                println!("Added gr2 repo '{}' -> {}", name, url);
+                Ok(())
+            }
+            RepoCommands::List => {
+                let workspace_root = require_workspace_root()?;
+                let repos_root = workspace_root.join("repos");
+
+                let mut repos = Vec::new();
+                for entry in fs::read_dir(&repos_root)? {
+                    let entry = entry?;
+                    let repo_toml = entry.path().join("repo.toml");
+                    if entry.file_type()?.is_dir() && repo_toml.exists() {
+                        let content = fs::read_to_string(repo_toml)?;
+                        let fallback_name = entry.file_name().to_string_lossy().into_owned();
+                        let name = content
+                            .lines()
+                            .find_map(|line| line.strip_prefix("name = \""))
+                            .and_then(|line| line.strip_suffix('"'))
+                            .map(str::to_owned)
+                            .unwrap_or(fallback_name);
+                        let url = content
+                            .lines()
+                            .find_map(|line| line.strip_prefix("url = \""))
+                            .and_then(|line| line.strip_suffix('"'))
+                            .unwrap_or("")
+                            .to_string();
+                        repos.push((name, url));
+                    }
+                }
+
+                repos.sort_by(|a, b| a.0.cmp(&b.0));
+
+                if repos.is_empty() {
+                    println!("No gr2 repos registered.");
+                } else {
+                    println!("Repos");
+                    for (name, url) in repos {
+                        println!("- {} -> {}", name, url);
+                    }
+                }
+
+                Ok(())
+            }
+            RepoCommands::Remove { name } => {
+                let workspace_root = require_workspace_root()?;
+                let repos_root = workspace_root.join("repos");
+                let repo_root = repos_root.join(&name);
+                let repo_toml = repo_root.join("repo.toml");
+
+                if !repo_toml.exists() {
+                    anyhow::bail!("repo '{}' not found", name);
+                }
+
+                fs::remove_dir_all(&repo_root)?;
+
+                let registry_path = workspace_root.join(".grip/repos.toml");
+                if registry_path.exists() {
+                    let registry = fs::read_to_string(&registry_path)?;
+                    let kept_entries = registry
+                        .split("\n[[repo]]\n")
+                        .filter_map(|chunk| {
+                            let chunk = chunk.trim();
+                            if chunk.is_empty() {
+                                return None;
+                            }
+                            let normalized = if chunk.starts_with("[[repo]]") {
+                                chunk.to_string()
+                            } else {
+                                format!("[[repo]]\n{}", chunk)
+                            };
+                            let matches_name = normalized
+                                .lines()
+                                .find_map(|line| line.strip_prefix("name = \""))
+                                .and_then(|line| line.strip_suffix('"'))
+                                .map(|entry_name| entry_name == name)
+                                .unwrap_or(false);
+                            if matches_name {
+                                None
+                            } else {
+                                Some(normalized)
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    if kept_entries.is_empty() {
+                        fs::remove_file(&registry_path)?;
+                    } else {
+                        fs::write(&registry_path, kept_entries.join("\n\n"))?;
+                    }
+                }
+
+                println!("Removed gr2 repo '{}'", name);
+                Ok(())
+            }
+        },
+    }
+}
+
+fn require_workspace_root() -> Result<PathBuf> {
+    let workspace_root = std::env::current_dir()?;
+    let workspace_toml = workspace_root.join(".grip/workspace.toml");
+    if !workspace_toml.exists() {
+        anyhow::bail!("not in a gr2 workspace: missing .grip/workspace.toml");
+    }
+    Ok(workspace_root)
+}

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -3,9 +3,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::args::{Commands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
-use crate::spec::{
-    read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec,
-};
+use crate::plan::ExecutionPlan;
+use crate::spec::{read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -360,6 +359,20 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 Ok(())
             }
         },
+        Commands::Plan { yes } => {
+            let workspace_root = require_workspace_root()?;
+            let (_spec, plan) = ExecutionPlan::from_workspace_spec(&workspace_root)?;
+            let guard_report = plan.guard_for_apply(&workspace_root, yes)?;
+
+            println!("{}", plan.render_table());
+            for warning in guard_report.warnings {
+                println!("warning: {}", warning);
+            }
+            if guard_report.requires_confirmation {
+                println!("warning: plan contains more than 3 operations; apply will require --yes");
+            }
+            Ok(())
+        }
     }
 }
 

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, RepoCommands, TeamCommands};
+use crate::args::{Commands, RepoCommands, TeamCommands, UnitCommands};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -223,6 +223,110 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 }
 
                 println!("Removed gr2 repo '{}'", name);
+                Ok(())
+            }
+        },
+        Commands::Unit { command } => match command {
+            UnitCommands::Add { name } => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+                let registry_path = workspace_root.join(".grip/units.toml");
+                let unit_root = units_root.join(&name);
+
+                if unit_root.exists() {
+                    anyhow::bail!("unit '{}' already exists", name);
+                }
+
+                fs::create_dir_all(&unit_root)?;
+                fs::write(
+                    unit_root.join("unit.toml"),
+                    format!("name = \"{}\"\nkind = \"unit\"\n", name),
+                )?;
+
+                let mut entries = Vec::new();
+                if registry_path.exists() {
+                    entries.push(fs::read_to_string(&registry_path)?);
+                }
+                entries.push(format!("[[unit]]\nname = \"{}\"\nkind = \"unit\"\n", name));
+                fs::write(&registry_path, entries.join("\n"))?;
+
+                println!("Added gr2 unit '{}'", name);
+                Ok(())
+            }
+            UnitCommands::List => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+
+                let mut names = Vec::new();
+                for entry in fs::read_dir(&units_root)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_dir() && entry.path().join("unit.toml").exists() {
+                        names.push(entry.file_name().to_string_lossy().into_owned());
+                    }
+                }
+
+                names.sort();
+
+                if names.is_empty() {
+                    println!("No gr2 units registered.");
+                } else {
+                    println!("Units");
+                    for name in names {
+                        println!("- {}", name);
+                    }
+                }
+
+                Ok(())
+            }
+            UnitCommands::Remove { name } => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+                let unit_root = units_root.join(&name);
+                let unit_toml = unit_root.join("unit.toml");
+
+                if !unit_toml.exists() {
+                    anyhow::bail!("unit '{}' not found", name);
+                }
+
+                fs::remove_dir_all(&unit_root)?;
+
+                let registry_path = workspace_root.join(".grip/units.toml");
+                if registry_path.exists() {
+                    let registry = fs::read_to_string(&registry_path)?;
+                    let kept_entries = registry
+                        .split("\n[[unit]]\n")
+                        .filter_map(|chunk| {
+                            let chunk = chunk.trim();
+                            if chunk.is_empty() {
+                                return None;
+                            }
+                            let normalized = if chunk.starts_with("[[unit]]") {
+                                chunk.to_string()
+                            } else {
+                                format!("[[unit]]\n{}", chunk)
+                            };
+                            let matches_name = normalized
+                                .lines()
+                                .find_map(|line| line.strip_prefix("name = \""))
+                                .and_then(|line| line.strip_suffix('"'))
+                                .map(|entry_name| entry_name == name)
+                                .unwrap_or(false);
+                            if matches_name {
+                                None
+                            } else {
+                                Some(normalized)
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    if kept_entries.is_empty() {
+                        fs::remove_file(&registry_path)?;
+                    } else {
+                        fs::write(&registry_path, kept_entries.join("\n\n"))?;
+                    }
+                }
+
+                println!("Removed gr2 unit '{}'", name);
                 Ok(())
             }
         },

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, RepoCommands, TeamCommands, UnitCommands};
+use crate::args::{Commands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
+use crate::spec::{
+    read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec,
+};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -328,6 +331,32 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 }
 
                 println!("Removed gr2 unit '{}'", name);
+                Ok(())
+            }
+        },
+        Commands::Spec { command } => match command {
+            SpecCommands::Show => {
+                let workspace_root = require_workspace_root()?;
+                let spec_path = workspace_spec_path(&workspace_root);
+                let spec = if spec_path.exists() {
+                    read_workspace_spec(&workspace_root)?
+                } else {
+                    let spec = WorkspaceSpec::from_workspace(&workspace_root)?;
+                    write_workspace_spec(&workspace_root, &spec)?;
+                    spec
+                };
+
+                println!("{}", toml::to_string_pretty(&spec)?);
+                Ok(())
+            }
+            SpecCommands::Validate => {
+                let workspace_root = require_workspace_root()?;
+                let spec = read_workspace_spec(&workspace_root)?;
+                spec.validate(&workspace_root)?;
+                println!(
+                    "Workspace spec is valid: {}",
+                    workspace_spec_path(&workspace_root).display()
+                );
                 Ok(())
             }
         },

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -4,3 +4,4 @@
 
 pub mod args;
 pub mod dispatch;
+pub mod spec;

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -4,4 +4,5 @@
 
 pub mod args;
 pub mod dispatch;
+pub mod plan;
 pub mod spec;

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -1,0 +1,6 @@
+//! gr2 CLI namespace
+//!
+//! This crate is the clean-break CLI surface for the new team-workspace model.
+
+pub mod args;
+pub mod dispatch;

--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -10,6 +10,13 @@ pub struct ExecutionPlan {
     pub operations: Vec<PlanOperation>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanBuild {
+    pub spec: WorkspaceSpec,
+    pub plan: ExecutionPlan,
+    pub generated_spec: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanOperation {
     pub unit_name: String,
@@ -34,14 +41,14 @@ pub struct PlanGuardReport {
 }
 
 impl ExecutionPlan {
-    pub fn from_workspace_spec(workspace_root: &Path) -> Result<(WorkspaceSpec, Self)> {
+    pub fn from_workspace_spec(workspace_root: &Path) -> Result<PlanBuild> {
         let spec_path = workspace_spec_path(workspace_root);
-        let spec = if spec_path.exists() {
-            read_workspace_spec(workspace_root)?
+        let (spec, generated_spec) = if spec_path.exists() {
+            (read_workspace_spec(workspace_root)?, false)
         } else {
             let generated = WorkspaceSpec::from_workspace(workspace_root)?;
             write_workspace_spec(workspace_root, &generated)?;
-            generated
+            (generated, true)
         };
 
         spec.validate_for_plan()?;
@@ -66,7 +73,7 @@ impl ExecutionPlan {
             }
 
             let expected_path = format!("agents/{}", unit.name);
-            if unit.path != expected_path || !unit.repos.is_empty() {
+            if unit.path != expected_path {
                 let mut parameters = BTreeMap::new();
                 parameters.insert("path".to_string(), unit.path.clone());
                 parameters.insert("repos".to_string(), unit.repos.join(","));
@@ -79,7 +86,11 @@ impl ExecutionPlan {
             }
         }
 
-        Ok((spec, Self { operations }))
+        Ok(PlanBuild {
+            spec,
+            plan: Self { operations },
+            generated_spec,
+        })
     }
 
     pub fn guard_for_apply(

--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -1,0 +1,151 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::spec::{read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionPlan {
+    pub operations: Vec<PlanOperation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanOperation {
+    pub unit_name: String,
+    pub operation: OperationType,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, String>,
+    pub preview: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationType {
+    Clone,
+    Configure,
+    Link,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanGuardReport {
+    pub warnings: Vec<String>,
+    pub requires_confirmation: bool,
+}
+
+impl ExecutionPlan {
+    pub fn from_workspace_spec(workspace_root: &Path) -> Result<(WorkspaceSpec, Self)> {
+        let spec_path = workspace_spec_path(workspace_root);
+        let spec = if spec_path.exists() {
+            read_workspace_spec(workspace_root)?
+        } else {
+            let generated = WorkspaceSpec::from_workspace(workspace_root)?;
+            write_workspace_spec(workspace_root, &generated)?;
+            generated
+        };
+
+        spec.validate_for_plan()?;
+
+        let mut operations = Vec::new();
+
+        for unit in &spec.units {
+            let unit_root = workspace_root.join(&unit.path);
+            let unit_toml = unit_root.join("unit.toml");
+
+            if !unit_toml.exists() {
+                let mut parameters = BTreeMap::new();
+                parameters.insert("path".to_string(), unit.path.clone());
+                parameters.insert("repos".to_string(), unit.repos.join(","));
+                operations.push(PlanOperation {
+                    unit_name: unit.name.clone(),
+                    operation: OperationType::Clone,
+                    parameters,
+                    preview: format!("clone unit '{}' into {}", unit.name, unit.path),
+                });
+                continue;
+            }
+
+            let expected_path = format!("agents/{}", unit.name);
+            if unit.path != expected_path || !unit.repos.is_empty() {
+                let mut parameters = BTreeMap::new();
+                parameters.insert("path".to_string(), unit.path.clone());
+                parameters.insert("repos".to_string(), unit.repos.join(","));
+                operations.push(PlanOperation {
+                    unit_name: unit.name.clone(),
+                    operation: OperationType::Configure,
+                    parameters,
+                    preview: format!("reconfigure unit '{}' to match {}", unit.name, unit.path),
+                });
+            }
+        }
+
+        Ok((spec, Self { operations }))
+    }
+
+    pub fn guard_for_apply(
+        &self,
+        workspace_root: &Path,
+        assume_yes: bool,
+    ) -> Result<PlanGuardReport> {
+        let mut warnings = Vec::new();
+
+        for operation in &self.operations {
+            let path = operation
+                .parameters
+                .get("path")
+                .map(|value| workspace_root.join(value))
+                .unwrap_or_else(|| workspace_root.join(format!("agents/{}", operation.unit_name)));
+
+            if matches!(operation.operation, OperationType::Link) && path.exists() {
+                anyhow::bail!(
+                    "refusing to apply plan: link operation for '{}' would overwrite existing directory {}",
+                    operation.unit_name,
+                    path.display()
+                );
+            }
+
+            if path.join(".git").exists() {
+                warnings.push(format!(
+                    "unit '{}' has a git checkout at {} with possible uncommitted changes; inspect before apply",
+                    operation.unit_name,
+                    path.display()
+                ));
+            }
+        }
+
+        Ok(PlanGuardReport {
+            warnings,
+            requires_confirmation: self.operations.len() > 3 && !assume_yes,
+        })
+    }
+
+    pub fn render_table(&self) -> String {
+        if self.operations.is_empty() {
+            return "ExecutionPlan\n- no changes required\n".to_string();
+        }
+
+        let mut lines = vec![
+            "ExecutionPlan".to_string(),
+            "UNIT\tOPERATION\tPREVIEW".to_string(),
+        ];
+        for operation in &self.operations {
+            lines.push(format!(
+                "{}\t{}\t{}",
+                operation.unit_name,
+                operation.operation.as_str(),
+                operation.preview
+            ));
+        }
+        lines.join("\n")
+    }
+}
+
+impl OperationType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Clone => "clone",
+            Self::Configure => "configure",
+            Self::Link => "link",
+        }
+    }
+}

--- a/gr2/src/spec.rs
+++ b/gr2/src/spec.rs
@@ -54,7 +54,7 @@ impl WorkspaceSpec {
         })
     }
 
-    pub fn validate(&self, workspace_root: &Path) -> Result<()> {
+    pub fn validate_for_plan(&self) -> Result<()> {
         if self.schema_version != WORKSPACE_SPEC_VERSION {
             anyhow::bail!(
                 "unsupported workspace spec schema_version {}: expected {}",
@@ -76,15 +76,6 @@ impl WorkspaceSpec {
             if repo.path.trim().is_empty() || repo.url.trim().is_empty() {
                 anyhow::bail!("repo '{}' must include non-empty path and url", repo.name);
             }
-
-            let repo_root = workspace_root.join(&repo.path);
-            if !repo_root.join("repo.toml").exists() {
-                anyhow::bail!(
-                    "workspace spec repo '{}' is missing repo metadata at {}",
-                    repo.name,
-                    repo_root.join("repo.toml").display()
-                );
-            }
         }
 
         let mut unit_names = HashSet::new();
@@ -95,15 +86,6 @@ impl WorkspaceSpec {
 
             if unit.path.trim().is_empty() {
                 anyhow::bail!("unit '{}' must include a non-empty path", unit.name);
-            }
-
-            let unit_root = workspace_root.join(&unit.path);
-            if !unit_root.join("unit.toml").exists() {
-                anyhow::bail!(
-                    "workspace spec unit '{}' is missing unit metadata at {}",
-                    unit.name,
-                    unit_root.join("unit.toml").display()
-                );
             }
 
             for repo_name in &unit.repos {
@@ -119,14 +101,41 @@ impl WorkspaceSpec {
 
         Ok(())
     }
+
+    pub fn validate(&self, workspace_root: &Path) -> Result<()> {
+        self.validate_for_plan()?;
+
+        for repo in &self.repos {
+            let repo_root = workspace_root.join(&repo.path);
+            if !repo_root.join("repo.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec repo '{}' is missing repo metadata at {}",
+                    repo.name,
+                    repo_root.join("repo.toml").display()
+                );
+            }
+        }
+
+        for unit in &self.units {
+            let unit_root = workspace_root.join(&unit.path);
+            if !unit_root.join("unit.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec unit '{}' is missing unit metadata at {}",
+                    unit.name,
+                    unit_root.join("unit.toml").display()
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
 pub fn write_workspace_spec(workspace_root: &Path, spec: &WorkspaceSpec) -> Result<PathBuf> {
     let spec_path = workspace_spec_path(workspace_root);
     let content = toml::to_string_pretty(spec).context("serialize workspace spec")?;
-    fs::write(&spec_path, content).with_context(|| {
-        format!("write workspace spec to {}", spec_path.display())
-    })?;
+    fs::write(&spec_path, content)
+        .with_context(|| format!("write workspace spec to {}", spec_path.display()))?;
     Ok(spec_path)
 }
 
@@ -197,6 +206,10 @@ fn read_registered_repos(workspace_root: &Path) -> Result<Vec<RepoSpec>> {
 fn read_registered_units(workspace_root: &Path) -> Result<Vec<UnitSpec>> {
     let units_root = workspace_root.join("agents");
     let mut units = Vec::new();
+
+    if !units_root.exists() {
+        return Ok(units);
+    }
 
     for entry in fs::read_dir(&units_root)? {
         let entry = entry?;

--- a/gr2/src/spec.rs
+++ b/gr2/src/spec.rs
@@ -1,0 +1,223 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const WORKSPACE_SPEC_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceSpec {
+    pub schema_version: u32,
+    pub workspace_name: String,
+    pub cache: CacheSpec,
+    #[serde(default)]
+    pub repos: Vec<RepoSpec>,
+    #[serde(default)]
+    pub units: Vec<UnitSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CacheSpec {
+    pub root: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoSpec {
+    pub name: String,
+    pub path: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UnitSpec {
+    pub name: String,
+    pub path: String,
+    #[serde(default)]
+    pub repos: Vec<String>,
+}
+
+impl WorkspaceSpec {
+    pub fn from_workspace(workspace_root: &Path) -> Result<Self> {
+        let workspace_name = read_workspace_name(workspace_root)?;
+        let repos = read_registered_repos(workspace_root)?;
+        let units = read_registered_units(workspace_root)?;
+
+        Ok(Self {
+            schema_version: WORKSPACE_SPEC_VERSION,
+            workspace_name,
+            cache: CacheSpec {
+                root: ".grip/cache".to_string(),
+            },
+            repos,
+            units,
+        })
+    }
+
+    pub fn validate(&self, workspace_root: &Path) -> Result<()> {
+        if self.schema_version != WORKSPACE_SPEC_VERSION {
+            anyhow::bail!(
+                "unsupported workspace spec schema_version {}: expected {}",
+                self.schema_version,
+                WORKSPACE_SPEC_VERSION
+            );
+        }
+
+        if self.workspace_name.trim().is_empty() {
+            anyhow::bail!("workspace spec workspace_name must not be empty");
+        }
+
+        let mut repo_names = HashSet::new();
+        for repo in &self.repos {
+            if !repo_names.insert(repo.name.clone()) {
+                anyhow::bail!("workspace spec contains duplicate repo '{}'", repo.name);
+            }
+
+            if repo.path.trim().is_empty() || repo.url.trim().is_empty() {
+                anyhow::bail!("repo '{}' must include non-empty path and url", repo.name);
+            }
+
+            let repo_root = workspace_root.join(&repo.path);
+            if !repo_root.join("repo.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec repo '{}' is missing repo metadata at {}",
+                    repo.name,
+                    repo_root.join("repo.toml").display()
+                );
+            }
+        }
+
+        let mut unit_names = HashSet::new();
+        for unit in &self.units {
+            if !unit_names.insert(unit.name.clone()) {
+                anyhow::bail!("workspace spec contains duplicate unit '{}'", unit.name);
+            }
+
+            if unit.path.trim().is_empty() {
+                anyhow::bail!("unit '{}' must include a non-empty path", unit.name);
+            }
+
+            let unit_root = workspace_root.join(&unit.path);
+            if !unit_root.join("unit.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec unit '{}' is missing unit metadata at {}",
+                    unit.name,
+                    unit_root.join("unit.toml").display()
+                );
+            }
+
+            for repo_name in &unit.repos {
+                if !repo_names.contains(repo_name) {
+                    anyhow::bail!(
+                        "unit '{}' references missing repo '{}'",
+                        unit.name,
+                        repo_name
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn write_workspace_spec(workspace_root: &Path, spec: &WorkspaceSpec) -> Result<PathBuf> {
+    let spec_path = workspace_spec_path(workspace_root);
+    let content = toml::to_string_pretty(spec).context("serialize workspace spec")?;
+    fs::write(&spec_path, content).with_context(|| {
+        format!("write workspace spec to {}", spec_path.display())
+    })?;
+    Ok(spec_path)
+}
+
+pub fn read_workspace_spec(workspace_root: &Path) -> Result<WorkspaceSpec> {
+    let spec_path = workspace_spec_path(workspace_root);
+    let content = fs::read_to_string(&spec_path)
+        .with_context(|| format!("read workspace spec from {}", spec_path.display()))?;
+    toml::from_str(&content).context("parse workspace spec")
+}
+
+pub fn workspace_spec_path(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".grip/workspace_spec.toml")
+}
+
+fn read_workspace_name(workspace_root: &Path) -> Result<String> {
+    let workspace_toml = fs::read_to_string(workspace_root.join(".grip/workspace.toml"))
+        .context("read .grip/workspace.toml")?;
+    workspace_toml
+        .lines()
+        .find_map(|line| line.strip_prefix("name = \""))
+        .and_then(|line| line.strip_suffix('"'))
+        .map(str::to_owned)
+        .context("workspace name missing from .grip/workspace.toml")
+}
+
+fn read_registered_repos(workspace_root: &Path) -> Result<Vec<RepoSpec>> {
+    let repos_root = workspace_root.join("repos");
+    let mut repos = Vec::new();
+
+    for entry in fs::read_dir(&repos_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let repo_root = entry.path();
+        let repo_toml = repo_root.join("repo.toml");
+        if !repo_toml.exists() {
+            continue;
+        }
+
+        let content = fs::read_to_string(&repo_toml)?;
+        let fallback_name = entry.file_name().to_string_lossy().into_owned();
+        let name = content
+            .lines()
+            .find_map(|line| line.strip_prefix("name = \""))
+            .and_then(|line| line.strip_suffix('"'))
+            .map(str::to_owned)
+            .unwrap_or(fallback_name.clone());
+        let url = content
+            .lines()
+            .find_map(|line| line.strip_prefix("url = \""))
+            .and_then(|line| line.strip_suffix('"'))
+            .unwrap_or("")
+            .to_string();
+
+        repos.push(RepoSpec {
+            name,
+            path: format!("repos/{}", fallback_name),
+            url,
+        });
+    }
+
+    repos.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(repos)
+}
+
+fn read_registered_units(workspace_root: &Path) -> Result<Vec<UnitSpec>> {
+    let units_root = workspace_root.join("agents");
+    let mut units = Vec::new();
+
+    for entry in fs::read_dir(&units_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let unit_root = entry.path();
+        let unit_toml = unit_root.join("unit.toml");
+        if !unit_toml.exists() {
+            continue;
+        }
+
+        let fallback_name = entry.file_name().to_string_lossy().into_owned();
+        units.push(UnitSpec {
+            name: fallback_name.clone(),
+            path: format!("agents/{}", fallback_name),
+            repos: Vec::new(),
+        });
+    }
+
+    units.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(units)
+}

--- a/src/bin/gr2.rs
+++ b/src/bin/gr2.rs
@@ -1,0 +1,22 @@
+//! gr2 CLI entry point
+
+use clap::Parser;
+use gr2_cli::args::Cli;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    if cli.verbose {
+        tracing_subscriber::fmt()
+            .with_env_filter("gitgrip=debug")
+            .with_target(false)
+            .init();
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+    }
+
+    gr2_cli::dispatch::dispatch_command(cli.command, cli.verbose).await
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -349,7 +349,7 @@ pub enum Commands {
         #[command(subcommand)]
         action: TargetCommands,
     },
-    /// Manage workspace repo caches (.grip/cache/)
+    /// Manage machine-level repo caches (~/.grip/cache/ by default)
     Cache {
         #[command(subcommand)]
         action: CacheCommands,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -127,11 +127,11 @@ pub enum Commands {
         group: Option<Vec<String>>,
     },
     #[command(
-        after_help = "Examples:\n  gr checkout feat/login\n  gr checkout --base\n  gr checkout add sandbox\n  gr checkout add docs-only --group docs\n  gr checkout add app-only --repo app"
+        after_help = "Examples:\n  gr checkout feat/login\n  gr checkout --base\n  gr checkout add sandbox\n  gr checkout add docs-only --group docs\n  gr checkout add app-only --repo app\n  gr checkout list\n  gr checkout remove sandbox"
     )]
-    /// Checkout a branch across repos or create an independent child checkout
+    /// Checkout a branch across repos or manage independent child checkouts
     Checkout {
-        /// Branch name, or `add` to create an independent child checkout
+        /// Branch name, or `add`/`list`/`remove` for child checkout lifecycle
         name: Option<String>,
         /// Additional checkout action args (e.g. `add <name>`)
         #[arg(hide = true)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -126,10 +126,16 @@ pub enum Commands {
         #[arg(long, value_delimiter = ',')]
         group: Option<Vec<String>>,
     },
-    /// Checkout a branch across repos
+    #[command(
+        after_help = "Examples:\n  gr checkout feat/login\n  gr checkout --base\n  gr checkout add sandbox\n  gr checkout add docs-only --group docs\n  gr checkout add app-only --repo app"
+    )]
+    /// Checkout a branch across repos or create an independent child checkout
     Checkout {
-        /// Branch name
+        /// Branch name, or `add` to create an independent child checkout
         name: Option<String>,
+        /// Additional checkout action args (e.g. `add <name>`)
+        #[arg(hide = true)]
+        extra: Vec<String>,
         /// Create branch if it doesn't exist
         #[arg(short = 'b', long)]
         create: bool,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -349,6 +349,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: TargetCommands,
     },
+    /// Manage workspace repo caches (.grip/cache/)
+    Cache {
+        #[command(subcommand)]
+        action: CacheCommands,
+    },
     /// Run garbage collection across repos
     Gc {
         /// More thorough gc (slower)
@@ -871,6 +876,21 @@ pub enum TargetCommands {
         /// Unset target for a specific repo instead of globally
         #[arg(long)]
         repo: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CacheCommands {
+    /// Bootstrap bare caches for all manifest repos
+    Bootstrap,
+    /// Fetch latest refs into all caches
+    Update,
+    /// Show cache status
+    Status,
+    /// Remove a repo cache
+    Remove {
+        /// Repo name
+        repo: String,
     },
 }
 

--- a/src/cli/commands/cache.rs
+++ b/src/cli/commands/cache.rs
@@ -1,6 +1,6 @@
 //! Cache command implementation
 //!
-//! Manages bare-repo caches under `.grip/cache/` for workspace repos.
+//! Manages bare-repo caches under the machine-level cache root for workspace repos.
 
 use crate::cli::args::CacheCommands;
 use crate::cli::output::Output;
@@ -50,7 +50,12 @@ pub fn run_cache(
                 Output::info("Updating all caches...");
             }
 
-            let count = workspace_cache::update_all(workspace_root)?;
+            let repo_pairs: Vec<(&str, &str)> = repos
+                .iter()
+                .map(|r| (r.name.as_str(), r.url.as_str()))
+                .collect();
+
+            let count = workspace_cache::update_all(workspace_root, repo_pairs.into_iter())?;
 
             if !quiet {
                 Output::success(&format!("Updated {} cache(s)", count));
@@ -58,12 +63,6 @@ pub fn run_cache(
         }
 
         CacheCommands::Status => {
-            let cache_dir = workspace_root.join(".grip").join("cache");
-            if !cache_dir.is_dir() {
-                Output::info("No caches exist yet. Run 'gr cache bootstrap' to create them.");
-                return Ok(());
-            }
-
             println!(
                 "{:<20} {:<8} {}",
                 "Repo".bold(),
@@ -73,8 +72,9 @@ pub fn run_cache(
             println!("{}", "─".repeat(70));
 
             for repo in &repos {
-                let exists = workspace_cache::cache_exists(workspace_root, &repo.name);
-                let path = workspace_cache::cache_path(workspace_root, &repo.name);
+                let exists = workspace_cache::cache_exists(workspace_root, &repo.name, &repo.url)?;
+                let path =
+                    workspace_cache::resolve_cache_path(workspace_root, &repo.name, &repo.url)?;
                 let status = if exists {
                     "cached".green().to_string()
                 } else {
@@ -85,7 +85,11 @@ pub fn run_cache(
         }
 
         CacheCommands::Remove { repo } => {
-            let removed = workspace_cache::remove_cache(workspace_root, &repo)?;
+            let Some(repo_info) = repos.iter().find(|r| r.name == repo) else {
+                anyhow::bail!("repo '{}' is not in this manifest", repo);
+            };
+            let removed =
+                workspace_cache::remove_cache(workspace_root, &repo_info.name, &repo_info.url)?;
             if removed {
                 Output::success(&format!("Removed cache for {}", repo));
             } else {

--- a/src/cli/commands/cache.rs
+++ b/src/cli/commands/cache.rs
@@ -1,0 +1,98 @@
+//! Cache command implementation
+//!
+//! Manages bare-repo caches under `.grip/cache/` for workspace repos.
+
+use crate::cli::args::CacheCommands;
+use crate::cli::output::Output;
+use crate::core::manifest::Manifest;
+use crate::core::repo::filter_repos;
+use crate::core::workspace_cache;
+use anyhow::Result;
+use colored::Colorize;
+use std::path::Path;
+
+pub fn run_cache(
+    workspace_root: &Path,
+    manifest: &Manifest,
+    action: CacheCommands,
+    quiet: bool,
+) -> Result<()> {
+    // Include reference repos in caching — they benefit from local caches too
+    let repos = filter_repos(manifest, workspace_root, None, None, true);
+
+    match action {
+        CacheCommands::Bootstrap => {
+            if !quiet {
+                Output::info(&format!(
+                    "Bootstrapping caches for {} repos...",
+                    repos.len()
+                ));
+            }
+
+            let repo_pairs: Vec<(&str, &str)> = repos
+                .iter()
+                .map(|r| (r.name.as_str(), r.url.as_str()))
+                .collect();
+
+            let count = workspace_cache::bootstrap_all(workspace_root, repo_pairs.into_iter())?;
+
+            if !quiet {
+                if count > 0 {
+                    Output::success(&format!("Bootstrapped {} new cache(s)", count));
+                } else {
+                    Output::info("All caches already exist");
+                }
+            }
+        }
+
+        CacheCommands::Update => {
+            if !quiet {
+                Output::info("Updating all caches...");
+            }
+
+            let count = workspace_cache::update_all(workspace_root)?;
+
+            if !quiet {
+                Output::success(&format!("Updated {} cache(s)", count));
+            }
+        }
+
+        CacheCommands::Status => {
+            let cache_dir = workspace_root.join(".grip").join("cache");
+            if !cache_dir.is_dir() {
+                Output::info("No caches exist yet. Run 'gr cache bootstrap' to create them.");
+                return Ok(());
+            }
+
+            println!(
+                "{:<20} {:<8} {}",
+                "Repo".bold(),
+                "Status".bold(),
+                "Path".bold()
+            );
+            println!("{}", "─".repeat(70));
+
+            for repo in &repos {
+                let exists = workspace_cache::cache_exists(workspace_root, &repo.name);
+                let path = workspace_cache::cache_path(workspace_root, &repo.name);
+                let status = if exists {
+                    "cached".green().to_string()
+                } else {
+                    "missing".yellow().to_string()
+                };
+                println!("{:<20} {:<8} {}", repo.name, status, path.display());
+            }
+        }
+
+        CacheCommands::Remove { repo } => {
+            let removed = workspace_cache::remove_cache(workspace_root, &repo)?;
+            if removed {
+                Output::success(&format!("Removed cache for {}", repo));
+            } else {
+                Output::warning(&format!("No cache found for {}", repo));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/commands/checkout.rs
+++ b/src/cli/commands/checkout.rs
@@ -3,6 +3,7 @@
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
 use crate::core::repo::{filter_repos, get_manifest_repo_info, RepoInfo};
+use crate::core::workspace_checkout;
 use crate::git::{
     branch::{branch_exists, checkout_branch, create_and_checkout_branch},
     open_repo,
@@ -111,5 +112,54 @@ pub fn run_checkout(
         Output::branch_name(branch_name)
     );
 
+    Ok(())
+}
+
+/// Materialize an independent child checkout from cached repos.
+///
+/// This reserves `gr checkout add <name>` while preserving the existing
+/// `gr checkout <branch>` behavior for cross-repo branch switching.
+pub fn run_checkout_add(
+    workspace_root: &Path,
+    manifest: &Manifest,
+    checkout_name: &str,
+    repos_filter: Option<&[String]>,
+    group_filter: Option<&[String]>,
+) -> anyhow::Result<()> {
+    let mut repos: Vec<RepoInfo> =
+        filter_repos(manifest, workspace_root, repos_filter, group_filter, false);
+
+    let include_manifest = match repos_filter {
+        None => true,
+        Some(filter) => filter.iter().any(|r| r == "manifest"),
+    };
+    if include_manifest {
+        if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
+            repos.push(manifest_repo);
+        }
+    }
+
+    if repos.is_empty() {
+        anyhow::bail!("no repos matched checkout filters");
+    }
+
+    let repo_specs: Vec<(&str, &str, &str)> = repos
+        .iter()
+        .map(|repo| (repo.name.as_str(), repo.url.as_str(), repo.path.as_str()))
+        .collect();
+
+    let info = workspace_checkout::create_checkout(
+        workspace_root,
+        checkout_name,
+        repo_specs.into_iter(),
+        None,
+    )?;
+
+    Output::success(&format!(
+        "Created checkout '{}' with {} repo(s)",
+        info.name,
+        info.repos.len()
+    ));
+    Output::info(&format!("Path: {}", info.path.display()));
     Ok(())
 }

--- a/src/cli/commands/checkout.rs
+++ b/src/cli/commands/checkout.rs
@@ -163,3 +163,35 @@ pub fn run_checkout_add(
     Output::info(&format!("Path: {}", info.path.display()));
     Ok(())
 }
+
+/// List cache-backed child checkouts.
+pub fn run_checkout_list(workspace_root: &Path) -> anyhow::Result<()> {
+    Output::header("Checkouts");
+    println!();
+
+    let checkouts = workspace_checkout::list_checkouts(workspace_root)?;
+    if checkouts.is_empty() {
+        println!("No checkouts configured.");
+        return Ok(());
+    }
+
+    for checkout in checkouts {
+        println!("{} -> {}", checkout.name, checkout.path.display());
+    }
+
+    Ok(())
+}
+
+/// Remove a cache-backed child checkout.
+pub fn run_checkout_remove(workspace_root: &Path, checkout_name: &str) -> anyhow::Result<()> {
+    Output::header(&format!("Removing checkout '{}'", checkout_name));
+    println!();
+
+    let removed = workspace_checkout::remove_checkout(workspace_root, checkout_name)?;
+    if removed {
+        Output::success(&format!("Removed checkout '{}'", checkout_name));
+        Ok(())
+    } else {
+        anyhow::bail!("Checkout '{}' not found", checkout_name);
+    }
+}

--- a/src/cli/commands/migrate.rs
+++ b/src/cli/commands/migrate.rs
@@ -99,19 +99,9 @@ pub async fn run_migrate_from_repos(
         Vec::new()
     };
 
-    let premium = if interactive {
-        let theme = ColorfulTheme::default();
-        Confirm::with_theme(&theme)
-            .with_prompt("Enable premium features (persistent agents, team sharing)?")
-            .default(false)
-            .interact()?
-    } else {
-        false
-    };
-
     // Generate all files
     let manifest_yaml = generate_manifest_yaml(&parsed_repos, org_str, prefix_str);
-    let claude_md = generate_claude_md(&parsed_repos, prefix_str, &agents, premium);
+    let claude_md = generate_claude_md(&parsed_repos, prefix_str, &agents);
     let agents_toml = generate_agents_toml(prefix_str, &agents);
     let prompts: Vec<(String, String)> = agents
         .iter()
@@ -157,7 +147,6 @@ pub async fn run_migrate_from_repos(
             "target_dir": target_dir.display().to_string(),
             "repos": repos,
             "agents": agents.iter().map(|a| &a.name).collect::<Vec<_>>(),
-            "premium": premium,
             "manifest": ".gitgrip/spaces/main/gripspace.yml",
             "config": "config/",
         });
@@ -281,7 +270,6 @@ fn generate_claude_md(
     repos: &[(String, String)],
     prefix: &str,
     agents: &[AgentSpec],
-    premium: bool,
 ) -> String {
     let mut md = String::new();
     md.push_str(&format!("# {}\n\n", prefix));
@@ -316,16 +304,6 @@ fn generate_claude_md(
     md.push_str("gr pr create -t \"feat: title\" --push\n");
     md.push_str("gr pr merge              # Merge linked PRs\n");
     md.push_str("```\n");
-
-    if premium {
-        md.push_str("\n## Premium Features\n\n");
-        md.push_str("This workspace has premium features enabled:\n");
-        md.push_str("- `recall_identity` — persistent agent identity\n");
-        md.push_str("- `recall_career` — cross-project career memory\n");
-        md.push_str("- `recall_promote` — share knowledge across team\n");
-        md.push_str("- `recall_approve` — approve promoted knowledge\n\n");
-        md.push_str("Use `recall_promote` after learning something reusable across projects.\n");
-    }
 
     md
 }
@@ -1068,12 +1046,12 @@ mod tests {
             model: "claude-opus-4-6".to_string(),
             tool: "claude".to_string(),
         }];
-        let md = generate_claude_md(&repos, "myproject", &agents, true);
+        let md = generate_claude_md(&repos, "myproject", &agents);
         assert!(md.contains("# myproject"));
         assert!(md.contains("| **myrepo**"));
         assert!(md.contains("| **atlas**"));
-        assert!(md.contains("Premium Features"));
-        assert!(md.contains("recall_identity"));
+        assert!(!md.contains("Premium Features"));
+        assert!(!md.contains("recall_identity"));
     }
 
     #[test]

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod add;
 pub mod agent;
 pub mod bench;
 pub mod branch;
+pub mod cache;
 pub mod channel;
 pub mod checkout;
 pub mod cherry_pick;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -93,30 +93,53 @@ pub async fn dispatch_command(
         }
         Some(Commands::Checkout {
             name,
+            extra,
             create,
             base,
             repo,
             group,
         }) => {
             let ctx = load_workspace_context(quiet, verbose, json)?;
-            let branch = if base {
-                let config = crate::core::griptree::GriptreeConfig::load_from_workspace(
-                    &ctx.workspace_root,
-                )?
-                .ok_or_else(|| anyhow::anyhow!("Not in a griptree workspace"))?;
-                config.branch
-            } else {
-                name.ok_or_else(|| anyhow::anyhow!("Branch name is required"))?
-            };
 
-            crate::cli::commands::checkout::run_checkout(
-                &ctx.workspace_root,
-                &ctx.manifest,
-                &branch,
-                create,
-                repo.as_deref(),
-                group.as_deref(),
-            )?;
+            if matches!(name.as_deref(), Some("add")) {
+                // `add` is reserved for checkout materialization, not branch switching.
+                if create || base {
+                    anyhow::bail!("--create and --base are not valid with 'add'");
+                }
+                if extra.len() > 1 {
+                    anyhow::bail!("unexpected extra arguments after checkout name");
+                }
+                let checkout_name = extra.first().ok_or_else(|| {
+                    anyhow::anyhow!("Checkout name is required: gr checkout add <name>")
+                })?;
+
+                crate::cli::commands::checkout::run_checkout_add(
+                    &ctx.workspace_root,
+                    &ctx.manifest,
+                    checkout_name,
+                    repo.as_deref(),
+                    group.as_deref(),
+                )?;
+            } else {
+                let branch = if base {
+                    let config = crate::core::griptree::GriptreeConfig::load_from_workspace(
+                        &ctx.workspace_root,
+                    )?
+                    .ok_or_else(|| anyhow::anyhow!("Not in a griptree workspace"))?;
+                    config.branch
+                } else {
+                    name.ok_or_else(|| anyhow::anyhow!("Branch name is required"))?
+                };
+
+                crate::cli::commands::checkout::run_checkout(
+                    &ctx.workspace_root,
+                    &ctx.manifest,
+                    &branch,
+                    create,
+                    repo.as_deref(),
+                    group.as_deref(),
+                )?;
+            }
         }
         Some(Commands::Add { files, repo, group }) => {
             let ctx = load_workspace_context(quiet, verbose, json)?;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -120,6 +120,25 @@ pub async fn dispatch_command(
                     repo.as_deref(),
                     group.as_deref(),
                 )?;
+            } else if matches!(name.as_deref(), Some("list")) {
+                if create || base || !extra.is_empty() {
+                    anyhow::bail!("`gr checkout list` does not accept extra arguments");
+                }
+                crate::cli::commands::checkout::run_checkout_list(&ctx.workspace_root)?;
+            } else if matches!(name.as_deref(), Some("remove")) {
+                if create || base {
+                    anyhow::bail!("--create and --base are not valid with 'remove'");
+                }
+                if extra.len() > 1 {
+                    anyhow::bail!("unexpected extra arguments after checkout name");
+                }
+                let checkout_name = extra.first().ok_or_else(|| {
+                    anyhow::anyhow!("Checkout name is required: gr checkout remove <name>")
+                })?;
+                crate::cli::commands::checkout::run_checkout_remove(
+                    &ctx.workspace_root,
+                    checkout_name,
+                )?;
             } else {
                 let branch = if base {
                     let config = crate::core::griptree::GriptreeConfig::load_from_workspace(

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -636,6 +636,15 @@ pub async fn dispatch_command(
                 }
             }
         }
+        Some(Commands::Cache { action }) => {
+            let ctx = load_workspace_context(quiet, verbose, json)?;
+            crate::cli::commands::cache::run_cache(
+                &ctx.workspace_root,
+                &ctx.manifest,
+                action,
+                ctx.quiet,
+            )?;
+        }
         Some(Commands::Gc {
             aggressive,
             dry_run,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,8 @@ pub mod repo;
 pub mod repo_manifest;
 pub mod state;
 pub mod sync_state;
+pub mod workspace_cache;
+pub mod workspace_checkout;
 
 pub use manifest::CloneStrategy;
 pub use manifest::Manifest;

--- a/src/core/workspace_cache.rs
+++ b/src/core/workspace_cache.rs
@@ -1,0 +1,362 @@
+//! Workspace cache — bare-repo cache layer for manifest repos
+//!
+//! Each manifest repo gets a bare clone under `.grip/cache/<name>.git`.
+//! These caches serve as fast local references for creating agent workspaces
+//! and manual checkouts without sharing mutable .git state.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::util::log_cmd;
+
+/// Directory name under .grip/ where bare caches live.
+const CACHE_DIR: &str = "cache";
+
+/// Resolve the cache path for a repo: `<workspace_root>/.grip/cache/<name>.git`
+pub fn cache_path(workspace_root: &Path, repo_name: &str) -> PathBuf {
+    workspace_root
+        .join(".grip")
+        .join(CACHE_DIR)
+        .join(format!("{}.git", repo_name))
+}
+
+/// Check whether a bare cache exists for the given repo.
+pub fn cache_exists(workspace_root: &Path, repo_name: &str) -> bool {
+    let path = cache_path(workspace_root, repo_name);
+    // A valid bare repo has a HEAD file
+    path.join("HEAD").is_file()
+}
+
+/// Bootstrap a bare cache by cloning from the canonical remote.
+///
+/// Creates `.grip/cache/<name>.git` as a bare clone of `url`.
+/// If the cache already exists, this is a no-op (use `update_cache` to fetch).
+pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<()> {
+    let path = cache_path(workspace_root, repo_name);
+
+    if cache_exists(workspace_root, repo_name) {
+        return Ok(());
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating cache directory: {}", parent.display()))?;
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(["clone", "--bare", url]).arg(&path);
+    log_cmd(&cmd);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("running git clone --bare for {}", repo_name))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to bootstrap cache for {}: {}",
+            repo_name,
+            stderr.trim()
+        );
+    }
+
+    Ok(())
+}
+
+/// Fetch latest refs into an existing bare cache.
+///
+/// Runs `git fetch --all --prune` inside the bare repo to bring it up to date.
+pub fn update_cache(workspace_root: &Path, repo_name: &str) -> Result<()> {
+    let path = cache_path(workspace_root, repo_name);
+
+    if !cache_exists(workspace_root, repo_name) {
+        anyhow::bail!("cache does not exist for {}: {}", repo_name, path.display());
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(["fetch", "--all", "--prune"]).current_dir(&path);
+    log_cmd(&cmd);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("fetching cache for {}", repo_name))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to update cache for {}: {}",
+            repo_name,
+            stderr.trim()
+        );
+    }
+
+    Ok(())
+}
+
+/// Get the remote URL stored in a bare cache.
+pub fn cache_remote_url(workspace_root: &Path, repo_name: &str) -> Result<Option<String>> {
+    let path = cache_path(workspace_root, repo_name);
+
+    if !cache_exists(workspace_root, repo_name) {
+        return Ok(None);
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(["remote", "get-url", "origin"]).current_dir(&path);
+    log_cmd(&cmd);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("reading cache remote for {}", repo_name))?;
+
+    if output.status.success() {
+        Ok(Some(
+            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Bootstrap caches for all repos in a manifest.
+///
+/// Takes an iterator of (name, url) pairs. Skips repos that already have caches.
+/// Returns the count of newly bootstrapped caches.
+pub fn bootstrap_all<'a>(
+    workspace_root: &Path,
+    repos: impl Iterator<Item = (&'a str, &'a str)>,
+) -> Result<usize> {
+    let mut count = 0;
+    for (name, url) in repos {
+        if !cache_exists(workspace_root, name) {
+            bootstrap_cache(workspace_root, name, url)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+/// Update all existing caches under `.grip/cache/`.
+///
+/// Returns the count of caches updated.
+pub fn update_all(workspace_root: &Path) -> Result<usize> {
+    let cache_dir = workspace_root.join(".grip").join(CACHE_DIR);
+    if !cache_dir.is_dir() {
+        return Ok(0);
+    }
+
+    let mut count = 0;
+    for entry in std::fs::read_dir(&cache_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Cache dirs are named <repo>.git
+        if name_str.ends_with(".git") && entry.path().join("HEAD").is_file() {
+            let repo_name = name_str.trim_end_matches(".git");
+            update_cache(workspace_root, repo_name)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+/// Remove a single repo cache.
+pub fn remove_cache(workspace_root: &Path, repo_name: &str) -> Result<bool> {
+    let path = cache_path(workspace_root, repo_name);
+    if path.is_dir() {
+        std::fs::remove_dir_all(&path)
+            .with_context(|| format!("removing cache: {}", path.display()))?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Helper: create a temporary "remote" repo to clone from
+    fn create_test_remote(dir: &Path) -> PathBuf {
+        let remote_path = dir.join("remote-repo.git");
+        // Init a bare repo to act as the remote
+        Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&remote_path)
+            .output()
+            .expect("git init --bare");
+
+        // Create a non-bare repo, add a commit, push to the bare repo
+        let work_path = dir.join("work-repo");
+        Command::new("git")
+            .args(["init"])
+            .arg(&work_path)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&work_path)
+            .output()
+            .expect("git config email");
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&work_path)
+            .output()
+            .expect("git config name");
+        fs::write(work_path.join("README.md"), "# test").expect("write file");
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&work_path)
+            .output()
+            .expect("git add");
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(&work_path)
+            .output()
+            .expect("git commit");
+        Command::new("git")
+            .args(["remote", "add", "origin"])
+            .arg(&remote_path)
+            .current_dir(&work_path)
+            .output()
+            .expect("git remote add");
+        Command::new("git")
+            .args(["push", "origin", "main"])
+            .current_dir(&work_path)
+            .output()
+            .ok(); // might be master, not main
+        Command::new("git")
+            .args(["push", "origin", "master"])
+            .current_dir(&work_path)
+            .output()
+            .ok();
+
+        remote_path
+    }
+
+    #[test]
+    fn test_cache_path() {
+        let root = Path::new("/workspace");
+        let path = cache_path(root, "myrepo");
+        assert_eq!(path, PathBuf::from("/workspace/.grip/cache/myrepo.git"));
+    }
+
+    #[test]
+    fn test_cache_does_not_exist_initially() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!cache_exists(tmp.path(), "nonexistent"));
+    }
+
+    #[test]
+    fn test_bootstrap_and_exists() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        assert!(!cache_exists(&workspace, "testrepo"));
+
+        bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap");
+        assert!(cache_exists(&workspace, "testrepo"));
+
+        // Verify it's a bare repo
+        let cp = cache_path(&workspace, "testrepo");
+        assert!(cp.join("HEAD").is_file());
+        assert!(!cp.join(".git").exists()); // bare repos don't have .git subdir
+    }
+
+    #[test]
+    fn test_bootstrap_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 1");
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 2"); // no-op
+        assert!(cache_exists(&workspace, "repo"));
+    }
+
+    #[test]
+    fn test_update_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+        update_cache(&workspace, "repo").expect("update");
+    }
+
+    #[test]
+    fn test_update_nonexistent_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = update_cache(tmp.path(), "nope");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cache_remote_url() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+
+        let stored_url = cache_remote_url(&workspace, "repo")
+            .expect("get url")
+            .expect("has url");
+        assert_eq!(stored_url, url);
+    }
+
+    #[test]
+    fn test_remove_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+        assert!(cache_exists(&workspace, "repo"));
+
+        let removed = remove_cache(&workspace, "repo").expect("remove");
+        assert!(removed);
+        assert!(!cache_exists(&workspace, "repo"));
+    }
+
+    #[test]
+    fn test_remove_nonexistent_returns_false() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let removed = remove_cache(tmp.path(), "nope").expect("remove");
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_bootstrap_all() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let remote = create_test_remote(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
+        let count = bootstrap_all(&workspace, repos.into_iter()).expect("bootstrap all");
+        assert_eq!(count, 2);
+        assert!(cache_exists(&workspace, "repo1"));
+        assert!(cache_exists(&workspace, "repo2"));
+
+        // Second call: no new bootstraps
+        let repos2 = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
+        let count2 = bootstrap_all(&workspace, repos2.into_iter()).expect("bootstrap all 2");
+        assert_eq!(count2, 0);
+    }
+}

--- a/src/core/workspace_cache.rs
+++ b/src/core/workspace_cache.rs
@@ -1,45 +1,139 @@
 //! Workspace cache — bare-repo cache layer for manifest repos
 //!
-//! Each manifest repo gets a bare clone under `.grip/cache/<name>.git`.
-//! These caches serve as fast local references for creating agent workspaces
-//! and manual checkouts without sharing mutable .git state.
+//! Caches now live at a machine-level root by default (`~/.grip/cache/`),
+//! keyed by normalized remote URL rather than workspace-local repo name.
+//! This lets multiple workspaces reuse the same object store without sharing
+//! mutable `.git` state between checkouts.
 
 use anyhow::{Context, Result};
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::util::log_cmd;
 
-/// Directory name under .grip/ where bare caches live.
+const CACHE_ENV_VAR: &str = "GRIP_CACHE_DIR";
+const GRIP_DIR: &str = ".grip";
 const CACHE_DIR: &str = "cache";
 
-/// Resolve the cache path for a repo: `<workspace_root>/.grip/cache/<name>.git`
-pub fn cache_path(workspace_root: &Path, repo_name: &str) -> PathBuf {
+fn home_dir() -> Result<PathBuf> {
+    if let Some(home) = env::var_os("HOME") {
+        return Ok(PathBuf::from(home));
+    }
+    if let Some(profile) = env::var_os("USERPROFILE") {
+        return Ok(PathBuf::from(profile));
+    }
+    anyhow::bail!("could not resolve home directory for global cache root")
+}
+
+/// Resolve the machine-level cache root.
+pub fn cache_root() -> Result<PathBuf> {
+    if let Some(override_dir) = env::var_os(CACHE_ENV_VAR) {
+        return Ok(PathBuf::from(override_dir));
+    }
+    Ok(home_dir()?.join(GRIP_DIR).join(CACHE_DIR))
+}
+
+fn legacy_cache_path(workspace_root: &Path, repo_name: &str) -> PathBuf {
     workspace_root
-        .join(".grip")
+        .join(GRIP_DIR)
         .join(CACHE_DIR)
         .join(format!("{}.git", repo_name))
 }
 
-/// Check whether a bare cache exists for the given repo.
-pub fn cache_exists(workspace_root: &Path, repo_name: &str) -> bool {
-    let path = cache_path(workspace_root, repo_name);
-    // A valid bare repo has a HEAD file
+fn normalize_git_url(url: &str) -> String {
+    let trimmed = url.trim().trim_end_matches('/').trim_end_matches(".git");
+
+    if !trimmed.contains("://") {
+        if let Some((user_host, path)) = trimmed.split_once(':') {
+            let host = user_host.rsplit('@').next().unwrap_or(user_host);
+            if !host.is_empty() && !path.is_empty() {
+                return format!(
+                    "{}:{}",
+                    host.to_ascii_lowercase(),
+                    path.trim_start_matches('/')
+                );
+            }
+        }
+    }
+
+    if let Some((_, rest)) = trimmed.split_once("://") {
+        if let Some((host_user, path)) = rest.split_once('/') {
+            let host = host_user.rsplit('@').next().unwrap_or(host_user);
+            if !host.is_empty() && !path.is_empty() {
+                return format!(
+                    "{}:{}",
+                    host.to_ascii_lowercase(),
+                    path.trim_start_matches('/')
+                );
+            }
+        }
+    }
+
+    trimmed.to_string()
+}
+
+/// Stable filesystem-safe cache key derived from a normalized remote URL.
+pub fn cache_key(url: &str) -> String {
+    let normalized = normalize_git_url(url);
+    let mut key = String::with_capacity(normalized.len());
+    let mut last_was_sep = false;
+
+    for ch in normalized.chars() {
+        if ch.is_ascii_alphanumeric() {
+            key.push(ch.to_ascii_lowercase());
+            last_was_sep = false;
+        } else if !last_was_sep {
+            key.push('_');
+            last_was_sep = true;
+        }
+    }
+
+    key.trim_matches('_').to_string()
+}
+
+/// Resolve the primary global cache path for a repo URL.
+pub fn cache_path(url: &str) -> Result<PathBuf> {
+    Ok(cache_root()?.join(format!("{}.git", cache_key(url))))
+}
+
+fn cache_is_valid(path: &Path) -> bool {
     path.join("HEAD").is_file()
 }
 
-/// Bootstrap a bare cache by cloning from the canonical remote.
-///
-/// Creates `.grip/cache/<name>.git` as a bare clone of `url`.
-/// If the cache already exists, this is a no-op (use `update_cache` to fetch).
-pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<()> {
-    let path = cache_path(workspace_root, repo_name);
+/// Resolve the cache path to use, preferring the global cache but falling back
+/// to an existing legacy workspace-local cache.
+pub fn resolve_cache_path(workspace_root: &Path, repo_name: &str, url: &str) -> Result<PathBuf> {
+    let global = cache_path(url)?;
+    if cache_is_valid(&global) {
+        return Ok(global);
+    }
 
-    if cache_exists(workspace_root, repo_name) {
+    let legacy = legacy_cache_path(workspace_root, repo_name);
+    if cache_is_valid(&legacy) {
+        return Ok(legacy);
+    }
+
+    Ok(global)
+}
+
+/// Check whether a cache exists for the given repo.
+pub fn cache_exists(workspace_root: &Path, repo_name: &str, url: &str) -> Result<bool> {
+    Ok(cache_is_valid(&resolve_cache_path(
+        workspace_root,
+        repo_name,
+        url,
+    )?))
+}
+
+/// Bootstrap a bare cache by cloning from the canonical remote.
+pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<()> {
+    let existing = resolve_cache_path(workspace_root, repo_name, url)?;
+    if cache_is_valid(&existing) {
         return Ok(());
     }
 
-    // Ensure parent directory exists
+    let path = cache_path(url)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating cache directory: {}", parent.display()))?;
@@ -66,12 +160,10 @@ pub fn bootstrap_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Res
 }
 
 /// Fetch latest refs into an existing bare cache.
-///
-/// Runs `git fetch --all --prune` inside the bare repo to bring it up to date.
-pub fn update_cache(workspace_root: &Path, repo_name: &str) -> Result<()> {
-    let path = cache_path(workspace_root, repo_name);
+pub fn update_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<()> {
+    let path = resolve_cache_path(workspace_root, repo_name, url)?;
 
-    if !cache_exists(workspace_root, repo_name) {
+    if !cache_is_valid(&path) {
         anyhow::bail!("cache does not exist for {}: {}", repo_name, path.display());
     }
 
@@ -96,10 +188,14 @@ pub fn update_cache(workspace_root: &Path, repo_name: &str) -> Result<()> {
 }
 
 /// Get the remote URL stored in a bare cache.
-pub fn cache_remote_url(workspace_root: &Path, repo_name: &str) -> Result<Option<String>> {
-    let path = cache_path(workspace_root, repo_name);
+pub fn cache_remote_url(
+    workspace_root: &Path,
+    repo_name: &str,
+    url: &str,
+) -> Result<Option<String>> {
+    let path = resolve_cache_path(workspace_root, repo_name, url)?;
 
-    if !cache_exists(workspace_root, repo_name) {
+    if !cache_is_valid(&path) {
         return Ok(None);
     }
 
@@ -121,16 +217,13 @@ pub fn cache_remote_url(workspace_root: &Path, repo_name: &str) -> Result<Option
 }
 
 /// Bootstrap caches for all repos in a manifest.
-///
-/// Takes an iterator of (name, url) pairs. Skips repos that already have caches.
-/// Returns the count of newly bootstrapped caches.
 pub fn bootstrap_all<'a>(
     workspace_root: &Path,
     repos: impl Iterator<Item = (&'a str, &'a str)>,
 ) -> Result<usize> {
     let mut count = 0;
     for (name, url) in repos {
-        if !cache_exists(workspace_root, name) {
+        if !cache_exists(workspace_root, name, url)? {
             bootstrap_cache(workspace_root, name, url)?;
             count += 1;
         }
@@ -138,24 +231,15 @@ pub fn bootstrap_all<'a>(
     Ok(count)
 }
 
-/// Update all existing caches under `.grip/cache/`.
-///
-/// Returns the count of caches updated.
-pub fn update_all(workspace_root: &Path) -> Result<usize> {
-    let cache_dir = workspace_root.join(".grip").join(CACHE_DIR);
-    if !cache_dir.is_dir() {
-        return Ok(0);
-    }
-
+/// Update all caches for repos in the current manifest.
+pub fn update_all<'a>(
+    workspace_root: &Path,
+    repos: impl Iterator<Item = (&'a str, &'a str)>,
+) -> Result<usize> {
     let mut count = 0;
-    for entry in std::fs::read_dir(&cache_dir)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        // Cache dirs are named <repo>.git
-        if name_str.ends_with(".git") && entry.path().join("HEAD").is_file() {
-            let repo_name = name_str.trim_end_matches(".git");
-            update_cache(workspace_root, repo_name)?;
+    for (name, url) in repos {
+        if cache_exists(workspace_root, name, url)? {
+            update_cache(workspace_root, name, url)?;
             count += 1;
         }
     }
@@ -163,8 +247,8 @@ pub fn update_all(workspace_root: &Path) -> Result<usize> {
 }
 
 /// Remove a single repo cache.
-pub fn remove_cache(workspace_root: &Path, repo_name: &str) -> Result<bool> {
-    let path = cache_path(workspace_root, repo_name);
+pub fn remove_cache(workspace_root: &Path, repo_name: &str, url: &str) -> Result<bool> {
+    let path = resolve_cache_path(workspace_root, repo_name, url)?;
     if path.is_dir() {
         std::fs::remove_dir_all(&path)
             .with_context(|| format!("removing cache: {}", path.display()))?;
@@ -175,21 +259,40 @@ pub fn remove_cache(workspace_root: &Path, repo_name: &str) -> Result<bool> {
 }
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use once_cell::sync::Lazy;
+    use std::sync::Mutex;
+
+    pub(crate) static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
 
-    /// Helper: create a temporary "remote" repo to clone from
+    fn with_cache_dir<T>(cache_dir: &Path, f: impl FnOnce() -> T) -> T {
+        let _guard = test_support::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = env::var_os(CACHE_ENV_VAR);
+        env::set_var(CACHE_ENV_VAR, cache_dir);
+        let result = f();
+        match previous {
+            Some(value) => env::set_var(CACHE_ENV_VAR, value),
+            None => env::remove_var(CACHE_ENV_VAR),
+        }
+        result
+    }
+
     fn create_test_remote(dir: &Path) -> PathBuf {
         let remote_path = dir.join("remote-repo.git");
-        // Init a bare repo to act as the remote
         Command::new("git")
             .args(["init", "--bare"])
             .arg(&remote_path)
             .output()
             .expect("git init --bare");
 
-        // Create a non-bare repo, add a commit, push to the bare repo
         let work_path = dir.join("work-repo");
         Command::new("git")
             .args(["init"])
@@ -227,7 +330,7 @@ mod tests {
             .args(["push", "origin", "main"])
             .current_dir(&work_path)
             .output()
-            .ok(); // might be master, not main
+            .ok();
         Command::new("git")
             .args(["push", "origin", "master"])
             .current_dir(&work_path)
@@ -238,16 +341,37 @@ mod tests {
     }
 
     #[test]
-    fn test_cache_path() {
-        let root = Path::new("/workspace");
-        let path = cache_path(root, "myrepo");
-        assert_eq!(path, PathBuf::from("/workspace/.grip/cache/myrepo.git"));
+    fn test_cache_key_normalizes_remote_url_forms() {
+        let ssh = cache_key("git@github.com:OpenAI/myrepo.git");
+        let https = cache_key("https://github.com/OpenAI/myrepo.git");
+        assert_eq!(ssh, "github_com_openai_myrepo");
+        assert_eq!(ssh, https);
+    }
+
+    #[test]
+    fn test_cache_path_uses_global_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let path = cache_path("git@github.com:OpenAI/myrepo.git").expect("cache path");
+            assert_eq!(path, cache_dir.join("github_com_openai_myrepo.git"));
+        });
     }
 
     #[test]
     fn test_cache_does_not_exist_initially() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        assert!(!cache_exists(tmp.path(), "nonexistent"));
+        let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        with_cache_dir(&cache_dir, || {
+            assert!(!cache_exists(
+                &workspace,
+                "nonexistent",
+                "git@github.com:user/nonexistent.git"
+            )
+            .expect("cache exists"));
+        });
     }
 
     #[test]
@@ -255,18 +379,20 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        assert!(!cache_exists(&workspace, "testrepo"));
+        with_cache_dir(&cache_dir, || {
+            assert!(!cache_exists(&workspace, "testrepo", &url).expect("cache exists before"));
 
-        bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap");
-        assert!(cache_exists(&workspace, "testrepo"));
+            bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap");
+            assert!(cache_exists(&workspace, "testrepo", &url).expect("cache exists after"));
 
-        // Verify it's a bare repo
-        let cp = cache_path(&workspace, "testrepo");
-        assert!(cp.join("HEAD").is_file());
-        assert!(!cp.join(".git").exists()); // bare repos don't have .git subdir
+            let cp = cache_path(&url).expect("cache path");
+            assert!(cp.join("HEAD").is_file());
+            assert!(!cp.join(".git").exists());
+        });
     }
 
     #[test]
@@ -274,12 +400,15 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 1");
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 2"); // no-op
-        assert!(cache_exists(&workspace, "repo"));
+        with_cache_dir(&cache_dir, || {
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 1");
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap 2");
+            assert!(cache_exists(&workspace, "repo", &url).expect("cache exists"));
+        });
     }
 
     #[test]
@@ -287,18 +416,26 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
-        update_cache(&workspace, "repo").expect("update");
+        with_cache_dir(&cache_dir, || {
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+            update_cache(&workspace, "repo", &url).expect("update");
+        });
     }
 
     #[test]
     fn test_update_nonexistent_fails() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let result = update_cache(tmp.path(), "nope");
-        assert!(result.is_err());
+        let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        with_cache_dir(&cache_dir, || {
+            let result = update_cache(&workspace, "nope", "git@github.com:user/nope.git");
+            assert!(result.is_err());
+        });
     }
 
     #[test]
@@ -306,15 +443,18 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+        with_cache_dir(&cache_dir, || {
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
 
-        let stored_url = cache_remote_url(&workspace, "repo")
-            .expect("get url")
-            .expect("has url");
-        assert_eq!(stored_url, url);
+            let stored_url = cache_remote_url(&workspace, "repo", &url)
+                .expect("get url")
+                .expect("has url");
+            assert_eq!(stored_url, url);
+        });
     }
 
     #[test]
@@ -322,22 +462,31 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
-        assert!(cache_exists(&workspace, "repo"));
+        with_cache_dir(&cache_dir, || {
+            bootstrap_cache(&workspace, "repo", &url).expect("bootstrap");
+            assert!(cache_exists(&workspace, "repo", &url).expect("cache exists"));
 
-        let removed = remove_cache(&workspace, "repo").expect("remove");
-        assert!(removed);
-        assert!(!cache_exists(&workspace, "repo"));
+            let removed = remove_cache(&workspace, "repo", &url).expect("remove");
+            assert!(removed);
+            assert!(!cache_exists(&workspace, "repo", &url).expect("cache removed"));
+        });
     }
 
     #[test]
     fn test_remove_nonexistent_returns_false() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let removed = remove_cache(tmp.path(), "nope").expect("remove");
-        assert!(!removed);
+        let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        with_cache_dir(&cache_dir, || {
+            let removed =
+                remove_cache(&workspace, "nope", "git@github.com:user/nope.git").expect("remove");
+            assert!(!removed);
+        });
     }
 
     #[test]
@@ -345,18 +494,33 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let remote = create_test_remote(tmp.path());
         let workspace = tmp.path().join("workspace");
+        let cache_dir = tmp.path().join("global-cache");
         fs::create_dir_all(&workspace).expect("mkdir workspace");
 
         let url = remote.to_string_lossy().to_string();
-        let repos = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
-        let count = bootstrap_all(&workspace, repos.into_iter()).expect("bootstrap all");
-        assert_eq!(count, 2);
-        assert!(cache_exists(&workspace, "repo1"));
-        assert!(cache_exists(&workspace, "repo2"));
+        with_cache_dir(&cache_dir, || {
+            let repos = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
+            let count = bootstrap_all(&workspace, repos.into_iter()).expect("bootstrap all");
+            assert_eq!(count, 1);
+            assert!(cache_exists(&workspace, "repo1", &url).expect("repo1 cached"));
+            assert!(cache_exists(&workspace, "repo2", &url).expect("repo2 cached"));
 
-        // Second call: no new bootstraps
-        let repos2 = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
-        let count2 = bootstrap_all(&workspace, repos2.into_iter()).expect("bootstrap all 2");
-        assert_eq!(count2, 0);
+            let repos2 = vec![("repo1", url.as_str()), ("repo2", url.as_str())];
+            let count2 = bootstrap_all(&workspace, repos2.into_iter()).expect("bootstrap all 2");
+            assert_eq!(count2, 0);
+        });
+    }
+
+    #[test]
+    fn test_resolve_cache_path_falls_back_to_legacy_workspace_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let legacy = workspace.join(".grip/cache/repo.git");
+        fs::create_dir_all(&legacy).expect("mkdir legacy cache");
+        fs::write(legacy.join("HEAD"), "ref: refs/heads/main\n").expect("write head");
+
+        let resolved = resolve_cache_path(&workspace, "repo", "git@github.com:org/repo.git")
+            .expect("resolve path");
+        assert_eq!(resolved, legacy);
     }
 }

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -69,8 +69,8 @@ pub fn materialize_repo(
             .with_context(|| format!("creating checkout dir: {}", parent.display()))?;
     }
 
-    let cache = workspace_cache::cache_path(workspace_root, repo_name);
-    let has_cache = workspace_cache::cache_exists(workspace_root, repo_name);
+    let cache = workspace_cache::resolve_cache_path(workspace_root, repo_name, repo_url)?;
+    let has_cache = workspace_cache::cache_exists(workspace_root, repo_name, repo_url)?;
 
     let mut cmd = Command::new("git");
     cmd.arg("clone");
@@ -200,7 +200,22 @@ pub fn remove_checkout(workspace_root: &Path, name: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::workspace_cache::test_support;
     use std::fs;
+
+    fn with_cache_dir<T>(cache_dir: &Path, f: impl FnOnce() -> T) -> T {
+        let _guard = test_support::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::var_os("GRIP_CACHE_DIR");
+        std::env::set_var("GRIP_CACHE_DIR", cache_dir);
+        let result = f();
+        match previous {
+            Some(value) => std::env::set_var("GRIP_CACHE_DIR", value),
+            None => std::env::remove_var("GRIP_CACHE_DIR"),
+        }
+        result
+    }
 
     /// Helper: create a test remote repo and bootstrap its cache
     fn setup_cached_workspace(dir: &Path) -> (PathBuf, PathBuf) {
@@ -279,111 +294,127 @@ mod tests {
     #[test]
     fn test_materialize_single_repo() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let target = materialize_repo(
-            &workspace,
-            "test-checkout",
-            "testrepo",
-            &url,
-            "testrepo",
-            None,
-        )
-        .expect("materialize");
+            let url = remote.to_string_lossy().to_string();
+            let target = materialize_repo(
+                &workspace,
+                "test-checkout",
+                "testrepo",
+                &url,
+                "testrepo",
+                None,
+            )
+            .expect("materialize");
 
-        assert!(target.join(".git").exists());
-        assert!(target.join("README.md").exists());
+            assert!(target.join(".git").exists());
+            assert!(target.join("README.md").exists());
+        });
     }
 
     #[test]
     fn test_materialize_is_independent_clone() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let target = materialize_repo(
-            &workspace,
-            "independent",
-            "testrepo",
-            &url,
-            "testrepo",
-            None,
-        )
-        .expect("materialize");
+            let url = remote.to_string_lossy().to_string();
+            let target = materialize_repo(
+                &workspace,
+                "independent",
+                "testrepo",
+                &url,
+                "testrepo",
+                None,
+            )
+            .expect("materialize");
 
-        // The clone has its own .git directory (not a worktree link)
-        assert!(target.join(".git").is_dir());
-        // Not a file pointing elsewhere (that would be a worktree)
-        assert!(!target.join(".git").is_file());
+            assert!(target.join(".git").is_dir());
+            assert!(!target.join(".git").is_file());
+        });
     }
 
     #[test]
     fn test_materialize_uses_cache_reference() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let target = materialize_repo(&workspace, "ref-test", "testrepo", &url, "testrepo", None)
-            .expect("materialize");
+            let url = remote.to_string_lossy().to_string();
+            let target =
+                materialize_repo(&workspace, "ref-test", "testrepo", &url, "testrepo", None)
+                    .expect("materialize");
 
-        // Check alternates file exists (proves --reference was used)
-        let alternates = target.join(".git/objects/info/alternates");
-        assert!(alternates.is_file(), "alternates file should exist");
-        let content = fs::read_to_string(&alternates).expect("read alternates");
-        assert!(
-            content.contains("cache/testrepo.git"),
-            "alternates should reference the cache"
-        );
+            let alternates = target.join(".git/objects/info/alternates");
+            assert!(alternates.is_file(), "alternates file should exist");
+            let content = fs::read_to_string(&alternates).expect("read alternates");
+            assert!(
+                content.contains(&workspace_cache::cache_key(&url)),
+                "alternates should reference the global cache path"
+            );
+        });
     }
 
     #[test]
     fn test_create_and_list_checkout() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            let url = remote.to_string_lossy().to_string();
+            let repos = vec![("testrepo", url.as_str(), "testrepo")];
 
-        let info = create_checkout(&workspace, "feat-x", repos.into_iter(), None)
-            .expect("create checkout");
+            let info = create_checkout(&workspace, "feat-x", repos.into_iter(), None)
+                .expect("create checkout");
 
-        assert_eq!(info.name, "feat-x");
-        assert_eq!(info.repos.len(), 1);
-        assert!(checkout_exists(&workspace, "feat-x"));
+            assert_eq!(info.name, "feat-x");
+            assert_eq!(info.repos.len(), 1);
+            assert!(checkout_exists(&workspace, "feat-x"));
 
-        let all = list_checkouts(&workspace).expect("list");
-        assert_eq!(all.len(), 1);
-        assert_eq!(all[0].name, "feat-x");
+            let all = list_checkouts(&workspace).expect("list");
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].name, "feat-x");
+        });
     }
 
     #[test]
     fn test_create_duplicate_fails() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let repos = vec![("testrepo", url.as_str(), "testrepo")];
-        create_checkout(&workspace, "dup", repos.into_iter(), None).expect("first");
+            let url = remote.to_string_lossy().to_string();
+            let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            create_checkout(&workspace, "dup", repos.into_iter(), None).expect("first");
 
-        let repos2 = vec![("testrepo", url.as_str(), "testrepo")];
-        let result = create_checkout(&workspace, "dup", repos2.into_iter(), None);
-        assert!(result.is_err());
+            let repos2 = vec![("testrepo", url.as_str(), "testrepo")];
+            let result = create_checkout(&workspace, "dup", repos2.into_iter(), None);
+            assert!(result.is_err());
+        });
     }
 
     #[test]
     fn test_remove_checkout() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let repos = vec![("testrepo", url.as_str(), "testrepo")];
-        create_checkout(&workspace, "removeme", repos.into_iter(), None).expect("create");
+            let url = remote.to_string_lossy().to_string();
+            let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            create_checkout(&workspace, "removeme", repos.into_iter(), None).expect("create");
 
-        assert!(checkout_exists(&workspace, "removeme"));
-        let removed = remove_checkout(&workspace, "removeme").expect("remove");
-        assert!(removed);
-        assert!(!checkout_exists(&workspace, "removeme"));
+            assert!(checkout_exists(&workspace, "removeme"));
+            let removed = remove_checkout(&workspace, "removeme").expect("remove");
+            assert!(removed);
+            assert!(!checkout_exists(&workspace, "removeme"));
+        });
     }
 
     #[test]
@@ -396,19 +427,20 @@ mod tests {
     #[test]
     fn test_cache_survives_checkout_removal() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let (workspace, remote) = setup_cached_workspace(tmp.path());
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
 
-        let url = remote.to_string_lossy().to_string();
-        let repos = vec![("testrepo", url.as_str(), "testrepo")];
-        create_checkout(&workspace, "ephemeral", repos.into_iter(), None).expect("create");
+            let url = remote.to_string_lossy().to_string();
+            let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            create_checkout(&workspace, "ephemeral", repos.into_iter(), None).expect("create");
 
-        // Remove the checkout
-        remove_checkout(&workspace, "ephemeral").expect("remove");
+            remove_checkout(&workspace, "ephemeral").expect("remove");
 
-        // Cache must still exist — this is a first-class guarantee
-        assert!(
-            workspace_cache::cache_exists(&workspace, "testrepo"),
-            "cache must survive checkout deletion"
-        );
+            assert!(
+                workspace_cache::cache_exists(&workspace, "testrepo", &url).expect("cache exists"),
+                "cache must survive checkout deletion"
+            );
+        });
     }
 }

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -1,0 +1,414 @@
+//! Workspace checkouts — independent child clones materialized from the cache
+//!
+//! Each checkout lives under `.grip/checkouts/<name>/` and contains full clones
+//! of manifest repos, created with `--reference` to reuse objects from the
+//! bare cache. Checkouts are independently disposable.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::core::workspace_cache;
+use crate::util::log_cmd;
+
+/// Directory name under .grip/ where checkouts live.
+const CHECKOUTS_DIR: &str = "checkouts";
+
+/// Metadata for a single checkout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckoutInfo {
+    pub name: String,
+    pub path: PathBuf,
+    pub repos: Vec<CheckoutRepo>,
+    pub created_at: String,
+}
+
+/// A single repo within a checkout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckoutRepo {
+    pub name: String,
+    pub path: PathBuf,
+    pub branch: Option<String>,
+}
+
+/// Resolve the checkout root: `<workspace_root>/.grip/checkouts/<name>/`
+pub fn checkout_path(workspace_root: &Path, name: &str) -> PathBuf {
+    workspace_root.join(".grip").join(CHECKOUTS_DIR).join(name)
+}
+
+/// Check whether a checkout exists.
+pub fn checkout_exists(workspace_root: &Path, name: &str) -> bool {
+    checkout_path(workspace_root, name).is_dir()
+}
+
+/// Materialize a single repo into a checkout from the cache.
+///
+/// Uses `git clone --reference <cache> <url> <target>` if a cache exists,
+/// otherwise falls back to a direct clone.
+/// Optionally checks out a specific branch.
+pub fn materialize_repo(
+    workspace_root: &Path,
+    checkout_name: &str,
+    repo_name: &str,
+    repo_url: &str,
+    repo_path: &str,
+    branch: Option<&str>,
+) -> Result<PathBuf> {
+    let checkout_root = checkout_path(workspace_root, checkout_name);
+    let target = checkout_root.join(repo_path);
+
+    if target.join(".git").exists() {
+        // Already materialized
+        return Ok(target);
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating checkout dir: {}", parent.display()))?;
+    }
+
+    let cache = workspace_cache::cache_path(workspace_root, repo_name);
+    let has_cache = workspace_cache::cache_exists(workspace_root, repo_name);
+
+    let mut cmd = Command::new("git");
+    cmd.arg("clone");
+
+    // Use cache as reference if available (fast, saves disk via hardlinks)
+    if has_cache {
+        cmd.args(["--reference", &cache.to_string_lossy()]);
+    }
+
+    // Optionally specify branch
+    if let Some(b) = branch {
+        cmd.args(["--branch", b]);
+    }
+
+    cmd.arg(repo_url).arg(&target);
+    log_cmd(&cmd);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("cloning {} into checkout {}", repo_name, checkout_name))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to clone {} into checkout {}: {}",
+            repo_name,
+            checkout_name,
+            stderr.trim()
+        );
+    }
+
+    Ok(target)
+}
+
+/// Create a full checkout with all provided repos.
+///
+/// Takes an iterator of (name, url, path) tuples.
+/// Returns info about the created checkout.
+pub fn create_checkout<'a>(
+    workspace_root: &Path,
+    checkout_name: &str,
+    repos: impl Iterator<Item = (&'a str, &'a str, &'a str)>,
+    branch: Option<&str>,
+) -> Result<CheckoutInfo> {
+    if checkout_exists(workspace_root, checkout_name) {
+        anyhow::bail!("checkout '{}' already exists", checkout_name);
+    }
+
+    let checkout_root = checkout_path(workspace_root, checkout_name);
+    std::fs::create_dir_all(&checkout_root)
+        .with_context(|| format!("creating checkout root: {}", checkout_root.display()))?;
+
+    let mut checkout_repos = Vec::new();
+
+    for (name, url, path) in repos {
+        let target = materialize_repo(workspace_root, checkout_name, name, url, path, branch)?;
+        checkout_repos.push(CheckoutRepo {
+            name: name.to_string(),
+            path: target,
+            branch: branch.map(String::from),
+        });
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let info = CheckoutInfo {
+        name: checkout_name.to_string(),
+        path: checkout_root.clone(),
+        repos: checkout_repos,
+        created_at: now,
+    };
+
+    // Write checkout metadata
+    let meta_path = checkout_root.join(".checkout.json");
+    let json = serde_json::to_string_pretty(&info)?;
+    std::fs::write(&meta_path, json)
+        .with_context(|| format!("writing checkout metadata: {}", meta_path.display()))?;
+
+    Ok(info)
+}
+
+/// List all checkouts under `.grip/checkouts/`.
+pub fn list_checkouts(workspace_root: &Path) -> Result<Vec<CheckoutInfo>> {
+    let checkouts_dir = workspace_root.join(".grip").join(CHECKOUTS_DIR);
+    if !checkouts_dir.is_dir() {
+        return Ok(vec![]);
+    }
+
+    let mut checkouts = Vec::new();
+    for entry in std::fs::read_dir(&checkouts_dir)? {
+        let entry = entry?;
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let meta_path = entry.path().join(".checkout.json");
+        if meta_path.is_file() {
+            let content = std::fs::read_to_string(&meta_path)?;
+            if let Ok(info) = serde_json::from_str::<CheckoutInfo>(&content) {
+                checkouts.push(info);
+            }
+        } else {
+            // Checkout dir exists but no metadata — construct minimal info
+            let name = entry.file_name().to_string_lossy().to_string();
+            checkouts.push(CheckoutInfo {
+                name: name.clone(),
+                path: entry.path(),
+                repos: vec![],
+                created_at: "unknown".to_string(),
+            });
+        }
+    }
+
+    Ok(checkouts)
+}
+
+/// Remove a checkout and all its contents.
+pub fn remove_checkout(workspace_root: &Path, name: &str) -> Result<bool> {
+    let path = checkout_path(workspace_root, name);
+    if path.is_dir() {
+        std::fs::remove_dir_all(&path)
+            .with_context(|| format!("removing checkout: {}", path.display()))?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Helper: create a test remote repo and bootstrap its cache
+    fn setup_cached_workspace(dir: &Path) -> (PathBuf, PathBuf) {
+        let remote_path = dir.join("remote-repo.git");
+        let workspace = dir.join("workspace");
+
+        // Init bare remote
+        Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&remote_path)
+            .output()
+            .expect("git init --bare");
+
+        // Create work repo with a commit
+        let work = dir.join("work-repo");
+        Command::new("git")
+            .args(["init"])
+            .arg(&work)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(&work)
+            .output()
+            .expect("config email");
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&work)
+            .output()
+            .expect("config name");
+        fs::write(work.join("README.md"), "# test repo").expect("write");
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&work)
+            .output()
+            .expect("add");
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(&work)
+            .output()
+            .expect("commit");
+        // Push to bare remote — try both main and master
+        let _ = Command::new("git")
+            .args(["remote", "add", "origin"])
+            .arg(&remote_path)
+            .current_dir(&work)
+            .output();
+        let _ = Command::new("git")
+            .args(["push", "origin", "HEAD"])
+            .current_dir(&work)
+            .output();
+
+        // Create workspace and bootstrap cache
+        fs::create_dir_all(&workspace).expect("mkdir workspace");
+        let url = remote_path.to_string_lossy().to_string();
+        workspace_cache::bootstrap_cache(&workspace, "testrepo", &url).expect("bootstrap cache");
+
+        (workspace, remote_path)
+    }
+
+    #[test]
+    fn test_checkout_path() {
+        let root = Path::new("/ws");
+        assert_eq!(
+            checkout_path(root, "mybranch"),
+            PathBuf::from("/ws/.grip/checkouts/mybranch")
+        );
+    }
+
+    #[test]
+    fn test_checkout_does_not_exist_initially() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!checkout_exists(tmp.path(), "nope"));
+    }
+
+    #[test]
+    fn test_materialize_single_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let target = materialize_repo(
+            &workspace,
+            "test-checkout",
+            "testrepo",
+            &url,
+            "testrepo",
+            None,
+        )
+        .expect("materialize");
+
+        assert!(target.join(".git").exists());
+        assert!(target.join("README.md").exists());
+    }
+
+    #[test]
+    fn test_materialize_is_independent_clone() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let target = materialize_repo(
+            &workspace,
+            "independent",
+            "testrepo",
+            &url,
+            "testrepo",
+            None,
+        )
+        .expect("materialize");
+
+        // The clone has its own .git directory (not a worktree link)
+        assert!(target.join(".git").is_dir());
+        // Not a file pointing elsewhere (that would be a worktree)
+        assert!(!target.join(".git").is_file());
+    }
+
+    #[test]
+    fn test_materialize_uses_cache_reference() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let target = materialize_repo(&workspace, "ref-test", "testrepo", &url, "testrepo", None)
+            .expect("materialize");
+
+        // Check alternates file exists (proves --reference was used)
+        let alternates = target.join(".git/objects/info/alternates");
+        assert!(alternates.is_file(), "alternates file should exist");
+        let content = fs::read_to_string(&alternates).expect("read alternates");
+        assert!(
+            content.contains("cache/testrepo.git"),
+            "alternates should reference the cache"
+        );
+    }
+
+    #[test]
+    fn test_create_and_list_checkout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+
+        let info = create_checkout(&workspace, "feat-x", repos.into_iter(), None)
+            .expect("create checkout");
+
+        assert_eq!(info.name, "feat-x");
+        assert_eq!(info.repos.len(), 1);
+        assert!(checkout_exists(&workspace, "feat-x"));
+
+        let all = list_checkouts(&workspace).expect("list");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].name, "feat-x");
+    }
+
+    #[test]
+    fn test_create_duplicate_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+        create_checkout(&workspace, "dup", repos.into_iter(), None).expect("first");
+
+        let repos2 = vec![("testrepo", url.as_str(), "testrepo")];
+        let result = create_checkout(&workspace, "dup", repos2.into_iter(), None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_remove_checkout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+        create_checkout(&workspace, "removeme", repos.into_iter(), None).expect("create");
+
+        assert!(checkout_exists(&workspace, "removeme"));
+        let removed = remove_checkout(&workspace, "removeme").expect("remove");
+        assert!(removed);
+        assert!(!checkout_exists(&workspace, "removeme"));
+    }
+
+    #[test]
+    fn test_remove_nonexistent_returns_false() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let removed = remove_checkout(tmp.path(), "nope").expect("remove");
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_cache_survives_checkout_removal() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+        let url = remote.to_string_lossy().to_string();
+        let repos = vec![("testrepo", url.as_str(), "testrepo")];
+        create_checkout(&workspace, "ephemeral", repos.into_iter(), None).expect("create");
+
+        // Remove the checkout
+        remove_checkout(&workspace, "ephemeral").expect("remove");
+
+        // Cache must still exist — this is a first-class guarantee
+        assert!(
+            workspace_cache::cache_exists(&workspace, "testrepo"),
+            "cache must survive checkout deletion"
+        );
+    }
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -971,6 +971,70 @@ fn test_gr2_plan_fully_materialized_workspace_produces_noop_plan() {
 }
 
 #[test]
+fn test_gr2_plan_does_not_flag_repo_attachment_presence_as_drift() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://github.com/synapt-dev/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no changes required"))
+        .stdout(predicate::str::contains("configure").not());
+}
+
+#[test]
 fn test_gr2_plan_missing_unit_produces_single_clone_plan() {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().join("demo-team");
@@ -1078,6 +1142,42 @@ repos = ["missing"]
         .stderr(predicate::str::contains(
             "unit 'atlas' references missing repo 'missing'",
         ));
+}
+
+#[test]
+fn test_gr2_plan_reports_when_it_generates_a_missing_workspace_spec() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let spec_path = workspace_root.join(".grip/workspace_spec.toml");
+    assert!(!spec_path.exists());
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generated workspace spec at"))
+        .stdout(predicate::str::contains("no changes required"));
+
+    assert!(spec_path.exists());
 }
 
 #[test]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -867,6 +867,220 @@ fn test_gr2_spec_validate_detects_conflicting_unit_names() {
 }
 
 #[test]
+fn test_gr2_plan_empty_workspace_produces_clone_all_plan() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://github.com/synapt-dev/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = []
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+    std::fs::create_dir_all(workspace_root.join("repos/app")).unwrap();
+    std::fs::write(
+        workspace_root.join("repos/app/repo.toml"),
+        "name = \"app\"\nurl = \"https://github.com/synapt-dev/app.git\"\n",
+    )
+    .unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ExecutionPlan"))
+        .stdout(predicate::str::contains("atlas\tclone"))
+        .stdout(predicate::str::contains("apollo\tclone"));
+}
+
+#[test]
+fn test_gr2_plan_fully_materialized_workspace_produces_noop_plan() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no changes required"));
+}
+
+#[test]
+fn test_gr2_plan_missing_unit_produces_single_clone_plan() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    std::fs::create_dir_all(workspace_root.join("agents/apollo")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/apollo/unit.toml"),
+        "name = \"apollo\"\nkind = \"unit\"\n",
+    )
+    .unwrap();
+
+    let spec_path = workspace_root.join(".grip/workspace_spec.toml");
+    let spec = std::fs::read_to_string(&spec_path).unwrap();
+    let with_apollo = format!(
+        "{}\n[[units]]\nname = \"apollo\"\npath = \"agents/apollo\"\nrepos = []\n",
+        spec.trim_end()
+    );
+    std::fs::write(&spec_path, with_apollo).unwrap();
+    std::fs::remove_file(workspace_root.join("agents/apollo/unit.toml")).unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("apollo\tclone"))
+        .stdout(predicate::str::contains("clone unit 'apollo'"));
+}
+
+#[test]
+fn test_gr2_plan_rejects_invalid_unit_repo_reference() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://github.com/synapt-dev/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["missing"]
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unit 'atlas' references missing repo 'missing'",
+        ));
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -546,6 +546,164 @@ fn test_gr2_repo_remove_requires_gr2_workspace() {
 }
 
 #[test]
+fn test_gr2_unit_add_registers_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Added gr2 unit 'atlas'"));
+
+    let unit_toml = std::fs::read_to_string(workspace_root.join("agents/atlas/unit.toml")).unwrap();
+    assert!(unit_toml.contains("name = \"atlas\""));
+    assert!(unit_toml.contains("kind = \"unit\""));
+
+    let registry = std::fs::read_to_string(workspace_root.join(".grip/units.toml")).unwrap();
+    assert!(registry.contains("[[unit]]"));
+    assert!(registry.contains("name = \"atlas\""));
+}
+
+#[test]
+fn test_gr2_unit_add_rejects_duplicate_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut first = Command::cargo_bin("gr2").unwrap();
+    first
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr2").unwrap();
+    duplicate
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unit 'atlas' already exists"));
+}
+
+#[test]
+fn test_gr2_unit_list_shows_registered_units() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add_atlas = Command::cargo_bin("gr2").unwrap();
+    add_atlas
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut add_opus = Command::cargo_bin("gr2").unwrap();
+    add_opus
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("opus")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Units"))
+        .stdout(predicate::str::contains("- atlas"))
+        .stdout(predicate::str::contains("- opus"));
+}
+
+#[test]
+fn test_gr2_unit_list_reports_empty_state() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No gr2 units registered."));
+}
+
+#[test]
+fn test_gr2_unit_remove_deletes_registered_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let unit_root = workspace_root.join("agents/atlas");
+    assert!(unit_root.join("unit.toml").exists());
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("remove")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed gr2 unit 'atlas'"));
+
+    assert!(!unit_root.exists());
+    assert!(!workspace_root.join(".grip/units.toml").exists());
+}
+
+#[test]
+fn test_gr2_unit_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(temp.path())
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -601,6 +601,27 @@ fn test_gr2_unit_add_rejects_duplicate_unit() {
 }
 
 #[test]
+fn test_gr2_unit_add_rejects_invalid_name() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut invalid = Command::cargo_bin("gr2").unwrap();
+    invalid
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas/dev")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "invalid unit name 'atlas/dev': use only ASCII letters, numbers, '_' or '-'",
+        ));
+}
+
+#[test]
 fn test_gr2_unit_list_shows_registered_units() {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().join("demo-team");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -32,6 +32,519 @@ fn test_version() {
         .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
 }
 
+#[test]
+fn test_gr2_help() {
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "gr2 is the clean-break gitgrip CLI for the new team-workspace, cache, and checkout model.",
+        ))
+        .stdout(predicate::str::contains("doctor"))
+        .stdout(predicate::str::contains("gr2"));
+}
+
+#[test]
+fn test_gr2_version() {
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("gr2 0.1.0"));
+}
+
+#[test]
+fn test_gr2_doctor() {
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("gr2 bootstrap OK"));
+}
+
+#[test]
+fn test_gr2_init_scaffolds_team_workspace() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Initialized gr2 team workspace 'demo'",
+        ));
+
+    assert!(workspace_root.join(".grip").is_dir());
+    assert!(workspace_root.join("config").is_dir());
+    assert!(workspace_root.join("agents").is_dir());
+    assert!(workspace_root.join("repos").is_dir());
+
+    let workspace_toml =
+        std::fs::read_to_string(workspace_root.join(".grip/workspace.toml")).unwrap();
+    assert!(workspace_toml.contains("version = 2"));
+    assert!(workspace_toml.contains("name = \"demo\""));
+    assert!(workspace_toml.contains("layout = \"team-workspace\""));
+}
+
+#[test]
+fn test_gr2_init_rejects_existing_path() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+    std::fs::create_dir_all(&workspace_root).unwrap();
+
+    let mut cmd = Command::cargo_bin("gr2").unwrap();
+    cmd.arg("init")
+        .arg(&workspace_root)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("workspace path already exists"));
+}
+
+#[test]
+fn test_gr2_team_add_registers_agent_workspace() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut team_add = Command::cargo_bin("gr2").unwrap();
+    team_add
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Added gr2 agent workspace 'atlas'",
+        ));
+
+    let agent_toml =
+        std::fs::read_to_string(workspace_root.join("agents/atlas/agent.toml")).unwrap();
+    assert!(agent_toml.contains("name = \"atlas\""));
+    assert!(agent_toml.contains("kind = \"agent-workspace\""));
+}
+
+#[test]
+fn test_gr2_team_add_rejects_duplicate_agent() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut first = Command::cargo_bin("gr2").unwrap();
+    first
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr2").unwrap();
+    duplicate
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("agent 'atlas' already exists"));
+}
+
+#[test]
+fn test_gr2_team_add_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut team_add = Command::cargo_bin("gr2").unwrap();
+    team_add
+        .current_dir(temp.path())
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
+#[test]
+fn test_gr2_team_list_shows_registered_agents() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add_atlas = Command::cargo_bin("gr2").unwrap();
+    add_atlas
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut add_opus = Command::cargo_bin("gr2").unwrap();
+    add_opus
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("opus")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("team")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Agent workspaces"))
+        .stdout(predicate::str::contains("- atlas"))
+        .stdout(predicate::str::contains("- opus"));
+}
+
+#[test]
+fn test_gr2_team_list_reports_empty_state() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("team")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No gr2 agent workspaces registered.",
+        ));
+}
+
+#[test]
+fn test_gr2_team_list_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(temp.path())
+        .arg("team")
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
+#[test]
+fn test_gr2_team_remove_deletes_registered_agent() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(&workspace_root)
+        .arg("team")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let agent_root = workspace_root.join("agents/atlas");
+    assert!(agent_root.join("agent.toml").exists());
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("remove")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Removed gr2 agent workspace 'atlas'",
+        ));
+
+    assert!(!agent_root.exists());
+}
+
+#[test]
+fn test_gr2_team_remove_rejects_missing_agent() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("team")
+        .arg("remove")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("agent 'atlas' not found"));
+}
+
+#[test]
+fn test_gr2_team_remove_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(temp.path())
+        .arg("team")
+        .arg("remove")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
+#[test]
+fn test_gr2_repo_add_registers_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Added gr2 repo 'app' -> https://github.com/synapt-dev/app.git",
+        ));
+
+    let repo_toml = std::fs::read_to_string(workspace_root.join("repos/app/repo.toml")).unwrap();
+    assert!(repo_toml.contains("name = \"app\""));
+    assert!(repo_toml.contains("url = \"https://github.com/synapt-dev/app.git\""));
+
+    let registry = std::fs::read_to_string(workspace_root.join(".grip/repos.toml")).unwrap();
+    assert!(registry.contains("[[repo]]"));
+    assert!(registry.contains("name = \"app\""));
+}
+
+#[test]
+fn test_gr2_repo_add_rejects_duplicate_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut first = Command::cargo_bin("gr2").unwrap();
+    first
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr2").unwrap();
+    duplicate
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("repo 'app' already exists"));
+}
+
+#[test]
+fn test_gr2_repo_add_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(temp.path())
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
+#[test]
+fn test_gr2_repo_list_shows_registered_repos() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add_app = Command::cargo_bin("gr2").unwrap();
+    add_app
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut add_docs = Command::cargo_bin("gr2").unwrap();
+    add_docs
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("docs")
+        .arg("https://github.com/synapt-dev/docs.git")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("repo")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Repos"))
+        .stdout(predicate::str::contains(
+            "- app -> https://github.com/synapt-dev/app.git",
+        ))
+        .stdout(predicate::str::contains(
+            "- docs -> https://github.com/synapt-dev/docs.git",
+        ));
+}
+
+#[test]
+fn test_gr2_repo_list_reports_empty_state() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("repo")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No gr2 repos registered."));
+}
+
+#[test]
+fn test_gr2_repo_list_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(temp.path())
+        .arg("repo")
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
+#[test]
+fn test_gr2_repo_remove_deletes_registered_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let repo_root = workspace_root.join("repos/app");
+    assert!(repo_root.join("repo.toml").exists());
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("remove")
+        .arg("app")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed gr2 repo 'app'"));
+
+    assert!(!repo_root.exists());
+    assert!(!workspace_root.join(".grip/repos.toml").exists());
+}
+
+#[test]
+fn test_gr2_repo_remove_rejects_missing_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("remove")
+        .arg("app")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("repo 'app' not found"));
+}
+
+#[test]
+fn test_gr2_repo_remove_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(temp.path())
+        .arg("repo")
+        .arg("remove")
+        .arg("app")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -725,6 +725,148 @@ fn test_gr2_unit_requires_gr2_workspace() {
 }
 
 #[test]
+fn test_gr2_spec_show_round_trips_workspace_spec() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("schema_version = 1"))
+        .stdout(predicate::str::contains("workspace_name = \"demo\""))
+        .stdout(predicate::str::contains("name = \"app\""))
+        .stdout(predicate::str::contains("name = \"atlas\""));
+
+    let spec = std::fs::read_to_string(workspace_root.join(".grip/workspace_spec.toml")).unwrap();
+    assert!(spec.contains("schema_version = 1"));
+    assert!(spec.contains("workspace_name = \"demo\""));
+    assert!(spec.contains("path = \"repos/app\""));
+    assert!(spec.contains("path = \"agents/atlas\""));
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Workspace spec is valid"));
+}
+
+#[test]
+fn test_gr2_spec_validate_detects_missing_repo_metadata() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    std::fs::remove_file(workspace_root.join("repos/app/repo.toml")).unwrap();
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "workspace spec repo 'app' is missing repo metadata",
+        ));
+}
+
+#[test]
+fn test_gr2_spec_validate_detects_conflicting_unit_names() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    let spec_path = workspace_root.join(".grip/workspace_spec.toml");
+    let spec = std::fs::read_to_string(&spec_path).unwrap();
+    let conflicting = format!(
+        "{}\n[[units]]\nname = \"atlas\"\npath = \"agents/atlas-copy\"\nrepos = []\n",
+        spec.trim_end()
+    );
+    std::fs::write(&spec_path, conflicting).unwrap();
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "workspace spec contains duplicate unit 'atlas'",
+        ));
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -553,15 +553,17 @@ fn test_checkout_help_mentions_add_mode() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Checkout a branch across repos or create an independent child checkout",
+            "Checkout a branch across repos or manage independent child checkouts",
         ))
         .stdout(predicate::str::contains(
-            "Branch name, or `add` to create an independent child checkout",
+            "Branch name, or `add`/`list`/`remove` for child checkout lifecycle",
         ))
         .stdout(predicate::str::contains("gr checkout add sandbox"))
         .stdout(predicate::str::contains(
             "gr checkout add docs-only --group docs",
-        ));
+        ))
+        .stdout(predicate::str::contains("gr checkout list"))
+        .stdout(predicate::str::contains("gr checkout remove sandbox"));
 }
 
 /// Test that `gr status` fails gracefully outside a workspace
@@ -833,5 +835,117 @@ fn test_checkout_add_rejects_duplicate_checkout_name() {
         .failure()
         .stderr(predicate::str::contains(
             "checkout 'sandbox' already exists",
+        ));
+}
+
+#[test]
+fn test_checkout_list_shows_materialized_checkouts() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut add = Command::cargo_bin("gr").unwrap();
+    add.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr").unwrap();
+    list.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Checkouts"))
+        .stdout(predicate::str::contains("sandbox ->"));
+}
+
+#[test]
+fn test_checkout_list_reports_empty_state() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut list = Command::cargo_bin("gr").unwrap();
+    list.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No checkouts configured."));
+}
+
+#[test]
+fn test_checkout_list_rejects_extra_positional_args() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut list = Command::cargo_bin("gr").unwrap();
+    list.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("list")
+        .arg("extra")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`gr checkout list` does not accept extra arguments",
+        ));
+}
+
+#[test]
+fn test_checkout_remove_deletes_materialized_checkout() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let checkout_root = ws.workspace_root.join(".grip/checkouts/sandbox");
+
+    let mut add = Command::cargo_bin("gr").unwrap();
+    add.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .success();
+
+    assert!(checkout_root.is_dir());
+
+    let mut remove = Command::cargo_bin("gr").unwrap();
+    remove
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("remove")
+        .arg("sandbox")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed checkout 'sandbox'"));
+
+    assert!(!checkout_root.exists());
+}
+
+#[test]
+fn test_checkout_remove_errors_for_missing_checkout() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut remove = Command::cargo_bin("gr").unwrap();
+    remove
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("remove")
+        .arg("missing")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Checkout 'missing' not found"));
+}
+
+#[test]
+fn test_checkout_remove_rejects_extra_positional_args() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut remove = Command::cargo_bin("gr").unwrap();
+    remove
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("remove")
+        .arg("sandbox")
+        .arg("extra")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unexpected extra arguments after checkout name",
         ));
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -545,6 +545,25 @@ fn test_gr2_repo_remove_requires_gr2_workspace() {
         ));
 }
 
+#[test]
+fn test_checkout_help_mentions_add_mode() {
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.arg("checkout")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Checkout a branch across repos or create an independent child checkout",
+        ))
+        .stdout(predicate::str::contains(
+            "Branch name, or `add` to create an independent child checkout",
+        ))
+        .stdout(predicate::str::contains("gr checkout add sandbox"))
+        .stdout(predicate::str::contains(
+            "gr checkout add docs-only --group docs",
+        ));
+}
+
 /// Test that `gr status` fails gracefully outside a workspace
 #[test]
 fn test_status_outside_workspace() {
@@ -625,4 +644,194 @@ fn test_checkout_base_uses_griptree_config() {
         git_helpers::current_branch(&ws.repo_path("lib")),
         "feat/base"
     );
+}
+
+#[test]
+fn test_checkout_add_materializes_independent_child_checkout() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_repo("lib")
+        .build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created checkout 'sandbox'"));
+
+    let checkout_root = ws.workspace_root.join(".grip/checkouts/sandbox");
+    let app_checkout = checkout_root.join("app");
+    let lib_checkout = checkout_root.join("lib");
+    assert!(app_checkout.join(".git").is_dir());
+    assert!(!app_checkout.join(".git").is_file());
+    assert!(lib_checkout.join(".git").is_dir());
+    assert!(!lib_checkout.join(".git").is_file());
+
+    let origin = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(&app_checkout)
+        .output()
+        .expect("git remote get-url");
+    let origin = String::from_utf8_lossy(&origin.stdout).trim().to_string();
+    assert_eq!(origin, ws.remote_url("app"));
+}
+
+#[test]
+fn test_checkout_add_respects_repo_filter() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .add_repo("lib")
+        .build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("app-only")
+        .arg("--repo")
+        .arg("app")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Created checkout 'app-only' with 1 repo(s)",
+        ));
+
+    let checkout_root = ws.workspace_root.join(".grip/checkouts/app-only");
+    assert!(checkout_root.join("app/.git").is_dir());
+    assert!(!checkout_root.join("lib").exists());
+}
+
+#[test]
+fn test_checkout_add_respects_group_filter() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo_with_groups("app", vec!["product"])
+        .add_repo_with_groups("docs", vec!["docs"])
+        .build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("docs-only")
+        .arg("--group")
+        .arg("docs")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Created checkout 'docs-only' with 1 repo(s)",
+        ));
+
+    let checkout_root = ws.workspace_root.join(".grip/checkouts/docs-only");
+    assert!(checkout_root.join("docs/.git").is_dir());
+    assert!(!checkout_root.join("app").exists());
+}
+
+#[test]
+fn test_checkout_add_requires_name() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Checkout name is required: gr checkout add <name>",
+        ));
+}
+
+#[test]
+fn test_checkout_add_errors_when_filters_match_no_repos() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("empty")
+        .arg("--repo")
+        .arg("missing")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no repos matched checkout filters",
+        ));
+}
+
+#[test]
+fn test_checkout_add_rejects_create_and_base_flags() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut create_cmd = Command::cargo_bin("gr").unwrap();
+    create_cmd
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .arg("--create")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--create and --base are not valid with 'add'",
+        ));
+
+    let mut base_cmd = Command::cargo_bin("gr").unwrap();
+    base_cmd
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .arg("--base")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--create and --base are not valid with 'add'",
+        ));
+}
+
+#[test]
+fn test_checkout_add_rejects_extra_positional_args() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .arg("extra")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unexpected extra arguments after checkout name",
+        ));
+}
+
+#[test]
+fn test_checkout_add_rejects_duplicate_checkout_name() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut first = Command::cargo_bin("gr").unwrap();
+    first
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr").unwrap();
+    duplicate
+        .current_dir(&ws.workspace_root)
+        .arg("checkout")
+        .arg("add")
+        .arg("sandbox")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "checkout 'sandbox' already exists",
+        ));
 }

--- a/tests/common/git_helpers.rs
+++ b/tests/common/git_helpers.rs
@@ -137,9 +137,13 @@ pub fn clone_repo(url: &str, dest: &Path) {
         "git clone failed: {}",
         String::from_utf8_lossy(&status.stderr)
     );
-    // Configure git identity (CI runners may not have global config)
-    git(dest, &["config", "user.email", "test@example.com"]);
-    git(dest, &["config", "user.name", "Test User"]);
+    configure_identity(dest);
+}
+
+/// Configure local git identity for commits in a repo.
+pub fn configure_identity(repo_path: &Path) {
+    git(repo_path, &["config", "user.email", "test@example.com"]);
+    git(repo_path, &["config", "user.name", "Test User"]);
 }
 
 /// Run a git command, panic on failure.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,3 +2,4 @@ pub mod assertions;
 pub mod fixtures;
 pub mod git_helpers;
 pub mod mock_platform;
+pub mod playground;

--- a/tests/common/playground.rs
+++ b/tests/common/playground.rs
@@ -1,0 +1,139 @@
+//! Disposable playground harness for binary-level CLI flows.
+//!
+//! This is the proving-ground layer for future team-workspace work. It starts
+//! from plain local git repos, initializes a workspace via `gr init --from-dirs`,
+//! and then drives real `gr` commands against that disposable workspace.
+
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+use super::git_helpers;
+
+pub struct PlaygroundHarness {
+    pub _temp: TempDir,
+    pub workspace_root: PathBuf,
+    pub remotes_dir: PathBuf,
+    pub repo_names: Vec<String>,
+}
+
+impl PlaygroundHarness {
+    pub fn new(repo_names: &[&str]) -> Self {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let workspace_root = temp.path().join("playground");
+        let remotes_dir = temp.path().join("remotes");
+        std::fs::create_dir_all(&workspace_root).expect("failed to create workspace root");
+        std::fs::create_dir_all(&remotes_dir).expect("failed to create remotes dir");
+
+        for repo_name in repo_names {
+            let bare_path = remotes_dir.join(format!("{}.git", repo_name));
+            let staging = temp.path().join(format!("staging-{}", repo_name));
+            let repo_path = workspace_root.join(repo_name);
+
+            git_helpers::init_bare_repo(&bare_path);
+            git_helpers::init_repo(&staging);
+            git_helpers::commit_file(
+                &staging,
+                "README.md",
+                &format!("# {}\n", repo_name),
+                "Initial commit",
+            );
+
+            let remote_url = format!("file://{}", bare_path.display());
+            git_helpers::add_remote(&staging, "origin", &remote_url);
+            git_helpers::push_upstream(&staging, "origin", "main");
+            git_helpers::clone_repo(&remote_url, &repo_path);
+        }
+
+        Self {
+            _temp: temp,
+            workspace_root,
+            remotes_dir,
+            repo_names: repo_names.iter().map(|name| (*name).to_string()).collect(),
+        }
+    }
+
+    pub fn repo_path(&self, name: &str) -> PathBuf {
+        self.workspace_root.join(name)
+    }
+
+    pub fn remote_url(&self, name: &str) -> String {
+        format!(
+            "file://{}",
+            self.remotes_dir.join(format!("{}.git", name)).display()
+        )
+    }
+
+    pub fn init_from_dirs(&self) {
+        self.run_from_manifest_dir([
+            "init",
+            "--from-dirs",
+            "-p",
+            self.workspace_root
+                .to_str()
+                .expect("workspace path should be utf-8"),
+        ]);
+        self.ensure_repo_identities();
+    }
+
+    pub fn run_in_workspace<I, S>(&self, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.run(args, &self.workspace_root);
+    }
+
+    pub fn run_from_manifest_dir<I, S>(&self, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.run(args, Path::new(env!("CARGO_MANIFEST_DIR")));
+    }
+
+    pub fn run_in_workspace_output<I, S>(&self, args: I) -> std::process::Output
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.run_output(args, &self.workspace_root)
+    }
+
+    pub fn ensure_repo_identities(&self) {
+        for repo_name in &self.repo_names {
+            let repo_path = self.repo_path(repo_name);
+            if repo_path.join(".git").exists() {
+                git_helpers::configure_identity(&repo_path);
+            }
+        }
+    }
+
+    fn run<I, S>(&self, args: I, current_dir: &Path)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let args_vec: Vec<String> = args.into_iter().map(|s| s.as_ref().to_string()).collect();
+        let output = self.run_output(args_vec.iter().map(String::as_str), current_dir);
+        assert!(
+            output.status.success(),
+            "gr {:?} failed in {}:\nstdout:\n{}\nstderr:\n{}",
+            args_vec,
+            current_dir.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn run_output<I, S>(&self, args: I, current_dir: &Path) -> std::process::Output
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let args_vec: Vec<String> = args.into_iter().map(|s| s.as_ref().to_string()).collect();
+        let mut cmd = std::process::Command::new(assert_cmd::cargo::cargo_bin!("gr"));
+        cmd.current_dir(current_dir)
+            .args(args_vec.iter().map(String::as_str));
+        cmd.output().expect("failed to run gr binary")
+    }
+}

--- a/tests/test_playground.rs
+++ b/tests/test_playground.rs
@@ -1,0 +1,176 @@
+//! Proving-ground tests for the team-workspace playground harness.
+//!
+//! These tests intentionally drive the `gr` binary against disposable local
+//! repos. The goal is to validate the workspace lifecycle in a safe, offline
+//! environment before later slices add cache-backed materialization and agent
+//! workspace flows.
+
+mod common;
+
+use common::assertions::{assert_branch_not_exists, assert_file_exists, assert_on_branch};
+use common::git_helpers;
+use common::playground::PlaygroundHarness;
+
+#[test]
+fn test_playground_cli_flow_init_sync_branch_checkout_and_prune() {
+    let playground = PlaygroundHarness::new(&["frontend", "backend"]);
+
+    playground.init_from_dirs();
+
+    let manifest_path = playground
+        .workspace_root
+        .join(".gitgrip")
+        .join("spaces")
+        .join("main")
+        .join("gripspace.yml");
+    assert_file_exists(&manifest_path);
+
+    std::fs::remove_dir_all(playground.repo_path("backend")).expect("failed to remove backend");
+    assert!(
+        !playground.repo_path("backend").exists(),
+        "backend repo should be removed before sync"
+    );
+
+    playground.run_in_workspace(["sync"]);
+    playground.ensure_repo_identities();
+    assert_file_exists(&playground.repo_path("backend").join(".git"));
+
+    playground.run_in_workspace(["branch", "feat/playground"]);
+    for repo_name in &playground.repo_names {
+        assert_on_branch(&playground.repo_path(repo_name), "feat/playground");
+    }
+
+    git_helpers::commit_file(
+        &playground.repo_path("frontend"),
+        "playground.txt",
+        "frontend playground content\n",
+        "Add frontend playground change",
+    );
+    git_helpers::commit_file(
+        &playground.repo_path("backend"),
+        "playground.txt",
+        "backend playground content\n",
+        "Add backend playground change",
+    );
+
+    playground.run_in_workspace(["checkout", "main"]);
+    for repo_name in &playground.repo_names {
+        assert_on_branch(&playground.repo_path(repo_name), "main");
+    }
+
+    for repo_name in &playground.repo_names {
+        let repo_path = playground.repo_path(repo_name);
+        let output = std::process::Command::new("git")
+            .args([
+                "merge",
+                "feat/playground",
+                "--no-ff",
+                "-m",
+                "Merge feat/playground",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .expect("failed to run git merge");
+        assert!(
+            output.status.success(),
+            "git merge failed in {}: {}",
+            repo_path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    playground.run_in_workspace(["prune", "--execute"]);
+    for repo_name in &playground.repo_names {
+        assert_branch_not_exists(&playground.repo_path(repo_name), "feat/playground");
+        assert_on_branch(&playground.repo_path(repo_name), "main");
+    }
+}
+
+#[test]
+fn test_playground_sync_cli_pulls_upstream_change() {
+    let playground = PlaygroundHarness::new(&["frontend"]);
+
+    playground.init_from_dirs();
+
+    let staging = playground._temp.path().join("sync-staging-frontend");
+    git_helpers::clone_repo(&playground.remote_url("frontend"), &staging);
+    git_helpers::commit_file(
+        &staging,
+        "upstream.txt",
+        "new upstream content\n",
+        "Add upstream change",
+    );
+    git_helpers::push_branch(&staging, "origin", "main");
+
+    let status_output = playground.run_in_workspace_output(["status", "--quiet"]);
+    assert!(
+        status_output.status.success(),
+        "status should succeed before sync: {}",
+        String::from_utf8_lossy(&status_output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&status_output.stdout);
+    assert!(
+        stdout.contains("SUMMARY:"),
+        "quiet status should include summary line, got:\n{}",
+        stdout
+    );
+
+    playground.run_in_workspace(["sync"]);
+
+    assert_file_exists(&playground.repo_path("frontend").join("upstream.txt"));
+    assert_on_branch(&playground.repo_path("frontend"), "main");
+}
+
+#[test]
+fn test_playground_prune_dry_run_keeps_merged_branch() {
+    let playground = PlaygroundHarness::new(&["frontend"]);
+
+    playground.init_from_dirs();
+    playground.run_in_workspace(["branch", "feat/dry-run"]);
+
+    git_helpers::commit_file(
+        &playground.repo_path("frontend"),
+        "dry-run.txt",
+        "dry run content\n",
+        "Add dry-run change",
+    );
+
+    playground.run_in_workspace(["checkout", "main"]);
+
+    let merge_output = std::process::Command::new("git")
+        .args([
+            "merge",
+            "feat/dry-run",
+            "--no-ff",
+            "-m",
+            "Merge feat/dry-run",
+        ])
+        .current_dir(playground.repo_path("frontend"))
+        .output()
+        .expect("failed to run git merge");
+    assert!(
+        merge_output.status.success(),
+        "git merge failed: {}",
+        String::from_utf8_lossy(&merge_output.stderr)
+    );
+
+    let prune_output = playground.run_in_workspace_output(["prune"]);
+    assert!(
+        prune_output.status.success(),
+        "prune dry-run should succeed: {}",
+        String::from_utf8_lossy(&prune_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&prune_output.stdout);
+    assert!(
+        stdout.contains("Would delete: feat/dry-run"),
+        "expected dry-run prune output to mention feat/dry-run, got:\n{}",
+        stdout
+    );
+
+    assert_on_branch(&playground.repo_path("frontend"), "main");
+    assert!(
+        git_helpers::branch_exists(&playground.repo_path("frontend"), "feat/dry-run"),
+        "dry-run prune should not delete the merged branch"
+    );
+}


### PR DESCRIPTION
## Summary
- add an `ExecutionPlan` model for the `gr2` pipeline
- wire `gr2 plan` to diff a validated `WorkspaceSpec` against the current workspace
- add plan-level apply guards and CLI coverage for clone/no-op/drift/error cases

## Included
- `gr2/src/plan.rs` with typed operations, dry-run previews, and apply guards
- `gr2 plan` CLI wiring in `gr2/src/args.rs` and `gr2/src/dispatch.rs`
- split spec validation so planning can validate semantics without requiring every unit to already exist on disk
- focused CLI tests for clone-all, no-op, single missing unit, and invalid unit repo references

## Note on base branch
`origin/sprint-16` was cut before the latest `gr2` Sprint 15 merges, so this PR carries the current `gr2` critical-path base forward into Sprint 16 along with the new planning slice.

## Verification
- `cargo test --test cli_tests test_gr2_plan --quiet`
- `cargo test --test cli_tests test_gr2_spec --quiet`
- `cargo check -p gr2-cli --quiet`
- `cargo clippy -p gr2-cli --quiet`
