### PR TITLE
chore: cargo fmt (ceremony prep)

### DIFF
--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -85,10 +85,7 @@ impl ExecutionPlan {
                         unit_name: unit.name.clone(),
                         operation: OperationType::Configure,
                         parameters,
-                        preview: format!(
-                            "reconfigure unit '{}' to match {}",
-                            unit.name, unit.path
-                        ),
+                        preview: format!("reconfigure unit '{}' to match {}", unit.name, unit.path),
                     });
                 }
             }
@@ -300,7 +297,10 @@ fn apply_link(workspace_root: &Path, unit: &UnitSpec, link: &LinkSpec) -> Result
     match link.kind {
         LinkKind::Symlink => {
             let abs_src = fs::canonicalize(&src_path).with_context(|| {
-                format!("resolve absolute path for link source {}", src_path.display())
+                format!(
+                    "resolve absolute path for link source {}",
+                    src_path.display()
+                )
             })?;
             #[cfg(unix)]
             std::os::unix::fs::symlink(&abs_src, &dest_path).with_context(|| {

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -23,11 +23,7 @@ fn is_glob_pattern(src: &str) -> bool {
 ///
 /// The glob base (the non-glob prefix before the first glob character) is
 /// stripped from each matched path, and the remainder is appended to `dest`.
-fn expand_glob(
-    src_pattern: &str,
-    dest: &str,
-    base_dir: &Path,
-) -> Vec<(PathBuf, PathBuf)> {
+fn expand_glob(src_pattern: &str, dest: &str, base_dir: &Path) -> Vec<(PathBuf, PathBuf)> {
     let full_pattern = base_dir.join(src_pattern);
     let pattern_str = match full_pattern.to_str() {
         Some(s) => s.to_string(),
@@ -721,10 +717,7 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
                     match result {
                         Ok(_) => {
                             if !quiet {
-                                Output::success(&format!(
-                                    "[link] {} -> {}",
-                                    label, linkfile.dest
-                                ));
+                                Output::success(&format!("[link] {} -> {}", label, linkfile.dest));
                             }
                             applied += 1;
                         }

--- a/src/cli/commands/migrate.rs
+++ b/src/cli/commands/migrate.rs
@@ -266,11 +266,7 @@ fn generate_manifest_yaml(repos: &[(String, String)], org: &str, prefix: &str) -
 }
 
 /// Generate CLAUDE.md with repo table and agent context.
-fn generate_claude_md(
-    repos: &[(String, String)],
-    prefix: &str,
-    agents: &[AgentSpec],
-) -> String {
+fn generate_claude_md(repos: &[(String, String)], prefix: &str, agents: &[AgentSpec]) -> String {
     let mut md = String::new();
     md.push_str(&format!("# {}\n\n", prefix));
     md.push_str("Multi-repo workspace managed by **gitgrip** (`gr`). Always use `gr` — never raw `git` or `gh`.\n\n");

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1718,7 +1718,11 @@ fn test_gr2_plan_detects_missing_symlink() {
         .success();
 
     // Create a source file that the link will point to
-    std::fs::write(workspace_root.join("config/shared.toml"), "key = \"value\"\n").unwrap();
+    std::fs::write(
+        workspace_root.join("config/shared.toml"),
+        "key = \"value\"\n",
+    )
+    .unwrap();
 
     // Create the unit directory so Clone isn't planned
     std::fs::create_dir_all(workspace_root.join("agents/atlas")).unwrap();
@@ -1774,7 +1778,11 @@ fn test_gr2_apply_creates_symlink() {
         .success();
 
     // Create a source file
-    std::fs::write(workspace_root.join("config/shared.toml"), "key = \"value\"\n").unwrap();
+    std::fs::write(
+        workspace_root.join("config/shared.toml"),
+        "key = \"value\"\n",
+    )
+    .unwrap();
 
     // Create the unit directory
     std::fs::create_dir_all(workspace_root.join("agents/atlas")).unwrap();
@@ -1813,12 +1821,18 @@ kind = "symlink"
         .arg("apply")
         .assert()
         .success()
-        .stdout(predicate::str::contains("symlink config/shared.toml -> agents/atlas/.config/shared.toml"));
+        .stdout(predicate::str::contains(
+            "symlink config/shared.toml -> agents/atlas/.config/shared.toml",
+        ));
 
     let link_path = workspace_root.join("agents/atlas/.config/shared.toml");
     assert!(link_path.exists(), "symlink destination should exist");
     assert!(
-        link_path.symlink_metadata().unwrap().file_type().is_symlink(),
+        link_path
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
         "destination should be a symlink"
     );
 
@@ -1881,12 +1895,18 @@ kind = "copy"
         .arg("apply")
         .assert()
         .success()
-        .stdout(predicate::str::contains("copy config/env.toml -> agents/apollo/env.toml"));
+        .stdout(predicate::str::contains(
+            "copy config/env.toml -> agents/apollo/env.toml",
+        ));
 
     let dest_path = workspace_root.join("agents/apollo/env.toml");
     assert!(dest_path.exists(), "copy destination should exist");
     assert!(
-        !dest_path.symlink_metadata().unwrap().file_type().is_symlink(),
+        !dest_path
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
         "copy destination should NOT be a symlink"
     );
 
@@ -1958,7 +1978,11 @@ fn test_gr2_plan_noop_when_link_already_exists() {
         .assert()
         .success();
 
-    std::fs::write(workspace_root.join("config/shared.toml"), "key = \"value\"\n").unwrap();
+    std::fs::write(
+        workspace_root.join("config/shared.toml"),
+        "key = \"value\"\n",
+    )
+    .unwrap();
 
     std::fs::create_dir_all(workspace_root.join("agents/atlas/.config")).unwrap();
     std::fs::write(
@@ -2045,8 +2069,14 @@ repos = []
     assert!(state_path.exists(), "apply should record state");
 
     let state = std::fs::read_to_string(&state_path).unwrap();
-    assert!(state.contains("[[applied]]"), "state should contain applied entries");
-    assert!(state.contains("cloned unit"), "state should record clone action");
+    assert!(
+        state.contains("[[applied]]"),
+        "state should contain applied entries"
+    );
+    assert!(
+        state.contains("cloned unit"),
+        "state should record clone action"
+    );
 }
 
 #[test]
@@ -2097,7 +2127,9 @@ kind = "symlink"
         .stdout(predicate::str::contains("symlink config/shared.toml"));
 
     assert!(workspace_root.join("agents/atlas/unit.toml").exists());
-    assert!(workspace_root.join("agents/atlas/.config/shared.toml").exists());
+    assert!(workspace_root
+        .join("agents/atlas/.config/shared.toml")
+        .exists());
 }
 
 // ── gr2 apply TDD specs (grip#514, grip#526) ────────────────────────────────


### PR DESCRIPTION
## Summary
- Run `cargo fmt --all` on sprint-17 to fix formatting drift before ceremony PR
- 4 files touched: plan.rs, link.rs, migrate.rs, cli_tests.rs
- All tests pass (48 suites, 0 failures)

Premium boundary: core OSS (formatting only, no logic changes)