### PR TITLE
test: regression tests for org URL parsing (grip#429)

### DIFF
--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -432,6 +432,22 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_github_org_ssh() {
+        // Regression test for grip#429: org URLs must extract owner correctly
+        let parsed = parse_git_url("git@github.com:synapt-dev/grip.git").unwrap();
+        assert_eq!(parsed.owner, "synapt-dev");
+        assert_eq!(parsed.repo, "grip");
+    }
+
+    #[test]
+    fn test_parse_github_org_https() {
+        // Regression test for grip#429: org URLs must extract owner correctly
+        let parsed = parse_git_url("https://github.com/synapt-dev/recall.git").unwrap();
+        assert_eq!(parsed.owner, "synapt-dev");
+        assert_eq!(parsed.repo, "recall");
+    }
+
+    #[test]
     fn test_detect_github() {
         assert_eq!(
             detect_platform("git@github.com:user/repo.git"),


### PR DESCRIPTION
## Summary
- Adds 2 regression tests confirming `parse_git_url` correctly extracts org owners from GitHub URLs
- `test_parse_github_org_ssh`: verifies `git@github.com:synapt-dev/grip.git` -> owner=`synapt-dev`
- `test_parse_github_org_https`: verifies `https://github.com/synapt-dev/recall.git` -> owner=`synapt-dev`

## Context
grip#429 reported that `gr pr create` failed against non-laynepenney GitHub orgs during Sprint 7. Investigation confirms the bug was resolved by subsequent refactors (manifest v2 schema, multi-branch support, error surfacing improvements). These tests prevent recurrence.

**Premium boundary**: OSS (grip core URL parsing infrastructure).

## Test plan
- [x] Both new tests pass: `cargo test test_parse_github_org`
- [x] No existing tests broken

Closes #429