### PR TITLE
Sprint 16 ceremony: grip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/gr2/Cargo.toml
+++ b/gr2/Cargo.toml
@@ -11,3 +11,5 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -55,6 +55,13 @@ pub enum Commands {
         #[command(subcommand)]
         command: SpecCommands,
     },
+
+    /// Diff the workspace spec into an execution plan
+    Plan {
+        /// Pre-approve plans with more than 3 operations
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -49,6 +49,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: UnitCommands,
     },
+
+    /// Declarative workspace spec operations
+    Spec {
+        #[command(subcommand)]
+        command: SpecCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -106,4 +112,13 @@ pub enum UnitCommands {
         /// Unit name
         name: String,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SpecCommands {
+    /// Print the current workspace spec
+    Show,
+
+    /// Validate the current workspace spec against the filesystem
+    Validate,
 }

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -62,6 +62,13 @@ pub enum Commands {
         #[arg(long)]
         yes: bool,
     },
+
+    /// Apply the current execution plan to the workspace
+    Apply {
+        /// Pre-approve plans with more than 3 operations
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -43,6 +43,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: RepoCommands,
     },
+
+    /// Unit registry operations
+    Unit {
+        #[command(subcommand)]
+        command: UnitCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -80,6 +86,24 @@ pub enum RepoCommands {
     /// Remove a registered repo
     Remove {
         /// Logical repo name
+        name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum UnitCommands {
+    /// Register a local unit in the workspace materialization model
+    Add {
+        /// Unit name
+        name: String,
+    },
+
+    /// List registered units
+    List,
+
+    /// Remove a registered unit
+    Remove {
+        /// Unit name
         name: String,
     },
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -361,10 +361,16 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
         },
         Commands::Plan { yes } => {
             let workspace_root = require_workspace_root()?;
-            let (_spec, plan) = ExecutionPlan::from_workspace_spec(&workspace_root)?;
-            let guard_report = plan.guard_for_apply(&workspace_root, yes)?;
+            let build = ExecutionPlan::from_workspace_spec(&workspace_root)?;
+            let guard_report = build.plan.guard_for_apply(&workspace_root, yes)?;
 
-            println!("{}", plan.render_table());
+            if build.generated_spec {
+                println!(
+                    "Generated workspace spec at {} from current workspace state.",
+                    workspace_spec_path(&workspace_root).display()
+                );
+            }
+            println!("{}", build.plan.render_table());
             for warning in guard_report.warnings {
                 println!("warning: {}", warning);
             }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -379,6 +379,38 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
             }
             Ok(())
         }
+        Commands::Apply { yes } => {
+            let workspace_root = require_workspace_root()?;
+            let build = ExecutionPlan::from_workspace_spec(&workspace_root)?;
+            let guard_report = build.plan.guard_for_apply(&workspace_root, yes)?;
+
+            if build.generated_spec {
+                println!(
+                    "Generated workspace spec at {} from current workspace state.",
+                    workspace_spec_path(&workspace_root).display()
+                );
+            }
+
+            if guard_report.requires_confirmation {
+                anyhow::bail!("plan contains more than 3 operations; rerun with --yes to apply it");
+            }
+
+            for warning in &guard_report.warnings {
+                println!("warning: {}", warning);
+            }
+
+            let applied = build.plan.apply(&workspace_root, &build.spec)?;
+            if applied.is_empty() {
+                println!("ExecutionPlan");
+                println!("- no changes required");
+            } else {
+                println!("Applied execution plan");
+                for line in applied {
+                    println!("- {}", line);
+                }
+            }
+            Ok(())
+        }
     }
 }
 

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -229,6 +229,7 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
         Commands::Unit { command } => match command {
             UnitCommands::Add { name } => {
                 let workspace_root = require_workspace_root()?;
+                validate_unit_name(&name)?;
                 let units_root = workspace_root.join("agents");
                 let registry_path = workspace_root.join(".grip/units.toml");
                 let unit_root = units_root.join(&name);
@@ -340,4 +341,22 @@ fn require_workspace_root() -> Result<PathBuf> {
         anyhow::bail!("not in a gr2 workspace: missing .grip/workspace.toml");
     }
     Ok(workspace_root)
+}
+
+fn validate_unit_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("unit name must not be empty");
+    }
+
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+    {
+        anyhow::bail!(
+            "invalid unit name '{}': use only ASCII letters, numbers, '_' or '-'",
+            name
+        );
+    }
+
+    Ok(())
 }

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -3,9 +3,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::args::{Commands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
-use crate::spec::{
-    read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec,
-};
+use crate::plan::ExecutionPlan;
+use crate::spec::{read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -360,6 +359,20 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 Ok(())
             }
         },
+        Commands::Plan { yes } => {
+            let workspace_root = require_workspace_root()?;
+            let (_spec, plan) = ExecutionPlan::from_workspace_spec(&workspace_root)?;
+            let guard_report = plan.guard_for_apply(&workspace_root, yes)?;
+
+            println!("{}", plan.render_table());
+            for warning in guard_report.warnings {
+                println!("warning: {}", warning);
+            }
+            if guard_report.requires_confirmation {
+                println!("warning: plan contains more than 3 operations; apply will require --yes");
+            }
+            Ok(())
+        }
     }
 }
 

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, RepoCommands, TeamCommands};
+use crate::args::{Commands, RepoCommands, TeamCommands, UnitCommands};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -223,6 +223,110 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 }
 
                 println!("Removed gr2 repo '{}'", name);
+                Ok(())
+            }
+        },
+        Commands::Unit { command } => match command {
+            UnitCommands::Add { name } => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+                let registry_path = workspace_root.join(".grip/units.toml");
+                let unit_root = units_root.join(&name);
+
+                if unit_root.exists() {
+                    anyhow::bail!("unit '{}' already exists", name);
+                }
+
+                fs::create_dir_all(&unit_root)?;
+                fs::write(
+                    unit_root.join("unit.toml"),
+                    format!("name = \"{}\"\nkind = \"unit\"\n", name),
+                )?;
+
+                let mut entries = Vec::new();
+                if registry_path.exists() {
+                    entries.push(fs::read_to_string(&registry_path)?);
+                }
+                entries.push(format!("[[unit]]\nname = \"{}\"\nkind = \"unit\"\n", name));
+                fs::write(&registry_path, entries.join("\n"))?;
+
+                println!("Added gr2 unit '{}'", name);
+                Ok(())
+            }
+            UnitCommands::List => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+
+                let mut names = Vec::new();
+                for entry in fs::read_dir(&units_root)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_dir() && entry.path().join("unit.toml").exists() {
+                        names.push(entry.file_name().to_string_lossy().into_owned());
+                    }
+                }
+
+                names.sort();
+
+                if names.is_empty() {
+                    println!("No gr2 units registered.");
+                } else {
+                    println!("Units");
+                    for name in names {
+                        println!("- {}", name);
+                    }
+                }
+
+                Ok(())
+            }
+            UnitCommands::Remove { name } => {
+                let workspace_root = require_workspace_root()?;
+                let units_root = workspace_root.join("agents");
+                let unit_root = units_root.join(&name);
+                let unit_toml = unit_root.join("unit.toml");
+
+                if !unit_toml.exists() {
+                    anyhow::bail!("unit '{}' not found", name);
+                }
+
+                fs::remove_dir_all(&unit_root)?;
+
+                let registry_path = workspace_root.join(".grip/units.toml");
+                if registry_path.exists() {
+                    let registry = fs::read_to_string(&registry_path)?;
+                    let kept_entries = registry
+                        .split("\n[[unit]]\n")
+                        .filter_map(|chunk| {
+                            let chunk = chunk.trim();
+                            if chunk.is_empty() {
+                                return None;
+                            }
+                            let normalized = if chunk.starts_with("[[unit]]") {
+                                chunk.to_string()
+                            } else {
+                                format!("[[unit]]\n{}", chunk)
+                            };
+                            let matches_name = normalized
+                                .lines()
+                                .find_map(|line| line.strip_prefix("name = \""))
+                                .and_then(|line| line.strip_suffix('"'))
+                                .map(|entry_name| entry_name == name)
+                                .unwrap_or(false);
+                            if matches_name {
+                                None
+                            } else {
+                                Some(normalized)
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    if kept_entries.is_empty() {
+                        fs::remove_file(&registry_path)?;
+                    } else {
+                        fs::write(&registry_path, kept_entries.join("\n\n"))?;
+                    }
+                }
+
+                println!("Removed gr2 unit '{}'", name);
                 Ok(())
             }
         },

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, RepoCommands, TeamCommands, UnitCommands};
+use crate::args::{Commands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
+use crate::spec::{
+    read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec,
+};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
     match command {
@@ -328,6 +331,32 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 }
 
                 println!("Removed gr2 unit '{}'", name);
+                Ok(())
+            }
+        },
+        Commands::Spec { command } => match command {
+            SpecCommands::Show => {
+                let workspace_root = require_workspace_root()?;
+                let spec_path = workspace_spec_path(&workspace_root);
+                let spec = if spec_path.exists() {
+                    read_workspace_spec(&workspace_root)?
+                } else {
+                    let spec = WorkspaceSpec::from_workspace(&workspace_root)?;
+                    write_workspace_spec(&workspace_root, &spec)?;
+                    spec
+                };
+
+                println!("{}", toml::to_string_pretty(&spec)?);
+                Ok(())
+            }
+            SpecCommands::Validate => {
+                let workspace_root = require_workspace_root()?;
+                let spec = read_workspace_spec(&workspace_root)?;
+                spec.validate(&workspace_root)?;
+                println!(
+                    "Workspace spec is valid: {}",
+                    workspace_spec_path(&workspace_root).display()
+                );
                 Ok(())
             }
         },

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -4,3 +4,4 @@
 
 pub mod args;
 pub mod dispatch;
+pub mod spec;

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -4,4 +4,5 @@
 
 pub mod args;
 pub mod dispatch;
+pub mod plan;
 pub mod spec;

--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -10,6 +10,13 @@ pub struct ExecutionPlan {
     pub operations: Vec<PlanOperation>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanBuild {
+    pub spec: WorkspaceSpec,
+    pub plan: ExecutionPlan,
+    pub generated_spec: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanOperation {
     pub unit_name: String,
@@ -34,14 +41,14 @@ pub struct PlanGuardReport {
 }
 
 impl ExecutionPlan {
-    pub fn from_workspace_spec(workspace_root: &Path) -> Result<(WorkspaceSpec, Self)> {
+    pub fn from_workspace_spec(workspace_root: &Path) -> Result<PlanBuild> {
         let spec_path = workspace_spec_path(workspace_root);
-        let spec = if spec_path.exists() {
-            read_workspace_spec(workspace_root)?
+        let (spec, generated_spec) = if spec_path.exists() {
+            (read_workspace_spec(workspace_root)?, false)
         } else {
             let generated = WorkspaceSpec::from_workspace(workspace_root)?;
             write_workspace_spec(workspace_root, &generated)?;
-            generated
+            (generated, true)
         };
 
         spec.validate_for_plan()?;
@@ -66,7 +73,7 @@ impl ExecutionPlan {
             }
 
             let expected_path = format!("agents/{}", unit.name);
-            if unit.path != expected_path || !unit.repos.is_empty() {
+            if unit.path != expected_path {
                 let mut parameters = BTreeMap::new();
                 parameters.insert("path".to_string(), unit.path.clone());
                 parameters.insert("repos".to_string(), unit.repos.join(","));
@@ -79,7 +86,11 @@ impl ExecutionPlan {
             }
         }
 
-        Ok((spec, Self { operations }))
+        Ok(PlanBuild {
+            spec,
+            plan: Self { operations },
+            generated_spec,
+        })
     }
 
     pub fn guard_for_apply(

--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -1,0 +1,151 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::spec::{read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionPlan {
+    pub operations: Vec<PlanOperation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanOperation {
+    pub unit_name: String,
+    pub operation: OperationType,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, String>,
+    pub preview: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationType {
+    Clone,
+    Configure,
+    Link,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanGuardReport {
+    pub warnings: Vec<String>,
+    pub requires_confirmation: bool,
+}
+
+impl ExecutionPlan {
+    pub fn from_workspace_spec(workspace_root: &Path) -> Result<(WorkspaceSpec, Self)> {
+        let spec_path = workspace_spec_path(workspace_root);
+        let spec = if spec_path.exists() {
+            read_workspace_spec(workspace_root)?
+        } else {
+            let generated = WorkspaceSpec::from_workspace(workspace_root)?;
+            write_workspace_spec(workspace_root, &generated)?;
+            generated
+        };
+
+        spec.validate_for_plan()?;
+
+        let mut operations = Vec::new();
+
+        for unit in &spec.units {
+            let unit_root = workspace_root.join(&unit.path);
+            let unit_toml = unit_root.join("unit.toml");
+
+            if !unit_toml.exists() {
+                let mut parameters = BTreeMap::new();
+                parameters.insert("path".to_string(), unit.path.clone());
+                parameters.insert("repos".to_string(), unit.repos.join(","));
+                operations.push(PlanOperation {
+                    unit_name: unit.name.clone(),
+                    operation: OperationType::Clone,
+                    parameters,
+                    preview: format!("clone unit '{}' into {}", unit.name, unit.path),
+                });
+                continue;
+            }
+
+            let expected_path = format!("agents/{}", unit.name);
+            if unit.path != expected_path || !unit.repos.is_empty() {
+                let mut parameters = BTreeMap::new();
+                parameters.insert("path".to_string(), unit.path.clone());
+                parameters.insert("repos".to_string(), unit.repos.join(","));
+                operations.push(PlanOperation {
+                    unit_name: unit.name.clone(),
+                    operation: OperationType::Configure,
+                    parameters,
+                    preview: format!("reconfigure unit '{}' to match {}", unit.name, unit.path),
+                });
+            }
+        }
+
+        Ok((spec, Self { operations }))
+    }
+
+    pub fn guard_for_apply(
+        &self,
+        workspace_root: &Path,
+        assume_yes: bool,
+    ) -> Result<PlanGuardReport> {
+        let mut warnings = Vec::new();
+
+        for operation in &self.operations {
+            let path = operation
+                .parameters
+                .get("path")
+                .map(|value| workspace_root.join(value))
+                .unwrap_or_else(|| workspace_root.join(format!("agents/{}", operation.unit_name)));
+
+            if matches!(operation.operation, OperationType::Link) && path.exists() {
+                anyhow::bail!(
+                    "refusing to apply plan: link operation for '{}' would overwrite existing directory {}",
+                    operation.unit_name,
+                    path.display()
+                );
+            }
+
+            if path.join(".git").exists() {
+                warnings.push(format!(
+                    "unit '{}' has a git checkout at {} with possible uncommitted changes; inspect before apply",
+                    operation.unit_name,
+                    path.display()
+                ));
+            }
+        }
+
+        Ok(PlanGuardReport {
+            warnings,
+            requires_confirmation: self.operations.len() > 3 && !assume_yes,
+        })
+    }
+
+    pub fn render_table(&self) -> String {
+        if self.operations.is_empty() {
+            return "ExecutionPlan\n- no changes required\n".to_string();
+        }
+
+        let mut lines = vec![
+            "ExecutionPlan".to_string(),
+            "UNIT\tOPERATION\tPREVIEW".to_string(),
+        ];
+        for operation in &self.operations {
+            lines.push(format!(
+                "{}\t{}\t{}",
+                operation.unit_name,
+                operation.operation.as_str(),
+                operation.preview
+            ));
+        }
+        lines.join("\n")
+    }
+}
+
+impl OperationType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Clone => "clone",
+            Self::Configure => "configure",
+            Self::Link => "link",
+        }
+    }
+}

--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -1,9 +1,12 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::Path;
 
-use crate::spec::{read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec};
+use crate::spec::{
+    read_workspace_spec, workspace_spec_path, write_workspace_spec, UnitSpec, WorkspaceSpec,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExecutionPlan {
@@ -93,6 +96,48 @@ impl ExecutionPlan {
         })
     }
 
+    pub fn apply(&self, workspace_root: &Path, spec: &WorkspaceSpec) -> Result<Vec<String>> {
+        let mut applied = Vec::new();
+
+        for operation in &self.operations {
+            let unit_spec = spec
+                .units
+                .iter()
+                .find(|unit| unit.name == operation.unit_name)
+                .with_context(|| {
+                    format!(
+                        "execution plan references unknown unit '{}'",
+                        operation.unit_name
+                    )
+                })?;
+
+            match operation.operation {
+                OperationType::Clone => {
+                    materialize_unit(workspace_root, unit_spec)?;
+                    applied.push(format!(
+                        "cloned unit '{}' into {}",
+                        unit_spec.name, unit_spec.path
+                    ));
+                }
+                OperationType::Configure => {
+                    materialize_unit(workspace_root, unit_spec)?;
+                    applied.push(format!(
+                        "configured unit '{}' at {}",
+                        unit_spec.name, unit_spec.path
+                    ));
+                }
+                OperationType::Link => {
+                    anyhow::bail!(
+                        "link operations are not implemented yet for unit '{}'",
+                        unit_spec.name
+                    );
+                }
+            }
+        }
+
+        Ok(applied)
+    }
+
     pub fn guard_for_apply(
         &self,
         workspace_root: &Path,
@@ -159,4 +204,33 @@ impl OperationType {
             Self::Link => "link",
         }
     }
+}
+
+fn materialize_unit(workspace_root: &Path, unit: &UnitSpec) -> Result<()> {
+    let unit_root = workspace_root.join(&unit.path);
+    fs::create_dir_all(&unit_root)
+        .with_context(|| format!("create unit directory {}", unit_root.display()))?;
+    fs::write(unit_root.join("unit.toml"), render_unit_toml(unit))
+        .with_context(|| format!("write unit metadata for '{}'", unit.name))?;
+    Ok(())
+}
+
+fn render_unit_toml(unit: &UnitSpec) -> String {
+    let repos = if unit.repos.is_empty() {
+        "[]".to_string()
+    } else {
+        format!(
+            "[{}]",
+            unit.repos
+                .iter()
+                .map(|repo| format!("\"{}\"", repo))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+
+    format!(
+        "name = \"{}\"\nkind = \"unit\"\nrepos = {}\n",
+        unit.name, repos
+    )
 }

--- a/gr2/src/spec.rs
+++ b/gr2/src/spec.rs
@@ -54,7 +54,7 @@ impl WorkspaceSpec {
         })
     }
 
-    pub fn validate(&self, workspace_root: &Path) -> Result<()> {
+    pub fn validate_for_plan(&self) -> Result<()> {
         if self.schema_version != WORKSPACE_SPEC_VERSION {
             anyhow::bail!(
                 "unsupported workspace spec schema_version {}: expected {}",
@@ -76,15 +76,6 @@ impl WorkspaceSpec {
             if repo.path.trim().is_empty() || repo.url.trim().is_empty() {
                 anyhow::bail!("repo '{}' must include non-empty path and url", repo.name);
             }
-
-            let repo_root = workspace_root.join(&repo.path);
-            if !repo_root.join("repo.toml").exists() {
-                anyhow::bail!(
-                    "workspace spec repo '{}' is missing repo metadata at {}",
-                    repo.name,
-                    repo_root.join("repo.toml").display()
-                );
-            }
         }
 
         let mut unit_names = HashSet::new();
@@ -95,15 +86,6 @@ impl WorkspaceSpec {
 
             if unit.path.trim().is_empty() {
                 anyhow::bail!("unit '{}' must include a non-empty path", unit.name);
-            }
-
-            let unit_root = workspace_root.join(&unit.path);
-            if !unit_root.join("unit.toml").exists() {
-                anyhow::bail!(
-                    "workspace spec unit '{}' is missing unit metadata at {}",
-                    unit.name,
-                    unit_root.join("unit.toml").display()
-                );
             }
 
             for repo_name in &unit.repos {
@@ -119,14 +101,41 @@ impl WorkspaceSpec {
 
         Ok(())
     }
+
+    pub fn validate(&self, workspace_root: &Path) -> Result<()> {
+        self.validate_for_plan()?;
+
+        for repo in &self.repos {
+            let repo_root = workspace_root.join(&repo.path);
+            if !repo_root.join("repo.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec repo '{}' is missing repo metadata at {}",
+                    repo.name,
+                    repo_root.join("repo.toml").display()
+                );
+            }
+        }
+
+        for unit in &self.units {
+            let unit_root = workspace_root.join(&unit.path);
+            if !unit_root.join("unit.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec unit '{}' is missing unit metadata at {}",
+                    unit.name,
+                    unit_root.join("unit.toml").display()
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
 pub fn write_workspace_spec(workspace_root: &Path, spec: &WorkspaceSpec) -> Result<PathBuf> {
     let spec_path = workspace_spec_path(workspace_root);
     let content = toml::to_string_pretty(spec).context("serialize workspace spec")?;
-    fs::write(&spec_path, content).with_context(|| {
-        format!("write workspace spec to {}", spec_path.display())
-    })?;
+    fs::write(&spec_path, content)
+        .with_context(|| format!("write workspace spec to {}", spec_path.display()))?;
     Ok(spec_path)
 }
 
@@ -197,6 +206,10 @@ fn read_registered_repos(workspace_root: &Path) -> Result<Vec<RepoSpec>> {
 fn read_registered_units(workspace_root: &Path) -> Result<Vec<UnitSpec>> {
     let units_root = workspace_root.join("agents");
     let mut units = Vec::new();
+
+    if !units_root.exists() {
+        return Ok(units);
+    }
 
     for entry in fs::read_dir(&units_root)? {
         let entry = entry?;

--- a/gr2/src/spec.rs
+++ b/gr2/src/spec.rs
@@ -1,0 +1,223 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const WORKSPACE_SPEC_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspaceSpec {
+    pub schema_version: u32,
+    pub workspace_name: String,
+    pub cache: CacheSpec,
+    #[serde(default)]
+    pub repos: Vec<RepoSpec>,
+    #[serde(default)]
+    pub units: Vec<UnitSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CacheSpec {
+    pub root: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RepoSpec {
+    pub name: String,
+    pub path: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UnitSpec {
+    pub name: String,
+    pub path: String,
+    #[serde(default)]
+    pub repos: Vec<String>,
+}
+
+impl WorkspaceSpec {
+    pub fn from_workspace(workspace_root: &Path) -> Result<Self> {
+        let workspace_name = read_workspace_name(workspace_root)?;
+        let repos = read_registered_repos(workspace_root)?;
+        let units = read_registered_units(workspace_root)?;
+
+        Ok(Self {
+            schema_version: WORKSPACE_SPEC_VERSION,
+            workspace_name,
+            cache: CacheSpec {
+                root: ".grip/cache".to_string(),
+            },
+            repos,
+            units,
+        })
+    }
+
+    pub fn validate(&self, workspace_root: &Path) -> Result<()> {
+        if self.schema_version != WORKSPACE_SPEC_VERSION {
+            anyhow::bail!(
+                "unsupported workspace spec schema_version {}: expected {}",
+                self.schema_version,
+                WORKSPACE_SPEC_VERSION
+            );
+        }
+
+        if self.workspace_name.trim().is_empty() {
+            anyhow::bail!("workspace spec workspace_name must not be empty");
+        }
+
+        let mut repo_names = HashSet::new();
+        for repo in &self.repos {
+            if !repo_names.insert(repo.name.clone()) {
+                anyhow::bail!("workspace spec contains duplicate repo '{}'", repo.name);
+            }
+
+            if repo.path.trim().is_empty() || repo.url.trim().is_empty() {
+                anyhow::bail!("repo '{}' must include non-empty path and url", repo.name);
+            }
+
+            let repo_root = workspace_root.join(&repo.path);
+            if !repo_root.join("repo.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec repo '{}' is missing repo metadata at {}",
+                    repo.name,
+                    repo_root.join("repo.toml").display()
+                );
+            }
+        }
+
+        let mut unit_names = HashSet::new();
+        for unit in &self.units {
+            if !unit_names.insert(unit.name.clone()) {
+                anyhow::bail!("workspace spec contains duplicate unit '{}'", unit.name);
+            }
+
+            if unit.path.trim().is_empty() {
+                anyhow::bail!("unit '{}' must include a non-empty path", unit.name);
+            }
+
+            let unit_root = workspace_root.join(&unit.path);
+            if !unit_root.join("unit.toml").exists() {
+                anyhow::bail!(
+                    "workspace spec unit '{}' is missing unit metadata at {}",
+                    unit.name,
+                    unit_root.join("unit.toml").display()
+                );
+            }
+
+            for repo_name in &unit.repos {
+                if !repo_names.contains(repo_name) {
+                    anyhow::bail!(
+                        "unit '{}' references missing repo '{}'",
+                        unit.name,
+                        repo_name
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn write_workspace_spec(workspace_root: &Path, spec: &WorkspaceSpec) -> Result<PathBuf> {
+    let spec_path = workspace_spec_path(workspace_root);
+    let content = toml::to_string_pretty(spec).context("serialize workspace spec")?;
+    fs::write(&spec_path, content).with_context(|| {
+        format!("write workspace spec to {}", spec_path.display())
+    })?;
+    Ok(spec_path)
+}
+
+pub fn read_workspace_spec(workspace_root: &Path) -> Result<WorkspaceSpec> {
+    let spec_path = workspace_spec_path(workspace_root);
+    let content = fs::read_to_string(&spec_path)
+        .with_context(|| format!("read workspace spec from {}", spec_path.display()))?;
+    toml::from_str(&content).context("parse workspace spec")
+}
+
+pub fn workspace_spec_path(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".grip/workspace_spec.toml")
+}
+
+fn read_workspace_name(workspace_root: &Path) -> Result<String> {
+    let workspace_toml = fs::read_to_string(workspace_root.join(".grip/workspace.toml"))
+        .context("read .grip/workspace.toml")?;
+    workspace_toml
+        .lines()
+        .find_map(|line| line.strip_prefix("name = \""))
+        .and_then(|line| line.strip_suffix('"'))
+        .map(str::to_owned)
+        .context("workspace name missing from .grip/workspace.toml")
+}
+
+fn read_registered_repos(workspace_root: &Path) -> Result<Vec<RepoSpec>> {
+    let repos_root = workspace_root.join("repos");
+    let mut repos = Vec::new();
+
+    for entry in fs::read_dir(&repos_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let repo_root = entry.path();
+        let repo_toml = repo_root.join("repo.toml");
+        if !repo_toml.exists() {
+            continue;
+        }
+
+        let content = fs::read_to_string(&repo_toml)?;
+        let fallback_name = entry.file_name().to_string_lossy().into_owned();
+        let name = content
+            .lines()
+            .find_map(|line| line.strip_prefix("name = \""))
+            .and_then(|line| line.strip_suffix('"'))
+            .map(str::to_owned)
+            .unwrap_or(fallback_name.clone());
+        let url = content
+            .lines()
+            .find_map(|line| line.strip_prefix("url = \""))
+            .and_then(|line| line.strip_suffix('"'))
+            .unwrap_or("")
+            .to_string();
+
+        repos.push(RepoSpec {
+            name,
+            path: format!("repos/{}", fallback_name),
+            url,
+        });
+    }
+
+    repos.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(repos)
+}
+
+fn read_registered_units(workspace_root: &Path) -> Result<Vec<UnitSpec>> {
+    let units_root = workspace_root.join("agents");
+    let mut units = Vec::new();
+
+    for entry in fs::read_dir(&units_root)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let unit_root = entry.path();
+        let unit_toml = unit_root.join("unit.toml");
+        if !unit_toml.exists() {
+            continue;
+        }
+
+        let fallback_name = entry.file_name().to_string_lossy().into_owned();
+        units.push(UnitSpec {
+            name: fallback_name.clone(),
+            path: format!("agents/{}", fallback_name),
+            repos: Vec::new(),
+        });
+    }
+
+    units.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(units)
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -971,6 +971,70 @@ fn test_gr2_plan_fully_materialized_workspace_produces_noop_plan() {
 }
 
 #[test]
+fn test_gr2_plan_does_not_flag_repo_attachment_presence_as_drift() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://github.com/synapt-dev/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no changes required"))
+        .stdout(predicate::str::contains("configure").not());
+}
+
+#[test]
 fn test_gr2_plan_missing_unit_produces_single_clone_plan() {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().join("demo-team");
@@ -1078,6 +1142,42 @@ repos = ["missing"]
         .stderr(predicate::str::contains(
             "unit 'atlas' references missing repo 'missing'",
         ));
+}
+
+#[test]
+fn test_gr2_plan_reports_when_it_generates_a_missing_workspace_spec() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let spec_path = workspace_root.join(".grip/workspace_spec.toml");
+    assert!(!spec_path.exists());
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generated workspace spec at"))
+        .stdout(predicate::str::contains("no changes required"));
+
+    assert!(spec_path.exists());
 }
 
 #[test]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1181,6 +1181,123 @@ fn test_gr2_plan_reports_when_it_generates_a_missing_workspace_spec() {
 }
 
 #[test]
+fn test_gr2_apply_materializes_missing_units_from_plan() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://github.com/synapt-dev/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+    std::fs::create_dir_all(workspace_root.join("repos/app")).unwrap();
+    std::fs::write(
+        workspace_root.join("repos/app/repo.toml"),
+        "name = \"app\"\nurl = \"https://github.com/synapt-dev/app.git\"\n",
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Applied execution plan"))
+        .stdout(predicate::str::contains("cloned unit 'atlas'"));
+
+    let unit_toml = std::fs::read_to_string(workspace_root.join("agents/atlas/unit.toml")).unwrap();
+    assert!(unit_toml.contains("name = \"atlas\""));
+    assert!(unit_toml.contains("kind = \"unit\""));
+    assert!(unit_toml.contains("repos = [\"app\"]"));
+}
+
+#[test]
+fn test_gr2_apply_requires_yes_for_large_plans() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = []
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = []
+
+[[units]]
+name = "sentinel"
+path = "agents/sentinel"
+repos = []
+
+[[units]]
+name = "opus"
+path = "agents/opus"
+repos = []
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "plan contains more than 3 operations; rerun with --yes to apply it",
+        ));
+
+    assert!(!workspace_root.join("agents/atlas/unit.toml").exists());
+    assert!(!workspace_root.join("agents/apollo/unit.toml").exists());
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -867,6 +867,220 @@ fn test_gr2_spec_validate_detects_conflicting_unit_names() {
 }
 
 #[test]
+fn test_gr2_plan_empty_workspace_produces_clone_all_plan() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://github.com/synapt-dev/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = []
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+    std::fs::create_dir_all(workspace_root.join("repos/app")).unwrap();
+    std::fs::write(
+        workspace_root.join("repos/app/repo.toml"),
+        "name = \"app\"\nurl = \"https://github.com/synapt-dev/app.git\"\n",
+    )
+    .unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ExecutionPlan"))
+        .stdout(predicate::str::contains("atlas\tclone"))
+        .stdout(predicate::str::contains("apollo\tclone"));
+}
+
+#[test]
+fn test_gr2_plan_fully_materialized_workspace_produces_noop_plan() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no changes required"));
+}
+
+#[test]
+fn test_gr2_plan_missing_unit_produces_single_clone_plan() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    std::fs::create_dir_all(workspace_root.join("agents/apollo")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/apollo/unit.toml"),
+        "name = \"apollo\"\nkind = \"unit\"\n",
+    )
+    .unwrap();
+
+    let spec_path = workspace_root.join(".grip/workspace_spec.toml");
+    let spec = std::fs::read_to_string(&spec_path).unwrap();
+    let with_apollo = format!(
+        "{}\n[[units]]\nname = \"apollo\"\npath = \"agents/apollo\"\nrepos = []\n",
+        spec.trim_end()
+    );
+    std::fs::write(&spec_path, with_apollo).unwrap();
+    std::fs::remove_file(workspace_root.join("agents/apollo/unit.toml")).unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("apollo\tclone"))
+        .stdout(predicate::str::contains("clone unit 'apollo'"));
+}
+
+#[test]
+fn test_gr2_plan_rejects_invalid_unit_repo_reference() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://github.com/synapt-dev/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["missing"]
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unit 'atlas' references missing repo 'missing'",
+        ));
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -546,6 +546,164 @@ fn test_gr2_repo_remove_requires_gr2_workspace() {
 }
 
 #[test]
+fn test_gr2_unit_add_registers_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Added gr2 unit 'atlas'"));
+
+    let unit_toml = std::fs::read_to_string(workspace_root.join("agents/atlas/unit.toml")).unwrap();
+    assert!(unit_toml.contains("name = \"atlas\""));
+    assert!(unit_toml.contains("kind = \"unit\""));
+
+    let registry = std::fs::read_to_string(workspace_root.join(".grip/units.toml")).unwrap();
+    assert!(registry.contains("[[unit]]"));
+    assert!(registry.contains("name = \"atlas\""));
+}
+
+#[test]
+fn test_gr2_unit_add_rejects_duplicate_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut first = Command::cargo_bin("gr2").unwrap();
+    first
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut duplicate = Command::cargo_bin("gr2").unwrap();
+    duplicate
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unit 'atlas' already exists"));
+}
+
+#[test]
+fn test_gr2_unit_list_shows_registered_units() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add_atlas = Command::cargo_bin("gr2").unwrap();
+    add_atlas
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut add_opus = Command::cargo_bin("gr2").unwrap();
+    add_opus
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("opus")
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Units"))
+        .stdout(predicate::str::contains("- atlas"))
+        .stdout(predicate::str::contains("- opus"));
+}
+
+#[test]
+fn test_gr2_unit_list_reports_empty_state() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No gr2 units registered."));
+}
+
+#[test]
+fn test_gr2_unit_remove_deletes_registered_unit() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let unit_root = workspace_root.join("agents/atlas");
+    assert!(unit_root.join("unit.toml").exists());
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("remove")
+        .arg("atlas")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed gr2 unit 'atlas'"));
+
+    assert!(!unit_root.exists());
+    assert!(!workspace_root.join(".grip/units.toml").exists());
+}
+
+#[test]
+fn test_gr2_unit_requires_gr2_workspace() {
+    let temp = TempDir::new().unwrap();
+
+    let mut add = Command::cargo_bin("gr2").unwrap();
+    add.current_dir(temp.path())
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "not in a gr2 workspace: missing .grip/workspace.toml",
+        ));
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -601,6 +601,27 @@ fn test_gr2_unit_add_rejects_duplicate_unit() {
 }
 
 #[test]
+fn test_gr2_unit_add_rejects_invalid_name() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut invalid = Command::cargo_bin("gr2").unwrap();
+    invalid
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas/dev")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "invalid unit name 'atlas/dev': use only ASCII letters, numbers, '_' or '-'",
+        ));
+}
+
+#[test]
 fn test_gr2_unit_list_shows_registered_units() {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().join("demo-team");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -725,6 +725,148 @@ fn test_gr2_unit_requires_gr2_workspace() {
 }
 
 #[test]
+fn test_gr2_spec_show_round_trips_workspace_spec() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("schema_version = 1"))
+        .stdout(predicate::str::contains("workspace_name = \"demo\""))
+        .stdout(predicate::str::contains("name = \"app\""))
+        .stdout(predicate::str::contains("name = \"atlas\""));
+
+    let spec = std::fs::read_to_string(workspace_root.join(".grip/workspace_spec.toml")).unwrap();
+    assert!(spec.contains("schema_version = 1"));
+    assert!(spec.contains("workspace_name = \"demo\""));
+    assert!(spec.contains("path = \"repos/app\""));
+    assert!(spec.contains("path = \"agents/atlas\""));
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Workspace spec is valid"));
+}
+
+#[test]
+fn test_gr2_spec_validate_detects_missing_repo_metadata() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .arg("repo")
+        .arg("add")
+        .arg("app")
+        .arg("https://github.com/synapt-dev/app.git")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    std::fs::remove_file(workspace_root.join("repos/app/repo.toml")).unwrap();
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "workspace spec repo 'app' is missing repo metadata",
+        ));
+}
+
+#[test]
+fn test_gr2_spec_validate_detects_conflicting_unit_names() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .arg("unit")
+        .arg("add")
+        .arg("atlas")
+        .assert()
+        .success();
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .arg("spec")
+        .arg("show")
+        .assert()
+        .success();
+
+    let spec_path = workspace_root.join(".grip/workspace_spec.toml");
+    let spec = std::fs::read_to_string(&spec_path).unwrap();
+    let conflicting = format!(
+        "{}\n[[units]]\nname = \"atlas\"\npath = \"agents/atlas-copy\"\nrepos = []\n",
+        spec.trim_end()
+    );
+    std::fs::write(&spec_path, conflicting).unwrap();
+
+    let mut validate = Command::cargo_bin("gr2").unwrap();
+    validate
+        .current_dir(&workspace_root)
+        .arg("spec")
+        .arg("validate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "workspace spec contains duplicate unit 'atlas'",
+        ));
+}
+
+#[test]
 fn test_checkout_help_mentions_add_mode() {
     let mut cmd = Command::cargo_bin("gr").unwrap();
     cmd.arg("checkout")


### PR DESCRIPTION
## Summary
Sprint 16 ceremony PR — sprint-16 → main for gitgrip.

**Merged to sprint-16:**
- grip#512 — feat: gr2 unit registry commands
- grip#518 — feat: gr2 execution planning (WorkspaceSpec → ExecutionPlan with typed operations)
- grip#519 — feat: gr2 apply command (materialize_unit for Clone/Configure operations)

This lands the complete gr2 plan/apply pipeline: declarative workspace specs, diffing against filesystem state, and materializing the result.

**Retro highlights:**
- Atlas's drift detection false positive caught by Sentinel (model diversity)
- grip#519 held on missing boundary declaration; fixed same session

Premium boundary: core OSS (workspace orchestration infrastructure).

## Test plan
- [ ] `cargo build` clean
- [ ] `cargo test` all passing
- [ ] `cargo fmt --all --check` clean
- [ ] Review all commits for completeness