### PR TITLE
feat: glob-based link patterns in manifest (grip#521)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "futures",
  "git2",
  "gix",
+ "glob",
  "indicatif",
  "octocrab",
  "once_cell",
@@ -1585,6 +1586,12 @@ dependencies = [
  "gix-path",
  "gix-validate 0.9.4",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ quick-xml = { version = "0.37", features = ["serialize"] }
 # TOML parsing
 toml = "0.8"
 
+# Glob patterns (for linkfile/copyfile glob expansion)
+glob = "0.3"
+
 # Misc
 once_cell = "1"
 regex = "1"

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -8,7 +8,108 @@ use crate::core::manifest_paths;
 use crate::core::repo::RepoInfo;
 use crate::files::{process_composefiles, resolve_file_source};
 use crate::git::path_exists;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Check if a source path contains glob characters (`*`, `?`, `[`).
+fn is_glob_pattern(src: &str) -> bool {
+    src.contains('*') || src.contains('?') || src.contains('[')
+}
+
+/// Expand a glob source pattern into individual (src, dest) pairs.
+///
+/// Given `src: "prompts/**"` and `dest: ".gitgrip/prompts/"`, this expands to:
+///   - `prompts/opus.md` -> `.gitgrip/prompts/opus.md`
+///   - `prompts/atlas.md` -> `.gitgrip/prompts/atlas.md`
+///
+/// The glob base (the non-glob prefix before the first glob character) is
+/// stripped from each matched path, and the remainder is appended to `dest`.
+fn expand_glob(
+    src_pattern: &str,
+    dest: &str,
+    base_dir: &Path,
+) -> Vec<(PathBuf, PathBuf)> {
+    let full_pattern = base_dir.join(src_pattern);
+    let pattern_str = match full_pattern.to_str() {
+        Some(s) => s.to_string(),
+        None => return Vec::new(),
+    };
+
+    let glob_base = glob_base_dir(src_pattern);
+
+    let entries = match glob::glob(&pattern_str) {
+        Ok(paths) => paths,
+        Err(e) => {
+            Output::warning(&format!("Invalid glob pattern '{}': {}", src_pattern, e));
+            return Vec::new();
+        }
+    };
+
+    let mut result = Vec::new();
+    for entry in entries.flatten() {
+        if entry.is_dir() {
+            continue; // only link/copy files, not directories
+        }
+        // Strip base_dir to get the repo-relative path
+        let rel_path = match entry.strip_prefix(base_dir) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        // Strip the glob base prefix to get the relative portion
+        let suffix = if glob_base.is_empty() {
+            rel_path.to_path_buf()
+        } else {
+            match rel_path.strip_prefix(&glob_base) {
+                Ok(s) => s.to_path_buf(),
+                Err(_) => rel_path.to_path_buf(),
+            }
+        };
+        let dest_path = PathBuf::from(dest).join(&suffix);
+        result.push((entry, dest_path));
+    }
+    result
+}
+
+/// Extract the non-glob directory prefix from a pattern.
+/// e.g. "prompts/**/*.md" -> "prompts", "**" -> "", "config/a*.toml" -> "config"
+fn glob_base_dir(pattern: &str) -> String {
+    let parts: Vec<&str> = pattern.split('/').collect();
+    let mut base_parts = Vec::new();
+    for part in parts {
+        if is_glob_pattern(part) {
+            break;
+        }
+        base_parts.push(part);
+    }
+    base_parts.join("/")
+}
+
+/// Expand a single src/dest pair, handling globs if present.
+/// For non-glob src, returns a single (absolute_source, dest) pair.
+/// For glob src, returns expanded pairs via `expand_glob`.
+fn expand_copy_pairs(src: &str, dest: &str, base_dir: &Path) -> Vec<(PathBuf, PathBuf)> {
+    if is_glob_pattern(src) {
+        expand_glob(src, dest, base_dir)
+    } else {
+        vec![(base_dir.join(src), PathBuf::from(dest))]
+    }
+}
+
+/// Create a symlink, returning (Result, label) for error reporting.
+/// Handles platform differences (unix symlink vs windows symlink_file/symlink_dir).
+fn apply_symlink(source: &Path, dest: &Path) -> (std::io::Result<()>, &'static str) {
+    #[cfg(unix)]
+    {
+        (std::os::unix::fs::symlink(source, dest), "symlink")
+    }
+    #[cfg(windows)]
+    {
+        if source.is_dir() {
+            (std::os::windows::fs::symlink_dir(source, dest), "symlink")
+        } else {
+            (std::os::windows::fs::symlink_file(source, dest), "symlink")
+        }
+    }
+}
 
 /// Run the link command
 pub fn run_link(
@@ -399,120 +500,80 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
             continue;
         }
 
-        // Apply copyfiles
+        // Apply copyfiles (with glob expansion)
         if let Some(ref copyfiles) = config.copyfile {
+            let base_dir = repo
+                .map(|r| r.absolute_path.clone())
+                .unwrap_or_else(|| workspace_root.join(&config.path));
+
             for copyfile in copyfiles {
-                let source = repo
-                    .map(|r| r.absolute_path.join(&copyfile.src))
-                    .unwrap_or_else(|| workspace_root.join(&config.path).join(&copyfile.src));
-                let dest = workspace_root.join(&copyfile.dest);
-
-                if !source.exists() {
-                    Output::warning(&format!("Source not found: {:?}", source));
-                    errors += 1;
-                    continue;
-                }
-
-                // Create parent directory if needed
-                if let Some(parent) = dest.parent() {
-                    std::fs::create_dir_all(parent)?;
-                }
-
-                match std::fs::copy(&source, &dest) {
-                    Ok(_) => {
-                        if !quiet {
-                            Output::success(&format!(
-                                "[copy] {} -> {}",
-                                copyfile.src, copyfile.dest
-                            ));
-                        }
-                        applied += 1;
-                    }
-                    Err(e) => {
-                        Output::error(&format!("Failed to copy: {}", e));
+                let pairs = expand_copy_pairs(&copyfile.src, &copyfile.dest, &base_dir);
+                for (source, rel_dest) in &pairs {
+                    let dest = workspace_root.join(rel_dest);
+                    if !source.exists() {
+                        Output::warning(&format!("Source not found: {:?}", source));
                         errors += 1;
+                        continue;
                     }
-                }
-            }
-        }
-
-        // Apply linkfiles
-        if let Some(ref linkfiles) = config.linkfile {
-            for linkfile in linkfiles {
-                let source = repo
-                    .map(|r| r.absolute_path.join(&linkfile.src))
-                    .unwrap_or_else(|| workspace_root.join(&config.path).join(&linkfile.src));
-                let dest = workspace_root.join(&linkfile.dest);
-
-                if !source.exists() {
-                    Output::warning(&format!("Source not found: {:?}", source));
-                    errors += 1;
-                    continue;
-                }
-
-                // Create parent directory if needed
-                if let Some(parent) = dest.parent() {
-                    std::fs::create_dir_all(parent)?;
-                }
-
-                // Remove existing link/file if present
-                if dest.exists() || dest.is_symlink() {
-                    let _ = std::fs::remove_file(&dest);
-                }
-
-                #[cfg(unix)]
-                {
-                    match std::os::unix::fs::symlink(&source, &dest) {
+                    if let Some(parent) = dest.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    match std::fs::copy(source, &dest) {
                         Ok(_) => {
                             if !quiet {
                                 Output::success(&format!(
-                                    "[link] {} -> {}",
-                                    linkfile.src, linkfile.dest
+                                    "[copy] {} -> {}",
+                                    source.display(),
+                                    rel_dest.display()
                                 ));
                             }
                             applied += 1;
                         }
                         Err(e) => {
-                            Output::error(&format!("Failed to create symlink: {}", e));
+                            Output::error(&format!("Failed to copy: {}", e));
                             errors += 1;
                         }
                     }
                 }
+            }
+        }
 
-                #[cfg(windows)]
-                {
-                    // On Windows, use junction for directories, symlink for files
-                    if source.is_dir() {
-                        match std::os::windows::fs::symlink_dir(&source, &dest) {
-                            Ok(_) => {
-                                if !quiet {
-                                    Output::success(&format!(
-                                        "[link] {} -> {}",
-                                        linkfile.src, linkfile.dest
-                                    ));
-                                }
-                                applied += 1;
+        // Apply linkfiles (with glob expansion)
+        if let Some(ref linkfiles) = config.linkfile {
+            let base_dir = repo
+                .map(|r| r.absolute_path.clone())
+                .unwrap_or_else(|| workspace_root.join(&config.path));
+
+            for linkfile in linkfiles {
+                let pairs = expand_copy_pairs(&linkfile.src, &linkfile.dest, &base_dir);
+                for (source, rel_dest) in &pairs {
+                    let dest = workspace_root.join(rel_dest);
+                    if !source.exists() {
+                        Output::warning(&format!("Source not found: {:?}", source));
+                        errors += 1;
+                        continue;
+                    }
+                    if let Some(parent) = dest.parent() {
+                        std::fs::create_dir_all(parent)?;
+                    }
+                    if dest.exists() || dest.is_symlink() {
+                        let _ = std::fs::remove_file(&dest);
+                    }
+                    let (result, label) = apply_symlink(source, &dest);
+                    match result {
+                        Ok(_) => {
+                            if !quiet {
+                                Output::success(&format!(
+                                    "[link] {} -> {}",
+                                    source.display(),
+                                    rel_dest.display()
+                                ));
                             }
-                            Err(e) => {
-                                Output::error(&format!("Failed to create symlink: {}", e));
-                                errors += 1;
-                            }
+                            applied += 1;
                         }
-                    } else {
-                        match std::os::windows::fs::symlink_file(&source, &dest) {
-                            Ok(_) => {
-                                if !quiet {
-                                    Output::success(&format!(
-                                        "[link] {} -> {}",
-                                        linkfile.src, linkfile.dest
-                                    ));
-                                }
-                                applied += 1;
-                            }
-                            Err(e) => {
-                                Output::error(&format!("Failed to create symlink: {}", e));
-                                errors += 1;
-                            }
+                        Err(e) => {
+                            Output::error(&format!("Failed to create {}: {}", label, e));
+                            errors += 1;
                         }
                     }
                 }
@@ -526,9 +587,37 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
         let spaces_dir = manifest_paths::spaces_dir(workspace_root);
 
         if manifests_dir.exists() {
-            // Apply manifest copyfiles
+            // Apply manifest copyfiles (with glob expansion)
             if let Some(ref copyfiles) = manifest_config.copyfile {
                 for copyfile in copyfiles {
+                    // Glob expansion only for non-gripspace sources
+                    if !copyfile.src.starts_with("gripspace:") && is_glob_pattern(&copyfile.src) {
+                        let pairs = expand_glob(&copyfile.src, &copyfile.dest, &manifests_dir);
+                        for (source, rel_dest) in &pairs {
+                            let dest = workspace_root.join(rel_dest);
+                            if let Some(parent) = dest.parent() {
+                                std::fs::create_dir_all(parent)?;
+                            }
+                            match std::fs::copy(source, &dest) {
+                                Ok(_) => {
+                                    if !quiet {
+                                        Output::success(&format!(
+                                            "[copy] manifest:{} -> {}",
+                                            source.display(),
+                                            rel_dest.display()
+                                        ));
+                                    }
+                                    applied += 1;
+                                }
+                                Err(e) => {
+                                    Output::error(&format!("Failed to copy: {}", e));
+                                    errors += 1;
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
                     let source =
                         match resolve_file_source(&copyfile.src, &manifests_dir, &spaces_dir) {
                             Ok(p) => p,
@@ -539,24 +628,19 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
                             }
                         };
                     let dest = workspace_root.join(&copyfile.dest);
-
                     if !source.exists() {
                         Output::warning(&format!("Source not found: {:?}", source));
                         errors += 1;
                         continue;
                     }
-
-                    // Create parent directory if needed
                     if let Some(parent) = dest.parent() {
                         std::fs::create_dir_all(parent)?;
                     }
-
                     let label = if copyfile.src.starts_with("gripspace:") {
                         copyfile.src.clone()
                     } else {
                         format!("manifest:{}", copyfile.src)
                     };
-
                     match std::fs::copy(&source, &dest) {
                         Ok(_) => {
                             if !quiet {
@@ -572,9 +656,41 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
                 }
             }
 
-            // Apply manifest linkfiles
+            // Apply manifest linkfiles (with glob expansion)
             if let Some(ref linkfiles) = manifest_config.linkfile {
                 for linkfile in linkfiles {
+                    // Glob expansion only for non-gripspace sources
+                    if !linkfile.src.starts_with("gripspace:") && is_glob_pattern(&linkfile.src) {
+                        let pairs = expand_glob(&linkfile.src, &linkfile.dest, &manifests_dir);
+                        for (source, rel_dest) in &pairs {
+                            let dest = workspace_root.join(rel_dest);
+                            if let Some(parent) = dest.parent() {
+                                std::fs::create_dir_all(parent)?;
+                            }
+                            if dest.exists() || dest.is_symlink() {
+                                let _ = std::fs::remove_file(&dest);
+                            }
+                            let (result, label) = apply_symlink(&source, &dest);
+                            match result {
+                                Ok(_) => {
+                                    if !quiet {
+                                        Output::success(&format!(
+                                            "[link] manifest:{} -> {}",
+                                            source.display(),
+                                            rel_dest.display()
+                                        ));
+                                    }
+                                    applied += 1;
+                                }
+                                Err(e) => {
+                                    Output::error(&format!("Failed to create {}: {}", label, e));
+                                    errors += 1;
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
                     let source =
                         match resolve_file_source(&linkfile.src, &manifests_dir, &spaces_dir) {
                             Ok(p) => p,
@@ -585,82 +701,36 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
                             }
                         };
                     let dest = workspace_root.join(&linkfile.dest);
-
                     if !source.exists() {
                         Output::warning(&format!("Source not found: {:?}", source));
                         errors += 1;
                         continue;
                     }
-
-                    // Create parent directory if needed
                     if let Some(parent) = dest.parent() {
                         std::fs::create_dir_all(parent)?;
                     }
-
-                    // Remove existing link/file if present
                     if dest.exists() || dest.is_symlink() {
                         let _ = std::fs::remove_file(&dest);
                     }
-
                     let label = if linkfile.src.starts_with("gripspace:") {
                         linkfile.src.clone()
                     } else {
                         format!("manifest:{}", linkfile.src)
                     };
-
-                    #[cfg(unix)]
-                    {
-                        match std::os::unix::fs::symlink(&source, &dest) {
-                            Ok(_) => {
-                                if !quiet {
-                                    Output::success(&format!(
-                                        "[link] {} -> {}",
-                                        label, linkfile.dest
-                                    ));
-                                }
-                                applied += 1;
+                    let (result, sym_label) = apply_symlink(&source, &dest);
+                    match result {
+                        Ok(_) => {
+                            if !quiet {
+                                Output::success(&format!(
+                                    "[link] {} -> {}",
+                                    label, linkfile.dest
+                                ));
                             }
-                            Err(e) => {
-                                Output::error(&format!("Failed to create symlink: {}", e));
-                                errors += 1;
-                            }
+                            applied += 1;
                         }
-                    }
-
-                    #[cfg(windows)]
-                    {
-                        if source.is_dir() {
-                            match std::os::windows::fs::symlink_dir(&source, &dest) {
-                                Ok(_) => {
-                                    if !quiet {
-                                        Output::success(&format!(
-                                            "[link] {} -> {}",
-                                            label, linkfile.dest
-                                        ));
-                                    }
-                                    applied += 1;
-                                }
-                                Err(e) => {
-                                    Output::error(&format!("Failed to create symlink: {}", e));
-                                    errors += 1;
-                                }
-                            }
-                        } else {
-                            match std::os::windows::fs::symlink_file(&source, &dest) {
-                                Ok(_) => {
-                                    if !quiet {
-                                        Output::success(&format!(
-                                            "[link] {} -> {}",
-                                            label, linkfile.dest
-                                        ));
-                                    }
-                                    applied += 1;
-                                }
-                                Err(e) => {
-                                    Output::error(&format!("Failed to create symlink: {}", e));
-                                    errors += 1;
-                                }
-                            }
+                        Err(e) => {
+                            Output::error(&format!("Failed to create {}: {}", sym_label, e));
+                            errors += 1;
                         }
                     }
                 }
@@ -1006,6 +1076,135 @@ mod tests {
             "Symlink should point to source, got: {:?}",
             link_target
         );
+    }
+
+    #[test]
+    fn test_is_glob_pattern() {
+        assert!(is_glob_pattern("**"));
+        assert!(is_glob_pattern("*.md"));
+        assert!(is_glob_pattern("prompts/**"));
+        assert!(is_glob_pattern("config/?.toml"));
+        assert!(is_glob_pattern("[abc].txt"));
+        assert!(!is_glob_pattern("README.md"));
+        assert!(!is_glob_pattern("prompts/opus.md"));
+    }
+
+    #[test]
+    fn test_glob_base_dir() {
+        assert_eq!(glob_base_dir("**"), "");
+        assert_eq!(glob_base_dir("*.md"), "");
+        assert_eq!(glob_base_dir("prompts/**"), "prompts");
+        assert_eq!(glob_base_dir("config/nested/**/*.md"), "config/nested");
+        assert_eq!(glob_base_dir("a/b/c/*.txt"), "a/b/c");
+    }
+
+    #[test]
+    fn test_expand_glob_basic() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+
+        // Create files
+        std::fs::create_dir_all(base.join("prompts")).unwrap();
+        std::fs::write(base.join("prompts/opus.md"), "opus").unwrap();
+        std::fs::write(base.join("prompts/atlas.md"), "atlas").unwrap();
+        std::fs::write(base.join("README.md"), "readme").unwrap();
+
+        let pairs = expand_glob("prompts/*", ".gitgrip/prompts/", base);
+        assert_eq!(pairs.len(), 2);
+
+        // Check that dest preserves the file name after stripping base
+        let dests: Vec<String> = pairs.iter().map(|(_, d)| d.display().to_string()).collect();
+        assert!(dests.contains(&".gitgrip/prompts/opus.md".to_string()));
+        assert!(dests.contains(&".gitgrip/prompts/atlas.md".to_string()));
+    }
+
+    #[test]
+    fn test_expand_glob_recursive() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+
+        std::fs::create_dir_all(base.join("config/sub")).unwrap();
+        std::fs::write(base.join("config/a.toml"), "a").unwrap();
+        std::fs::write(base.join("config/sub/b.toml"), "b").unwrap();
+
+        let pairs = expand_glob("config/**/*.toml", "./", base);
+        assert_eq!(pairs.len(), 2);
+
+        let dests: Vec<String> = pairs.iter().map(|(_, d)| d.display().to_string()).collect();
+        assert!(dests.contains(&"a.toml".to_string()) || dests.contains(&"./a.toml".to_string()));
+    }
+
+    #[test]
+    fn test_expand_glob_skips_directories() {
+        let temp = TempDir::new().unwrap();
+        let base = temp.path();
+
+        std::fs::create_dir_all(base.join("config/subdir")).unwrap();
+        std::fs::write(base.join("config/file.txt"), "content").unwrap();
+
+        let pairs = expand_glob("config/*", "./", base);
+        // Should only include the file, not the directory
+        assert_eq!(pairs.len(), 1);
+    }
+
+    #[test]
+    fn test_apply_copyfile_glob() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path().to_path_buf();
+
+        // Create repo directory with multiple files
+        let repo_dir = workspace.join("test-repo");
+        let prompts_dir = repo_dir.join("prompts");
+        std::fs::create_dir_all(&prompts_dir).unwrap();
+        std::fs::write(prompts_dir.join("opus.md"), "# Opus").unwrap();
+        std::fs::write(prompts_dir.join("atlas.md"), "# Atlas").unwrap();
+
+        let copyfiles = vec![CopyFileConfig {
+            src: "prompts/*.md".to_string(),
+            dest: ".gitgrip/prompts/".to_string(),
+        }];
+
+        let manifest = create_test_manifest(Some(copyfiles), None);
+        let result = apply_links(&workspace, &manifest, true);
+        assert!(result.is_ok());
+
+        // Verify both files were copied
+        assert!(workspace.join(".gitgrip/prompts/opus.md").exists());
+        assert!(workspace.join(".gitgrip/prompts/atlas.md").exists());
+        assert_eq!(
+            std::fs::read_to_string(workspace.join(".gitgrip/prompts/opus.md")).unwrap(),
+            "# Opus"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_apply_linkfile_glob() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path().to_path_buf();
+
+        let repo_dir = workspace.join("test-repo");
+        let prompts_dir = repo_dir.join("prompts");
+        std::fs::create_dir_all(&prompts_dir).unwrap();
+        std::fs::write(prompts_dir.join("opus.md"), "# Opus").unwrap();
+        std::fs::write(prompts_dir.join("atlas.md"), "# Atlas").unwrap();
+
+        let linkfiles = vec![LinkFileConfig {
+            src: "prompts/*.md".to_string(),
+            dest: ".gitgrip/prompts/".to_string(),
+        }];
+
+        let manifest = create_test_manifest(None, Some(linkfiles));
+        let result = apply_links(&workspace, &manifest, true);
+        assert!(result.is_ok());
+
+        // Verify symlinks were created
+        let opus_dest = workspace.join(".gitgrip/prompts/opus.md");
+        let atlas_dest = workspace.join(".gitgrip/prompts/atlas.md");
+        assert!(opus_dest.exists());
+        assert!(opus_dest.is_symlink());
+        assert!(atlas_dest.exists());
+        assert!(atlas_dest.is_symlink());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds glob pattern support (`*`, `**`, `?`, `[...]`) to `linkfile` and `copyfile` entries in the manifest
- Patterns like `docs/**/*.md` or `src/*.rs` expand at sync time, creating links/copies for each matched file
- `dest` is treated as a directory prefix when the source is a glob pattern; matched files are placed under it preserving relative paths from the glob base directory
- Refactors `apply_links()` to use unified `expand_copy_pairs()` helper, eliminating ~160 lines of duplicated per-file logic
- 7 new tests covering glob detection, base directory extraction, expansion, directory skipping, and integration with copyfile/linkfile application

Premium boundary: core OSS (workspace orchestration / file linking infrastructure).

## Test plan

- [x] All 47 link tests pass (7 new + 40 existing)
- [x] Full test suite passes: `cargo test` (all 188 tests green)
- [ ] Manual verification: create a manifest with glob linkfile/copyfile entries and run `gr sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)