### PR TITLE
fix: gr branch switches to existing branch (grip#401)

### DIFF
--- a/src/cli/commands/branch.rs
+++ b/src/cli/commands/branch.rs
@@ -4,7 +4,10 @@ use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
 use crate::core::repo::{filter_repos, get_manifest_repo_info, RepoInfo};
 use crate::git::{
-    branch::{branch_exists, create_and_checkout_branch, delete_local_branch, list_local_branches},
+    branch::{
+        branch_exists, checkout_branch, create_and_checkout_branch, delete_local_branch,
+        list_local_branches,
+    },
     get_current_branch, open_repo,
 };
 use std::path::PathBuf;
@@ -473,15 +476,42 @@ pub fn run_branch(opts: BranchOptions<'_>) -> anyhow::Result<()> {
                 match open_repo(&repo.absolute_path) {
                     Ok(git_repo) => {
                         if branch_exists(&git_repo, branch_name) {
-                            if opts.json {
-                                json_results.push(JsonCreateResult {
-                                    repo: repo.name.clone(),
-                                    branch: branch_name.to_string(),
-                                    action: "already_exists".to_string(),
-                                    error: None,
-                                });
-                            } else {
-                                Output::info(&format!("{}: already exists", repo.name));
+                            // Branch exists — switch to it so subsequent commits
+                            // land on this branch, not the previous one (grip#401).
+                            match checkout_branch(&git_repo, branch_name) {
+                                Ok(()) => {
+                                    if opts.json {
+                                        json_results.push(JsonCreateResult {
+                                            repo: repo.name.clone(),
+                                            branch: branch_name.to_string(),
+                                            action: "switched".to_string(),
+                                            error: None,
+                                        });
+                                    } else {
+                                        Output::info(&format!(
+                                            "{}: already exists, switched",
+                                            repo.name
+                                        ));
+                                    }
+                                }
+                                Err(e) => {
+                                    if opts.json {
+                                        json_results.push(JsonCreateResult {
+                                            repo: repo.name.clone(),
+                                            branch: branch_name.to_string(),
+                                            action: "error".to_string(),
+                                            error: Some(format!(
+                                                "exists but failed to switch: {}",
+                                                e
+                                            )),
+                                        });
+                                    } else {
+                                        Output::error(&format!(
+                                            "{}: exists but failed to switch: {}",
+                                            repo.name, e
+                                        ));
+                                    }
+                                }
                             }
                             continue;
                         }

--- a/tests/test_branch.rs
+++ b/tests/test_branch.rs
@@ -300,3 +300,51 @@ fn test_branch_create_then_verify_branches_exist() {
     assert_branch_exists(&ws.repo_path("alpha"), "main");
     assert_branch_exists(&ws.repo_path("beta"), "main");
 }
+
+/// Regression test for grip#401: `gr branch` on an existing branch must
+/// switch to it so subsequent commits land on the correct branch.
+#[test]
+fn test_branch_switches_to_existing_branch() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Create feat/target and then switch back to main
+    gitgrip::cli::commands::branch::run_branch(gitgrip::cli::commands::branch::BranchOptions {
+        workspace_root: &ws.workspace_root,
+        manifest: &manifest,
+        name: Some("feat/target"),
+        delete: false,
+        move_commits: false,
+        repos_filter: None,
+        group_filter: None,
+        json: false,
+    })
+    .unwrap();
+
+    gitgrip::cli::commands::checkout::run_checkout(
+        &ws.workspace_root,
+        &manifest,
+        "main",
+        false,
+        None,
+        None,
+    )
+    .unwrap();
+    assert_on_branch(&ws.repo_path("app"), "main");
+
+    // Run `gr branch feat/target` again — should switch to it
+    gitgrip::cli::commands::branch::run_branch(gitgrip::cli::commands::branch::BranchOptions {
+        workspace_root: &ws.workspace_root,
+        manifest: &manifest,
+        name: Some("feat/target"),
+        delete: false,
+        move_commits: false,
+        repos_filter: None,
+        group_filter: None,
+        json: false,
+    })
+    .unwrap();
+
+    // Must be on feat/target, not main
+    assert_on_branch(&ws.repo_path("app"), "feat/target");
+}


### PR DESCRIPTION
## Summary
- When `gr branch <name>` found an existing branch, it printed "already exists" and silently stayed on the current branch
- Now calls `checkout_branch()` to switch to the existing branch, so subsequent commits land on the correct branch
- JSON output reports `"action": "switched"` instead of `"already_exists"`

## Root cause
Real incident from Sprint 7: agent created a new branch but commits kept landing on the old branch because `gr branch` skipped the checkout when the branch already existed. The orphaned commits were only recoverable via `git reflog`.

## Changes
- `src/cli/commands/branch.rs`: In the "branch already exists" path, switch to the branch instead of `continue`. Reports success as "already exists, switched" or error if checkout fails.
- `tests/test_branch.rs`: New `test_branch_switches_to_existing_branch` regression test verifying the branch is actually switched after a second `gr branch` call.

**Premium boundary**: OSS (grip core branch management).

## Test plan
- [x] `test_branch_switches_to_existing_branch` passes (new)
- [x] All 13 branch tests pass (no regressions)
- [x] `test_branch_idempotent_creation` still passes (existing)
- [x] `test_branch_already_exists` still passes (existing)

Closes #401