### PR TITLE
feat: add initial gr2 apply command

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -62,6 +62,13 @@ pub enum Commands {
         #[arg(long)]
         yes: bool,
     },
+
+    /// Apply the current execution plan to the workspace
+    Apply {
+        /// Pre-approve plans with more than 3 operations
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -379,6 +379,38 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
             }
             Ok(())
         }
+        Commands::Apply { yes } => {
+            let workspace_root = require_workspace_root()?;
+            let build = ExecutionPlan::from_workspace_spec(&workspace_root)?;
+            let guard_report = build.plan.guard_for_apply(&workspace_root, yes)?;
+
+            if build.generated_spec {
+                println!(
+                    "Generated workspace spec at {} from current workspace state.",
+                    workspace_spec_path(&workspace_root).display()
+                );
+            }
+
+            if guard_report.requires_confirmation {
+                anyhow::bail!("plan contains more than 3 operations; rerun with --yes to apply it");
+            }
+
+            for warning in &guard_report.warnings {
+                println!("warning: {}", warning);
+            }
+
+            let applied = build.plan.apply(&workspace_root, &build.spec)?;
+            if applied.is_empty() {
+                println!("ExecutionPlan");
+                println!("- no changes required");
+            } else {
+                println!("Applied execution plan");
+                for line in applied {
+                    println!("- {}", line);
+                }
+            }
+            Ok(())
+        }
     }
 }
 

--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -1,9 +1,12 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::Path;
 
-use crate::spec::{read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec};
+use crate::spec::{
+    read_workspace_spec, workspace_spec_path, write_workspace_spec, UnitSpec, WorkspaceSpec,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExecutionPlan {
@@ -93,6 +96,48 @@ impl ExecutionPlan {
         })
     }
 
+    pub fn apply(&self, workspace_root: &Path, spec: &WorkspaceSpec) -> Result<Vec<String>> {
+        let mut applied = Vec::new();
+
+        for operation in &self.operations {
+            let unit_spec = spec
+                .units
+                .iter()
+                .find(|unit| unit.name == operation.unit_name)
+                .with_context(|| {
+                    format!(
+                        "execution plan references unknown unit '{}'",
+                        operation.unit_name
+                    )
+                })?;
+
+            match operation.operation {
+                OperationType::Clone => {
+                    materialize_unit(workspace_root, unit_spec)?;
+                    applied.push(format!(
+                        "cloned unit '{}' into {}",
+                        unit_spec.name, unit_spec.path
+                    ));
+                }
+                OperationType::Configure => {
+                    materialize_unit(workspace_root, unit_spec)?;
+                    applied.push(format!(
+                        "configured unit '{}' at {}",
+                        unit_spec.name, unit_spec.path
+                    ));
+                }
+                OperationType::Link => {
+                    anyhow::bail!(
+                        "link operations are not implemented yet for unit '{}'",
+                        unit_spec.name
+                    );
+                }
+            }
+        }
+
+        Ok(applied)
+    }
+
     pub fn guard_for_apply(
         &self,
         workspace_root: &Path,
@@ -159,4 +204,33 @@ impl OperationType {
             Self::Link => "link",
         }
     }
+}
+
+fn materialize_unit(workspace_root: &Path, unit: &UnitSpec) -> Result<()> {
+    let unit_root = workspace_root.join(&unit.path);
+    fs::create_dir_all(&unit_root)
+        .with_context(|| format!("create unit directory {}", unit_root.display()))?;
+    fs::write(unit_root.join("unit.toml"), render_unit_toml(unit))
+        .with_context(|| format!("write unit metadata for '{}'", unit.name))?;
+    Ok(())
+}
+
+fn render_unit_toml(unit: &UnitSpec) -> String {
+    let repos = if unit.repos.is_empty() {
+        "[]".to_string()
+    } else {
+        format!(
+            "[{}]",
+            unit.repos
+                .iter()
+                .map(|repo| format!("\"{}\"", repo))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+
+    format!(
+        "name = \"{}\"\nkind = \"unit\"\nrepos = {}\n",
+        unit.name, repos
+    )
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1181,6 +1181,123 @@ fn test_gr2_plan_reports_when_it_generates_a_missing_workspace_spec() {
 }
 
 #[test]
+fn test_gr2_apply_materializes_missing_units_from_plan() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://github.com/synapt-dev/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+    std::fs::create_dir_all(workspace_root.join("repos/app")).unwrap();
+    std::fs::write(
+        workspace_root.join("repos/app/repo.toml"),
+        "name = \"app\"\nurl = \"https://github.com/synapt-dev/app.git\"\n",
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Applied execution plan"))
+        .stdout(predicate::str::contains("cloned unit 'atlas'"));
+
+    let unit_toml = std::fs::read_to_string(workspace_root.join("agents/atlas/unit.toml")).unwrap();
+    assert!(unit_toml.contains("name = \"atlas\""));
+    assert!(unit_toml.contains("kind = \"unit\""));
+    assert!(unit_toml.contains("repos = [\"app\"]"));
+}
+
+#[test]
+fn test_gr2_apply_requires_yes_for_large_plans() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = []
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = []
+
+[[units]]
+name = "sentinel"
+path = "agents/sentinel"
+repos = []
+
+[[units]]
+name = "opus"
+path = "agents/opus"
+repos = []
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "plan contains more than 3 operations; rerun with --yes to apply it",
+        ));
+
+    assert!(!workspace_root.join("agents/atlas/unit.toml").exists());
+    assert!(!workspace_root.join("agents/apollo/unit.toml").exists());
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")


### PR DESCRIPTION
## Summary
- add the first `gr2 apply` command on top of the existing `ExecutionPlan` model
- execute `clone` and `configure` plan operations by materializing unit directories and `unit.toml` metadata
- reuse the existing plan guardrails, including the >3 operation `--yes` confirmation boundary

## Included
- `gr2 apply --yes` CLI wiring
- `ExecutionPlan::apply()` for the current first-pass operation set
- focused CLI coverage for applying a missing-unit plan and rejecting large plans without `--yes`

## Scope note
This is the follow-on slice after `grip#518` (`gr2 plan`). It stays intentionally narrow: no link execution yet, and no repo clone/materialization beyond unit metadata.

**Premium boundary**: grip is OSS. `gr2 apply` is local workspace orchestration/materialization, not identity, org control plane, quality improvement, or premium IP differentiation.

## Verification
- `cargo test --test cli_tests test_gr2_plan --quiet`
- `cargo test --test cli_tests test_gr2_apply --quiet`
- `cargo check -p gr2-cli --quiet`