### PR TITLE
feat: add gr2 exec status surface

### DIFF
--- a/docs/MANIFESTO-gr2-ux.md
+++ b/docs/MANIFESTO-gr2-ux.md
@@ -1,0 +1,171 @@
+# gr2 UX Manifesto
+
+## Why `gr2` Exists
+
+Developers do not struggle because git is broken.
+
+They struggle because modern work is larger than one checkout:
+
+- one feature spans multiple repositories
+- one review interrupts another active task
+- one human works alongside multiple agents
+- one team needs both private work areas and lightweight shared collaboration
+
+`gr2` exists to make that multi-repo, multi-lane reality simpler, safer, and
+more legible.
+
+## Primary Thesis
+
+`gr2` is not a git replacement.
+
+`gr2` is a multi-repo workspace router.
+
+It should make it easy to:
+
+- start the right task context
+- see which repos and branches belong to that context
+- switch to another context without losing your place
+- review, collaborate, and execute work in the right scope
+
+Once the user is in the correct checkout, normal git should still feel normal.
+
+## User-First Principles
+
+### 1. The Primary Object Is The Task Context
+
+Users think:
+
+- "I am working on feature X"
+- "I need to review PR Y"
+- "I need a shared place to draft Z"
+
+They do not think:
+
+- "I need to manually coordinate three checkouts and remember which branch is
+  active in each one"
+
+So `gr2` must center:
+
+- feature lanes
+- review lanes
+- shared scratchpads
+
+Repos are part of the context. They are not the context.
+
+### 2. Private Work And Shared Work Must Stay Separate
+
+Users need both:
+
+- private implementation surfaces
+- shared collaboration surfaces
+
+Private lanes protect active work.
+Shared scratchpads make lightweight collaboration possible without violating
+private workspace boundaries or paying the full cost of a PR.
+
+The system must make that distinction explicit.
+
+### 3. Use `gr2` To Choose Context, Use Git To Work
+
+The intended user flow is:
+
+1. use `gr2` to enter the correct lane or review context
+2. use git normally inside the selected checkout
+3. return to `gr2` when changing task, scope, or execution surface
+
+If `gr2` tries to replace normal repo-local git, users will distrust it.
+If `gr2` does not simplify multi-repo context changes, users will route around
+it.
+
+### 4. The Tool Must Never Hide Important State
+
+Users should not have to guess:
+
+- which repos are in scope
+- which branches are intended
+- which paths are active
+- whether a command is structural or mutating
+- whether local work is at risk
+
+`gr2` should prefer explicit status over magical convenience.
+
+### 5. Safety Beats Cleverness
+
+`gr2 apply` must not silently:
+
+- pull
+- merge
+- rebase
+- switch branches
+- discard dirty work
+
+Users will trust `gr2` only if the safety boundary is simple and consistent:
+
+- structural convergence belongs to `apply`
+- repo maintenance belongs to explicit repo commands
+
+## Human UX Requirements
+
+A human should be able to:
+
+- keep feature A active while feature B waits in review
+- inspect PR C without disturbing either one
+- collaborate on a blog post or spec without editing another person's private
+  lane
+- tell, quickly, which repos matter for the current task
+- run the right build/test commands without reconstructing scope manually
+
+## Agent UX Requirements
+
+An agent should be able to:
+
+- discover the current task context quickly
+- consume stable machine-readable state
+- know which repos matter without guessing
+- avoid entering another worker's private directory
+- choose the right next command from explicit status surfaces
+
+This means structured output is not optional polish. It is first-class product
+surface.
+
+## Mixed Human + Agent Requirements
+
+The same model must work for:
+
+- a solo human
+- one agent
+- many agents
+- one human working alongside many agents
+
+That requires:
+
+- one shared vocabulary for lanes, review, and scratchpads
+- one shared status model
+- private lanes by default
+- shared collaboration surfaces when collaboration is the point
+
+## What Good Looks Like
+
+The user says:
+
+- "start feature auth across app and api"
+- "show me what this lane would run"
+- "open a review lane for PR 548"
+- "create a shared scratchpad for the sprint blog"
+- "switch back to my feature without losing my place"
+
+And the system responds with explicit, trustworthy state.
+
+That is the bar.
+
+## Product Test
+
+When choosing a `gr2` feature, ask:
+
+1. Does this make multi-repo context easier than ad hoc shell plus raw git?
+2. Does this preserve private work while allowing shared collaboration?
+3. Does this make the active task more legible?
+4. Does this reduce guessing for both humans and agents?
+5. Does this keep git normal once the user is in the correct checkout?
+
+If the answer is not clearly yes, the design should be revised.

--- a/docs/PLAN-gr2-needs-and-criteria.md
+++ b/docs/PLAN-gr2-needs-and-criteria.md
@@ -28,6 +28,46 @@ If `gr2` gets that right, humans and agents can work safely in parallel.
 If it gets that wrong, users will fall back to ad hoc worktrees, raw git, and
 hidden state.
 
+## Tool Boundary Principle
+
+`gr2` is not a replacement for git.
+
+`gr2` should be the first-class surface for multi-repo workspace routing.
+Git should remain the first-class surface for normal repo-local work inside a
+chosen checkout.
+
+If that boundary gets blurred, users and agents will distrust the system for
+opposite reasons:
+
+- if `gr2` does too much, it feels magical and unsafe
+- if `gr2` does too little, users will ignore it and fall back to ad hoc shell
+
+So the system must make this split legible.
+
+### `gr2` Must Own
+
+- lane selection and switching
+- review-lane setup
+- shared scratchpads
+- multi-repo status and scope
+- structural workspace planning and apply
+- lane-aware execution planning
+
+### Git Must Still Own
+
+- repo-local `status`, `diff`, `log`
+- staging and committing
+- normal branch work inside one checkout
+- low-level recovery when a user is already in the correct repo
+
+### User Decision Rule
+
+The default user rule should be:
+
+1. use `gr2` to get into the right workspace context
+2. use git to work inside that chosen repo checkout
+3. return to `gr2` when changing context, scope, or execution surface
+
 ## User Modes
 
 `gr2` must support all of these without changing its core model.
@@ -40,6 +80,7 @@ The user needs to:
 - review another PR without disturbing that feature
 - start a second feature while the first waits on review
 - run build/test/verify for the active multi-repo lane
+- know when to use raw git versus `gr2` without second-guessing
 
 ### Single Agent
 
@@ -50,6 +91,7 @@ The agent needs to:
 - branch and execute commands without guessing
 - report deterministic status
 - avoid clobbering unrelated work
+- prefer the workspace primitives over ad hoc raw git when the task is multi-repo
 
 ### Multi-Agent Team
 
@@ -60,6 +102,7 @@ The team needs to:
 - preserve private context where appropriate
 - coordinate across linked PRs and sprint lanes
 - switch between tasks without contaminating each other's state
+- avoid entering each other's private directories just to collaborate
 
 ## Hard Requirements
 
@@ -205,7 +248,56 @@ Agents and humans need trustworthy read surfaces.
 
 These should be machine-readable as well as human-readable.
 
-### 10. Multi-Repo Scratchpads
+### 9a. Structured Output Must Be First-Class
+
+Machine-readable output should not be treated as an optional afterthought.
+
+Agents routinely need:
+
+- stable field names
+- stable object shapes
+- deterministic exit codes
+- explicit next-step hints
+- explicit scope metadata
+
+So every status-style surface should support structured output as a first-class
+mode, not a best-effort pretty-print after the human CLI is finished.
+
+Required properties:
+
+- all read surfaces support structured output
+- structured output is versioned
+- field names are stable across patch releases
+- error output is also structured when structured mode is enabled
+- command scope is explicit in the payload
+
+Examples of required structured surfaces:
+
+- `gr2 spec show`
+- `gr2 plan`
+- `gr2 repo status`
+- `gr2 lane list`
+- `gr2 lane show`
+- `gr2 exec status`
+
+The target user problem is simple:
+
+- agents should not have to scrape prose
+- humans should not lose readable output by default
+
+### 10. Strong UX Guidance
+
+The product must teach the user which surface to use.
+
+That means:
+
+- CLI help must state command scope clearly
+- status output should suggest likely next steps
+- docs should include "use `gr2` for this, use git for that"
+- common workflows should be expressed as short procedural paths
+- structured output should be easy to enable and hard to forget
+
+### 11. Multi-Repo Scratchpads
 
 The system must support two or more temporary scratchpads simultaneously.
 
@@ -250,6 +342,9 @@ Required surfaces:
 - `gr2 repo fetch`
 - `gr2 repo sync`
 - `gr2 repo checkout`
+
+This surface must remain explicit enough that users do not confuse it with
+plain repo-local git operations.
 
 ### Lane Surface
 

--- a/docs/PLAN-gr2-repo-maintenance-and-lanes.md
+++ b/docs/PLAN-gr2-repo-maintenance-and-lanes.md
@@ -42,6 +42,100 @@ The workspace model needs to support:
 - make shared context and unit-private context explicit
 - make multi-repo execution lane-aware
 
+## UX Principles
+
+`gr2` should not try to replace git.
+
+It should make workspace-level behavior easier than raw git, while still
+leaving normal repo-local git workflows available when they are the right tool.
+
+The design should optimize for a user who thinks:
+
+- "I need to keep working on feature A while feature B is in review"
+- "I need to review a PR without disturbing my current work"
+- "I need to run the right commands in the right repos without guessing"
+- "I do not want a tool to silently move my branches or hide my work"
+
+That leads to four UX rules.
+
+### 1. `gr2` Owns Workspace Context
+
+`gr2` should own:
+
+- lane creation and switching
+- review-lane setup
+- shared scratchpads
+- multi-repo scope selection
+- workspace and lane status
+- lane-aware execution planning
+
+These are the things raw git does poorly across many repos.
+
+### 2. Git Still Owns Repo-Local Work
+
+Raw git should still own:
+
+- `status`
+- `diff`
+- `log`
+- `add`
+- `commit`
+- repo-local branch surgery
+- low-level recovery inside one checkout
+
+Once a user is in the correct lane and repo root, git should still feel normal.
+
+### 3. `gr2` Must Be Easier Than Raw Git For Multi-Repo Tasks
+
+If a multi-repo task is easier with ad hoc shell plus raw git, users and agents
+will route around `gr2`.
+
+So `gr2` should be the easiest path for:
+
+- starting a multi-repo feature context
+- checking out a PR across one or more repos
+- seeing which repos and branches belong to a task
+- running build/test/verify in the right scope
+- creating a lightweight shared collaboration surface
+
+### 4. Commands Must Explain Their Scope
+
+Users should not have to guess whether a command is:
+
+- structural
+- repo-maintenance
+- lane-management
+- execution
+
+The CLI, help text, and status output should make that obvious.
+
+### 5. Structured Output Must Be Easy To Keep On
+
+Agents benefit from machine-readable output, but "remember to pass `--json`"
+is not a reliable workflow.
+
+So `gr2` should support a persistent structured-output mode for users or
+agents that prefer it.
+
+The design should support:
+
+- one-shot structured output with `--json`
+- persistent structured output via config or environment
+- readable human output as the default for casual interactive use
+
+The likely shape is:
+
+- `--json` for per-command override
+- workspace or user setting such as `output.mode = "json"`
+- environment override such as `GR2_OUTPUT=json`
+- possibly a higher-level `agent_mode = true` preset later, but only if it
+  remains transparent and does not hide command behavior
+
+The important UX rule is:
+
+- agents should not need to remember flags
+- humans should not be forced into JSON when they do not want it
+
 ## Non-Goals
 
 - `gr2 apply` is not a global "make it all right somehow" button
@@ -92,6 +186,60 @@ Repo maintenance should be an explicit surface above structural apply:
 - divergence handling
 
 That should become a separate command family, not hidden inside `apply`.
+
+## When To Use `gr2` vs Raw Git
+
+This should be an explicit user rule, not tribal knowledge.
+
+### Use `gr2` When You Need Workspace-Level Coordination
+
+Use `gr2` for:
+
+- creating or selecting a lane
+- checking out a PR into an isolated review context
+- understanding repo membership and branch intent across a task
+- planning multi-repo execution
+- creating or inspecting shared scratchpads
+- inspecting structural workspace drift
+
+### Use Raw Git When You Are Already In The Right Checkout
+
+Use raw git for:
+
+- looking at diffs and logs
+- staging and committing
+- local branch cleanup
+- low-level repo repair
+- any normal single-repo operation inside the selected lane checkout
+
+The intended model is:
+
+1. use `gr2` to get into the right workspace context
+2. use git normally inside that context
+
+## Structured Output Policy
+
+Structured output should be treated as part of the product surface, not only
+as a convenience flag.
+
+For read-heavy commands, the command should be able to emit:
+
+- human output
+- structured output with stable field names
+- deterministic exit codes
+
+That matters most for:
+
+- `gr2 repo status`
+- `gr2 lane list`
+- `gr2 lane show`
+- `gr2 exec status`
+- later `gr2 plan`
+
+This helps both agents and humans:
+
+- agents can consume stable payloads
+- humans can switch into structured mode when scripting or debugging
 
 ## Proposed Workspace Model
 

--- a/gr2/src/args.rs
+++ b/gr2/src/args.rs
@@ -56,6 +56,12 @@ pub enum Commands {
         command: LaneCommands,
     },
 
+    /// Lane-aware execution planning and commands
+    Exec {
+        #[command(subcommand)]
+        command: ExecCommands,
+    },
+
     /// Declarative workspace spec operations
     Spec {
         #[command(subcommand)]
@@ -226,6 +232,24 @@ pub enum LaneCommands {
         /// Owning unit
         #[arg(long = "owner-unit")]
         owner_unit: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ExecCommands {
+    /// Show the execution plan surface for one lane
+    Status {
+        /// Lane name
+        #[arg(long = "lane")]
+        lane: String,
+
+        /// Owning unit
+        #[arg(long = "owner-unit")]
+        owner_unit: String,
+
+        /// Filter to one or more repos inside the lane
+        #[arg(long = "repo")]
+        repos: Vec<String>,
     },
 }
 

--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{Commands, LaneCommands, RepoCommands, SpecCommands, TeamCommands, UnitCommands};
+use crate::args::{
+    Commands, ExecCommands, LaneCommands, RepoCommands, SpecCommands, TeamCommands, UnitCommands,
+};
+use crate::exec::{ExecStatusFilter, ExecStatusReport};
 use crate::lane::{
     create_lane, list_lanes, remove_lane, render_lane_table, show_lane, validate_lane_name,
     LaneCreateRequest, LanePrAssociation, LaneType,
@@ -414,6 +417,27 @@ pub async fn dispatch_command(command: Commands, verbose: bool) -> Result<()> {
                 validate_lane_name(&name)?;
                 remove_lane(&workspace_root, &owner_unit, &name)?;
                 println!("Removed lane '{}' for unit '{}'", name, owner_unit);
+                Ok(())
+            }
+        },
+        Commands::Exec { command } => match command {
+            ExecCommands::Status {
+                lane,
+                owner_unit,
+                repos,
+            } => {
+                let workspace_root = require_workspace_root()?;
+                validate_unit_name(&owner_unit)?;
+                validate_lane_name(&lane)?;
+                let report = ExecStatusReport::load(
+                    &workspace_root,
+                    &ExecStatusFilter {
+                        owner_unit,
+                        lane_name: lane,
+                        repos,
+                    },
+                )?;
+                println!("{}", report.render_table());
                 Ok(())
             }
         },

--- a/gr2/src/exec.rs
+++ b/gr2/src/exec.rs
@@ -1,0 +1,169 @@
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::lane::{lane_root_path, load_lane, LaneRecord};
+use crate::spec::{read_workspace_spec, workspace_spec_path, WorkspaceSpec};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecStatusFilter {
+    pub owner_unit: String,
+    pub lane_name: String,
+    pub repos: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecStatusEntry {
+    pub repo: String,
+    pub exec_path: PathBuf,
+    pub path_kind: &'static str,
+    pub branch: Option<String>,
+    pub pr: Option<u64>,
+    pub command_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecStatusReport {
+    pub lane: LaneRecord,
+    pub entries: Vec<ExecStatusEntry>,
+}
+
+impl ExecStatusReport {
+    pub fn load(workspace_root: &Path, filter: &ExecStatusFilter) -> Result<Self> {
+        let spec = load_workspace_spec_for_exec(workspace_root)?;
+        let lane = load_lane(workspace_root, &filter.owner_unit, &filter.lane_name)?;
+
+        let mut requested = filter.repos.clone();
+        requested.sort();
+        requested.dedup();
+
+        for repo in &requested {
+            if !lane.repos.iter().any(|member| member == repo) {
+                anyhow::bail!(
+                    "lane '{}' for unit '{}' does not include repo '{}'",
+                    lane.lane_name,
+                    lane.owner_unit,
+                    repo
+                );
+            }
+        }
+
+        let repo_names = if requested.is_empty() {
+            lane.repos.clone()
+        } else {
+            requested
+        };
+
+        let repo_specs = spec
+            .repos
+            .into_iter()
+            .map(|repo| (repo.name.clone(), repo))
+            .collect::<BTreeMap<_, _>>();
+
+        let lane_root = lane_root_path(workspace_root, &lane.owner_unit, &lane.lane_name);
+        let command_count = lane.exec_defaults.commands.len();
+
+        let mut entries = Vec::new();
+        for repo_name in repo_names {
+            let repo_spec = repo_specs
+                .get(&repo_name)
+                .with_context(|| format!("lane references unknown repo '{}'", repo_name))?;
+
+            let lane_repo_path = lane_root.join("repos").join(&repo_name);
+            let shared_repo_path = workspace_root.join(&repo_spec.path);
+            let (exec_path, path_kind) = if lane_repo_path.exists() {
+                (lane_repo_path, "lane")
+            } else if shared_repo_path.exists() {
+                (shared_repo_path, "shared")
+            } else {
+                (lane_repo_path, "missing")
+            };
+
+            let pr = lane
+                .pr_associations
+                .iter()
+                .find(|pr| pr.repo == repo_name)
+                .map(|pr| pr.number);
+
+            entries.push(ExecStatusEntry {
+                repo: repo_name.clone(),
+                exec_path,
+                path_kind,
+                branch: lane.branch_map.get(&repo_name).cloned(),
+                pr,
+                command_count,
+            });
+        }
+
+        Ok(Self { lane, entries })
+    }
+
+    pub fn render_table(&self) -> String {
+        let mut out = String::new();
+        out.push_str("gr2 exec status\n");
+        out.push_str(&format!(
+            "lane: {}/{}\n",
+            self.lane.owner_unit, self.lane.lane_name
+        ));
+        out.push_str(&format!("type: {}\n", self.lane.lane_type.as_str()));
+        out.push_str(&format!(
+            "parallel: {}\n",
+            if self.lane.exec_defaults.parallel {
+                "true"
+            } else {
+                "false"
+            }
+        ));
+        out.push_str(&format!(
+            "fail_fast: {}\n",
+            if self.lane.exec_defaults.fail_fast {
+                "true"
+            } else {
+                "false"
+            }
+        ));
+
+        if self.lane.exec_defaults.commands.is_empty() {
+            out.push_str("commands: none\n");
+        } else {
+            out.push_str("commands:\n");
+            for command in &self.lane.exec_defaults.commands {
+                out.push_str(&format!("- {}\n", command));
+            }
+        }
+
+        if self.entries.is_empty() {
+            out.push_str("repos: none");
+            return out;
+        }
+
+        out.push_str("repos:\n");
+        out.push_str("REPO PATH_KIND EXEC_PATH BRANCH PR COMMANDS\n");
+        for entry in &self.entries {
+            out.push_str(&format!(
+                "{} {} {} {} {} {}\n",
+                entry.repo,
+                entry.path_kind,
+                entry.exec_path.display(),
+                entry.branch.as_deref().unwrap_or("-"),
+                entry
+                    .pr
+                    .map(|pr| pr.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                entry.command_count
+            ));
+        }
+        out.trim_end().to_string()
+    }
+}
+
+fn load_workspace_spec_for_exec(workspace_root: &Path) -> Result<WorkspaceSpec> {
+    let spec_path = workspace_spec_path(workspace_root);
+    if !spec_path.exists() {
+        anyhow::bail!(
+            "workspace spec missing at {}; run 'gr2 spec show' or write .grip/workspace_spec.toml first",
+            spec_path.display()
+        );
+    }
+    read_workspace_spec(workspace_root)
+}

--- a/gr2/src/exec.rs
+++ b/gr2/src/exec.rs
@@ -65,16 +65,13 @@ impl ExecStatusReport {
 
         let mut entries = Vec::new();
         for repo_name in repo_names {
-            let repo_spec = repo_specs
+            repo_specs
                 .get(&repo_name)
                 .with_context(|| format!("lane references unknown repo '{}'", repo_name))?;
 
             let lane_repo_path = lane_root.join("repos").join(&repo_name);
-            let shared_repo_path = workspace_root.join(&repo_spec.path);
             let (exec_path, path_kind) = if lane_repo_path.exists() {
                 (lane_repo_path, "lane")
-            } else if shared_repo_path.exists() {
-                (shared_repo_path, "shared")
             } else {
                 (lane_repo_path, "missing")
             };

--- a/gr2/src/lane.rs
+++ b/gr2/src/lane.rs
@@ -292,6 +292,14 @@ pub fn show_lane(workspace_root: &Path, owner_unit: &str, lane_name: &str) -> Re
     fs::read_to_string(&path).with_context(|| format!("read lane metadata from {}", path.display()))
 }
 
+pub fn load_lane(workspace_root: &Path, owner_unit: &str, lane_name: &str) -> Result<LaneRecord> {
+    let path = lane_metadata_path(workspace_root, owner_unit, lane_name);
+    if !path.exists() {
+        anyhow::bail!("lane '{}' for unit '{}' not found", lane_name, owner_unit);
+    }
+    load_lane_record_path(&path)
+}
+
 pub fn remove_lane(workspace_root: &Path, owner_unit: &str, lane_name: &str) -> Result<()> {
     let metadata_path = lane_metadata_path(workspace_root, owner_unit, lane_name);
     if !metadata_path.exists() {

--- a/gr2/src/lib.rs
+++ b/gr2/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod args;
 pub mod dispatch;
+pub mod exec;
 pub mod lane;
 pub mod plan;
 pub mod repo_status;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -3466,3 +3466,203 @@ path = "agents/atlas"
         .failure()
         .stderr(predicate::str::contains("unknown repo 'missing'"));
 }
+
+#[test]
+fn test_gr2_exec_status_reports_lane_execution_surface() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    for (name, url) in [
+        ("app", "https://example.com/app.git"),
+        ("api", "https://example.com/api.git"),
+    ] {
+        let mut repo_add = Command::cargo_bin("gr2").unwrap();
+        repo_add
+            .current_dir(&workspace_root)
+            .args(["repo", "add", name, url])
+            .assert()
+            .success();
+    }
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .args(["unit", "add", "atlas"])
+        .assert()
+        .success();
+
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://example.com/app.git"
+
+[[repos]]
+name = "api"
+path = "repos/api"
+url = "https://example.com/api.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app", "api"]
+"#,
+    )
+    .unwrap();
+
+    let mut create = Command::cargo_bin("gr2").unwrap();
+    create
+        .current_dir(&workspace_root)
+        .args([
+            "lane",
+            "create",
+            "feat-auth",
+            "--owner-unit",
+            "atlas",
+            "--branch",
+            "app=feat-auth",
+            "--pr",
+            "app:548",
+            "--exec",
+            "cargo test -p app",
+            "--exec",
+            "cargo test -p api",
+        ])
+        .assert()
+        .success();
+
+    let mut exec_status = Command::cargo_bin("gr2").unwrap();
+    exec_status
+        .current_dir(&workspace_root)
+        .args([
+            "exec",
+            "status",
+            "--lane",
+            "feat-auth",
+            "--owner-unit",
+            "atlas",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("gr2 exec status"))
+        .stdout(predicate::str::contains("lane: atlas/feat-auth"))
+        .stdout(predicate::str::contains("parallel: false"))
+        .stdout(predicate::str::contains("fail_fast: true"))
+        .stdout(predicate::str::contains("- cargo test -p app"))
+        .stdout(predicate::str::contains("app shared"))
+        .stdout(predicate::str::contains("repos/app feat-auth 548 2"))
+        .stdout(predicate::str::contains("api shared"))
+        .stdout(predicate::str::contains("repos/api - - 2"));
+}
+
+#[test]
+fn test_gr2_exec_status_filters_to_selected_repo() {
+    let temp = TempDir::new().unwrap();
+    let workspace_root = temp.path().join("demo-team");
+
+    let mut init = Command::cargo_bin("gr2").unwrap();
+    init.arg("init")
+        .arg(&workspace_root)
+        .arg("--name")
+        .arg("demo")
+        .assert()
+        .success();
+
+    for (name, url) in [
+        ("app", "https://example.com/app.git"),
+        ("api", "https://example.com/api.git"),
+    ] {
+        let mut repo_add = Command::cargo_bin("gr2").unwrap();
+        repo_add
+            .current_dir(&workspace_root)
+            .args(["repo", "add", name, url])
+            .assert()
+            .success();
+    }
+
+    let mut unit_add = Command::cargo_bin("gr2").unwrap();
+    unit_add
+        .current_dir(&workspace_root)
+        .args(["unit", "add", "atlas"])
+        .assert()
+        .success();
+
+    std::fs::write(
+        workspace_root.join(".grip/workspace_spec.toml"),
+        r#"
+schema_version = 1
+workspace_name = "demo"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://example.com/app.git"
+
+[[repos]]
+name = "api"
+path = "repos/api"
+url = "https://example.com/api.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app", "api"]
+"#,
+    )
+    .unwrap();
+
+    let mut create = Command::cargo_bin("gr2").unwrap();
+    create
+        .current_dir(&workspace_root)
+        .args([
+            "lane",
+            "create",
+            "feat-filter",
+            "--owner-unit",
+            "atlas",
+            "--repo",
+            "app",
+            "--repo",
+            "api",
+        ])
+        .assert()
+        .success();
+
+    let mut exec_status = Command::cargo_bin("gr2").unwrap();
+    exec_status
+        .current_dir(&workspace_root)
+        .args([
+            "exec",
+            "status",
+            "--lane",
+            "feat-filter",
+            "--owner-unit",
+            "atlas",
+            "--repo",
+            "api",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("api shared"))
+        .stdout(predicate::str::contains("repos/api"))
+        .stdout(predicate::str::contains("app").not());
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -3566,13 +3566,12 @@ repos = ["app", "api"]
         .stdout(predicate::str::contains("fail_fast: true"))
         .stdout(predicate::str::contains("- cargo test -p app"))
         .stdout(predicate::str::contains("app missing"))
-        .stdout(predicate::str::contains(
-            "agents/atlas/lanes/feat-auth/repos/app feat-auth 548 2",
-        ))
+        .stdout(predicate::str::contains("feat-auth"))
+        .stdout(predicate::str::contains("548 2"))
         .stdout(predicate::str::contains("api missing"))
-        .stdout(predicate::str::contains(
-            "agents/atlas/lanes/feat-auth/repos/api - - 2",
-        ));
+        .stdout(predicate::str::contains("repos"))
+        .stdout(predicate::str::contains("api"))
+        .stdout(predicate::str::contains(" - - 2"));
 }
 
 #[test]
@@ -3667,8 +3666,7 @@ repos = ["app", "api"]
         .assert()
         .success()
         .stdout(predicate::str::contains("api missing"))
-        .stdout(predicate::str::contains(
-            "agents/atlas/lanes/feat-filter/repos/api",
-        ))
+        .stdout(predicate::str::contains("feat-filter"))
+        .stdout(predicate::str::contains("repos"))
         .stdout(predicate::str::contains("app").not());
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -3566,9 +3566,13 @@ repos = ["app", "api"]
         .stdout(predicate::str::contains("fail_fast: true"))
         .stdout(predicate::str::contains("- cargo test -p app"))
         .stdout(predicate::str::contains("app missing"))
-        .stdout(predicate::str::contains("agents/atlas/lanes/feat-auth/repos/app feat-auth 548 2"))
+        .stdout(predicate::str::contains(
+            "agents/atlas/lanes/feat-auth/repos/app feat-auth 548 2",
+        ))
         .stdout(predicate::str::contains("api missing"))
-        .stdout(predicate::str::contains("agents/atlas/lanes/feat-auth/repos/api - - 2"));
+        .stdout(predicate::str::contains(
+            "agents/atlas/lanes/feat-auth/repos/api - - 2",
+        ));
 }
 
 #[test]
@@ -3663,6 +3667,8 @@ repos = ["app", "api"]
         .assert()
         .success()
         .stdout(predicate::str::contains("api missing"))
-        .stdout(predicate::str::contains("agents/atlas/lanes/feat-filter/repos/api"))
+        .stdout(predicate::str::contains(
+            "agents/atlas/lanes/feat-filter/repos/api",
+        ))
         .stdout(predicate::str::contains("app").not());
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -3565,10 +3565,10 @@ repos = ["app", "api"]
         .stdout(predicate::str::contains("parallel: false"))
         .stdout(predicate::str::contains("fail_fast: true"))
         .stdout(predicate::str::contains("- cargo test -p app"))
-        .stdout(predicate::str::contains("app shared"))
-        .stdout(predicate::str::contains("repos/app feat-auth 548 2"))
-        .stdout(predicate::str::contains("api shared"))
-        .stdout(predicate::str::contains("repos/api - - 2"));
+        .stdout(predicate::str::contains("app missing"))
+        .stdout(predicate::str::contains("agents/atlas/lanes/feat-auth/repos/app feat-auth 548 2"))
+        .stdout(predicate::str::contains("api missing"))
+        .stdout(predicate::str::contains("agents/atlas/lanes/feat-auth/repos/api - - 2"));
 }
 
 #[test]
@@ -3662,7 +3662,7 @@ repos = ["app", "api"]
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("api shared"))
-        .stdout(predicate::str::contains("repos/api"))
+        .stdout(predicate::str::contains("api missing"))
+        .stdout(predicate::str::contains("agents/atlas/lanes/feat-filter/repos/api"))
         .stdout(predicate::str::contains("app").not());
 }


### PR DESCRIPTION
## Summary
- add the first lane-aware gr2 exec surface with a read-only `exec status` command
- resolve execution scope from persisted lane metadata, including repo filtering, branch intent, PR association, and fail-fast/parallel defaults
- render the effective execution root per repo so users and agents can see what would run before we add mutation commands

Closes #544

## Testing
- cargo check -p gr2-cli --quiet
- cargo test --test cli_tests --quiet
