### PR TITLE
docs: prototype gr2 shared scratchpads

### DIFF
--- a/docs/ASSESS-gr2-shared-scratchpads-stress.md
+++ b/docs/ASSESS-gr2-shared-scratchpads-stress.md
@@ -1,0 +1,184 @@
+# gr2 Shared Scratchpads Stress Matrix
+
+## Purpose
+
+This is the break-case matrix for the shared scratchpad prototype.
+
+The prototype is not "verified" because the happy path worked once.
+It is only verified if it survives the scenarios most likely to fail in
+real human + agent workflows.
+
+This document is intentionally adversarial.
+
+## Stress Dimensions
+
+Every new `gr2` surface should be pressured along at least these dimensions:
+
+- concurrency
+- stale metadata
+- ambiguous ownership
+- partial cleanup
+- wrong-surface use
+- escalation path to PR / implementation lane
+- recovery after interruption
+- discoverability under pressure
+
+## Shared Scratchpad Scenarios
+
+### 1. Two users edit at once
+
+Scenario:
+- Atlas and Layne both use the same doc scratchpad
+- both update the same draft in close succession
+
+What can break:
+- participants are recorded, but the workflow gives no clue how to coordinate
+- a scratchpad quietly becomes a conflict zone
+
+What the prototype must answer:
+- does the metadata make shared ownership explicit?
+- is the scratchpad clearly marked as shared rather than private?
+- is there a legible next-step path when coordination is needed?
+
+### 2. Scratchpad goes stale
+
+Scenario:
+- a blog draft scratchpad is created
+- no one touches it for a week
+- a new worker sees it later
+
+What can break:
+- no one knows if it is still active
+- stale drafts clutter the workspace
+
+Required design pressure:
+- lifecycle state must be visible
+- the model needs a pause/done path
+- stale scratchpads must be distinguishable from active ones
+
+### 3. Scratchpad scope creep into implementation
+
+Scenario:
+- users start dropping code or repo-specific implementation into a doc-first scratchpad
+
+What can break:
+- the scratchpad becomes an unofficial shared coding area
+- private-lane boundaries erode
+
+Required design pressure:
+- doc-first scope must stay explicit
+- the system must make it obvious that this is not a private feature lane
+- there should be a clear escalation path into a real lane or PR
+
+### 4. Wrong tool chosen
+
+Scenario:
+- user should have used a review lane, but instead creates a scratchpad
+- or should have used a scratchpad, but opens a PR too early
+
+What can break:
+- the tool surface becomes confusing
+- users stop trusting the model
+
+Required design pressure:
+- next-step guidance should help distinguish:
+  - private lane
+  - review lane
+  - shared scratchpad
+  - PR
+
+### 5. Missing or wrong participants
+
+Scenario:
+- scratchpad is created without the right people listed
+- later a third worker joins
+
+What can break:
+- implied ownership diverges from recorded ownership
+- people edit without being visible in metadata
+
+Required design pressure:
+- participant list must be editable
+- participant visibility must be cheap
+- absence of participants should not imply private ownership
+
+### 6. Scratchpad linked to the wrong issue or no issue
+
+Scenario:
+- scratchpad is linked to the wrong issue
+- or there is no linked issue yet
+
+What can break:
+- scratchpad loses traceability
+- coordination falls back into chat memory
+
+Required design pressure:
+- refs should be optional but visible
+- it should be easy to add or fix refs later
+
+### 7. Scratchpad completed, but content needs to graduate
+
+Scenario:
+- draft blog post is approved
+- now it needs to become a proper repo artifact and PR
+
+What can break:
+- there is no obvious promotion path
+- content gets stranded in the shared scratchpad
+
+Required design pressure:
+- the model needs a clear handoff path:
+  - scratchpad -> repo file -> PR
+
+### 8. Partial cleanup
+
+Scenario:
+- scratchpad metadata is removed, but docs remain
+- or docs are removed, but metadata remains
+
+What can break:
+- orphaned shared state
+- misleading listings
+
+Required design pressure:
+- cleanup needs to be explicit and symmetric
+- the status surface must expose orphaned scratchpads
+
+### 9. Discoverability under time pressure
+
+Scenario:
+- user just wants to collaborate on a blog now
+- they should not have to reverse-engineer the whole workspace model
+
+What can break:
+- the feature is technically correct but too cognitively expensive
+
+Required design pressure:
+- one obvious create path
+- one obvious list path
+- one obvious "what now?" path
+
+### 10. Private-workspace safety regression
+
+Scenario:
+- users begin treating scratchpads as permission to work in each other's spaces again
+
+What can break:
+- the original safety model regresses
+
+Required design pressure:
+- shared scratchpads must be framed as workspace-owned collaboration surfaces
+- they must not blur into private lanes
+
+## Gate Before MVP
+
+Before `grip#553` should be considered ready to build or finalize, we should be
+able to answer these questions clearly:
+
+- how is a scratchpad different from a review lane?
+- how is a scratchpad different from a PR?
+- how is a scratchpad kept from turning into shared implementation sprawl?
+- how does a stale scratchpad become visible and cleanable?
+- how does content graduate from scratchpad to repo artifact?
+
+If those are still fuzzy, the prototype is not ready for MVP.

--- a/docs/MANIFESTO-gr2-ux.md
+++ b/docs/MANIFESTO-gr2-ux.md
@@ -1,0 +1,171 @@
+# gr2 UX Manifesto
+
+## Why `gr2` Exists
+
+Developers do not struggle because git is broken.
+
+They struggle because modern work is larger than one checkout:
+
+- one feature spans multiple repositories
+- one review interrupts another active task
+- one human works alongside multiple agents
+- one team needs both private work areas and lightweight shared collaboration
+
+`gr2` exists to make that multi-repo, multi-lane reality simpler, safer, and
+more legible.
+
+## Primary Thesis
+
+`gr2` is not a git replacement.
+
+`gr2` is a multi-repo workspace router.
+
+It should make it easy to:
+
+- start the right task context
+- see which repos and branches belong to that context
+- switch to another context without losing your place
+- review, collaborate, and execute work in the right scope
+
+Once the user is in the correct checkout, normal git should still feel normal.
+
+## User-First Principles
+
+### 1. The Primary Object Is The Task Context
+
+Users think:
+
+- "I am working on feature X"
+- "I need to review PR Y"
+- "I need a shared place to draft Z"
+
+They do not think:
+
+- "I need to manually coordinate three checkouts and remember which branch is
+  active in each one"
+
+So `gr2` must center:
+
+- feature lanes
+- review lanes
+- shared scratchpads
+
+Repos are part of the context. They are not the context.
+
+### 2. Private Work And Shared Work Must Stay Separate
+
+Users need both:
+
+- private implementation surfaces
+- shared collaboration surfaces
+
+Private lanes protect active work.
+Shared scratchpads make lightweight collaboration possible without violating
+private workspace boundaries or paying the full cost of a PR.
+
+The system must make that distinction explicit.
+
+### 3. Use `gr2` To Choose Context, Use Git To Work
+
+The intended user flow is:
+
+1. use `gr2` to enter the correct lane or review context
+2. use git normally inside the selected checkout
+3. return to `gr2` when changing task, scope, or execution surface
+
+If `gr2` tries to replace normal repo-local git, users will distrust it.
+If `gr2` does not simplify multi-repo context changes, users will route around
+it.
+
+### 4. The Tool Must Never Hide Important State
+
+Users should not have to guess:
+
+- which repos are in scope
+- which branches are intended
+- which paths are active
+- whether a command is structural or mutating
+- whether local work is at risk
+
+`gr2` should prefer explicit status over magical convenience.
+
+### 5. Safety Beats Cleverness
+
+`gr2 apply` must not silently:
+
+- pull
+- merge
+- rebase
+- switch branches
+- discard dirty work
+
+Users will trust `gr2` only if the safety boundary is simple and consistent:
+
+- structural convergence belongs to `apply`
+- repo maintenance belongs to explicit repo commands
+
+## Human UX Requirements
+
+A human should be able to:
+
+- keep feature A active while feature B waits in review
+- inspect PR C without disturbing either one
+- collaborate on a blog post or spec without editing another person's private
+  lane
+- tell, quickly, which repos matter for the current task
+- run the right build/test commands without reconstructing scope manually
+
+## Agent UX Requirements
+
+An agent should be able to:
+
+- discover the current task context quickly
+- consume stable machine-readable state
+- know which repos matter without guessing
+- avoid entering another worker's private directory
+- choose the right next command from explicit status surfaces
+
+This means structured output is not optional polish. It is first-class product
+surface.
+
+## Mixed Human + Agent Requirements
+
+The same model must work for:
+
+- a solo human
+- one agent
+- many agents
+- one human working alongside many agents
+
+That requires:
+
+- one shared vocabulary for lanes, review, and scratchpads
+- one shared status model
+- private lanes by default
+- shared collaboration surfaces when collaboration is the point
+
+## What Good Looks Like
+
+The user says:
+
+- "start feature auth across app and api"
+- "show me what this lane would run"
+- "open a review lane for PR 548"
+- "create a shared scratchpad for the sprint blog"
+- "switch back to my feature without losing my place"
+
+And the system responds with explicit, trustworthy state.
+
+That is the bar.
+
+## Product Test
+
+When choosing a `gr2` feature, ask:
+
+1. Does this make multi-repo context easier than ad hoc shell plus raw git?
+2. Does this preserve private work while allowing shared collaboration?
+3. Does this make the active task more legible?
+4. Does this reduce guessing for both humans and agents?
+5. Does this keep git normal once the user is in the correct checkout?
+
+If the answer is not clearly yes, the design should be revised.

--- a/docs/PLAN-gr2-shared-scratchpads.md
+++ b/docs/PLAN-gr2-shared-scratchpads.md
@@ -123,3 +123,18 @@ The prototype should answer:
 - does the metadata feel sufficient?
 - do users understand when to use a scratchpad instead of a PR or private lane?
 - does this preserve the private-workspace safety model?
+
+## Verification Gate
+
+This prototype is only considered verified if it survives the adversarial
+scenarios in:
+
+- `docs/ASSESS-gr2-shared-scratchpads-stress.md`
+
+That includes pressure around:
+
+- concurrency
+- stale state
+- wrong-surface use
+- lifecycle and cleanup
+- graduation from scratchpad to real repo artifact / PR

--- a/docs/PLAN-gr2-shared-scratchpads.md
+++ b/docs/PLAN-gr2-shared-scratchpads.md
@@ -1,0 +1,125 @@
+# gr2 Shared Scratchpads
+
+## Problem
+
+Private lanes are the right default for implementation work, but they leave a
+collaboration gap:
+
+- a PR is too heavy for early drafting
+- another worker's private directory is the wrong place for joint editing
+- ad hoc shared files have weak ownership and poor lifecycle
+
+The blog workflow is the clearest example. Multiple workers may need to draft,
+review, and refine shared content before anyone wants a formal PR.
+
+## User Need
+
+"I need a lightweight shared place to collaborate without crossing into someone
+else's private workspace and without paying the full cost of a PR."
+
+## Principle
+
+Shared scratchpads are a sibling to private lanes, not an exception to them.
+
+- private lanes stay private
+- shared scratchpads are explicit shared workspace objects
+- both should be cheap
+- both should be inspectable
+
+## First Slice
+
+The first slice should be doc-first.
+
+That keeps the initial surface focused on the actual pain:
+
+- blogs
+- RFCs
+- release notes
+- planning docs
+
+It avoids turning "shared scratchpad" into an excuse for ambiguous shared code
+ownership too early.
+
+## Proposed Model
+
+```text
+<workspace>/
+├── agents/
+│   └── <unit>/
+│       └── lanes/
+│           └── ...
+└── shared/
+    └── scratchpads/
+        └── <name>/
+            ├── scratchpad.toml
+            ├── docs/
+            ├── notes/
+            └── context/
+```
+
+## Scratchpad Metadata
+
+Each shared scratchpad should record:
+
+- name
+- kind
+- purpose
+- participants
+- linked issue / PR if any
+- lifecycle state
+- creation source
+- default paths
+
+Suggested kinds for the first pass:
+
+- `doc`
+- `review`
+- `planning`
+
+Suggested lifecycle states:
+
+- `draft`
+- `active`
+- `paused`
+- `done`
+
+## Rules
+
+Shared scratchpads should:
+
+- be workspace-owned
+- support multiple named participants
+- make purpose explicit
+- be easy to create and remove
+- stay separate from private implementation lanes
+
+Shared scratchpads should not:
+
+- replace private feature lanes
+- become the default place for multi-repo coding
+- weaken the "do not enter someone else's private directory" rule
+
+## UX Goals
+
+The user should be able to:
+
+1. create a shared scratchpad quickly
+2. see who it is for
+3. see what it is for
+4. know whether it is still active
+5. know what to do next
+
+That implies explicit read surfaces:
+
+- list scratchpads
+- show one scratchpad
+- suggest next step
+
+## Prototype Goal
+
+The prototype should answer:
+
+- does a doc-first shared scratchpad actually reduce coordination friction?
+- does the metadata feel sufficient?
+- do users understand when to use a scratchpad instead of a PR or private lane?
+- does this preserve the private-workspace safety model?

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -155,3 +155,31 @@ The MVP should not be finalized until the prototype has been evaluated against:
 - scope creep into shared implementation
 - cleanup and lifecycle handling
 - promotion from scratchpad to real repo artifact / PR
+
+## Real Git Verification
+
+Prototype confidence should not stop at metadata or tempdir-only happy paths.
+
+The next verification phase should use real GitHub repos in `synapt-dev`:
+
+- `synapt-dev/gr2-playground-app`
+- `synapt-dev/gr2-playground-api`
+- `synapt-dev/gr2-playground-web`
+
+These repos exist specifically to pressure the UX against actual git behavior:
+
+- cloning and default branches
+- multi-repo branch switching
+- review-lane isolation
+- dirty-work detection and recovery
+- shared scratchpad usage alongside private lanes
+
+That real-git verification phase is now tracked in:
+
+- `grip#523`
+- `grip#555`
+
+The design standard should be:
+
+- prototype behavior must survive both synthetic stress cases and real-repo
+  workflow checks before the MVP is treated as solid

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -138,3 +138,20 @@ That is why it includes:
 - `next-step`
 - `create-review-lane`
 - `create-shared-scratchpad`
+
+## Stress Testing
+
+This prototype is not considered verified on the happy path alone.
+
+The break-case matrix lives at:
+
+- `docs/ASSESS-gr2-shared-scratchpads-stress.md`
+
+The MVP should not be finalized until the prototype has been evaluated against:
+
+- concurrent shared editing
+- stale / abandoned scratchpads
+- wrong-surface selection
+- scope creep into shared implementation
+- cleanup and lifecycle handling
+- promotion from scratchpad to real repo artifact / PR

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -1,4 +1,4 @@
-# gr2 Repo Maintenance Prototype
+# gr2 Repo Maintenance + Collaboration Prototypes
 
 This prototype explores a split between:
 
@@ -80,6 +80,7 @@ without turning plain `gr2 apply` into an unsafe catch-all mutation command.
 - lane-local repo membership and branch map
 - shared + private context roots
 - lane-aware execution planning
+- shared scratchpads for lightweight collaboration
 
 Example:
 
@@ -91,10 +92,49 @@ python3 gr2/prototypes/lane_workspace_prototype.py plan-exec \
   /path/to/workspace atlas feat-auth 'cargo test'
 ```
 
-This prototype does not execute commands. It proves that lane metadata can
-become the durable source of truth for:
+Review lane example:
+
+```bash
+python3 gr2/prototypes/lane_workspace_prototype.py create-review-lane \
+  /path/to/workspace atlas grip 548
+```
+
+Shared scratchpad example:
+
+```bash
+python3 gr2/prototypes/lane_workspace_prototype.py create-shared-scratchpad \
+  /path/to/workspace blog-s17 \
+  --kind doc \
+  --purpose "Sprint 17 blog draft" \
+  --participant atlas \
+  --participant layne \
+  --ref grip#552
+
+python3 gr2/prototypes/lane_workspace_prototype.py list-shared-scratchpads \
+  /path/to/workspace
+```
+
+This prototype still does not execute commands. It proves that lane and
+scratchpad metadata can become the durable source of truth for:
 
 - which repos belong to a lane
 - which branch each repo should use
 - which context roots apply
 - where multi-repo commands should run
+- where lightweight collaboration should happen without violating private
+  workspaces
+
+## UX Focus
+
+This prototype is intentionally trying to answer user-facing questions:
+
+- how do I create a review lane quickly?
+- how do I know what I should do next in this lane?
+- when should I use a shared scratchpad instead of a PR or a private lane?
+
+That is why it includes:
+
+- `list-lanes`
+- `next-step`
+- `create-review-lane`
+- `create-shared-scratchpad`

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -183,3 +183,19 @@ The design standard should be:
 
 - prototype behavior must survive both synthetic stress cases and real-repo
   workflow checks before the MVP is treated as solid
+
+Bootstrap command:
+
+```bash
+python3 gr2/prototypes/real_git_playground.py /tmp/gr2-real-git-demo
+```
+
+That harness will:
+
+- initialize a fresh gr2 workspace
+- register the three private playground repos
+- write a real `WorkspaceSpec`
+- run `plan` and `apply`
+- create real local git branches in the cloned repos
+- create multiple lanes and one shared scratchpad
+- print repo, lane, exec, and scratchpad status surfaces

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-"""Prototype lane metadata and lane-aware execution planning for gr2.
+"""Prototype lane metadata, execution planning, and shared scratchpads for gr2.
 
-This prototype does not mutate git state. It proves the lane model is useful by
-persisting explicit lane metadata and generating execution plans scoped by lane.
+This prototype does not mutate git state. It explores three UX questions:
+
+1. are lane records legible enough to guide multi-repo work?
+2. can lightweight shared scratchpads fill the collaboration gap without
+   violating private-workspace rules?
+3. can the tool tell the user what to do next instead of forcing them to infer
+   the workflow?
 """
 
 from __future__ import annotations
@@ -17,6 +22,7 @@ from pathlib import Path
 
 
 LANE_SCHEMA_VERSION = 1
+SCRATCHPAD_SCHEMA_VERSION = 1
 
 
 @dataclasses.dataclass
@@ -48,32 +54,14 @@ class LaneMetadata:
         for repo, branch in sorted(self.branch_map.items()):
             lines.append(f'{repo} = "{branch}"')
 
-        lines.extend(
-            [
-                "",
-                "[context]",
-                "shared_roots = ["
-            ]
-        )
+        lines.extend(["", "[context]", "shared_roots = ["])
         for root in self.shared_context_roots:
             lines.append(f'  "{root}",')
-
-        lines.extend(
-            [
-                "]",
-                "private_roots = [",
-            ]
-        )
+        lines.extend(["]", "private_roots = ["])
         for root in self.private_context_roots:
             lines.append(f'  "{root}",')
 
-        lines.extend(
-            [
-                "]",
-                "",
-                "[exec_defaults]",
-            ]
-        )
+        lines.extend(["]", "", "[exec_defaults]"])
         for key, value in self.exec_defaults.items():
             if isinstance(value, bool):
                 encoded = str(value).lower()
@@ -85,16 +73,50 @@ class LaneMetadata:
                 encoded = f'"{value}"'
             lines.append(f"{key} = {encoded}")
 
-        if self.pr_associations:
-            lines.extend(["", "[[pr_associations]]"])
-            for assoc in self.pr_associations:
-                lines.append(f'ref = "{assoc}"')
+        for assoc in self.pr_associations:
+            lines.extend(["", "[[pr_associations]]", f'ref = "{assoc}"'])
 
         return "\n".join(lines) + "\n"
 
 
+@dataclasses.dataclass
+class SharedScratchpad:
+    schema_version: int
+    name: str
+    kind: str
+    purpose: str
+    participants: list[str]
+    linked_refs: list[str]
+    lifecycle: str
+    creation_source: str
+    docs_root: str
+    notes_root: str
+    context_root: str
+
+    def as_toml(self) -> str:
+        lines = [
+            f"schema_version = {self.schema_version}",
+            f'name = "{self.name}"',
+            f'kind = "{self.kind}"',
+            f'purpose = "{self.purpose}"',
+            f'lifecycle = "{self.lifecycle}"',
+            f'creation_source = "{self.creation_source}"',
+            "",
+            f'participants = [{", ".join(f"\"{p}\"" for p in self.participants)}]',
+            f'linked_refs = [{", ".join(f"\"{r}\"" for r in self.linked_refs)}]',
+            "",
+            "[paths]",
+            f'docs_root = "{self.docs_root}"',
+            f'notes_root = "{self.notes_root}"',
+            f'context_root = "{self.context_root}"',
+        ]
+        return "\n".join(lines) + "\n"
+
+
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Prototype gr2 lane metadata + exec planner")
+    parser = argparse.ArgumentParser(
+        description="Prototype gr2 lanes + shared scratchpads"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     create = sub.add_parser("create-lane")
@@ -103,13 +125,41 @@ def parse_args() -> argparse.Namespace:
     create.add_argument("lane_name")
     create.add_argument("--type", default="feature")
     create.add_argument("--repos", required=True, help="comma-separated repo names")
-    create.add_argument("--branch", required=True, help="default branch for included repos")
+    create.add_argument(
+        "--branch",
+        required=True,
+        help="default branch or repo=branch mappings separated by commas",
+    )
     create.add_argument("--source", default="manual")
+    create.add_argument(
+        "--command",
+        dest="default_commands",
+        action="append",
+        default=[],
+        help="default lane command",
+    )
+
+    review = sub.add_parser("create-review-lane")
+    review.add_argument("workspace_root", type=Path)
+    review.add_argument("owner_unit")
+    review.add_argument("repo")
+    review.add_argument("pr_number", type=int)
+    review.add_argument("--lane-name")
+    review.add_argument("--branch")
 
     show = sub.add_parser("show-lane")
     show.add_argument("workspace_root", type=Path)
     show.add_argument("owner_unit")
     show.add_argument("lane_name")
+
+    lane_list = sub.add_parser("list-lanes")
+    lane_list.add_argument("workspace_root", type=Path)
+    lane_list.add_argument("--owner-unit")
+
+    next_step = sub.add_parser("next-step")
+    next_step.add_argument("workspace_root", type=Path)
+    next_step.add_argument("owner_unit")
+    next_step.add_argument("lane_name")
 
     plan = sub.add_parser("plan-exec")
     plan.add_argument("workspace_root", type=Path)
@@ -118,6 +168,22 @@ def parse_args() -> argparse.Namespace:
     plan.add_argument("command_text")
     plan.add_argument("--repos", help="optional comma-separated repo subset")
     plan.add_argument("--json", action="store_true")
+
+    scratch = sub.add_parser("create-shared-scratchpad")
+    scratch.add_argument("workspace_root", type=Path)
+    scratch.add_argument("name")
+    scratch.add_argument("--kind", default="doc")
+    scratch.add_argument("--purpose", required=True)
+    scratch.add_argument("--participant", action="append", default=[])
+    scratch.add_argument("--ref", action="append", default=[])
+    scratch.add_argument("--source", default="manual")
+
+    scratch_show = sub.add_parser("show-shared-scratchpad")
+    scratch_show.add_argument("workspace_root", type=Path)
+    scratch_show.add_argument("name")
+
+    scratch_list = sub.add_parser("list-shared-scratchpads")
+    scratch_list.add_argument("workspace_root", type=Path)
 
     return parser.parse_args()
 
@@ -130,16 +196,89 @@ def lane_file(workspace_root: Path, owner_unit: str, lane_name: str) -> Path:
     return lane_dir(workspace_root, owner_unit, lane_name) / "lane.toml"
 
 
+def shared_scratchpad_dir(workspace_root: Path, name: str) -> Path:
+    return workspace_root / "shared" / "scratchpads" / name
+
+
+def shared_scratchpad_file(workspace_root: Path, name: str) -> Path:
+    return shared_scratchpad_dir(workspace_root, name) / "scratchpad.toml"
+
+
 def load_workspace_spec(workspace_root: Path) -> dict:
     with (workspace_root / ".grip" / "workspace_spec.toml").open("rb") as fh:
         return tomllib.load(fh)
+
+
+def load_lane_doc(workspace_root: Path, owner_unit: str, lane_name: str) -> dict:
+    path = lane_file(workspace_root, owner_unit, lane_name)
+    if not path.exists():
+        raise SystemExit(f"lane not found: {owner_unit}/{lane_name}")
+    return tomllib.loads(path.read_text())
+
+
+def load_shared_scratchpad_doc(workspace_root: Path, name: str) -> dict:
+    path = shared_scratchpad_file(workspace_root, name)
+    if not path.exists():
+        raise SystemExit(f"shared scratchpad not found: {name}")
+    return tomllib.loads(path.read_text())
+
+
+def iter_lane_files(workspace_root: Path, owner_unit: str | None = None) -> list[Path]:
+    agents_root = workspace_root / "agents"
+    if owner_unit:
+        lane_roots = [agents_root / owner_unit / "lanes"]
+    else:
+        lane_roots = [path / "lanes" for path in agents_root.iterdir() if path.is_dir()]
+
+    files: list[Path] = []
+    for root in lane_roots:
+        if not root.exists():
+            continue
+        files.extend(sorted(root.glob("*/lane.toml")))
+    return files
+
+
+def iter_shared_scratchpad_files(workspace_root: Path) -> list[Path]:
+    root = workspace_root / "shared" / "scratchpads"
+    if not root.exists():
+        return []
+    return sorted(root.glob("*/scratchpad.toml"))
+
+
+def parse_repo_list(raw: str) -> list[str]:
+    return [repo.strip() for repo in raw.split(",") if repo.strip()]
+
+
+def parse_branch_arg(raw: str, repos: list[str]) -> dict[str, str]:
+    if "=" not in raw:
+        return {repo: raw for repo in repos}
+
+    branch_map: dict[str, str] = {}
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        repo, branch = item.split("=", 1)
+        repo = repo.strip()
+        branch = branch.strip()
+        if repo not in repos:
+            raise SystemExit(f"branch mapping references repo outside lane: {repo}")
+        if not branch:
+            raise SystemExit(f"empty branch in mapping: {item}")
+        branch_map[repo] = branch
+
+    missing = [repo for repo in repos if repo not in branch_map]
+    if missing:
+        raise SystemExit("missing branch mapping for repos: " + ", ".join(missing))
+
+    return branch_map
 
 
 def create_lane(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     spec = load_workspace_spec(workspace_root)
     repo_names = [item["name"] for item in spec.get("repos", [])]
-    repos = [repo.strip() for repo in args.repos.split(",") if repo.strip()]
+    repos = parse_repo_list(args.repos)
 
     missing = [repo for repo in repos if repo not in repo_names]
     if missing:
@@ -156,7 +295,7 @@ def create_lane(args: argparse.Namespace) -> int:
         owner_unit=args.owner_unit,
         lane_type=args.type,
         repos=repos,
-        branch_map={repo: args.branch for repo in repos},
+        branch_map=parse_branch_arg(args.branch, repos),
         pr_associations=[],
         shared_context_roots=["config", ".grip/context/shared"],
         private_context_roots=[
@@ -167,6 +306,7 @@ def create_lane(args: argparse.Namespace) -> int:
             "parallelism": "workspace-default",
             "fail_fast": True,
             "default_command_family": ["build", "test"],
+            "commands": args.default_commands,
         },
         creation_source=args.source,
     )
@@ -175,20 +315,134 @@ def create_lane(args: argparse.Namespace) -> int:
     return 0
 
 
+def create_review_lane(args: argparse.Namespace) -> int:
+    lane_name = args.lane_name or f"review-{args.pr_number}"
+    branch = args.branch or f"pr/{args.pr_number}"
+    create_args = argparse.Namespace(
+        workspace_root=args.workspace_root,
+        owner_unit=args.owner_unit,
+        lane_name=lane_name,
+        type="review",
+        repos=args.repo,
+        branch=f"{args.repo}={branch}",
+        source="pull-request",
+        default_commands=[],
+    )
+    create_lane(create_args)
+    lane_path = lane_file(args.workspace_root.resolve(), args.owner_unit, lane_name)
+    content = lane_path.read_text().rstrip()
+    content += f'\n\n[[pr_associations]]\nref = "{args.repo}#{args.pr_number}"\n'
+    lane_path.write_text(content)
+    print(f"created review lane {args.owner_unit}/{lane_name} for {args.repo}#{args.pr_number}")
+    return 0
+
+
+def create_shared_scratchpad(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    root = shared_scratchpad_dir(workspace_root, args.name)
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "docs").mkdir(exist_ok=True)
+    (root / "notes").mkdir(exist_ok=True)
+    (root / "context").mkdir(exist_ok=True)
+
+    scratchpad = SharedScratchpad(
+        schema_version=SCRATCHPAD_SCHEMA_VERSION,
+        name=args.name,
+        kind=args.kind,
+        purpose=args.purpose,
+        participants=sorted(set(args.participant)),
+        linked_refs=args.ref,
+        lifecycle="draft",
+        creation_source=args.source,
+        docs_root=f"shared/scratchpads/{args.name}/docs",
+        notes_root=f"shared/scratchpads/{args.name}/notes",
+        context_root=f"shared/scratchpads/{args.name}/context",
+    )
+    shared_scratchpad_file(workspace_root, args.name).write_text(scratchpad.as_toml())
+    readme = root / "docs" / "README.md"
+    if not readme.exists():
+        readme.write_text(
+            f"# {args.name}\n\nPurpose: {args.purpose}\n\nParticipants: "
+            + (", ".join(scratchpad.participants) if scratchpad.participants else "unassigned")
+            + "\n"
+        )
+    print(shared_scratchpad_file(workspace_root, args.name))
+    return 0
+
+
+def list_lanes(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    print("OWNER\tLANE\tTYPE\tREPOS\tPRS")
+    for path in iter_lane_files(workspace_root, args.owner_unit):
+        doc = tomllib.loads(path.read_text())
+        refs = ",".join(item["ref"] for item in doc.get("pr_associations", [])) or "-"
+        print(
+            f'{doc["owner_unit"]}\t{doc["lane_name"]}\t{doc["lane_type"]}\t{len(doc.get("repos", []))}\t{refs}'
+        )
+    return 0
+
+
 def show_lane(args: argparse.Namespace) -> int:
     print(lane_file(args.workspace_root.resolve(), args.owner_unit, args.lane_name).read_text())
     return 0
 
 
+def show_shared_scratchpad(args: argparse.Namespace) -> int:
+    print(shared_scratchpad_file(args.workspace_root.resolve(), args.name).read_text())
+    return 0
+
+
+def list_shared_scratchpads(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    print("NAME\tKIND\tLIFECYCLE\tPARTICIPANTS\tPURPOSE")
+    for path in iter_shared_scratchpad_files(workspace_root):
+        doc = tomllib.loads(path.read_text())
+        participants = ",".join(doc.get("participants", [])) or "-"
+        print(
+            f'{doc["name"]}\t{doc["kind"]}\t{doc["lifecycle"]}\t{participants}\t{doc["purpose"]}'
+        )
+    return 0
+
+
+def next_step(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    print("gr2 prototype next-step")
+    print(f'lane: {args.owner_unit}/{lane_doc["lane_name"]}')
+    print(f'type: {lane_doc["lane_type"]}')
+    print(f'repos: {", ".join(lane_doc["repos"])}')
+    if lane_doc.get("pr_associations"):
+        print("mode: review")
+        print("recommended:")
+        print(
+            f"  python3 gr2/prototypes/lane_workspace_prototype.py plan-exec {workspace_root} {args.owner_unit} {args.lane_name} 'cargo test'"
+        )
+        print("  inspect the review lane, then return to your feature or home lane")
+    elif lane_doc["lane_type"] == "feature":
+        print("mode: feature")
+        print("recommended:")
+        print(
+            f"  python3 gr2/prototypes/lane_workspace_prototype.py plan-exec {workspace_root} {args.owner_unit} {args.lane_name} 'cargo test'"
+        )
+        print(
+            f"  python3 gr2/prototypes/lane_workspace_prototype.py list-shared-scratchpads {workspace_root}"
+        )
+    else:
+        print("mode: general")
+        print("recommended:")
+        print(
+            f"  python3 gr2/prototypes/lane_workspace_prototype.py show-lane {workspace_root} {args.owner_unit} {args.lane_name}"
+        )
+    return 0
+
+
 def plan_exec(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
-    lane_doc = tomllib.loads(
-        lane_file(workspace_root, args.owner_unit, args.lane_name).read_text()
-    )
+    lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
 
     selected_repos = lane_doc["repos"]
     if args.repos:
-        requested = [repo.strip() for repo in args.repos.split(",") if repo.strip()]
+        requested = parse_repo_list(args.repos)
         selected_repos = [repo for repo in selected_repos if repo in requested]
 
     command_argv = shlex.split(args.command_text)
@@ -200,7 +454,15 @@ def plan_exec(args: argparse.Namespace) -> int:
                 "owner_unit": lane_doc["owner_unit"],
                 "repo": repo,
                 "branch": lane_doc["branch_map"].get(repo),
-                "cwd": str(workspace_root / "agents" / args.owner_unit / "lanes" / args.lane_name / "repos" / repo),
+                "cwd": str(
+                    workspace_root
+                    / "agents"
+                    / args.owner_unit
+                    / "lanes"
+                    / args.lane_name
+                    / "repos"
+                    / repo
+                ),
                 "command": command_argv,
                 "shared_context_roots": lane_doc.get("context", {}).get("shared_roots", []),
                 "private_context_roots": lane_doc.get("context", {}).get("private_roots", []),
@@ -212,10 +474,13 @@ def plan_exec(args: argparse.Namespace) -> int:
         print(json.dumps(rows, indent=2))
     else:
         print("gr2 lane-exec prototype")
+        print(
+            f'owner={lane_doc["owner_unit"]} lane={lane_doc["lane_name"]} type={lane_doc["lane_type"]} fail_fast={lane_doc["exec_defaults"]["fail_fast"]}'
+        )
         print("LANE\tREPO\tBRANCH\tCWD\tCOMMAND")
         for row in rows:
             print(
-                f"{row['lane']}\t{row['repo']}\t{row['branch']}\t{row['cwd']}\t{' '.join(row['command'])}"
+                f'{row["lane"]}\t{row["repo"]}\t{row["branch"]}\t{row["cwd"]}\t{" ".join(row["command"])}'
             )
     return 0
 
@@ -224,10 +489,22 @@ def main() -> int:
     args = parse_args()
     if args.command == "create-lane":
         return create_lane(args)
+    if args.command == "create-review-lane":
+        return create_review_lane(args)
     if args.command == "show-lane":
         return show_lane(args)
+    if args.command == "list-lanes":
+        return list_lanes(args)
+    if args.command == "next-step":
+        return next_step(args)
     if args.command == "plan-exec":
         return plan_exec(args)
+    if args.command == "create-shared-scratchpad":
+        return create_shared_scratchpad(args)
+    if args.command == "show-shared-scratchpad":
+        return show_shared_scratchpad(args)
+    if args.command == "list-shared-scratchpads":
+        return list_shared_scratchpads(args)
     raise SystemExit(f"unknown command: {args.command}")
 
 

--- a/gr2/prototypes/real_git_playground.py
+++ b/gr2/prototypes/real_git_playground.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Bootstrap and verify a real-git gr2 playground workspace.
+
+This harness is intentionally pragmatic:
+
+- it uses actual GitHub repos in synapt-dev
+- it exercises the current shipped gr2 surfaces against real remotes
+- it combines current gr2 commands with prototype-only scratchpad commands
+
+The goal is not to pretend gr2 is further along than it is. The goal is to
+pressure the UX against real git state so we can iterate with data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PLAYGROUND_REPOS = {
+    "app": "git@github.com:synapt-dev/gr2-playground-app.git",
+    "api": "git@github.com:synapt-dev/gr2-playground-api.git",
+    "web": "git@github.com:synapt-dev/gr2-playground-web.git",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap a real-git gr2 playground workspace"
+    )
+    parser.add_argument("workspace_root", type=Path)
+    parser.add_argument("--owner-unit", default="atlas")
+    parser.add_argument("--workspace-name", default="gr2-real-git-playground")
+    parser.add_argument(
+        "--keep-existing",
+        action="store_true",
+        help="reuse an existing workspace root instead of failing",
+    )
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def gr2_binary(root: Path) -> Path:
+    binary = root / "target" / "debug" / "gr2"
+    if binary.exists():
+        return binary
+    run(["cargo", "build", "--quiet", "--bin", "gr2"], cwd=root)
+    return binary
+
+
+def lane_proto(root: Path) -> Path:
+    return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
+
+
+def run(
+    argv: list[str],
+    *,
+    cwd: Path | None = None,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    print("+", " ".join(argv))
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def gr2_supports_exec(gr2: Path) -> bool:
+    help_out = run([str(gr2), "--help"], capture=True)
+    return "\n  exec" in help_out.stdout
+
+
+def write_workspace_spec(workspace_root: Path, owner_unit: str, workspace_name: str) -> None:
+    spec = f"""schema_version = 1
+workspace_name = "{workspace_name}"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{PLAYGROUND_REPOS["app"]}"
+
+[[repos]]
+name = "api"
+path = "repos/api"
+url = "{PLAYGROUND_REPOS["api"]}"
+
+[[repos]]
+name = "web"
+path = "repos/web"
+url = "{PLAYGROUND_REPOS["web"]}"
+
+[[units]]
+name = "{owner_unit}"
+path = "agents/{owner_unit}"
+repos = ["app", "api", "web"]
+"""
+    spec_path = workspace_root / ".grip" / "workspace_spec.toml"
+    spec_path.write_text(spec)
+
+
+def ensure(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def unit_repo_path(workspace_root: Path, owner_unit: str, repo_name: str) -> Path:
+    return workspace_root / "agents" / owner_unit / repo_name
+
+
+def verify_paths(workspace_root: Path, owner_unit: str) -> None:
+    for rel in [
+        ".grip/workspace.toml",
+        ".grip/workspace_spec.toml",
+        f"agents/{owner_unit}/app/.git",
+        f"agents/{owner_unit}/api/.git",
+        f"agents/{owner_unit}/web/.git",
+        f".grip/state/lanes/{owner_unit}/feat-auth.toml",
+        f".grip/state/lanes/{owner_unit}/feat-web.toml",
+        f".grip/state/lanes/{owner_unit}/review-app-123.toml",
+        "shared/scratchpads/blog-draft/scratchpad.toml",
+    ]:
+        ensure((workspace_root / rel).exists(), f"expected path missing: {rel}")
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root()
+    workspace_root = args.workspace_root.resolve()
+
+    if workspace_root.exists() and not args.keep_existing:
+        if any(workspace_root.iterdir()):
+            raise SystemExit(
+                f"workspace root already exists and is not empty: {workspace_root} "
+                "(pass --keep-existing to reuse)"
+            )
+        workspace_root.rmdir()
+
+    gr2 = gr2_binary(root)
+    lane_script = lane_proto(root)
+    has_exec = gr2_supports_exec(gr2)
+
+    if not workspace_root.exists():
+        run(
+            [
+                str(gr2),
+                "init",
+                str(workspace_root),
+                "--name",
+                args.workspace_name,
+            ],
+            cwd=root,
+        )
+
+    run([str(gr2), "unit", "add", args.owner_unit], cwd=workspace_root)
+
+    for repo_name, repo_url in PLAYGROUND_REPOS.items():
+        run([str(gr2), "repo", "add", repo_name, repo_url], cwd=workspace_root)
+
+    write_workspace_spec(workspace_root, args.owner_unit, args.workspace_name)
+
+    run([str(gr2), "spec", "validate"], cwd=workspace_root)
+    run([str(gr2), "plan", "--yes"], cwd=workspace_root)
+    run([str(gr2), "apply", "--yes"], cwd=workspace_root)
+
+    run(["git", "-C", str(unit_repo_path(workspace_root, args.owner_unit, "app")), "checkout", "-b", "feat/auth"])
+    run(["git", "-C", str(unit_repo_path(workspace_root, args.owner_unit, "api")), "checkout", "-b", "feat/auth"])
+    run(["git", "-C", str(unit_repo_path(workspace_root, args.owner_unit, "web")), "checkout", "-b", "feat/web"])
+
+    app_readme = unit_repo_path(workspace_root, args.owner_unit, "app") / "README.md"
+    app_readme.write_text(app_readme.read_text() + "\nDirty playground change.\n")
+
+    repo_status = run(
+        [str(gr2), "repo", "status"],
+        cwd=workspace_root,
+        capture=True,
+    )
+    print(repo_status.stdout)
+
+    run(
+        [
+            str(gr2),
+            "lane",
+            "create",
+            "feat-auth",
+            "--owner-unit",
+            args.owner_unit,
+            "--repo",
+            "app",
+            "--repo",
+            "api",
+            "--branch",
+            "app=feat/auth",
+            "--branch",
+            "api=feat/auth",
+            "--exec",
+            "cargo test -p app",
+            "--exec",
+            "cargo test -p api",
+        ],
+        cwd=workspace_root,
+    )
+    run(
+        [
+            str(gr2),
+            "lane",
+            "create",
+            "feat-web",
+            "--owner-unit",
+            args.owner_unit,
+            "--repo",
+            "web",
+            "--branch",
+            "web=feat/web",
+            "--exec",
+            "npm test",
+        ],
+        cwd=workspace_root,
+    )
+    run(
+        [
+            str(gr2),
+            "lane",
+            "create",
+            "review-app-123",
+            "--owner-unit",
+            args.owner_unit,
+            "--type",
+            "review",
+            "--repo",
+            "app",
+            "--pr",
+            "app:123",
+            "--branch",
+            "app=review/pr-123",
+        ],
+        cwd=workspace_root,
+    )
+
+    lane_list = run(
+        [str(gr2), "lane", "list", "--owner-unit", args.owner_unit],
+        cwd=workspace_root,
+        capture=True,
+    )
+    print(lane_list.stdout)
+
+    if has_exec:
+        exec_status = run(
+            [
+                str(gr2),
+                "exec",
+                "status",
+                "--lane",
+                "feat-auth",
+                "--owner-unit",
+                args.owner_unit,
+            ],
+            cwd=workspace_root,
+            capture=True,
+        )
+        print(exec_status.stdout)
+    else:
+        print(
+            "note: this branch does not ship `gr2 exec status`; "
+            "real-git exec verification is deferred until the exec surface lands "
+            "on the same branch as the playground flow"
+        )
+
+    run(
+        [
+            sys.executable,
+            str(lane_script),
+            "create-shared-scratchpad",
+            str(workspace_root),
+            "blog-draft",
+            "--kind",
+            "doc",
+            "--purpose",
+            "Real-git shared drafting verification",
+            "--participant",
+            args.owner_unit,
+            "--participant",
+            "layne",
+            "--ref",
+            "grip#552",
+            "--ref",
+            "grip#555",
+        ],
+        cwd=root,
+    )
+    scratchpads = run(
+        [sys.executable, str(lane_script), "list-shared-scratchpads", str(workspace_root)],
+        cwd=root,
+        capture=True,
+    )
+    print(scratchpads.stdout)
+
+    verify_paths(workspace_root, args.owner_unit)
+
+    print("\nreal-git playground bootstrap complete")
+    print(f"workspace: {workspace_root}")
+    print("verified:")
+    print("- real remotes cloned into unit-local repo paths")
+    print("- dirty local git state can be observed")
+    print("- multiple lanes can coexist in metadata")
+    if has_exec:
+        print("- exec status stays lane-scoped")
+    else:
+        print("- exec verification is still pending branch convergence with the shipped exec surface")
+    print("- shared scratchpad can exist beside private lanes")
+    print("observation:")
+    print("- current apply converges unit-local checkouts under agents/<unit>/..., not repos/<repo>")
+    if not has_exec:
+        print("- current prototype and shipped lane metadata are not yet unified enough for one exec harness")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dedicated shared scratchpad design note
- extend the lane workspace prototype with shared scratchpads, review-lane helpers, list surfaces, and next-step guidance
- verify the doc-first collaboration workflow before freezing a production surface

Closes #552

## Verification
- python3 -m py_compile gr2/prototypes/lane_workspace_prototype.py
- disposable workspace walkthrough covering:
  - feature lane creation
  - review lane creation
  - shared scratchpad creation
  - lane listing
  - shared scratchpad listing
  - next-step guidance
  - shared scratchpad metadata inspection

## Outcome
The prototype supports the recommendation captured on #552:
- first production slice should be doc-first shared scratchpads
- shared scratchpads remain separate from private implementation lanes
