### PR TITLE
feat: gr2 apply autostash policy (grip#534)

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -68,6 +68,10 @@ pub enum Commands {
         /// Pre-approve plans with more than 3 operations
         #[arg(long)]
         yes: bool,
+
+        /// Automatically stash and restore uncommitted changes in dirty repos
+        #[arg(long)]
+        autostash: bool,
     },
 }
 

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -362,7 +362,10 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
         Commands::Plan { yes } => {
             let workspace_root = require_workspace_root()?;
             let build = ExecutionPlan::from_workspace_spec(&workspace_root)?;
-            let guard_report = build.plan.guard_for_apply(&workspace_root, &build.spec, yes)?;
+            let guard_report =
+                build
+                    .plan
+                    .guard_for_apply(&workspace_root, &build.spec, yes, false)?;
 
             if build.generated_spec {
                 println!(
@@ -379,10 +382,13 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
             }
             Ok(())
         }
-        Commands::Apply { yes } => {
+        Commands::Apply { yes, autostash } => {
             let workspace_root = require_workspace_root()?;
             let build = ExecutionPlan::from_workspace_spec(&workspace_root)?;
-            let guard_report = build.plan.guard_for_apply(&workspace_root, &build.spec, yes)?;
+            let guard_report =
+                build
+                    .plan
+                    .guard_for_apply(&workspace_root, &build.spec, yes, autostash)?;
 
             if build.generated_spec {
                 println!(
@@ -395,11 +401,21 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 anyhow::bail!("plan contains more than 3 operations; rerun with --yes to apply it");
             }
 
+            if guard_report.has_dirty_repos && !autostash {
+                anyhow::bail!(
+                    "refusing to apply: units have repos with uncommitted changes; \
+                     rerun with --autostash to stash and restore them automatically"
+                );
+            }
+
             for warning in &guard_report.warnings {
                 println!("warning: {}", warning);
             }
 
-            let applied = build.plan.apply(&workspace_root, &build.spec)?;
+            let applied =
+                build
+                    .plan
+                    .apply(&workspace_root, &build.spec, &guard_report.dirty_repos)?;
             if applied.is_empty() {
                 println!("ExecutionPlan");
                 println!("- no changes required");

--- a/gr2/src/plan.rs
+++ b/gr2/src/plan.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::spec::{
     read_workspace_spec, workspace_spec_path, write_workspace_spec, LinkKind, LinkSpec, UnitSpec,
@@ -38,10 +38,20 @@ pub enum OperationType {
     Link,
 }
 
+/// A repo inside a unit that has uncommitted changes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirtyRepo {
+    pub unit_name: String,
+    pub repo_name: String,
+    pub repo_path: PathBuf,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlanGuardReport {
     pub warnings: Vec<String>,
     pub requires_confirmation: bool,
+    pub has_dirty_repos: bool,
+    pub dirty_repos: Vec<DirtyRepo>,
 }
 
 impl ExecutionPlan {
@@ -121,9 +131,48 @@ impl ExecutionPlan {
         })
     }
 
-    pub fn apply(&self, workspace_root: &Path, spec: &WorkspaceSpec) -> Result<Vec<String>> {
+    pub fn apply(
+        &self,
+        workspace_root: &Path,
+        spec: &WorkspaceSpec,
+        dirty_repos: &[DirtyRepo],
+    ) -> Result<Vec<String>> {
         let mut applied = Vec::new();
 
+        // Autostash: stash dirty repos before operations
+        let stashed = autostash_dirty_repos(dirty_repos)?;
+
+        let result = self.apply_operations(workspace_root, spec, &mut applied);
+
+        // Autostash: pop stashes regardless of operation success
+        let pop_errors = autostash_pop(&stashed);
+
+        // Record stash state if any stashes were created
+        if !stashed.is_empty() {
+            record_stash_state(workspace_root, &stashed, &pop_errors)?;
+        }
+
+        // Propagate operation errors after cleanup
+        result?;
+
+        if !applied.is_empty() {
+            record_apply_state(workspace_root, &applied)?;
+        }
+
+        // Report pop errors as warnings but don't fail
+        for err in &pop_errors {
+            applied.push(format!("warning: stash pop failed: {}", err));
+        }
+
+        Ok(applied)
+    }
+
+    fn apply_operations(
+        &self,
+        workspace_root: &Path,
+        spec: &WorkspaceSpec,
+        applied: &mut Vec<String>,
+    ) -> Result<()> {
         for operation in &self.operations {
             let unit_spec = spec
                 .units
@@ -180,12 +229,7 @@ impl ExecutionPlan {
                 }
             }
         }
-
-        if !applied.is_empty() {
-            record_apply_state(workspace_root, &applied)?;
-        }
-
-        Ok(applied)
+        Ok(())
     }
 
     pub fn guard_for_apply(
@@ -193,8 +237,16 @@ impl ExecutionPlan {
         workspace_root: &Path,
         spec: &WorkspaceSpec,
         assume_yes: bool,
+        _autostash: bool,
     ) -> Result<PlanGuardReport> {
         let mut warnings = Vec::new();
+        let mut dirty_repos = Vec::new();
+
+        // Collect unit names that have planned operations
+        let mut units_with_ops: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for operation in &self.operations {
+            units_with_ops.insert(&operation.unit_name);
+        }
 
         for operation in &self.operations {
             // Resolve the unit's actual path from the spec, not from parameters
@@ -238,9 +290,42 @@ impl ExecutionPlan {
             }
         }
 
+        // Check for dirty repos in units that have planned operations
+        for unit in &spec.units {
+            if !units_with_ops.contains(unit.name.as_str()) {
+                continue;
+            }
+
+            let unit_root = workspace_root.join(&unit.path);
+            for repo_name in &unit.repos {
+                let repo_checkout = unit_root.join(repo_name);
+                if !repo_checkout.join(".git").exists() {
+                    continue;
+                }
+
+                if is_repo_dirty(&repo_checkout)? {
+                    warnings.push(format!(
+                        "unit '{}' repo '{}' has uncommitted changes at {}",
+                        unit.name,
+                        repo_name,
+                        repo_checkout.display()
+                    ));
+                    dirty_repos.push(DirtyRepo {
+                        unit_name: unit.name.clone(),
+                        repo_name: repo_name.clone(),
+                        repo_path: repo_checkout,
+                    });
+                }
+            }
+        }
+
+        let has_dirty_repos = !dirty_repos.is_empty();
+
         Ok(PlanGuardReport {
             warnings,
             requires_confirmation: self.operations.len() > 3 && !assume_yes,
+            has_dirty_repos,
+            dirty_repos,
         })
     }
 
@@ -414,6 +499,133 @@ fn materialize_unit(workspace_root: &Path, unit: &UnitSpec, spec: &WorkspaceSpec
             );
         }
     }
+
+    Ok(())
+}
+
+fn is_repo_dirty(repo_path: &Path) -> Result<bool> {
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(repo_path)
+        .output()
+        .with_context(|| format!("run git status in {}", repo_path.display()))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "git status failed in {}: {}",
+            repo_path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    Ok(!output.stdout.is_empty())
+}
+
+/// Stash dirty repos, returning the list of repos that were successfully stashed.
+fn autostash_dirty_repos(dirty_repos: &[DirtyRepo]) -> Result<Vec<DirtyRepo>> {
+    let mut stashed = Vec::new();
+
+    for dirty in dirty_repos {
+        let output = std::process::Command::new("git")
+            .args(["stash", "push", "-m", "gr2-autostash"])
+            .current_dir(&dirty.repo_path)
+            .output()
+            .with_context(|| {
+                format!(
+                    "git stash in {} for unit '{}' repo '{}'",
+                    dirty.repo_path.display(),
+                    dirty.unit_name,
+                    dirty.repo_name
+                )
+            })?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "git stash failed in {} for unit '{}' repo '{}': {}",
+                dirty.repo_path.display(),
+                dirty.unit_name,
+                dirty.repo_name,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        stashed.push(dirty.clone());
+    }
+
+    Ok(stashed)
+}
+
+/// Pop stashes for repos that were stashed. Returns errors for repos that
+/// failed to pop (e.g. conflict), but does not abort.
+fn autostash_pop(stashed: &[DirtyRepo]) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    for dirty in stashed {
+        let output = std::process::Command::new("git")
+            .args(["stash", "pop"])
+            .current_dir(&dirty.repo_path)
+            .output();
+
+        match output {
+            Ok(out) if !out.status.success() => {
+                errors.push(format!(
+                    "unit '{}' repo '{}' at {}: {}",
+                    dirty.unit_name,
+                    dirty.repo_name,
+                    dirty.repo_path.display(),
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ));
+            }
+            Err(e) => {
+                errors.push(format!(
+                    "unit '{}' repo '{}' at {}: {}",
+                    dirty.unit_name,
+                    dirty.repo_name,
+                    dirty.repo_path.display(),
+                    e
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    errors
+}
+
+fn record_stash_state(
+    workspace_root: &Path,
+    stashed: &[DirtyRepo],
+    pop_errors: &[String],
+) -> Result<()> {
+    let state_dir = workspace_root.join(".grip/state");
+    fs::create_dir_all(&state_dir)
+        .with_context(|| format!("create state directory {}", state_dir.display()))?;
+
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    let mut content = format!("# Autostash record: {}\n\n", timestamp);
+
+    for dirty in stashed {
+        content.push_str("[[stash]]\n");
+        content.push_str(&format!("timestamp = \"{}\"\n", timestamp));
+        content.push_str(&format!("unit = \"{}\"\n", dirty.unit_name));
+        content.push_str(&format!("repo = \"{}\"\n", dirty.repo_name));
+        content.push_str(&format!("path = \"{}\"\n", dirty.repo_path.display()));
+        let restored = !pop_errors
+            .iter()
+            .any(|e| e.contains(&dirty.unit_name) && e.contains(&dirty.repo_name));
+        content.push_str(&format!("restored = {}\n\n", restored));
+    }
+
+    if !pop_errors.is_empty() {
+        content.push_str("# Pop errors (manual recovery needed):\n");
+        for err in pop_errors {
+            content.push_str(&format!("# {}\n", err));
+        }
+    }
+
+    let stash_path = state_dir.join("stash.toml");
+    fs::write(&stash_path, content)
+        .with_context(|| format!("write stash state to {}", stash_path.display()))?;
 
     Ok(())
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -2428,3 +2428,364 @@ repos = ["test-repo"]
         .stdout(predicate::str::contains("clone"))
         .stdout(predicate::str::contains("apollo"));
 }
+
+// ── gr2 apply: autostash policy (grip#534) ────────────────────────────────────
+
+/// Helper: create a local bare repo with one committed file, suitable for
+/// cloning into unit workspaces. Returns the path to the bare repo.
+fn create_bare_repo_with_content(parent: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let bare = parent.join(format!("{}.git", name));
+    std::process::Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&bare)
+        .output()
+        .unwrap();
+
+    // Clone into a temp working copy, add a file, push back
+    let work = parent.join(format!("{}-work", name));
+    std::process::Command::new("git")
+        .args(["clone"])
+        .arg(&bare)
+        .arg(&work)
+        .output()
+        .unwrap();
+    std::fs::write(work.join("README.md"), "# test\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["push"])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+
+    bare
+}
+
+/// Helper: set up a workspace with a unit that has an already-cloned repo.
+/// Returns the workspace root path.
+fn setup_workspace_with_cloned_unit(
+    temp: &TempDir,
+    bare_repo: &std::path::Path,
+) -> std::path::PathBuf {
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    // Register the repo
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .args(["repo", "add", "app"])
+        .arg(bare_repo.to_str().unwrap())
+        .assert()
+        .success();
+
+    // Write spec with the unit referencing the repo
+    let spec = format!(
+        r#"schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{}"
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = ["app"]
+"#,
+        bare_repo.display()
+    );
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        &spec,
+    )
+    .unwrap();
+
+    // Run apply once to materialize the unit + clone the repo
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .success();
+
+    // Verify the repo is cloned
+    assert!(workspace_root.join("agents/apollo/app/.git").exists());
+
+    workspace_root
+}
+
+/// gr2 apply should block when a unit's cloned repo has uncommitted changes
+/// and --autostash is not provided. Default must be safe: no silent discard.
+#[test]
+fn test_gr2_apply_blocks_dirty_repo_without_autostash() {
+    let temp = TempDir::new().unwrap();
+    let bare = create_bare_repo_with_content(temp.path(), "app");
+    let workspace_root = setup_workspace_with_cloned_unit(&temp, &bare);
+
+    // Dirty the cloned repo: modify the tracked file
+    let repo_checkout = workspace_root.join("agents/apollo/app");
+    std::fs::write(repo_checkout.join("README.md"), "# modified\n").unwrap();
+
+    // Create a shared config file so we can add a link operation to the plan
+    std::fs::write(workspace_root.join("config/shared.toml"), "shared = true\n").unwrap();
+
+    // Rewrite spec to add a link (triggers a Link operation since dest doesn't exist)
+    let spec = format!(
+        r#"schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{}"
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = ["app"]
+
+[[units.links]]
+src = "config/shared.toml"
+dest = ".config/shared.toml"
+kind = "symlink"
+"#,
+        bare.display()
+    );
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        &spec,
+    )
+    .unwrap();
+
+    // Apply without --autostash should fail because the unit's repo is dirty
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dirty")
+            .or(predicate::str::contains("uncommitted")));
+}
+
+/// gr2 apply --autostash should preserve dirty changes by stashing before
+/// the operation and popping after.
+#[test]
+fn test_gr2_apply_autostash_preserves_dirty_changes() {
+    let temp = TempDir::new().unwrap();
+    let bare = create_bare_repo_with_content(temp.path(), "app");
+    let workspace_root = setup_workspace_with_cloned_unit(&temp, &bare);
+
+    // Dirty the cloned repo
+    let repo_checkout = workspace_root.join("agents/apollo/app");
+    std::fs::write(repo_checkout.join("README.md"), "# modified by agent\n").unwrap();
+
+    // Add a link to trigger an operation
+    std::fs::write(workspace_root.join("config/shared.toml"), "shared = true\n").unwrap();
+    let spec = format!(
+        r#"schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{}"
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = ["app"]
+
+[[units.links]]
+src = "config/shared.toml"
+dest = ".config/shared.toml"
+kind = "symlink"
+"#,
+        bare.display()
+    );
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        &spec,
+    )
+    .unwrap();
+
+    // Apply with --autostash should succeed
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .args(["apply", "--autostash"])
+        .assert()
+        .success();
+
+    // The dirty change should still be present after apply
+    let content = std::fs::read_to_string(repo_checkout.join("README.md")).unwrap();
+    assert!(
+        content.contains("modified by agent"),
+        "autostash should preserve the dirty change; got: {}",
+        content
+    );
+}
+
+/// gr2 plan should report actual dirty state (uncommitted changes detected)
+/// rather than just "possible uncommitted changes" based on .git existence.
+#[test]
+fn test_gr2_plan_shows_actual_dirty_state() {
+    let temp = TempDir::new().unwrap();
+    let bare = create_bare_repo_with_content(temp.path(), "app");
+    let workspace_root = setup_workspace_with_cloned_unit(&temp, &bare);
+
+    // Dirty the cloned repo
+    let repo_checkout = workspace_root.join("agents/apollo/app");
+    std::fs::write(repo_checkout.join("README.md"), "# dirty\n").unwrap();
+
+    // Add a link to trigger an operation in the plan
+    std::fs::write(workspace_root.join("config/shared.toml"), "shared = true\n").unwrap();
+    let spec = format!(
+        r#"schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{}"
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = ["app"]
+
+[[units.links]]
+src = "config/shared.toml"
+dest = ".config/shared.toml"
+kind = "symlink"
+"#,
+        bare.display()
+    );
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        &spec,
+    )
+    .unwrap();
+
+    // Plan should report the dirty state with specifics
+    let mut plan = Command::cargo_bin("gr2").unwrap();
+    plan.current_dir(&workspace_root)
+        .arg("plan")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("uncommitted changes"));
+}
+
+/// When --autostash is used, gr2 apply should record the stash action
+/// in .grip/state for recovery and auditability.
+#[test]
+fn test_gr2_autostash_records_state() {
+    let temp = TempDir::new().unwrap();
+    let bare = create_bare_repo_with_content(temp.path(), "app");
+    let workspace_root = setup_workspace_with_cloned_unit(&temp, &bare);
+
+    // Dirty the cloned repo
+    let repo_checkout = workspace_root.join("agents/apollo/app");
+    std::fs::write(repo_checkout.join("README.md"), "# dirty for stash\n").unwrap();
+
+    // Add a link to trigger an operation
+    std::fs::write(workspace_root.join("config/shared.toml"), "shared = true\n").unwrap();
+    let spec = format!(
+        r#"schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{}"
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = ["app"]
+
+[[units.links]]
+src = "config/shared.toml"
+dest = ".config/shared.toml"
+kind = "symlink"
+"#,
+        bare.display()
+    );
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        &spec,
+    )
+    .unwrap();
+
+    // Apply with --autostash
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .args(["apply", "--autostash"])
+        .assert()
+        .success();
+
+    // Stash state should be recorded
+    let stash_state = workspace_root.join(".grip/state/stash.toml");
+    assert!(
+        stash_state.exists(),
+        "autostash should record state in .grip/state/stash.toml"
+    );
+    let content = std::fs::read_to_string(&stash_state).unwrap();
+    assert!(
+        content.contains("apollo") && content.contains("app"),
+        "stash state should reference the unit and repo; got: {}",
+        content
+    );
+}
+
+/// gr2 apply should succeed without --autostash when repos are clean
+/// (no uncommitted changes). Clean workspaces need no special handling.
+#[test]
+fn test_gr2_apply_clean_repo_no_autostash_needed() {
+    let temp = TempDir::new().unwrap();
+    let bare = create_bare_repo_with_content(temp.path(), "app");
+    let workspace_root = setup_workspace_with_cloned_unit(&temp, &bare);
+
+    // Don't dirty anything — the repo is clean
+
+    // Apply without --autostash should succeed on clean workspace
+    let mut apply = Command::cargo_bin("gr2").unwrap();
+    apply
+        .current_dir(&workspace_root)
+        .arg("apply")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary
- Add `--autostash` flag to `gr2 apply` that stashes and restores uncommitted changes in unit repos before/after plan operations
- Without the flag, `apply` now blocks when dirty repos are detected (safe default: no silent discard)
- Guard detects actual dirty state via `git status --porcelain` instead of just checking `.git` presence
- Stash actions recorded in `.grip/state/stash.toml` for recovery and auditability

## Premium boundary
Premium boundary: grip is OSS (workspace orchestration infrastructure).

## Test plan
- [x] `test_gr2_apply_blocks_dirty_repo_without_autostash` - apply fails on dirty repo without flag
- [x] `test_gr2_apply_autostash_preserves_dirty_changes` - --autostash stashes/pops correctly
- [x] `test_gr2_plan_shows_actual_dirty_state` - plan reports uncommitted changes
- [x] `test_gr2_autostash_records_state` - stash.toml written with unit/repo references
- [x] `test_gr2_apply_clean_repo_no_autostash_needed` - clean repos work without flag
- [x] Full suite: 81/81 pass, Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)