### PR TITLE
fix: clippy lints blocking ceremony PR

### DIFF
--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -165,7 +165,7 @@ impl ExecutionPlan {
                         .get("kind")
                         .map(|s| s.as_str())
                         .unwrap_or("symlink");
-                    let kind = LinkKind::from_str(kind_str)?;
+                    let kind = kind_str.parse::<LinkKind>()?;
 
                     let link_spec = LinkSpec {
                         src: src.clone(),

--- a/gr2/src/spec.rs
+++ b/gr2/src/spec.rs
@@ -64,8 +64,12 @@ impl LinkKind {
             Self::Copy => "copy",
         }
     }
+}
 
-    pub fn from_str(s: &str) -> anyhow::Result<Self> {
+impl std::str::FromStr for LinkKind {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
         match s {
             "symlink" => Ok(Self::Symlink),
             "copy" => Ok(Self::Copy),

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -666,7 +666,7 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
                             if dest.exists() || dest.is_symlink() {
                                 let _ = std::fs::remove_file(&dest);
                             }
-                            let (result, label) = apply_symlink(&source, &dest);
+                            let (result, label) = apply_symlink(source, &dest);
                             match result {
                                 Ok(_) => {
                                     if !quiet {
@@ -828,7 +828,7 @@ mod tests {
         let manifest = create_test_manifest(None, None);
 
         // Should not error even with no links
-        let result = show_link_status(&temp.path().to_path_buf(), &manifest, false);
+        let result = show_link_status(temp.path(), &manifest, false);
         assert!(result.is_ok());
     }
 
@@ -1061,7 +1061,7 @@ mod tests {
         // Verify symlink points to the source file
         let dest_path = workspace.join("linked.config");
         let link_target = std::fs::read_link(&dest_path).unwrap();
-        let expected_source = repo_dir.join("shared.config");
+        let _expected_source = repo_dir.join("shared.config");
 
         // The target should resolve to the source file
         assert!(

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -1160,7 +1160,7 @@ version = "0.2.0"
             clone_strategy: crate::core::manifest::CloneStrategy::Clone,
         }];
 
-        let files = detect_version_files(&dir.path().to_path_buf(), &repos);
+        let files = detect_version_files(dir.path(), &repos);
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].0, "my-repo");
         assert!(files[0].1.ends_with("Cargo.toml"));
@@ -1193,7 +1193,7 @@ version = "0.2.0"
             clone_strategy: crate::core::manifest::CloneStrategy::Clone,
         }];
 
-        let files = detect_version_files(&dir.path().to_path_buf(), &repos);
+        let files = detect_version_files(dir.path(), &repos);
         assert!(files.is_empty());
     }
 }

--- a/src/cli/commands/repo.rs
+++ b/src/cli/commands/repo.rs
@@ -288,7 +288,6 @@ mod tests {
 
 #[cfg(test)]
 mod yaml_insertion_tests {
-    use super::*;
 
     /// Helper function to extract the insertion logic for testing
     fn test_insert_yaml(content: &str, new_entry: &str) -> String {

--- a/src/cli/commands/tree.rs
+++ b/src/cli/commands/tree.rs
@@ -1075,7 +1075,7 @@ fn stash_pop_repo(repo_path: &Path) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use tempfile::TempDir;
 
     #[test]

--- a/src/core/griptree.rs
+++ b/src/core/griptree.rs
@@ -355,7 +355,7 @@ mod tests {
     #[test]
     fn test_load_from_workspace_none_when_missing() {
         let temp = tempfile::TempDir::new().unwrap();
-        let result = GriptreeConfig::load_from_workspace(&temp.path().to_path_buf()).unwrap();
+        let result = GriptreeConfig::load_from_workspace(temp.path()).unwrap();
         assert!(result.is_none());
     }
 
@@ -369,7 +369,7 @@ mod tests {
         let config_path = gitgrip_dir.join("griptree.json");
         config.save(&config_path).unwrap();
 
-        let loaded = GriptreeConfig::load_from_workspace(&temp.path().to_path_buf())
+        let loaded = GriptreeConfig::load_from_workspace(temp.path())
             .unwrap()
             .expect("should find config");
         assert_eq!(loaded.branch, "feat/ws");

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -680,13 +680,7 @@ mod tests {
         };
 
         let filter = vec!["app".to_string()];
-        let result = filter_repos(
-            &manifest,
-            &temp.path().to_path_buf(),
-            Some(&filter),
-            None,
-            false,
-        );
+        let result = filter_repos(&manifest, temp.path(), Some(&filter), None, false);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "app");
     }
@@ -748,12 +742,12 @@ mod tests {
             workspace: None,
         };
 
-        let result = filter_repos(&manifest, &temp.path().to_path_buf(), None, None, false);
+        let result = filter_repos(&manifest, temp.path(), None, None, false);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "normal");
 
         // With include_reference = true
-        let result = filter_repos(&manifest, &temp.path().to_path_buf(), None, None, true);
+        let result = filter_repos(&manifest, temp.path(), None, None, true);
         assert_eq!(result.len(), 2);
     }
 
@@ -815,13 +809,7 @@ mod tests {
         };
 
         let groups = vec!["web".to_string()];
-        let result = filter_repos(
-            &manifest,
-            &temp.path().to_path_buf(),
-            None,
-            Some(&groups),
-            false,
-        );
+        let result = filter_repos(&manifest, temp.path(), None, Some(&groups), false);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "frontend");
     }
@@ -851,9 +839,7 @@ mod tests {
             clone_strategy: None,
         };
         let settings = ManifestSettings::default();
-        let info =
-            RepoInfo::from_config("app", &config, &temp.path().to_path_buf(), &settings, None)
-                .unwrap();
+        let info = RepoInfo::from_config("app", &config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.revision, "develop");
 
         // repo omits revision, inherits from settings
@@ -877,16 +863,12 @@ mod tests {
             revision: Some("master".to_string()),
             ..Default::default()
         };
-        let info =
-            RepoInfo::from_config("app", &config, &temp.path().to_path_buf(), &settings, None)
-                .unwrap();
+        let info = RepoInfo::from_config("app", &config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.revision, "master");
 
         // both omit → falls back to "main"
         let settings = ManifestSettings::default();
-        let info =
-            RepoInfo::from_config("app", &config, &temp.path().to_path_buf(), &settings, None)
-                .unwrap();
+        let info = RepoInfo::from_config("app", &config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.revision, "main");
     }
 
@@ -915,14 +897,8 @@ mod tests {
 
         // No target → falls back to revision
         let settings = ManifestSettings::default();
-        let info = RepoInfo::from_config(
-            "app",
-            &base_config,
-            &temp.path().to_path_buf(),
-            &settings,
-            None,
-        )
-        .unwrap();
+        let info =
+            RepoInfo::from_config("app", &base_config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.target, "main");
         assert_eq!(info.target_branch(), "main");
         assert_eq!(info.sync_ref(), "origin/main");
@@ -932,14 +908,8 @@ mod tests {
             target: Some("develop".to_string()),
             ..Default::default()
         };
-        let info = RepoInfo::from_config(
-            "app",
-            &base_config,
-            &temp.path().to_path_buf(),
-            &settings,
-            None,
-        )
-        .unwrap();
+        let info =
+            RepoInfo::from_config("app", &base_config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.target, "develop");
         assert_eq!(info.target_branch(), "develop");
 
@@ -952,9 +922,7 @@ mod tests {
             target: Some("develop".to_string()),
             ..Default::default()
         };
-        let info =
-            RepoInfo::from_config("app", &config, &temp.path().to_path_buf(), &settings, None)
-                .unwrap();
+        let info = RepoInfo::from_config("app", &config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.target, "staging");
         assert_eq!(info.target_branch(), "staging");
     }
@@ -984,14 +952,8 @@ mod tests {
 
         // Defaults to "origin"
         let settings = ManifestSettings::default();
-        let info = RepoInfo::from_config(
-            "app",
-            &base_config,
-            &temp.path().to_path_buf(),
-            &settings,
-            None,
-        )
-        .unwrap();
+        let info =
+            RepoInfo::from_config("app", &base_config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.sync_remote, "origin");
         assert_eq!(info.push_remote, "origin");
 
@@ -1001,14 +963,8 @@ mod tests {
             push_remote: Some("myfork".to_string()),
             ..Default::default()
         };
-        let info = RepoInfo::from_config(
-            "app",
-            &base_config,
-            &temp.path().to_path_buf(),
-            &settings,
-            None,
-        )
-        .unwrap();
+        let info =
+            RepoInfo::from_config("app", &base_config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.sync_remote, "upstream");
         assert_eq!(info.push_remote, "myfork");
 
@@ -1018,9 +974,7 @@ mod tests {
             push_remote: Some("origin".to_string()),
             ..base_config.clone()
         };
-        let info =
-            RepoInfo::from_config("app", &config, &temp.path().to_path_buf(), &settings, None)
-                .unwrap();
+        let info = RepoInfo::from_config("app", &config, temp.path(), &settings, None).unwrap();
         assert_eq!(info.sync_remote, "other");
         assert_eq!(info.push_remote, "origin");
     }
@@ -1057,14 +1011,8 @@ mod tests {
             clone_strategy: None,
         };
         let settings = ManifestSettings::default();
-        let info = RepoInfo::from_config(
-            "myrepo",
-            &config,
-            &temp.path().to_path_buf(),
-            &settings,
-            Some(&remotes),
-        )
-        .unwrap();
+        let info = RepoInfo::from_config("myrepo", &config, temp.path(), &settings, Some(&remotes))
+            .unwrap();
         assert_eq!(info.url, "git@github.com:org/myrepo.git");
     }
 
@@ -1160,7 +1108,7 @@ repos:
         let info = RepoInfo::from_config(
             "app",
             &manifest.repos["app"],
-            &temp.path().to_path_buf(),
+            temp.path(),
             &manifest.settings,
             manifest.remotes.as_ref(),
         )

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn test_create_and_checkout_branch() {
-        let (temp, repo) = setup_test_repo();
+        let (_temp, repo) = setup_test_repo();
 
         create_and_checkout_branch(&repo, "feature").unwrap();
 
@@ -384,7 +384,7 @@ mod tests {
 
     #[test]
     fn test_branch_exists() {
-        let (temp, repo) = setup_test_repo();
+        let (_temp, repo) = setup_test_repo();
 
         assert!(!branch_exists(&repo, "feature"));
 
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn test_checkout_branch() {
-        let (temp, repo) = setup_test_repo();
+        let (_temp, repo) = setup_test_repo();
 
         // Create a feature branch
         create_and_checkout_branch(&repo, "feature").unwrap();
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_list_local_branches() {
-        let (temp, repo) = setup_test_repo();
+        let (_temp, repo) = setup_test_repo();
 
         create_and_checkout_branch(&repo, "feature1").unwrap();
         create_and_checkout_branch(&repo, "feature2").unwrap();

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -725,7 +725,7 @@ mod tests {
 
     #[test]
     fn test_set_remote_url() {
-        let (temp, repo) = setup_test_repo();
+        let (_temp, repo) = setup_test_repo();
 
         // Create new remote
         set_remote_url(&repo, "origin", "https://github.com/test/repo1.git").unwrap();

--- a/src/platform/rate_limit.rs
+++ b/src/platform/rate_limit.rs
@@ -238,7 +238,7 @@ mod tests {
         };
         let wait = info.wait_seconds().unwrap();
         // Should be approximately 120 seconds (allow 2s tolerance for test execution)
-        assert!(wait >= 118 && wait <= 122, "wait_seconds was {}", wait);
+        assert!((118..=122).contains(&wait), "wait_seconds was {}", wait);
     }
 
     #[test]

--- a/src/telemetry/metrics.rs
+++ b/src/telemetry/metrics.rs
@@ -399,7 +399,7 @@ mod tests {
 
         // p50 should be around 50 (rounding may cause slight differences)
         let p50 = hist.p50().unwrap().as_millis();
-        assert!(p50 >= 49 && p50 <= 51, "p50 was {p50}, expected ~50");
+        assert!((49..=51).contains(&p50), "p50 was {p50}, expected ~50");
         assert!(hist.p99().unwrap() >= Duration::from_millis(99));
     }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1379,7 +1379,7 @@ fn test_checkout_base_uses_griptree_config() {
     git_helpers::create_branch(&ws.repo_path("lib"), "feat/base");
     git_helpers::checkout(&ws.repo_path("lib"), "main");
 
-    let mut config = GriptreeConfig::new("feat/base", &ws.workspace_root.to_string_lossy());
+    let config = GriptreeConfig::new("feat/base", &ws.workspace_root.to_string_lossy());
     let config_path = ws.workspace_root.join(".gitgrip").join("griptree.json");
     config.save(&config_path).unwrap();
 

--- a/tests/common/mock_platform.rs
+++ b/tests/common/mock_platform.rs
@@ -194,7 +194,7 @@ fn github_pr_json(
     body: &str,
 ) -> Value {
     let repo = github_repo_json("owner", "repo");
-    let api_base = format!("https://api.github.com/repos/owner/repo");
+    let api_base = "https://api.github.com/repos/owner/repo".to_string();
 
     let mut m = Map::new();
     m.insert("id".into(), json!(number));

--- a/tests/griptree_tests.rs
+++ b/tests/griptree_tests.rs
@@ -82,7 +82,7 @@ fn test_griptree_pointer_new_fields() {
     assert_eq!(pointer.repos.len(), 1);
     assert_eq!(pointer.repos[0].name, "codi");
     assert_eq!(pointer.repos[0].original_branch, "main");
-    assert_eq!(pointer.repos[0].is_reference, false);
+    assert!(!pointer.repos[0].is_reference);
     assert_eq!(
         pointer.manifest_branch,
         Some("griptree-feat-test".to_string())
@@ -206,5 +206,5 @@ fn test_griptree_repo_info_camel_case() {
 
     let deserialized: GriptreeRepoInfo = serde_json::from_str(&json).unwrap();
     assert_eq!(deserialized.original_branch, "develop");
-    assert_eq!(deserialized.is_reference, false);
+    assert!(!deserialized.is_reference);
 }

--- a/tests/integration_agent_id.rs
+++ b/tests/integration_agent_id.rs
@@ -6,7 +6,6 @@
 //! Conversa migration test in CI.
 
 use std::fs;
-use std::path::PathBuf;
 use tempfile::TempDir;
 
 // Re-export the registry functions we're testing

--- a/tests/multi_provider_e2e.rs
+++ b/tests/multi_provider_e2e.rs
@@ -151,7 +151,7 @@ mod github_tests {
 
         // Verify manifest
         let manifest_path =
-            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(&workspace)
+            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(workspace)
                 .expect("manifest not found");
         let manifest = fs::read_to_string(&manifest_path).unwrap();
         assert!(manifest.contains("repo1"), "repo1 not in manifest");
@@ -339,7 +339,7 @@ mod gitlab_tests {
         );
 
         let manifest_path =
-            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(&workspace)
+            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(workspace)
                 .expect("manifest not found");
         let manifest = fs::read_to_string(&manifest_path).unwrap();
         assert!(manifest.contains("repo1"));
@@ -454,7 +454,7 @@ mod gitlab_tests {
 
         // Read and print the manifest
         let manifest_path =
-            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(&workspace)
+            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(workspace)
                 .expect("manifest not found");
         if manifest_path.exists() {
             let manifest_content = fs::read_to_string(&manifest_path).unwrap();
@@ -633,7 +633,7 @@ mod azure_tests {
         );
 
         let manifest_path =
-            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(&workspace)
+            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(workspace)
                 .expect("manifest not found");
         let manifest = fs::read_to_string(&manifest_path).unwrap();
         assert!(manifest.contains("repo1"));
@@ -853,7 +853,7 @@ mod mixed_platform_tests {
         );
 
         let manifest_path =
-            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(&workspace)
+            gitgrip::core::manifest_paths::resolve_gripspace_manifest_path(workspace)
                 .expect("manifest not found");
         let manifest = fs::read_to_string(&manifest_path).unwrap();
 

--- a/tests/test_add.rs
+++ b/tests/test_add.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use common::assertions::assert_repo_clean;
 use common::fixtures::WorkspaceBuilder;
 
 #[test]

--- a/tests/test_branch.rs
+++ b/tests/test_branch.rs
@@ -2,9 +2,7 @@
 
 mod common;
 
-use common::assertions::{
-    assert_all_on_branch, assert_branch_exists, assert_branch_not_exists, assert_on_branch,
-};
+use common::assertions::{assert_branch_exists, assert_branch_not_exists, assert_on_branch};
 use common::fixtures::WorkspaceBuilder;
 use common::git_helpers;
 

--- a/tests/test_commit.rs
+++ b/tests/test_commit.rs
@@ -4,7 +4,6 @@ mod common;
 
 use common::assertions::assert_repo_clean;
 use common::fixtures::WorkspaceBuilder;
-use common::git_helpers;
 
 #[test]
 fn test_commit_across_repos() {

--- a/tests/test_status.rs
+++ b/tests/test_status.rs
@@ -2,9 +2,7 @@
 
 mod common;
 
-use common::assertions;
 use common::fixtures::WorkspaceBuilder;
-use common::git_helpers;
 
 #[test]
 fn test_status_clean_workspace() {


### PR DESCRIPTION
## Summary
- `impl FromStr for LinkKind` instead of inherent `from_str` method (fixes `should_implement_trait` lint)
- Remove unnecessary `to_path_buf()` calls across `repo.rs`, `griptree.rs`, `link.rs`
- Use `RangeInclusive::contains` in test assertions (`rate_limit.rs`, `metrics.rs`)
- Remove unused imports in test files
- `cargo fmt --all` for consistency

Premium boundary: core OSS (workspace orchestration tooling).

## Test plan
- [x] `cargo clippy` passes clean
- [x] `cargo fmt --all --check` passes clean
- [x] `cargo test` all green