### PR TITLE
feat: add gr2 lane metadata surface

### DIFF
--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -50,6 +50,12 @@ pub enum Commands {
         command: UnitCommands,
     },
 
+    /// Lane metadata operations
+    Lane {
+        #[command(subcommand)]
+        command: LaneCommands,
+    },
+
     /// Declarative workspace spec operations
     Spec {
         #[command(subcommand)]
@@ -140,6 +146,86 @@ pub enum UnitCommands {
     Remove {
         /// Unit name
         name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum LaneCommands {
+    /// Create a lane record and scaffold its workspace directories
+    Create {
+        /// Lane name
+        name: String,
+
+        /// Owning unit
+        #[arg(long = "owner-unit")]
+        owner_unit: String,
+
+        /// Lane type
+        #[arg(long = "type", default_value = "feature")]
+        lane_type: String,
+
+        /// Repo membership for the lane (defaults to unit repos from workspace spec)
+        #[arg(long = "repo")]
+        repos: Vec<String>,
+
+        /// Branch intent entries in repo=branch form
+        #[arg(long = "branch")]
+        branches: Vec<String>,
+
+        /// Extra shared context roots relative to workspace root
+        #[arg(long = "shared-context")]
+        shared_context: Vec<String>,
+
+        /// Extra private context roots relative to workspace root
+        #[arg(long = "private-context")]
+        private_context: Vec<String>,
+
+        /// Default execution command for the lane (repeatable)
+        #[arg(long = "exec")]
+        exec: Vec<String>,
+
+        /// PR associations in repo:number form
+        #[arg(long = "pr")]
+        prs: Vec<String>,
+
+        /// Creation source label
+        #[arg(long)]
+        source: Option<String>,
+
+        /// Allow execution fan-out across repos by default
+        #[arg(long)]
+        parallel: bool,
+
+        /// Do not fail fast when running multi-repo commands
+        #[arg(long)]
+        no_fail_fast: bool,
+    },
+
+    /// List persisted lanes
+    List {
+        /// Filter to one owner unit
+        #[arg(long = "owner-unit")]
+        owner_unit: Option<String>,
+    },
+
+    /// Print one lane record
+    Show {
+        /// Lane name
+        name: String,
+
+        /// Owning unit
+        #[arg(long = "owner-unit")]
+        owner_unit: String,
+    },
+
+    /// Remove one lane record and its scaffolded directories
+    Remove {
+        /// Lane name
+        name: String,
+
+        /// Owning unit
+        #[arg(long = "owner-unit")]
+        owner_unit: String,
     },
 }
 

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -1,8 +1,13 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
+use crate::args::{Commands, LaneCommands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
+use crate::lane::{
+    create_lane, list_lanes, remove_lane, render_lane_table, show_lane, validate_lane_name,
+    LaneCreateRequest, LanePrAssociation, LaneType,
+};
 use crate::plan::ExecutionPlan;
 use crate::repo_status::{RepoStatusFilter, RepoStatusReport};
 use crate::spec::{read_workspace_spec, workspace_spec_path, write_workspace_spec, WorkspaceSpec};
@@ -341,6 +346,77 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 Ok(())
             }
         },
+        Commands::Lane { command } => match command {
+            LaneCommands::Create {
+                name,
+                owner_unit,
+                lane_type,
+                repos,
+                branches,
+                shared_context,
+                private_context,
+                exec,
+                prs,
+                source,
+                parallel,
+                no_fail_fast,
+            } => {
+                let workspace_root = require_workspace_root()?;
+                validate_unit_name(&owner_unit)?;
+                validate_lane_name(&name)?;
+
+                let branch_map = parse_branch_map(branches)?;
+                let pr_associations = parse_pr_associations(prs)?;
+                let request = LaneCreateRequest {
+                    name: name.clone(),
+                    owner_unit: owner_unit.clone(),
+                    lane_type: lane_type.parse::<LaneType>()?,
+                    repos,
+                    branch_map,
+                    shared_context,
+                    private_context,
+                    exec_commands: exec,
+                    creation_source: source.unwrap_or_else(|| "manual".to_string()),
+                    pr_associations,
+                    parallel,
+                    fail_fast: !no_fail_fast,
+                };
+
+                let record = create_lane(&workspace_root, request)?;
+                println!(
+                    "Created lane '{}'\n- owner: {}\n- type: {}\n- repos: {}",
+                    record.lane_name,
+                    record.owner_unit,
+                    record.lane_type.as_str(),
+                    record.repos.join(", ")
+                );
+                Ok(())
+            }
+            LaneCommands::List { owner_unit } => {
+                let workspace_root = require_workspace_root()?;
+                if let Some(owner_unit) = &owner_unit {
+                    validate_unit_name(owner_unit)?;
+                }
+                let lanes = list_lanes(&workspace_root, owner_unit.as_deref())?;
+                println!("{}", render_lane_table(&lanes));
+                Ok(())
+            }
+            LaneCommands::Show { name, owner_unit } => {
+                let workspace_root = require_workspace_root()?;
+                validate_unit_name(&owner_unit)?;
+                validate_lane_name(&name)?;
+                println!("{}", show_lane(&workspace_root, &owner_unit, &name)?);
+                Ok(())
+            }
+            LaneCommands::Remove { name, owner_unit } => {
+                let workspace_root = require_workspace_root()?;
+                validate_unit_name(&owner_unit)?;
+                validate_lane_name(&name)?;
+                remove_lane(&workspace_root, &owner_unit, &name)?;
+                println!("Removed lane '{}' for unit '{}'", name, owner_unit);
+                Ok(())
+            }
+        },
         Commands::Spec { command } => match command {
             SpecCommands::Show => {
                 let workspace_root = require_workspace_root()?;
@@ -463,4 +539,41 @@ fn validate_unit_name(name: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn parse_branch_map(entries: Vec<String>) -> Result<BTreeMap<String, String>> {
+    let mut branch_map = BTreeMap::new();
+    for entry in entries {
+        let (repo, branch) = entry
+            .split_once('=')
+            .with_context(|| format!("invalid branch mapping '{}': expected repo=branch", entry))?;
+        if repo.trim().is_empty() || branch.trim().is_empty() {
+            anyhow::bail!(
+                "invalid branch mapping '{}': repo and branch must both be non-empty",
+                entry
+            );
+        }
+        branch_map.insert(repo.trim().to_string(), branch.trim().to_string());
+    }
+    Ok(branch_map)
+}
+
+fn parse_pr_associations(entries: Vec<String>) -> Result<Vec<LanePrAssociation>> {
+    let mut prs = Vec::new();
+    for entry in entries {
+        let (repo, number) = entry
+            .split_once(':')
+            .with_context(|| format!("invalid PR association '{}': expected repo:number", entry))?;
+        if repo.trim().is_empty() {
+            anyhow::bail!("invalid PR association '{}': repo must not be empty", entry);
+        }
+        prs.push(LanePrAssociation {
+            repo: repo.trim().to_string(),
+            number: number
+                .trim()
+                .parse::<u64>()
+                .with_context(|| format!("invalid PR number in '{}'", entry))?,
+        });
+    }
+    Ok(prs)
 }

--- a/gr2/src/lane.rs
+++ b/gr2/src/lane.rs
@@ -1,0 +1,400 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::spec::{read_workspace_spec, workspace_spec_path, WorkspaceSpec};
+
+pub const LANE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaneRecord {
+    pub schema_version: u32,
+    pub lane_id: String,
+    pub lane_name: String,
+    pub owner_unit: String,
+    pub lane_type: LaneType,
+    pub repos: Vec<String>,
+    #[serde(default)]
+    pub branch_map: BTreeMap<String, String>,
+    pub creation_source: String,
+    pub context: LaneContextRoots,
+    pub exec_defaults: LaneExecDefaults,
+    #[serde(default)]
+    pub pr_associations: Vec<LanePrAssociation>,
+    pub recovery: LaneRecoveryState,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LaneType {
+    Home,
+    Feature,
+    Review,
+    Scratch,
+}
+
+impl LaneType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Home => "home",
+            Self::Feature => "feature",
+            Self::Review => "review",
+            Self::Scratch => "scratch",
+        }
+    }
+}
+
+impl std::str::FromStr for LaneType {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "home" => Ok(Self::Home),
+            "feature" => Ok(Self::Feature),
+            "review" => Ok(Self::Review),
+            "scratch" => Ok(Self::Scratch),
+            other => anyhow::bail!(
+                "unknown lane type '{}': expected home, feature, review, or scratch",
+                other
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaneContextRoots {
+    #[serde(default)]
+    pub shared_roots: Vec<String>,
+    #[serde(default)]
+    pub private_roots: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LaneExecDefaults {
+    #[serde(default)]
+    pub commands: Vec<String>,
+    pub fail_fast: bool,
+    pub parallel: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LanePrAssociation {
+    pub repo: String,
+    pub number: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct LaneRecoveryState {
+    #[serde(default)]
+    pub autostash_refs: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaneCreateRequest {
+    pub name: String,
+    pub owner_unit: String,
+    pub lane_type: LaneType,
+    pub repos: Vec<String>,
+    pub branch_map: BTreeMap<String, String>,
+    pub shared_context: Vec<String>,
+    pub private_context: Vec<String>,
+    pub exec_commands: Vec<String>,
+    pub creation_source: String,
+    pub pr_associations: Vec<LanePrAssociation>,
+    pub parallel: bool,
+    pub fail_fast: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaneSummary {
+    pub owner_unit: String,
+    pub lane_name: String,
+    pub lane_type: LaneType,
+    pub repo_count: usize,
+}
+
+pub fn create_lane(workspace_root: &Path, request: LaneCreateRequest) -> Result<LaneRecord> {
+    validate_lane_name(&request.name)?;
+    validate_lane_name(&request.owner_unit)?;
+
+    let spec = load_workspace_spec_for_lanes(workspace_root)?;
+    let unit = spec
+        .units
+        .iter()
+        .find(|unit| unit.name == request.owner_unit)
+        .with_context(|| format!("unit '{}' not found in workspace spec", request.owner_unit))?;
+
+    let known_repos = spec
+        .repos
+        .iter()
+        .map(|repo| repo.name.clone())
+        .collect::<BTreeSet<_>>();
+
+    let mut repos = if request.repos.is_empty() {
+        unit.repos.clone()
+    } else {
+        request.repos.clone()
+    };
+    repos.sort();
+    repos.dedup();
+
+    if repos.is_empty() {
+        anyhow::bail!(
+            "lane '{}' has no repo membership; pass --repo or add repos to unit '{}' in workspace spec",
+            request.name,
+            request.owner_unit
+        );
+    }
+
+    for repo in &repos {
+        if !known_repos.contains(repo) {
+            anyhow::bail!("lane '{}' references unknown repo '{}'", request.name, repo);
+        }
+    }
+
+    for repo in request.branch_map.keys() {
+        if !repos.iter().any(|member| member == repo) {
+            anyhow::bail!(
+                "lane '{}' branch map references repo '{}' outside lane membership",
+                request.name,
+                repo
+            );
+        }
+    }
+
+    for pr in &request.pr_associations {
+        if !repos.iter().any(|repo| repo == &pr.repo) {
+            anyhow::bail!(
+                "lane '{}' PR association references repo '{}' outside lane membership",
+                request.name,
+                pr.repo
+            );
+        }
+    }
+
+    let metadata_path = lane_metadata_path(workspace_root, &request.owner_unit, &request.name);
+    if metadata_path.exists() {
+        anyhow::bail!(
+            "lane '{}' for unit '{}' already exists",
+            request.name,
+            request.owner_unit
+        );
+    }
+
+    let lane_root = lane_root_path(workspace_root, &request.owner_unit, &request.name);
+    fs::create_dir_all(lane_root.join("repos"))
+        .with_context(|| format!("create lane repos directory {}", lane_root.display()))?;
+    fs::create_dir_all(lane_root.join("context"))
+        .with_context(|| format!("create lane context directory {}", lane_root.display()))?;
+    fs::create_dir_all(
+        metadata_path
+            .parent()
+            .context("lane metadata parent missing")?,
+    )
+    .with_context(|| format!("create lane state directory {}", metadata_path.display()))?;
+
+    let shared_roots = merge_roots(
+        vec!["config".to_string(), ".grip/context/shared".to_string()],
+        request.shared_context,
+    );
+    let private_roots = merge_roots(
+        vec![
+            format!("agents/{}/home/context", request.owner_unit),
+            format!(
+                "agents/{}/lanes/{}/context",
+                request.owner_unit, request.name
+            ),
+        ],
+        request.private_context,
+    );
+
+    let record = LaneRecord {
+        schema_version: LANE_SCHEMA_VERSION,
+        lane_id: format!("{}:{}", request.owner_unit, request.name),
+        lane_name: request.name,
+        owner_unit: request.owner_unit,
+        lane_type: request.lane_type,
+        repos,
+        branch_map: request.branch_map,
+        creation_source: request.creation_source,
+        context: LaneContextRoots {
+            shared_roots,
+            private_roots,
+        },
+        exec_defaults: LaneExecDefaults {
+            commands: request.exec_commands,
+            fail_fast: request.fail_fast,
+            parallel: request.parallel,
+        },
+        pr_associations: request.pr_associations,
+        recovery: LaneRecoveryState::default(),
+    };
+
+    let content = toml::to_string_pretty(&record).context("serialize lane record")?;
+    fs::write(&metadata_path, content)
+        .with_context(|| format!("write lane metadata to {}", metadata_path.display()))?;
+
+    Ok(record)
+}
+
+pub fn list_lanes(workspace_root: &Path, owner_filter: Option<&str>) -> Result<Vec<LaneSummary>> {
+    let state_root = lane_state_root(workspace_root);
+    if !state_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut lanes = Vec::new();
+    for owner_entry in fs::read_dir(&state_root)? {
+        let owner_entry = owner_entry?;
+        if !owner_entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let owner_unit = owner_entry.file_name().to_string_lossy().into_owned();
+        if let Some(filter) = owner_filter {
+            if filter != owner_unit {
+                continue;
+            }
+        }
+
+        for lane_entry in fs::read_dir(owner_entry.path())? {
+            let lane_entry = lane_entry?;
+            if !lane_entry.file_type()?.is_file() {
+                continue;
+            }
+
+            if lane_entry.path().extension().and_then(|ext| ext.to_str()) != Some("toml") {
+                continue;
+            }
+
+            let record = load_lane_record_path(&lane_entry.path())?;
+            lanes.push(LaneSummary {
+                owner_unit: record.owner_unit,
+                lane_name: record.lane_name,
+                lane_type: record.lane_type,
+                repo_count: record.repos.len(),
+            });
+        }
+    }
+
+    lanes.sort_by(|left, right| {
+        left.owner_unit
+            .cmp(&right.owner_unit)
+            .then_with(|| left.lane_name.cmp(&right.lane_name))
+    });
+    Ok(lanes)
+}
+
+pub fn show_lane(workspace_root: &Path, owner_unit: &str, lane_name: &str) -> Result<String> {
+    let path = lane_metadata_path(workspace_root, owner_unit, lane_name);
+    fs::read_to_string(&path).with_context(|| format!("read lane metadata from {}", path.display()))
+}
+
+pub fn remove_lane(workspace_root: &Path, owner_unit: &str, lane_name: &str) -> Result<()> {
+    let metadata_path = lane_metadata_path(workspace_root, owner_unit, lane_name);
+    if !metadata_path.exists() {
+        anyhow::bail!("lane '{}' for unit '{}' not found", lane_name, owner_unit);
+    }
+
+    fs::remove_file(&metadata_path)
+        .with_context(|| format!("remove lane metadata {}", metadata_path.display()))?;
+
+    let owner_state_root = lane_state_root(workspace_root).join(owner_unit);
+    if owner_state_root.exists() && owner_state_root.read_dir()?.next().is_none() {
+        fs::remove_dir(&owner_state_root).with_context(|| {
+            format!(
+                "remove empty lane owner state {}",
+                owner_state_root.display()
+            )
+        })?;
+    }
+
+    let lane_root = lane_root_path(workspace_root, owner_unit, lane_name);
+    if lane_root.exists() {
+        fs::remove_dir_all(&lane_root)
+            .with_context(|| format!("remove lane root {}", lane_root.display()))?;
+    }
+
+    Ok(())
+}
+
+pub fn render_lane_table(lanes: &[LaneSummary]) -> String {
+    if lanes.is_empty() {
+        return "No gr2 lanes registered.".to_string();
+    }
+
+    let mut out = String::from("Lanes\nOWNER NAME TYPE REPOS\n");
+    for lane in lanes {
+        out.push_str(&format!(
+            "{} {} {} {}\n",
+            lane.owner_unit,
+            lane.lane_name,
+            lane.lane_type.as_str(),
+            lane.repo_count
+        ));
+    }
+    out.trim_end().to_string()
+}
+
+fn load_workspace_spec_for_lanes(workspace_root: &Path) -> Result<WorkspaceSpec> {
+    let spec_path = workspace_spec_path(workspace_root);
+    if spec_path.exists() {
+        read_workspace_spec(workspace_root)
+    } else {
+        WorkspaceSpec::from_workspace(workspace_root)
+    }
+}
+
+fn load_lane_record_path(path: &Path) -> Result<LaneRecord> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("read lane metadata from {}", path.display()))?;
+    toml::from_str(&content).context("parse lane metadata")
+}
+
+fn merge_roots(defaults: Vec<String>, extras: Vec<String>) -> Vec<String> {
+    let mut merged = defaults;
+    for extra in extras {
+        if !merged.iter().any(|existing| existing == &extra) {
+            merged.push(extra);
+        }
+    }
+    merged
+}
+
+pub fn lane_state_root(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(".grip/state/lanes")
+}
+
+pub fn lane_metadata_path(workspace_root: &Path, owner_unit: &str, lane_name: &str) -> PathBuf {
+    lane_state_root(workspace_root)
+        .join(owner_unit)
+        .join(format!("{}.toml", lane_name))
+}
+
+pub fn lane_root_path(workspace_root: &Path, owner_unit: &str, lane_name: &str) -> PathBuf {
+    workspace_root
+        .join("agents")
+        .join(owner_unit)
+        .join("lanes")
+        .join(lane_name)
+}
+
+pub fn validate_lane_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("lane name must not be empty");
+    }
+
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.')
+    {
+        anyhow::bail!(
+            "invalid lane name '{}': use only ASCII letters, numbers, '.', '_' or '-'",
+            name
+        );
+    }
+
+    Ok(())
+}

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod args;
 pub mod dispatch;
+pub mod lane;
 pub mod plan;
 pub mod repo_status;
 pub mod spec;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -3156,3 +3156,313 @@ repos = ["myrepo"]
         .success()
         .stdout(predicate::str::contains("no changes required"));
 }
+
+#[test]
+fn test_gr2_lane_create_persists_metadata_and_scaffolds_lane_root() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .args(["repo", "add", "app", "https://example.com/app.git"])
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .args(["unit", "add", "atlas"])
+        .assert()
+        .success();
+
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://example.com/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#,
+    )
+    .unwrap();
+
+    let mut create = Command::cargo_bin("gr2").unwrap();
+    create
+        .current_dir(&workspace_root)
+        .args([
+            "lane",
+            "create",
+            "feat-123",
+            "--owner-unit",
+            "atlas",
+            "--type",
+            "feature",
+            "--branch",
+            "app=feat-123",
+            "--exec",
+            "cargo test -p app",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created lane 'feat-123'"))
+        .stdout(predicate::str::contains("repos: app"));
+
+    let metadata_path = workspace_root.join(".grip/state/lanes/atlas/feat-123.toml");
+    assert!(metadata_path.exists());
+    let metadata = std::fs::read_to_string(&metadata_path).unwrap();
+    assert!(metadata.contains("lane_id = \"atlas:feat-123\""));
+    assert!(metadata.contains("lane_name = \"feat-123\""));
+    assert!(metadata.contains("owner_unit = \"atlas\""));
+    assert!(metadata.contains("lane_type = \"feature\""));
+    assert!(metadata.contains("repos = [\"app\"]"));
+    assert!(metadata.contains("app = \"feat-123\""));
+    assert!(metadata.contains("commands = [\"cargo test -p app\"]"));
+
+    assert!(workspace_root
+        .join("agents/atlas/lanes/feat-123/repos")
+        .is_dir());
+    assert!(workspace_root
+        .join("agents/atlas/lanes/feat-123/context")
+        .is_dir());
+}
+
+#[test]
+fn test_gr2_lane_list_and_show_report_persisted_lane() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .args(["repo", "add", "app", "https://example.com/app.git"])
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .args(["unit", "add", "atlas"])
+        .assert()
+        .success();
+
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://example.com/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#,
+    )
+    .unwrap();
+
+    let mut create = Command::cargo_bin("gr2").unwrap();
+    create
+        .current_dir(&workspace_root)
+        .args([
+            "lane",
+            "create",
+            "review-548",
+            "--owner-unit",
+            "atlas",
+            "--type",
+            "review",
+            "--repo",
+            "app",
+            "--pr",
+            "app:548",
+        ])
+        .assert()
+        .success();
+
+    let mut list = Command::cargo_bin("gr2").unwrap();
+    list.current_dir(&workspace_root)
+        .args(["lane", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Lanes"))
+        .stdout(predicate::str::contains("atlas review-548 review 1"));
+
+    let mut show = Command::cargo_bin("gr2").unwrap();
+    show.current_dir(&workspace_root)
+        .args(["lane", "show", "review-548", "--owner-unit", "atlas"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lane_name = \"review-548\""))
+        .stdout(predicate::str::contains("number = 548"));
+}
+
+#[test]
+fn test_gr2_lane_remove_deletes_metadata_and_lane_root() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut repo_add = Command::cargo_bin("gr2").unwrap();
+    repo_add
+        .current_dir(&workspace_root)
+        .args(["repo", "add", "app", "https://example.com/app.git"])
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .args(["unit", "add", "atlas"])
+        .assert()
+        .success();
+
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://example.com/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+"#,
+    )
+    .unwrap();
+
+    let mut create = Command::cargo_bin("gr2").unwrap();
+    create
+        .current_dir(&workspace_root)
+        .args([
+            "lane",
+            "create",
+            "scratch-a",
+            "--owner-unit",
+            "atlas",
+            "--type",
+            "scratch",
+        ])
+        .assert()
+        .success();
+
+    let metadata_path = workspace_root.join(".grip/state/lanes/atlas/scratch-a.toml");
+    let lane_root = workspace_root.join("agents/atlas/lanes/scratch-a");
+    assert!(metadata_path.exists());
+    assert!(lane_root.exists());
+
+    let mut remove = Command::cargo_bin("gr2").unwrap();
+    remove
+        .current_dir(&workspace_root)
+        .args(["lane", "remove", "scratch-a", "--owner-unit", "atlas"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Removed lane 'scratch-a' for unit 'atlas'",
+        ));
+
+    assert!(!metadata_path.exists());
+    assert!(!lane_root.exists());
+}
+
+#[test]
+fn test_gr2_lane_create_rejects_unknown_repo_membership() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .args(["unit", "add", "atlas"])
+        .assert()
+        .success();
+
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+"#,
+    )
+    .unwrap();
+
+    let mut create = Command::cargo_bin("gr2").unwrap();
+    create
+        .current_dir(&workspace_root)
+        .args([
+            "lane",
+            "create",
+            "feat-unknown",
+            "--owner-unit",
+            "atlas",
+            "--repo",
+            "missing",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown repo 'missing'"));
+}


### PR DESCRIPTION
## Summary
- add a first read-write gr2 lane surface with create/list/show/remove commands
- persist lane metadata under .grip/state/lanes and scaffold lane roots under agents/<owner>/lanes/<lane>
- validate repo membership and record lane context, exec defaults, PR associations, and recovery state

Closes #547

## Testing
- cargo check -p gr2-cli --quiet
- cargo test --test cli_tests --quiet
