### PR TITLE
feat: add gr2 repo status surface

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -107,6 +107,17 @@ pub enum RepoCommands {
     /// List registered repos
     List,
 
+    /// Inspect repo-maintenance state across shared repos and unit repos
+    Status {
+        /// Only show repo state for a specific unit
+        #[arg(long)]
+        unit: Option<String>,
+
+        /// Only show a specific repo name
+        #[arg(long)]
+        repo: Option<String>,
+    },
+
     /// Remove a registered repo
     Remove {
         /// Logical repo name

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use crate::args::{Commands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
 use crate::plan::ExecutionPlan;
+use crate::repo_status::{RepoStatusFilter, RepoStatusReport};
 use crate::spec::{read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec};
 
 pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
@@ -174,6 +175,13 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                     }
                 }
 
+                Ok(())
+            }
+            RepoCommands::Status { unit, repo } => {
+                let workspace_root = require_workspace_root()?;
+                let report =
+                    RepoStatusReport::load(&workspace_root, &RepoStatusFilter { unit, repo })?;
+                println!("{}", report.render_table());
                 Ok(())
             }
             RepoCommands::Remove { name } => {

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -5,4 +5,5 @@
 pub mod args;
 pub mod dispatch;
 pub mod plan;
+pub mod repo_status;
 pub mod spec;

--- a/gr2/src/repo_status.rs
+++ b/gr2/src/repo_status.rs
@@ -1,0 +1,329 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::spec::{read_workspace_spec, RepoSpec, UnitSpec};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoAction {
+    CloneMissing,
+    BlockPathConflict,
+    BlockDirty,
+    FastForward,
+    ManualSync,
+    NoChange,
+}
+
+impl RepoAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CloneMissing => "clone_missing",
+            Self::BlockPathConflict => "block_path_conflict",
+            Self::BlockDirty => "block_dirty",
+            Self::FastForward => "fast_forward",
+            Self::ManualSync => "manual_sync",
+            Self::NoChange => "no_change",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoScope {
+    Shared,
+    Unit,
+}
+
+impl RepoScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Shared => "shared",
+            Self::Unit => "unit",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoStatusRow {
+    pub scope: RepoScope,
+    pub target: String,
+    pub repo: String,
+    pub path: PathBuf,
+    pub action: RepoAction,
+    pub branch: Option<String>,
+    pub upstream: Option<String>,
+    pub dirty: bool,
+    pub ahead: u32,
+    pub behind: u32,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoStatusReport {
+    pub rows: Vec<RepoStatusRow>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RepoStatusFilter {
+    pub unit: Option<String>,
+    pub repo: Option<String>,
+}
+
+impl RepoStatusReport {
+    pub fn load(workspace_root: &Path, filter: &RepoStatusFilter) -> Result<Self> {
+        let spec = read_workspace_spec(workspace_root)?;
+        let mut rows = Vec::new();
+
+        for repo in &spec.repos {
+            if filter.repo.as_deref().is_some_and(|name| name != repo.name) {
+                continue;
+            }
+            rows.push(classify_shared_repo(workspace_root, repo)?);
+        }
+
+        for unit in &spec.units {
+            if filter.unit.as_deref().is_some_and(|name| name != unit.name) {
+                continue;
+            }
+            for repo_name in &unit.repos {
+                if filter.repo.as_deref().is_some_and(|name| name != repo_name) {
+                    continue;
+                }
+                let repo = spec
+                    .repos
+                    .iter()
+                    .find(|repo| repo.name == *repo_name)
+                    .with_context(|| {
+                        format!(
+                            "unit '{}' references repo '{}' which is missing from workspace spec",
+                            unit.name, repo_name
+                        )
+                    })?;
+                rows.push(classify_unit_repo(workspace_root, unit, repo)?);
+            }
+        }
+
+        rows.sort_by(|a, b| {
+            a.scope
+                .as_str()
+                .cmp(b.scope.as_str())
+                .then_with(|| a.target.cmp(&b.target))
+                .then_with(|| a.repo.cmp(&b.repo))
+        });
+
+        Ok(Self { rows })
+    }
+
+    pub fn render_table(&self) -> String {
+        if self.rows.is_empty() {
+            return "RepoStatus\n- no repo targets matched\n".to_string();
+        }
+
+        let mut lines = vec![
+            "RepoStatus".to_string(),
+            "SCOPE\tTARGET\tREPO\tACTION\tBRANCH\tUPSTREAM\tSTATE\tREASON".to_string(),
+        ];
+
+        for row in &self.rows {
+            let mut state = Vec::new();
+            if row.dirty {
+                state.push("dirty".to_string());
+            }
+            if row.ahead > 0 {
+                state.push(format!("ahead={}", row.ahead));
+            }
+            if row.behind > 0 {
+                state.push(format!("behind={}", row.behind));
+            }
+            if state.is_empty() {
+                state.push("clean".to_string());
+            }
+
+            lines.push(format!(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                row.scope.as_str(),
+                row.target,
+                row.repo,
+                row.action.as_str(),
+                row.branch.as_deref().unwrap_or("-"),
+                row.upstream.as_deref().unwrap_or("-"),
+                state.join(","),
+                row.reason
+            ));
+        }
+
+        lines.join("\n")
+    }
+}
+
+fn classify_shared_repo(workspace_root: &Path, repo: &RepoSpec) -> Result<RepoStatusRow> {
+    let path = workspace_root.join(&repo.path);
+    let mut row = base_row(
+        RepoScope::Shared,
+        repo.name.clone(),
+        repo.name.clone(),
+        path.clone(),
+    );
+
+    if !path.exists() {
+        row.action = RepoAction::CloneMissing;
+        row.reason = "shared repo path is absent".to_string();
+        return Ok(row);
+    }
+
+    if !is_git_repo(&path)? {
+        row.action = RepoAction::BlockPathConflict;
+        row.reason = "shared repo path exists but is not a git repo".to_string();
+        return Ok(row);
+    }
+
+    fill_git_status(&path, &mut row)?;
+    classify_repo_state(&mut row, true);
+    Ok(row)
+}
+
+fn classify_unit_repo(
+    workspace_root: &Path,
+    unit: &UnitSpec,
+    repo: &RepoSpec,
+) -> Result<RepoStatusRow> {
+    let path = workspace_root.join(&unit.path).join(&repo.name);
+    let mut row = base_row(
+        RepoScope::Unit,
+        unit.name.clone(),
+        repo.name.clone(),
+        path.clone(),
+    );
+
+    if !path.exists() {
+        row.action = RepoAction::CloneMissing;
+        row.reason = "unit repo checkout is absent".to_string();
+        return Ok(row);
+    }
+
+    if !is_git_repo(&path)? {
+        row.action = RepoAction::BlockPathConflict;
+        row.reason = "unit repo path exists but is not a git repo".to_string();
+        return Ok(row);
+    }
+
+    fill_git_status(&path, &mut row)?;
+    classify_repo_state(&mut row, false);
+    Ok(row)
+}
+
+fn base_row(scope: RepoScope, target: String, repo: String, path: PathBuf) -> RepoStatusRow {
+    RepoStatusRow {
+        scope,
+        target,
+        repo,
+        path,
+        action: RepoAction::NoChange,
+        branch: None,
+        upstream: None,
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        reason: String::new(),
+    }
+}
+
+fn classify_repo_state(row: &mut RepoStatusRow, allow_ff: bool) {
+    if row.dirty {
+        row.action = RepoAction::BlockDirty;
+        row.reason = "working tree is dirty; stop by default".to_string();
+        return;
+    }
+
+    match (row.ahead, row.behind, row.upstream.is_some()) {
+        (_, _, false) => {
+            row.action = RepoAction::ManualSync;
+            row.reason = "repo has no upstream tracking branch".to_string();
+        }
+        (0, 0, true) => {
+            row.action = RepoAction::NoChange;
+            row.reason = "repo is already aligned with upstream".to_string();
+        }
+        (0, behind, true) if behind > 0 && allow_ff => {
+            row.action = RepoAction::FastForward;
+            row.reason = format!("repo is behind upstream by {} commit(s)", behind);
+        }
+        (0, behind, true) if behind > 0 => {
+            row.action = RepoAction::ManualSync;
+            row.reason = format!(
+                "repo is behind upstream by {} commit(s), but unit repos require explicit sync",
+                behind
+            );
+        }
+        (ahead, behind, true) if ahead > 0 && behind > 0 => {
+            row.action = RepoAction::ManualSync;
+            row.reason = format!(
+                "repo diverged from upstream (ahead {}, behind {})",
+                ahead, behind
+            );
+        }
+        (ahead, 0, true) if ahead > 0 => {
+            row.action = RepoAction::ManualSync;
+            row.reason = format!("repo has {} local commit(s) ahead of upstream", ahead);
+        }
+        _ => {
+            row.action = RepoAction::ManualSync;
+            row.reason = "repo requires explicit inspection".to_string();
+        }
+    }
+}
+
+fn fill_git_status(repo_path: &Path, row: &mut RepoStatusRow) -> Result<()> {
+    row.branch = git_stdout(repo_path, &["symbolic-ref", "--quiet", "--short", "HEAD"]).ok();
+    row.upstream = git_stdout(
+        repo_path,
+        &[
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ],
+    )
+    .ok();
+    row.dirty = !git_stdout(repo_path, &["status", "--porcelain"])?.is_empty();
+
+    if row.upstream.is_some() {
+        let counts = git_stdout(
+            repo_path,
+            &["rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
+        )?;
+        let mut parts = counts.split_whitespace();
+        row.ahead = parts.next().unwrap_or("0").parse().unwrap_or(0);
+        row.behind = parts.next().unwrap_or("0").parse().unwrap_or(0);
+    }
+
+    Ok(())
+}
+
+fn is_git_repo(path: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(path)
+        .output()
+        .with_context(|| format!("run git rev-parse in {}", path.display()))?;
+
+    Ok(output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true")
+}
+
+fn git_stdout(repo_path: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo_path)
+        .output()
+        .with_context(|| format!("run git {:?} in {}", args, repo_path.display()))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {:?} failed in {}: {}",
+            args,
+            repo_path.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -476,6 +476,172 @@ fn test_gr2_repo_list_requires_gr2_workspace() {
 }
 
 #[test]
+fn test_gr2_repo_status_reports_missing_unit_checkout_as_clone_missing() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let bare = create_bare_repo_with_content(temp.path(), "app");
+
+    let spec = format!(
+        r#"schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{}"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#,
+        toml_path(&bare)
+    );
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), spec).unwrap();
+    std::fs::create_dir_all(workspace_root.join("agents/atlas")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/atlas/unit.toml"),
+        "name = \"atlas\"\nkind = \"unit\"\nrepos = [\"app\"]\n",
+    )
+    .unwrap();
+
+    let mut status = Command::cargo_bin("gr2").unwrap();
+    status
+        .current_dir(&workspace_root)
+        .args(["repo", "status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("RepoStatus"))
+        .stdout(predicate::str::contains("clone_missing"))
+        .stdout(predicate::str::contains("atlas"))
+        .stdout(predicate::str::contains("app"));
+}
+
+#[test]
+fn test_gr2_repo_status_reports_dirty_unit_repo_as_block_dirty() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let bare = create_bare_repo_with_content(temp.path(), "app");
+
+    let spec = format!(
+        r#"schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{}"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#,
+        toml_path(&bare)
+    );
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), spec).unwrap();
+    std::fs::create_dir_all(workspace_root.join("agents/atlas")).unwrap();
+    std::fs::write(
+        workspace_root.join("agents/atlas/unit.toml"),
+        "name = \"atlas\"\nkind = \"unit\"\nrepos = [\"app\"]\n",
+    )
+    .unwrap();
+
+    let clone_dest = workspace_root.join("agents/atlas/app");
+    let status = std::process::Command::new("git")
+        .arg("clone")
+        .arg(&bare)
+        .arg(&clone_dest)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    std::fs::write(clone_dest.join("dirty.txt"), "local change").unwrap();
+
+    let mut repo_status = Command::cargo_bin("gr2").unwrap();
+    repo_status
+        .current_dir(&workspace_root)
+        .args(["repo", "status", "--unit", "atlas"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("block_dirty"))
+        .stdout(predicate::str::contains("working tree is dirty"));
+}
+
+#[test]
+fn test_gr2_repo_status_reports_shared_repo_behind_upstream_as_fast_forward() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init").arg(&workspace_root).assert().success();
+
+    let bare = create_bare_repo_with_content(temp.path(), "app");
+
+    let spec = format!(
+        r#"schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{}"
+"#,
+        toml_path(&bare)
+    );
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), spec).unwrap();
+
+    let shared_repo = workspace_root.join("repos/app");
+    let status = std::process::Command::new("git")
+        .arg("clone")
+        .arg(&bare)
+        .arg(&shared_repo)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let staging = temp.path().join("staging");
+    let status = std::process::Command::new("git")
+        .arg("clone")
+        .arg(&bare)
+        .arg(&staging)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    git_helpers::configure_identity(&staging);
+    git_helpers::commit_file(&staging, "later.txt", "upstream", "Add upstream");
+    let branch = git_helpers::current_branch(&staging);
+    git_helpers::push_branch(&staging, "origin", &branch);
+    git_helpers::fetch(&shared_repo, "origin", Some(&branch));
+
+    let mut repo_status = Command::cargo_bin("gr2").unwrap();
+    repo_status
+        .current_dir(&workspace_root)
+        .args(["repo", "status", "--repo", "app"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fast_forward"))
+        .stdout(predicate::str::contains("shared"))
+        .stdout(predicate::str::contains("behind=1"));
+}
+
+#[test]
 fn test_gr2_repo_remove_deletes_registered_repo() {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().join("demo-team");
@@ -1032,7 +1198,7 @@ name = "atlas"
 path = "agents/atlas"
 repos = ["app"]
 "#,
-        bare.display()
+        toml_path(&bare)
     );
     std::fs::write(
         workspace_root.join(".grip/workspace_spec.toml"),
@@ -1233,17 +1399,13 @@ name = "atlas"
 path = "agents/atlas"
 repos = ["app"]
 "#,
-        bare_repo.display()
+        toml_path(&bare_repo)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
     std::fs::create_dir_all(workspace_root.join("repos/app")).unwrap();
     std::fs::write(
         workspace_root.join("repos/app/repo.toml"),
-        format!("name = \"app\"\nurl = \"{}\"\n", bare_repo.display()),
+        format!("name = \"app\"\nurl = \"{}\"\n", toml_path(&bare_repo)),
     )
     .unwrap();
 
@@ -2351,13 +2513,9 @@ name = "apollo"
 path = "agents/apollo"
 repos = ["test-repo"]
 "#,
-        bare_repo.display()
+        toml_path(&bare_repo)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     let mut apply = Command::cargo_bin("gr2").unwrap();
     apply
@@ -2427,13 +2585,9 @@ name = "apollo"
 path = "agents/apollo"
 repos = ["test-repo"]
 "#,
-        bare_repo.display()
+        toml_path(&bare_repo)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     let mut plan = Command::cargo_bin("gr2").unwrap();
     plan.current_dir(&workspace_root)
@@ -2451,7 +2605,7 @@ repos = ["test-repo"]
 fn create_bare_repo_with_content(parent: &std::path::Path, name: &str) -> std::path::PathBuf {
     let bare = parent.join(format!("{}.git", name));
     std::process::Command::new("git")
-        .args(["init", "--bare"])
+        .args(["init", "--bare", "-b", "main"])
         .arg(&bare)
         .output()
         .unwrap();
@@ -2464,6 +2618,7 @@ fn create_bare_repo_with_content(parent: &std::path::Path, name: &str) -> std::p
         .arg(&work)
         .output()
         .unwrap();
+    git_helpers::configure_identity(&work);
     std::fs::write(work.join("README.md"), "# test\n").unwrap();
     std::process::Command::new("git")
         .args(["add", "."])
@@ -2482,6 +2637,10 @@ fn create_bare_repo_with_content(parent: &std::path::Path, name: &str) -> std::p
         .unwrap();
 
     bare
+}
+
+fn toml_path(path: &std::path::Path) -> String {
+    path.display().to_string().replace('\\', "\\\\")
 }
 
 /// Helper: set up a workspace with a unit that has an already-cloned repo.
@@ -2527,13 +2686,9 @@ name = "apollo"
 path = "agents/apollo"
 repos = ["app"]
 "#,
-        bare_repo.display()
+        toml_path(&bare_repo)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     // Run apply once to materialize the unit + clone the repo
     let mut apply = Command::cargo_bin("gr2").unwrap();
@@ -2587,13 +2742,9 @@ src = "config/shared.toml"
 dest = ".config/shared.toml"
 kind = "symlink"
 "#,
-        bare.display()
+        toml_path(&bare)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     // Apply without --autostash should fail because the unit's repo is dirty
     let mut apply = Command::cargo_bin("gr2").unwrap();
@@ -2602,8 +2753,7 @@ kind = "symlink"
         .arg("apply")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("dirty")
-            .or(predicate::str::contains("uncommitted")));
+        .stderr(predicate::str::contains("dirty").or(predicate::str::contains("uncommitted")));
 }
 
 /// gr2 apply --autostash should preserve dirty changes by stashing before
@@ -2642,13 +2792,9 @@ src = "config/shared.toml"
 dest = ".config/shared.toml"
 kind = "symlink"
 "#,
-        bare.display()
+        toml_path(&bare)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     // Apply with --autostash should succeed
     let mut apply = Command::cargo_bin("gr2").unwrap();
@@ -2703,13 +2849,9 @@ src = "config/shared.toml"
 dest = ".config/shared.toml"
 kind = "symlink"
 "#,
-        bare.display()
+        toml_path(&bare)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     // Plan should report the dirty state with specifics
     let mut plan = Command::cargo_bin("gr2").unwrap();
@@ -2756,13 +2898,9 @@ src = "config/shared.toml"
 dest = ".config/shared.toml"
 kind = "symlink"
 "#,
-        bare.display()
+        toml_path(&bare)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     // Apply with --autostash
     let mut apply = Command::cargo_bin("gr2").unwrap();
@@ -2861,13 +2999,9 @@ name = "apollo"
 path = "agents/apollo"
 repos = ["myrepo"]
 "#,
-        bare.display()
+        toml_path(&bare)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     // Plan should detect the missing repo and emit a non-empty plan
     let mut plan = Command::cargo_bin("gr2").unwrap();
@@ -2930,13 +3064,9 @@ name = "apollo"
 path = "agents/apollo"
 repos = ["myrepo"]
 "#,
-        bare.display()
+        toml_path(&bare)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     // Apply should converge: clone the missing repo
     let mut apply = Command::cargo_bin("gr2").unwrap();
@@ -3005,13 +3135,9 @@ name = "apollo"
 path = "agents/apollo"
 repos = ["myrepo"]
 "#,
-        bare.display()
+        toml_path(&bare)
     );
-    std::fs::write(
-        workspace_root.join(".grip/workspace_spec.toml"),
-        &spec,
-    )
-    .unwrap();
+    std::fs::write(workspace_root.join(".grip/workspace_spec.toml"), &spec).unwrap();
 
     // First apply converges
     let mut first = Command::cargo_bin("gr2").unwrap();


### PR DESCRIPTION
## Summary
- add a read-only `gr2 repo status` surface across shared repos and unit repos
- classify repo-maintenance state with explicit actions instead of implicit sync behavior
- add focused CLI coverage for missing, dirty, and behind-upstream cases

Closes #545.

## Behavior
- inspects shared repos and unit-mounted repos from the live workspace spec
- reports actions such as `clone_missing`, `block_dirty`, `fast_forward`, `manual_sync`, and `no_change`
- intentionally does not fetch remotes in this first slice; ahead/behind is based on already-known upstream state

## Verification
- `cargo check -p gr2-cli --quiet`
- `cargo test --test cli_tests test_gr2_repo_status_reports_missing_unit_checkout_as_clone_missing --quiet`
- `cargo test --test cli_tests test_gr2_repo_status_reports_dirty_unit_repo_as_block_dirty --quiet`
- `cargo test --test cli_tests test_gr2_repo_status_reports_shared_repo_behind_upstream_as_fast_forward --quiet`
