### PR TITLE
feat: gr2 apply link operations and state tracking (grip#514)

### DIFF
--- a/gr2/Cargo.toml
+++ b/gr2/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"

--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -5,7 +5,8 @@ use std::fs;
 use std::path::Path;
 
 use crate::spec::{
-    read_workspace_spec, workspace_spec_path, write_workspace_spec, UnitSpec, WorkspaceSpec,
+    read_workspace_spec, workspace_spec_path, write_workspace_spec, LinkKind, LinkSpec, UnitSpec,
+    WorkspaceSpec,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -72,20 +73,47 @@ impl ExecutionPlan {
                     parameters,
                     preview: format!("clone unit '{}' into {}", unit.name, unit.path),
                 });
-                continue;
+                // Fall through to check links (they'll all be missing since the unit
+                // doesn't exist yet, but they should be planned alongside the Clone)
+            } else {
+                let expected_path = format!("agents/{}", unit.name);
+                if unit.path != expected_path {
+                    let mut parameters = BTreeMap::new();
+                    parameters.insert("path".to_string(), unit.path.clone());
+                    parameters.insert("repos".to_string(), unit.repos.join(","));
+                    operations.push(PlanOperation {
+                        unit_name: unit.name.clone(),
+                        operation: OperationType::Configure,
+                        parameters,
+                        preview: format!(
+                            "reconfigure unit '{}' to match {}",
+                            unit.name, unit.path
+                        ),
+                    });
+                }
             }
 
-            let expected_path = format!("agents/{}", unit.name);
-            if unit.path != expected_path {
-                let mut parameters = BTreeMap::new();
-                parameters.insert("path".to_string(), unit.path.clone());
-                parameters.insert("repos".to_string(), unit.repos.join(","));
-                operations.push(PlanOperation {
-                    unit_name: unit.name.clone(),
-                    operation: OperationType::Configure,
-                    parameters,
-                    preview: format!("reconfigure unit '{}' to match {}", unit.name, unit.path),
-                });
+            // Check declared links against filesystem
+            for link in &unit.links {
+                let dest_path = unit_root.join(&link.dest);
+                if !dest_path.exists() {
+                    let mut parameters = BTreeMap::new();
+                    parameters.insert("src".to_string(), link.src.clone());
+                    parameters.insert("dest".to_string(), link.dest.clone());
+                    parameters.insert("kind".to_string(), link.kind.as_str().to_string());
+                    operations.push(PlanOperation {
+                        unit_name: unit.name.clone(),
+                        operation: OperationType::Link,
+                        parameters,
+                        preview: format!(
+                            "{} {} -> {}/{}",
+                            link.kind.as_str(),
+                            link.src,
+                            unit.path,
+                            link.dest
+                        ),
+                    });
+                }
             }
         }
 
@@ -127,12 +155,37 @@ impl ExecutionPlan {
                     ));
                 }
                 OperationType::Link => {
-                    anyhow::bail!(
-                        "link operations are not implemented yet for unit '{}'",
-                        unit_spec.name
-                    );
+                    let src = operation
+                        .parameters
+                        .get("src")
+                        .context("link operation missing 'src' parameter")?;
+                    let dest = operation
+                        .parameters
+                        .get("dest")
+                        .context("link operation missing 'dest' parameter")?;
+                    let kind_str = operation
+                        .parameters
+                        .get("kind")
+                        .map(|s| s.as_str())
+                        .unwrap_or("symlink");
+                    let kind = LinkKind::from_str(kind_str)?;
+
+                    let link_spec = LinkSpec {
+                        src: src.clone(),
+                        dest: dest.clone(),
+                        kind,
+                    };
+                    apply_link(workspace_root, unit_spec, &link_spec)?;
+                    applied.push(format!(
+                        "{} {} -> {}/{}",
+                        kind_str, src, unit_spec.path, dest
+                    ));
                 }
             }
+        }
+
+        if !applied.is_empty() {
+            record_apply_state(workspace_root, &applied)?;
         }
 
         Ok(applied)
@@ -146,26 +199,42 @@ impl ExecutionPlan {
         let mut warnings = Vec::new();
 
         for operation in &self.operations {
-            let path = operation
-                .parameters
-                .get("path")
-                .map(|value| workspace_root.join(value))
-                .unwrap_or_else(|| workspace_root.join(format!("agents/{}", operation.unit_name)));
+            match operation.operation {
+                OperationType::Link => {
+                    // For link operations, check the destination path inside the unit
+                    let unit_path = operation
+                        .parameters
+                        .get("path")
+                        .cloned()
+                        .unwrap_or_else(|| format!("agents/{}", operation.unit_name));
+                    if let Some(dest) = operation.parameters.get("dest") {
+                        let dest_path = workspace_root.join(&unit_path).join(dest);
+                        if dest_path.exists() {
+                            anyhow::bail!(
+                                "refusing to apply plan: link destination already exists for unit '{}': {}",
+                                operation.unit_name,
+                                dest_path.display()
+                            );
+                        }
+                    }
+                }
+                _ => {
+                    let path = operation
+                        .parameters
+                        .get("path")
+                        .map(|value| workspace_root.join(value))
+                        .unwrap_or_else(|| {
+                            workspace_root.join(format!("agents/{}", operation.unit_name))
+                        });
 
-            if matches!(operation.operation, OperationType::Link) && path.exists() {
-                anyhow::bail!(
-                    "refusing to apply plan: link operation for '{}' would overwrite existing directory {}",
-                    operation.unit_name,
-                    path.display()
-                );
-            }
-
-            if path.join(".git").exists() {
-                warnings.push(format!(
-                    "unit '{}' has a git checkout at {} with possible uncommitted changes; inspect before apply",
-                    operation.unit_name,
-                    path.display()
-                ));
+                    if path.join(".git").exists() {
+                        warnings.push(format!(
+                            "unit '{}' has a git checkout at {} with possible uncommitted changes; inspect before apply",
+                            operation.unit_name,
+                            path.display()
+                        ));
+                    }
+                }
             }
         }
 
@@ -206,12 +275,133 @@ impl OperationType {
     }
 }
 
+fn apply_link(workspace_root: &Path, unit: &UnitSpec, link: &LinkSpec) -> Result<()> {
+    let src_path = workspace_root.join(&link.src);
+    let unit_root = workspace_root.join(&unit.path);
+    let dest_path = unit_root.join(&link.dest);
+
+    if !src_path.exists() {
+        anyhow::bail!(
+            "link source does not exist: {} (for unit '{}')",
+            src_path.display(),
+            unit.name
+        );
+    }
+
+    if let Some(parent) = dest_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "create parent directory for link destination {}",
+                dest_path.display()
+            )
+        })?;
+    }
+
+    match link.kind {
+        LinkKind::Symlink => {
+            let abs_src = fs::canonicalize(&src_path).with_context(|| {
+                format!("resolve absolute path for link source {}", src_path.display())
+            })?;
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&abs_src, &dest_path).with_context(|| {
+                format!(
+                    "create symlink {} -> {}",
+                    dest_path.display(),
+                    abs_src.display()
+                )
+            })?;
+            #[cfg(windows)]
+            {
+                if abs_src.is_dir() {
+                    std::os::windows::fs::symlink_dir(&abs_src, &dest_path)
+                } else {
+                    std::os::windows::fs::symlink_file(&abs_src, &dest_path)
+                }
+                .with_context(|| {
+                    format!(
+                        "create symlink {} -> {}",
+                        dest_path.display(),
+                        abs_src.display()
+                    )
+                })?;
+            }
+        }
+        LinkKind::Copy => {
+            if src_path.is_dir() {
+                copy_dir_recursive(&src_path, &dest_path).with_context(|| {
+                    format!(
+                        "copy directory {} -> {}",
+                        src_path.display(),
+                        dest_path.display()
+                    )
+                })?;
+            } else {
+                fs::copy(&src_path, &dest_path).with_context(|| {
+                    format!(
+                        "copy file {} -> {}",
+                        src_path.display(),
+                        dest_path.display()
+                    )
+                })?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
+    fs::create_dir_all(dest)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let entry_dest = dest.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&entry.path(), &entry_dest)?;
+        } else {
+            fs::copy(entry.path(), &entry_dest)?;
+        }
+    }
+    Ok(())
+}
+
 fn materialize_unit(workspace_root: &Path, unit: &UnitSpec) -> Result<()> {
     let unit_root = workspace_root.join(&unit.path);
     fs::create_dir_all(&unit_root)
         .with_context(|| format!("create unit directory {}", unit_root.display()))?;
     fs::write(unit_root.join("unit.toml"), render_unit_toml(unit))
         .with_context(|| format!("write unit metadata for '{}'", unit.name))?;
+    Ok(())
+}
+
+fn record_apply_state(workspace_root: &Path, actions: &[String]) -> Result<()> {
+    let state_dir = workspace_root.join(".grip/state");
+    fs::create_dir_all(&state_dir)
+        .with_context(|| format!("create state directory {}", state_dir.display()))?;
+
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    let mut content = format!("# Last apply: {}\n\n", timestamp);
+    content.push_str("[[applied]]\n");
+    content.push_str(&format!("timestamp = \"{}\"\n", timestamp));
+    content.push_str(&format!(
+        "actions = [{}]\n",
+        actions
+            .iter()
+            .map(|a| format!("\"{}\"", a.replace('"', "\\\"")))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    let state_path = state_dir.join("applied.toml");
+
+    // Append to existing state file
+    if state_path.exists() {
+        let existing = fs::read_to_string(&state_path)?;
+        content = format!("{}\n{}", existing.trim_end(), content);
+    }
+
+    fs::write(&state_path, content)
+        .with_context(|| format!("write apply state to {}", state_path.display()))?;
+
     Ok(())
 }
 

--- a/gr2/src/spec.rs
+++ b/gr2/src/spec.rs
@@ -35,6 +35,43 @@ pub struct UnitSpec {
     pub path: String,
     #[serde(default)]
     pub repos: Vec<String>,
+    #[serde(default)]
+    pub links: Vec<LinkSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LinkSpec {
+    /// Source path relative to workspace root
+    pub src: String,
+    /// Destination path relative to unit root
+    pub dest: String,
+    #[serde(default)]
+    pub kind: LinkKind,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkKind {
+    #[default]
+    Symlink,
+    Copy,
+}
+
+impl LinkKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Symlink => "symlink",
+            Self::Copy => "copy",
+        }
+    }
+
+    pub fn from_str(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "symlink" => Ok(Self::Symlink),
+            "copy" => Ok(Self::Copy),
+            _ => anyhow::bail!("unknown link kind '{}': expected 'symlink' or 'copy'", s),
+        }
+    }
 }
 
 impl WorkspaceSpec {
@@ -228,6 +265,7 @@ fn read_registered_units(workspace_root: &Path) -> Result<Vec<UnitSpec>> {
             name: fallback_name.clone(),
             path: format!("agents/{}", fallback_name),
             repos: Vec::new(),
+            links: Vec::new(),
         });
     }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1701,3 +1701,401 @@ fn test_checkout_remove_rejects_extra_positional_args() {
             "unexpected extra arguments after checkout name",
         ));
 }
+
+// ─── gr2 apply link operations (grip#514) ──────────────────────────────
+
+#[test]
+fn test_gr2_plan_detects_missing_symlink() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    // Create a source file that the link will point to
+    std::fs::write(workspace_root.join("config/shared.toml"), "key = \"value\"\n").unwrap();
+
+    // Create the unit directory so Clone isn't planned
+    std::fs::create_dir_all(workspace_root.join("agents/atlas")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/atlas/unit.toml"),
+        "name = \"atlas\"\nkind = \"unit\"\n",
+    )
+    .unwrap();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = []
+
+[[units.links]]
+src = "config/shared.toml"
+dest = ".config/shared.toml"
+kind = "symlink"
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("link"))
+        .stdout(predicate::str::contains("config/shared.toml"));
+}
+
+#[test]
+fn test_gr2_apply_creates_symlink() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    // Create a source file
+    std::fs::write(workspace_root.join("config/shared.toml"), "key = \"value\"\n").unwrap();
+
+    // Create the unit directory
+    std::fs::create_dir_all(workspace_root.join("agents/atlas")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/atlas/unit.toml"),
+        "name = \"atlas\"\nkind = \"unit\"\n",
+    )
+    .unwrap();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = []
+
+[[units.links]]
+src = "config/shared.toml"
+dest = ".config/shared.toml"
+kind = "symlink"
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("symlink config/shared.toml -> agents/atlas/.config/shared.toml"));
+
+    let link_path = workspace_root.join("agents/atlas/.config/shared.toml");
+    assert!(link_path.exists(), "symlink destination should exist");
+    assert!(
+        link_path.symlink_metadata().unwrap().file_type().is_symlink(),
+        "destination should be a symlink"
+    );
+
+    let content = std::fs::read_to_string(&link_path).unwrap();
+    assert_eq!(content, "key = \"value\"\n");
+}
+
+#[test]
+fn test_gr2_apply_creates_copy() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    std::fs::write(
+        workspace_root.join("config/env.toml"),
+        "env = \"production\"\n",
+    )
+    .unwrap();
+
+    std::fs::create_dir_all(workspace_root.join("agents/apollo")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/apollo/unit.toml"),
+        "name = \"apollo\"\nkind = \"unit\"\n",
+    )
+    .unwrap();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = []
+
+[[units.links]]
+src = "config/env.toml"
+dest = "env.toml"
+kind = "copy"
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("copy config/env.toml -> agents/apollo/env.toml"));
+
+    let dest_path = workspace_root.join("agents/apollo/env.toml");
+    assert!(dest_path.exists(), "copy destination should exist");
+    assert!(
+        !dest_path.symlink_metadata().unwrap().file_type().is_symlink(),
+        "copy destination should NOT be a symlink"
+    );
+
+    let content = std::fs::read_to_string(&dest_path).unwrap();
+    assert_eq!(content, "env = \"production\"\n");
+}
+
+#[test]
+fn test_gr2_apply_link_fails_for_missing_source() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    std::fs::create_dir_all(workspace_root.join("agents/atlas")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/atlas/unit.toml"),
+        "name = \"atlas\"\nkind = \"unit\"\n",
+    )
+    .unwrap();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = []
+
+[[units.links]]
+src = "nonexistent/file.toml"
+dest = "file.toml"
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("link source does not exist"));
+}
+
+#[test]
+fn test_gr2_plan_noop_when_link_already_exists() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    std::fs::write(workspace_root.join("config/shared.toml"), "key = \"value\"\n").unwrap();
+
+    std::fs::create_dir_all(workspace_root.join("agents/atlas/.config")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/atlas/unit.toml"),
+        "name = \"atlas\"\nkind = \"unit\"\n",
+    )
+    .unwrap();
+    // Pre-create the destination so the link is already satisfied
+    std::fs::write(
+        workspace_root.join("agents/atlas/.config/shared.toml"),
+        "existing",
+    )
+    .unwrap();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = []
+
+[[units.links]]
+src = "config/shared.toml"
+dest = ".config/shared.toml"
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no changes required"));
+}
+
+#[test]
+fn test_gr2_apply_records_state() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = []
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .success();
+
+    let state_path = workspace_root.join(".grip/state/applied.toml");
+    assert!(state_path.exists(), "apply should record state");
+
+    let state = std::fs::read_to_string(&state_path).unwrap();
+    assert!(state.contains("[[applied]]"), "state should contain applied entries");
+    assert!(state.contains("cloned unit"), "state should record clone action");
+}
+
+#[test]
+fn test_gr2_apply_mixed_clone_and_link() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    std::fs::write(workspace_root.join("config/shared.toml"), "shared = true\n").unwrap();
+
+    let spec = r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = []
+
+[[units.links]]
+src = "config/shared.toml"
+dest = ".config/shared.toml"
+kind = "symlink"
+"#;
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        spec.trim_start(),
+    )
+    .unwrap();
+
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("cloned unit 'atlas'"))
+        .stdout(predicate::str::contains("symlink config/shared.toml"));
+
+    assert!(workspace_root.join("agents/atlas/unit.toml").exists());
+    assert!(workspace_root.join("agents/atlas/.config/shared.toml").exists());
+}


### PR DESCRIPTION
## Summary

- Adds `LinkSpec` model to `UnitSpec` for declaring symlinks and copies in the workspace spec
- Planner detects missing links and generates `Link` operations alongside `Clone`/`Configure`
- Apply executes link operations: creates symlinks (absolute path resolution) or file copies (including recursive directory copies)
- Validates source existence before applying; fails fast with clear error messages
- Records all applied actions to `.grip/state/applied.toml` with timestamps for drift detection
- Fixes planning logic to include links when a unit also needs cloning (removed premature `continue`)
- Fixes guard to check actual link destination paths instead of unit directory paths
- 7 new integration tests covering: plan detection, symlink creation, copy creation, missing source error, noop when satisfied, state recording, mixed clone+link

Premium boundary: core OSS (workspace materialization infrastructure).

## Test plan

- [x] All 7 new gr2 link tests pass
- [x] All 48 gr2 tests pass (41 existing + 7 new)
- [x] Full test suite green: 708 tests (638 unit + 70 integration)
- [ ] Manual verification: create a workspace spec with link declarations and run `gr2 apply`

Closes grip#514

🤖 Generated with [Claude Code](https://claude.com/claude-code)