### PR TITLE
docs: stack shared scratchpad prototype on exec surface

### DIFF
--- a/docs/ASSESS-gr2-lanes-cross-mode-stress.md
+++ b/docs/ASSESS-gr2-lanes-cross-mode-stress.md
@@ -1,0 +1,30 @@
+# gr2 Lane Model Cross-Mode Stress Matrix
+
+This branch-local copy exists so the executable prototype work on `#556` has a
+nearby assessment target.
+
+The canonical docs version should live in the docs/rulebook lane, but the
+prototype branch needs the same adversarial model while the design and
+verification loop is still active.
+
+The prototype harness for this document is:
+
+- `gr2/prototypes/cross_mode_lane_stress.py`
+
+It currently pressures four scenarios:
+
+1. two agents create lanes that touch the same repo
+2. human edits in a lane while an agent plans exec in the same lane
+3. agent is interrupted mid-task and must recover lane context
+4. solo human has three feature lanes, switches to review, then forgets which
+   lane they were in before
+
+The current expected outcomes are mixed by design:
+
+- same-repo multi-agent lane creation should hold
+- mixed same-lane human/agent execution should fail until occupancy or lease
+  semantics exist
+- interruption recovery should only partially hold until current/recent lane
+  surfaces exist
+- solo-human lane recovery should only partially hold until return-to-previous
+  flow exists

--- a/docs/ASSESS-gr2-lanes-cross-mode-stress.md
+++ b/docs/ASSESS-gr2-lanes-cross-mode-stress.md
@@ -28,3 +28,27 @@ The current expected outcomes are mixed by design:
   surfaces exist
 - solo-human lane recovery should only partially hold until return-to-previous
   flow exists
+
+## Concurrent Lease Stress Result
+
+The concurrent lease harness lives at:
+
+- `gr2/prototypes/concurrent_lease_stress.py`
+
+Current before/after result over 50 rounds:
+
+- before locking
+  - `corruption_count = 0`
+  - `both_succeeded_count = 23`
+  - `unexpected_lease_count = 0`
+- after locking
+  - `corruption_count = 0`
+  - `both_succeeded_count = 0`
+  - `unexpected_lease_count = 0`
+
+Important interpretation:
+
+- the pre-locking failure mode was semantic race, not invalid JSON
+- atomic replace kept the file parseable
+- transaction-level locking was still required because conflicting edit leases
+  could both succeed without it

--- a/docs/ASSESS-gr2-shared-scratchpads-stress.md
+++ b/docs/ASSESS-gr2-shared-scratchpads-stress.md
@@ -182,3 +182,10 @@ able to answer these questions clearly:
 - how does content graduate from scratchpad to repo artifact?
 
 If those are still fuzzy, the prototype is not ready for MVP.
+
+The prototype should also expose explicit operator surfaces for those cases:
+
+- a recommendation surface when the user is choosing between feature lane,
+  review lane, shared scratchpad, and PR
+- an audit surface for stale, orphaned, or weakly tracked scratchpads
+- a promotion surface that makes the handoff to repo artifact and PR explicit

--- a/docs/ASSESS-gr2-shared-scratchpads-stress.md
+++ b/docs/ASSESS-gr2-shared-scratchpads-stress.md
@@ -1,0 +1,184 @@
+# gr2 Shared Scratchpads Stress Matrix
+
+## Purpose
+
+This is the break-case matrix for the shared scratchpad prototype.
+
+The prototype is not "verified" because the happy path worked once.
+It is only verified if it survives the scenarios most likely to fail in
+real human + agent workflows.
+
+This document is intentionally adversarial.
+
+## Stress Dimensions
+
+Every new `gr2` surface should be pressured along at least these dimensions:
+
+- concurrency
+- stale metadata
+- ambiguous ownership
+- partial cleanup
+- wrong-surface use
+- escalation path to PR / implementation lane
+- recovery after interruption
+- discoverability under pressure
+
+## Shared Scratchpad Scenarios
+
+### 1. Two users edit at once
+
+Scenario:
+- Atlas and Layne both use the same doc scratchpad
+- both update the same draft in close succession
+
+What can break:
+- participants are recorded, but the workflow gives no clue how to coordinate
+- a scratchpad quietly becomes a conflict zone
+
+What the prototype must answer:
+- does the metadata make shared ownership explicit?
+- is the scratchpad clearly marked as shared rather than private?
+- is there a legible next-step path when coordination is needed?
+
+### 2. Scratchpad goes stale
+
+Scenario:
+- a blog draft scratchpad is created
+- no one touches it for a week
+- a new worker sees it later
+
+What can break:
+- no one knows if it is still active
+- stale drafts clutter the workspace
+
+Required design pressure:
+- lifecycle state must be visible
+- the model needs a pause/done path
+- stale scratchpads must be distinguishable from active ones
+
+### 3. Scratchpad scope creep into implementation
+
+Scenario:
+- users start dropping code or repo-specific implementation into a doc-first scratchpad
+
+What can break:
+- the scratchpad becomes an unofficial shared coding area
+- private-lane boundaries erode
+
+Required design pressure:
+- doc-first scope must stay explicit
+- the system must make it obvious that this is not a private feature lane
+- there should be a clear escalation path into a real lane or PR
+
+### 4. Wrong tool chosen
+
+Scenario:
+- user should have used a review lane, but instead creates a scratchpad
+- or should have used a scratchpad, but opens a PR too early
+
+What can break:
+- the tool surface becomes confusing
+- users stop trusting the model
+
+Required design pressure:
+- next-step guidance should help distinguish:
+  - private lane
+  - review lane
+  - shared scratchpad
+  - PR
+
+### 5. Missing or wrong participants
+
+Scenario:
+- scratchpad is created without the right people listed
+- later a third worker joins
+
+What can break:
+- implied ownership diverges from recorded ownership
+- people edit without being visible in metadata
+
+Required design pressure:
+- participant list must be editable
+- participant visibility must be cheap
+- absence of participants should not imply private ownership
+
+### 6. Scratchpad linked to the wrong issue or no issue
+
+Scenario:
+- scratchpad is linked to the wrong issue
+- or there is no linked issue yet
+
+What can break:
+- scratchpad loses traceability
+- coordination falls back into chat memory
+
+Required design pressure:
+- refs should be optional but visible
+- it should be easy to add or fix refs later
+
+### 7. Scratchpad completed, but content needs to graduate
+
+Scenario:
+- draft blog post is approved
+- now it needs to become a proper repo artifact and PR
+
+What can break:
+- there is no obvious promotion path
+- content gets stranded in the shared scratchpad
+
+Required design pressure:
+- the model needs a clear handoff path:
+  - scratchpad -> repo file -> PR
+
+### 8. Partial cleanup
+
+Scenario:
+- scratchpad metadata is removed, but docs remain
+- or docs are removed, but metadata remains
+
+What can break:
+- orphaned shared state
+- misleading listings
+
+Required design pressure:
+- cleanup needs to be explicit and symmetric
+- the status surface must expose orphaned scratchpads
+
+### 9. Discoverability under time pressure
+
+Scenario:
+- user just wants to collaborate on a blog now
+- they should not have to reverse-engineer the whole workspace model
+
+What can break:
+- the feature is technically correct but too cognitively expensive
+
+Required design pressure:
+- one obvious create path
+- one obvious list path
+- one obvious "what now?" path
+
+### 10. Private-workspace safety regression
+
+Scenario:
+- users begin treating scratchpads as permission to work in each other's spaces again
+
+What can break:
+- the original safety model regresses
+
+Required design pressure:
+- shared scratchpads must be framed as workspace-owned collaboration surfaces
+- they must not blur into private lanes
+
+## Gate Before MVP
+
+Before `grip#553` should be considered ready to build or finalize, we should be
+able to answer these questions clearly:
+
+- how is a scratchpad different from a review lane?
+- how is a scratchpad different from a PR?
+- how is a scratchpad kept from turning into shared implementation sprawl?
+- how does a stale scratchpad become visible and cleanable?
+- how does content graduate from scratchpad to repo artifact?
+
+If those are still fuzzy, the prototype is not ready for MVP.

--- a/docs/MANIFESTO-gr2-ux.md
+++ b/docs/MANIFESTO-gr2-ux.md
@@ -52,6 +52,9 @@ So `gr2` must center:
 
 Repos are part of the context. They are not the context.
 
+Shared repo caches may exist underneath `gr2`, but they are implementation
+substrate, not the user-facing place where work is expected to happen.
+
 ### 2. Private Work And Shared Work Must Stay Separate
 
 Users need both:
@@ -76,6 +79,14 @@ The intended user flow is:
 If `gr2` tries to replace normal repo-local git, users will distrust it.
 If `gr2` does not simplify multi-repo context changes, users will route around
 it.
+
+### 3a. Optimization Must Stay Behind The UX
+
+If `gr2 apply` uses shared local repo caches, mirrors, or `git clone
+--reference-if-able`, that should improve speed and disk use without changing
+the user mental model.
+
+Users should not need to understand cache topology to work effectively.
 
 ### 4. The Tool Must Never Hide Important State
 
@@ -115,6 +126,13 @@ A human should be able to:
 - tell, quickly, which repos matter for the current task
 - run the right build/test commands without reconstructing scope manually
 
+The human should not need to care whether a working checkout was materialized
+from:
+
+- a shared local mirror
+- a reference clone
+- a direct remote clone
+
 ## Agent UX Requirements
 
 An agent should be able to:
@@ -124,6 +142,9 @@ An agent should be able to:
 - know which repos matter without guessing
 - avoid entering another worker's private directory
 - choose the right next command from explicit status surfaces
+
+The agent should be able to trust that optimization layers are invisible unless
+they matter for diagnosis or repair.
 
 This means structured output is not optional polish. It is first-class product
 surface.
@@ -143,6 +164,8 @@ That requires:
 - one shared status model
 - private lanes by default
 - shared collaboration surfaces when collaboration is the point
+- cache/materialization optimization that speeds up everyone without becoming a
+  new conceptual burden
 
 ## What Good Looks Like
 

--- a/docs/MANIFESTO-gr2-ux.md
+++ b/docs/MANIFESTO-gr2-ux.md
@@ -20,6 +20,12 @@ more legible.
 
 `gr2` is a multi-repo workspace router.
 
+And for Synapt, it is more than that:
+
+- `gr2` is the workspace infrastructure layer
+- Synapt org shape should compile into `gr2`
+- channels, recall, and agent lanes should feel native to the workspace
+
 It should make it easy to:
 
 - start the right task context
@@ -167,6 +173,28 @@ That requires:
 - cache/materialization optimization that speeds up everyone without becoming a
   new conceptual burden
 
+## Synapt-Native Integration Requirements
+
+`gr2` should work with Synapt out of the box.
+
+That means:
+
+- a Synapt-backed workspace should not treat channels, recall, or agent identity
+  as optional afterthoughts
+- a premium org/control-plane should compile into `WorkspaceSpec` and lane
+  policy rather than bypassing the workspace model
+- the local workspace should materialize the result of org, team, agent, and
+  access policy decisions without leaking premium-only control-plane semantics
+  into the wrong layer
+
+The user should be able to think:
+
+- "init the workspace"
+- "enter the right lane"
+- "use channels and recall in that workspace"
+
+without first assembling plugin wiring manually.
+
 ## What Good Looks Like
 
 The user says:
@@ -190,5 +218,15 @@ When choosing a `gr2` feature, ask:
 3. Does this make the active task more legible?
 4. Does this reduce guessing for both humans and agents?
 5. Does this keep git normal once the user is in the correct checkout?
+6. Does this improve the Synapt workspace model instead of working around it?
 
 If the answer is not clearly yes, the design should be revised.
+
+The four user modes are not just examples. They are the product test:
+
+- solo human
+- single agent
+- multi-agent
+- mixed human + agent
+
+If a surface works for only one of them, it is not finished.

--- a/docs/MANIFESTO-gr2-ux.md
+++ b/docs/MANIFESTO-gr2-ux.md
@@ -1,0 +1,171 @@
+# gr2 UX Manifesto
+
+## Why `gr2` Exists
+
+Developers do not struggle because git is broken.
+
+They struggle because modern work is larger than one checkout:
+
+- one feature spans multiple repositories
+- one review interrupts another active task
+- one human works alongside multiple agents
+- one team needs both private work areas and lightweight shared collaboration
+
+`gr2` exists to make that multi-repo, multi-lane reality simpler, safer, and
+more legible.
+
+## Primary Thesis
+
+`gr2` is not a git replacement.
+
+`gr2` is a multi-repo workspace router.
+
+It should make it easy to:
+
+- start the right task context
+- see which repos and branches belong to that context
+- switch to another context without losing your place
+- review, collaborate, and execute work in the right scope
+
+Once the user is in the correct checkout, normal git should still feel normal.
+
+## User-First Principles
+
+### 1. The Primary Object Is The Task Context
+
+Users think:
+
+- "I am working on feature X"
+- "I need to review PR Y"
+- "I need a shared place to draft Z"
+
+They do not think:
+
+- "I need to manually coordinate three checkouts and remember which branch is
+  active in each one"
+
+So `gr2` must center:
+
+- feature lanes
+- review lanes
+- shared scratchpads
+
+Repos are part of the context. They are not the context.
+
+### 2. Private Work And Shared Work Must Stay Separate
+
+Users need both:
+
+- private implementation surfaces
+- shared collaboration surfaces
+
+Private lanes protect active work.
+Shared scratchpads make lightweight collaboration possible without violating
+private workspace boundaries or paying the full cost of a PR.
+
+The system must make that distinction explicit.
+
+### 3. Use `gr2` To Choose Context, Use Git To Work
+
+The intended user flow is:
+
+1. use `gr2` to enter the correct lane or review context
+2. use git normally inside the selected checkout
+3. return to `gr2` when changing task, scope, or execution surface
+
+If `gr2` tries to replace normal repo-local git, users will distrust it.
+If `gr2` does not simplify multi-repo context changes, users will route around
+it.
+
+### 4. The Tool Must Never Hide Important State
+
+Users should not have to guess:
+
+- which repos are in scope
+- which branches are intended
+- which paths are active
+- whether a command is structural or mutating
+- whether local work is at risk
+
+`gr2` should prefer explicit status over magical convenience.
+
+### 5. Safety Beats Cleverness
+
+`gr2 apply` must not silently:
+
+- pull
+- merge
+- rebase
+- switch branches
+- discard dirty work
+
+Users will trust `gr2` only if the safety boundary is simple and consistent:
+
+- structural convergence belongs to `apply`
+- repo maintenance belongs to explicit repo commands
+
+## Human UX Requirements
+
+A human should be able to:
+
+- keep feature A active while feature B waits in review
+- inspect PR C without disturbing either one
+- collaborate on a blog post or spec without editing another person's private
+  lane
+- tell, quickly, which repos matter for the current task
+- run the right build/test commands without reconstructing scope manually
+
+## Agent UX Requirements
+
+An agent should be able to:
+
+- discover the current task context quickly
+- consume stable machine-readable state
+- know which repos matter without guessing
+- avoid entering another worker's private directory
+- choose the right next command from explicit status surfaces
+
+This means structured output is not optional polish. It is first-class product
+surface.
+
+## Mixed Human + Agent Requirements
+
+The same model must work for:
+
+- a solo human
+- one agent
+- many agents
+- one human working alongside many agents
+
+That requires:
+
+- one shared vocabulary for lanes, review, and scratchpads
+- one shared status model
+- private lanes by default
+- shared collaboration surfaces when collaboration is the point
+
+## What Good Looks Like
+
+The user says:
+
+- "start feature auth across app and api"
+- "show me what this lane would run"
+- "open a review lane for PR 548"
+- "create a shared scratchpad for the sprint blog"
+- "switch back to my feature without losing my place"
+
+And the system responds with explicit, trustworthy state.
+
+That is the bar.
+
+## Product Test
+
+When choosing a `gr2` feature, ask:
+
+1. Does this make multi-repo context easier than ad hoc shell plus raw git?
+2. Does this preserve private work while allowing shared collaboration?
+3. Does this make the active task more legible?
+4. Does this reduce guessing for both humans and agents?
+5. Does this keep git normal once the user is in the correct checkout?
+
+If the answer is not clearly yes, the design should be revised.

--- a/docs/PLAN-gr2-needs-and-criteria.md
+++ b/docs/PLAN-gr2-needs-and-criteria.md
@@ -12,6 +12,9 @@ workspace that must work for:
 It is not a feature wishlist. It is the rulebook for what the workspace must
 be able to do without unsafe workarounds.
 
+For Synapt, `gr2` is the workspace infrastructure layer, not just a helper
+around multi-repo git state.
+
 ## Primary Design Principle
 
 The workspace unit is not a single repo checkout.
@@ -43,6 +46,23 @@ opposite reasons:
 - if `gr2` does too little, users will ignore it and fall back to ad hoc shell
 
 So the system must make this split legible.
+
+## Synapt Infrastructure Principle
+
+`gr2` should be the local workspace substrate that Synapt compiles into.
+
+That means:
+
+- premium org shape compiles into `WorkspaceSpec` and lane policy
+- local workspaces materialize teams, agents, repo scope, and context surfaces
+- channels, recall, and agent lanes should feel native to the workspace model
+
+This is still compatible with the local-first split:
+
+- premium owns org identity, policy, entitlements, and coordination semantics
+- `gr2` owns local workspace materialization and lane execution surfaces
+
+But the user experience should feel integrated rather than patched together.
 
 ### `gr2` Must Own
 
@@ -115,6 +135,20 @@ The team needs to:
 The team should benefit from shared clone acceleration, but the optimization
 must not weaken private-workspace boundaries or turn `repos/<repo>` into a
 confusing second place where work might be happening.
+
+### Mixed Human + Agent
+
+The mixed mode is a primary operating mode, not a special case.
+
+The workspace needs to let a human and an agent collaborate without either of
+them needing to enter the other's private lane just to get work done.
+
+That requires:
+
+- private implementation lanes
+- shared scratchpads for lightweight collaboration
+- isolated review lanes
+- status surfaces that work for both humans and machines
 
 ## Hard Requirements
 

--- a/docs/PLAN-gr2-needs-and-criteria.md
+++ b/docs/PLAN-gr2-needs-and-criteria.md
@@ -82,6 +82,10 @@ The user needs to:
 - run build/test/verify for the active multi-repo lane
 - know when to use raw git versus `gr2` without second-guessing
 
+The solo human should not need to understand or manage a shared repo cache.
+If clone acceleration exists, it should feel like faster materialization, not a
+second workspace concept.
+
 ### Single Agent
 
 The agent needs to:
@@ -93,6 +97,10 @@ The agent needs to:
 - avoid clobbering unrelated work
 - prefer the workspace primitives over ad hoc raw git when the task is multi-repo
 
+The agent should receive explicit status about active working checkouts, not be
+forced to reason about cache internals unless a clone/materialization problem
+actually occurs.
+
 ### Multi-Agent Team
 
 The team needs to:
@@ -103,6 +111,10 @@ The team needs to:
 - coordinate across linked PRs and sprint lanes
 - switch between tasks without contaminating each other's state
 - avoid entering each other's private directories just to collaborate
+
+The team should benefit from shared clone acceleration, but the optimization
+must not weaken private-workspace boundaries or turn `repos/<repo>` into a
+confusing second place where work might be happening.
 
 ## Hard Requirements
 
@@ -160,6 +172,8 @@ That implies:
 - disposable review lanes
 
 If lane creation is slow or expensive, users will bypass the model.
+
+The cache is an implementation detail. The UX object remains the lane.
 
 ### 4. Shared and Private Context
 
@@ -246,6 +260,9 @@ Agents and humans need trustworthy read surfaces.
 - execution status
 - PR linkage
 
+Cache or transport state should only surface when it affects the user's ability
+to materialize or repair a lane.
+
 These should be machine-readable as well as human-readable.
 
 ### 9a. Structured Output Must Be First-Class
@@ -258,6 +275,29 @@ Agents routinely need:
 - stable object shapes
 - deterministic exit codes
 - explicit next-step hints
+
+### 10. Materialization Optimization Must Not Become A Second UX Model
+
+`gr2 apply` may use shared local mirrors or reference clones as its materialization
+substrate.
+
+That is desirable for:
+
+- speed
+- disk reuse
+- cheap review lanes
+- adoptability on large workspaces
+
+But the optimization must not become a user-facing mental model.
+
+Required rule:
+
+- users work in unit-local or lane-local checkouts
+- `.grip/cache/repos/` is infrastructure
+- status surfaces should describe active working checkouts first
+
+If the design makes users reason about shared cache topology during normal work,
+the UX has failed.
 - explicit scope metadata
 
 So every status-style surface should support structured output as a first-class

--- a/docs/PLAN-gr2-repo-maintenance-and-lanes.md
+++ b/docs/PLAN-gr2-repo-maintenance-and-lanes.md
@@ -174,6 +174,11 @@ It should not silently:
 - rebase local work
 - switch active branches unexpectedly
 
+Materialization may use a shared cache or local mirror under `.grip/cache/repos`
+to accelerate clone/setup.
+
+That is an implementation strategy, not a separate workspace surface.
+
 ### 3. Repo Maintenance
 
 Repo maintenance should be an explicit surface above structural apply:
@@ -270,19 +275,39 @@ The workspace should have three layers:
 
 ### Shared Cache
 
-`.grip/cache/repos/` stores reusable repo sources.
+`.grip/cache/repos/` stores reusable repo sources or mirrors.
 
 This is the acceleration layer:
 
-- clone once
+- fetch once
 - materialize many
 - cheap temporary sandboxes
+- reference-clone substrate for `apply`
 
-### Shared Repos
+The likely implementation path is:
 
-`repos/` is for shared baseline or stable workspace-level repos.
+- maintain a shared local mirror/cache under `.grip/cache/repos/`
+- materialize unit/lane working clones from that cache with
+  `git clone --reference-if-able` or equivalent
 
-These are not where active feature work should live by default.
+This should improve adoptability on large workspaces without introducing a new
+user-facing concept.
+
+### `repos/` Is Not The Primary Working Surface
+
+The real-git prototype currently shows that active work materializes under
+`agents/<unit>/...`, not under `repos/<repo>`.
+
+That should be treated as the primary UX model unless the implementation
+changes substantially.
+
+So:
+
+- `repos/` should not be presented as where users normally work
+- shared repo state belongs in cache/infrastructure unless a concrete UX need
+  emerges
+- unit-local and lane-local checkouts are the places users and agents actually
+  operate
 
 ### Unit Home
 
@@ -306,6 +331,11 @@ A lane contains:
 
 This is the multi-repo equivalent of a worktree, but not tied to git's
 single-repo worktree mechanism.
+
+For UX purposes, the important distinction is:
+
+- cache and reference clones exist to make lanes cheap
+- lanes are still the thing the user thinks in
 
 ## Context Model
 

--- a/docs/PLAN-gr2-shared-scratchpads.md
+++ b/docs/PLAN-gr2-shared-scratchpads.md
@@ -123,3 +123,18 @@ The prototype should answer:
 - does the metadata feel sufficient?
 - do users understand when to use a scratchpad instead of a PR or private lane?
 - does this preserve the private-workspace safety model?
+
+## Verification Gate
+
+This prototype is only considered verified if it survives the adversarial
+scenarios in:
+
+- `docs/ASSESS-gr2-shared-scratchpads-stress.md`
+
+That includes pressure around:
+
+- concurrency
+- stale state
+- wrong-surface use
+- lifecycle and cleanup
+- graduation from scratchpad to real repo artifact / PR

--- a/docs/PLAN-gr2-shared-scratchpads.md
+++ b/docs/PLAN-gr2-shared-scratchpads.md
@@ -1,0 +1,125 @@
+# gr2 Shared Scratchpads
+
+## Problem
+
+Private lanes are the right default for implementation work, but they leave a
+collaboration gap:
+
+- a PR is too heavy for early drafting
+- another worker's private directory is the wrong place for joint editing
+- ad hoc shared files have weak ownership and poor lifecycle
+
+The blog workflow is the clearest example. Multiple workers may need to draft,
+review, and refine shared content before anyone wants a formal PR.
+
+## User Need
+
+"I need a lightweight shared place to collaborate without crossing into someone
+else's private workspace and without paying the full cost of a PR."
+
+## Principle
+
+Shared scratchpads are a sibling to private lanes, not an exception to them.
+
+- private lanes stay private
+- shared scratchpads are explicit shared workspace objects
+- both should be cheap
+- both should be inspectable
+
+## First Slice
+
+The first slice should be doc-first.
+
+That keeps the initial surface focused on the actual pain:
+
+- blogs
+- RFCs
+- release notes
+- planning docs
+
+It avoids turning "shared scratchpad" into an excuse for ambiguous shared code
+ownership too early.
+
+## Proposed Model
+
+```text
+<workspace>/
+├── agents/
+│   └── <unit>/
+│       └── lanes/
+│           └── ...
+└── shared/
+    └── scratchpads/
+        └── <name>/
+            ├── scratchpad.toml
+            ├── docs/
+            ├── notes/
+            └── context/
+```
+
+## Scratchpad Metadata
+
+Each shared scratchpad should record:
+
+- name
+- kind
+- purpose
+- participants
+- linked issue / PR if any
+- lifecycle state
+- creation source
+- default paths
+
+Suggested kinds for the first pass:
+
+- `doc`
+- `review`
+- `planning`
+
+Suggested lifecycle states:
+
+- `draft`
+- `active`
+- `paused`
+- `done`
+
+## Rules
+
+Shared scratchpads should:
+
+- be workspace-owned
+- support multiple named participants
+- make purpose explicit
+- be easy to create and remove
+- stay separate from private implementation lanes
+
+Shared scratchpads should not:
+
+- replace private feature lanes
+- become the default place for multi-repo coding
+- weaken the "do not enter someone else's private directory" rule
+
+## UX Goals
+
+The user should be able to:
+
+1. create a shared scratchpad quickly
+2. see who it is for
+3. see what it is for
+4. know whether it is still active
+5. know what to do next
+
+That implies explicit read surfaces:
+
+- list scratchpads
+- show one scratchpad
+- suggest next step
+
+## Prototype Goal
+
+The prototype should answer:
+
+- does a doc-first shared scratchpad actually reduce coordination friction?
+- does the metadata feel sufficient?
+- do users understand when to use a scratchpad instead of a PR or private lane?
+- does this preserve the private-workspace safety model?

--- a/docs/PLAN-gr2-shared-scratchpads.md
+++ b/docs/PLAN-gr2-shared-scratchpads.md
@@ -113,6 +113,8 @@ That implies explicit read surfaces:
 
 - list scratchpads
 - show one scratchpad
+- audit stale or orphaned scratchpads
+- plan promotion into a repo artifact
 - suggest next step
 
 ## Prototype Goal
@@ -123,6 +125,11 @@ The prototype should answer:
 - does the metadata feel sufficient?
 - do users understand when to use a scratchpad instead of a PR or private lane?
 - does this preserve the private-workspace safety model?
+- can the tool help the user choose between scratchpad, review lane, feature lane,
+  and PR without guesswork?
+- can the tool surface stale or weakly tracked scratchpads before they become
+  clutter or coordination debt?
+- can the tool show a clear graduation path from scratchpad to repo artifact?
 
 ## Verification Gate
 

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -258,3 +258,23 @@ This reports, per repo:
 The real-git playground harness now runs this probe before `gr2 apply` so
 transport/auth problems are surfaced as an explicit status surface instead of a
 late clone failure buried inside apply output.
+
+## Layout Model Probe
+
+The real-git playground also needs to answer a harder product question:
+
+- does the observed layout actually match the mental model we are designing?
+
+The prototype now includes:
+
+```bash
+python3 gr2/prototypes/layout_model_probe.py /path/to/workspace --owner-unit atlas
+```
+
+This compares the observed workspace against two candidate models:
+
+- shared-repo-first
+- unit-local-first
+
+It is intentionally blunt. If the workspace behaves like one model while the
+docs imply another, the prototype should say so directly.

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -273,6 +273,25 @@ This harness:
 - makes independent commits in each checkout
 - verifies the checkouts do not interfere
 
+## Concurrent Lease Stress
+
+To verify that lease writes survive contention, run:
+
+```bash
+python3 gr2/prototypes/concurrent_lease_stress.py
+```
+
+This harness runs two phases in one command:
+
+- before locking: `GR2_DISABLE_LEASE_LOCKING=1`
+- after locking: default locking enabled
+
+It reports:
+
+- JSON corruption count
+- rounds where both conflicting edit acquisitions succeeded
+- rounds where the final lease count was wrong
+
 Bootstrap command:
 
 ```bash

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -237,3 +237,24 @@ These are intentionally user-first:
 
 This keeps the prototype from overfitting to happy-path metadata creation while
 ignoring the actual decisions users struggle with.
+
+## Transport/Auth Preflight
+
+Real multi-repo bootstrap fails early if transport or auth is wrong, so the
+prototype now includes a dedicated preflight surface:
+
+```bash
+python3 gr2/prototypes/repo_transport_probe.py \
+  /path/to/workspace/.grip/workspace_spec.toml
+```
+
+This reports, per repo:
+
+- transport type
+- whether the remote looks reachable
+- whether auth is failing
+- the next recommended action
+
+The real-git playground harness now runs this probe before `gr2 apply` so
+transport/auth problems are surfaced as an explicit status surface instead of a
+late clone failure buried inside apply output.

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -155,3 +155,31 @@ The MVP should not be finalized until the prototype has been evaluated against:
 - scope creep into shared implementation
 - cleanup and lifecycle handling
 - promotion from scratchpad to real repo artifact / PR
+
+## Real Git Verification
+
+Prototype confidence should not stop at metadata or tempdir-only happy paths.
+
+The next verification phase should use real GitHub repos in `synapt-dev`:
+
+- `synapt-dev/gr2-playground-app`
+- `synapt-dev/gr2-playground-api`
+- `synapt-dev/gr2-playground-web`
+
+These repos exist specifically to pressure the UX against actual git behavior:
+
+- cloning and default branches
+- multi-repo branch switching
+- review-lane isolation
+- dirty-work detection and recovery
+- shared scratchpad usage alongside private lanes
+
+That real-git verification phase is now tracked in:
+
+- `grip#523`
+- `grip#555`
+
+The design standard should be:
+
+- prototype behavior must survive both synthetic stress cases and real-repo
+  workflow checks before the MVP is treated as solid

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -255,6 +255,24 @@ This is still prototype scope, but it tests the right product direction:
 lane transitions and lease changes should be observable workspace events rather
 than invisible local state.
 
+## Real-Git Same-Repo Multi-Agent Materialization
+
+To verify that unit-local-first is real and not only metadata, run:
+
+```bash
+python3 gr2/prototypes/real_git_lane_materialization.py
+```
+
+This harness:
+
+- creates a local bare remote
+- writes a workspace spec that points at it
+- creates two lanes for two different units that both touch the same repo
+- verifies `plan-exec` produces distinct cwd paths
+- clones into those lane cwd paths
+- makes independent commits in each checkout
+- verifies the checkouts do not interfere
+
 Bootstrap command:
 
 ```bash

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -190,6 +190,13 @@ Bootstrap command:
 python3 gr2/prototypes/real_git_playground.py /tmp/gr2-real-git-demo
 ```
 
+If the local environment cannot reach GitHub over SSH, use:
+
+```bash
+python3 gr2/prototypes/real_git_playground.py /tmp/gr2-real-git-demo \
+  --transport https
+```
+
 That harness will:
 
 - initialize a fresh gr2 workspace
@@ -199,3 +206,34 @@ That harness will:
 - create real local git branches in the cloned repos
 - create multiple lanes and one shared scratchpad
 - print repo, lane, exec, and scratchpad status surfaces
+
+## New UX-Focused Prototype Surfaces
+
+The prototype now includes explicit user-guidance commands for the cases that
+usually break first in real workflows:
+
+```bash
+python3 gr2/prototypes/lane_workspace_prototype.py recommend-surface \
+  --kind doc --collaborative --shared-draft
+
+python3 gr2/prototypes/lane_workspace_prototype.py audit-shared-scratchpads \
+  /path/to/workspace --stale-days 3
+
+python3 gr2/prototypes/lane_workspace_prototype.py plan-promote-scratchpad \
+  /path/to/workspace blog-s17 \
+  --target-repo app \
+  --target-path docs/blog/sprint-17.md \
+  --owner-unit atlas
+```
+
+These are intentionally user-first:
+
+- `recommend-surface`
+  - answers "should this be a feature lane, review lane, or shared scratchpad?"
+- `audit-shared-scratchpads`
+  - exposes stale, orphaned, or weakly tracked scratchpads
+- `plan-promote-scratchpad`
+  - makes the graduation path from shared draft to repo artifact explicit
+
+This keeps the prototype from overfitting to happy-path metadata creation while
+ignoring the actual decisions users struggle with.

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -138,3 +138,20 @@ That is why it includes:
 - `next-step`
 - `create-review-lane`
 - `create-shared-scratchpad`
+
+## Stress Testing
+
+This prototype is not considered verified on the happy path alone.
+
+The break-case matrix lives at:
+
+- `docs/ASSESS-gr2-shared-scratchpads-stress.md`
+
+The MVP should not be finalized until the prototype has been evaluated against:
+
+- concurrent shared editing
+- stale / abandoned scratchpads
+- wrong-surface selection
+- scope creep into shared implementation
+- cleanup and lifecycle handling
+- promotion from scratchpad to real repo artifact / PR

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -1,4 +1,4 @@
-# gr2 Repo Maintenance Prototype
+# gr2 Repo Maintenance + Collaboration Prototypes
 
 This prototype explores a split between:
 
@@ -80,6 +80,7 @@ without turning plain `gr2 apply` into an unsafe catch-all mutation command.
 - lane-local repo membership and branch map
 - shared + private context roots
 - lane-aware execution planning
+- shared scratchpads for lightweight collaboration
 
 Example:
 
@@ -91,10 +92,49 @@ python3 gr2/prototypes/lane_workspace_prototype.py plan-exec \
   /path/to/workspace atlas feat-auth 'cargo test'
 ```
 
-This prototype does not execute commands. It proves that lane metadata can
-become the durable source of truth for:
+Review lane example:
+
+```bash
+python3 gr2/prototypes/lane_workspace_prototype.py create-review-lane \
+  /path/to/workspace atlas grip 548
+```
+
+Shared scratchpad example:
+
+```bash
+python3 gr2/prototypes/lane_workspace_prototype.py create-shared-scratchpad \
+  /path/to/workspace blog-s17 \
+  --kind doc \
+  --purpose "Sprint 17 blog draft" \
+  --participant atlas \
+  --participant layne \
+  --ref grip#552
+
+python3 gr2/prototypes/lane_workspace_prototype.py list-shared-scratchpads \
+  /path/to/workspace
+```
+
+This prototype still does not execute commands. It proves that lane and
+scratchpad metadata can become the durable source of truth for:
 
 - which repos belong to a lane
 - which branch each repo should use
 - which context roots apply
 - where multi-repo commands should run
+- where lightweight collaboration should happen without violating private
+  workspaces
+
+## UX Focus
+
+This prototype is intentionally trying to answer user-facing questions:
+
+- how do I create a review lane quickly?
+- how do I know what I should do next in this lane?
+- when should I use a shared scratchpad instead of a PR or a private lane?
+
+That is why it includes:
+
+- `list-lanes`
+- `next-step`
+- `create-review-lane`
+- `create-shared-scratchpad`

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -225,6 +225,16 @@ Those are still prototype surfaces, but they let us test whether the lane
 model can survive interruption and mixed human/agent use rather than only
 describe those needs abstractly.
 
+Lease behavior is now explicit in the prototype:
+
+- leases have `ttl_seconds`
+- stale leases are detectable
+- `acquire-lane-lease --force` can break stale conflicting leases
+- the conflict matrix is deliberate:
+  - `edit` conflicts with `edit`, `exec`, and `review`
+  - `exec` conflicts with `edit` and `review`, but not `exec`
+  - `review` is exclusive
+
 Bootstrap command:
 
 ```bash

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -184,6 +184,47 @@ The design standard should be:
 - prototype behavior must survive both synthetic stress cases and real-repo
   workflow checks before the MVP is treated as solid
 
+## Cross-Mode Lane Stress
+
+The lane model also needs adversarial verification across the four primary
+operating modes:
+
+- solo human
+- single agent
+- multi-agent
+- mixed human + agent
+
+Run:
+
+```bash
+python3 gr2/prototypes/cross_mode_lane_stress.py
+```
+
+This harness does not just show happy-path lane creation. It reports where the
+current model:
+
+- holds
+- partially holds
+- still fails
+
+across interruption recovery, same-repo parallelism, mixed-mode conflicts, and
+lane-recovery ambiguity.
+
+The current prototype adds two explicit recovery/safety concepts to support
+that stress loop:
+
+- lane session state
+  - `enter-lane`
+  - `current-lane`
+- lane leases
+  - `acquire-lane-lease`
+  - `release-lane-lease`
+  - `show-lane-leases`
+
+Those are still prototype surfaces, but they let us test whether the lane
+model can survive interruption and mixed human/agent use rather than only
+describe those needs abstractly.
+
 Bootstrap command:
 
 ```bash

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -183,3 +183,19 @@ The design standard should be:
 
 - prototype behavior must survive both synthetic stress cases and real-repo
   workflow checks before the MVP is treated as solid
+
+Bootstrap command:
+
+```bash
+python3 gr2/prototypes/real_git_playground.py /tmp/gr2-real-git-demo
+```
+
+That harness will:
+
+- initialize a fresh gr2 workspace
+- register the three private playground repos
+- write a real `WorkspaceSpec`
+- run `plan` and `apply`
+- create real local git branches in the cloned repos
+- create multiple lanes and one shared scratchpad
+- print repo, lane, exec, and scratchpad status surfaces

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -278,3 +278,28 @@ This compares the observed workspace against two candidate models:
 
 It is intentionally blunt. If the workspace behaves like one model while the
 docs imply another, the prototype should say so directly.
+
+## Cache Materialization Probe
+
+The next question is whether shared cache as apply substrate is actually worth
+it in practice.
+
+The prototype now includes:
+
+```bash
+python3 gr2/prototypes/cache_materialization_probe.py --transport ssh
+```
+
+This measures, per playground repo:
+
+- direct remote clone time
+- one-time mirror seed time
+- cache-backed working clone time using `git clone --reference-if-able`
+- whether the resulting working clone actually uses alternates
+
+This keeps the cache discussion grounded in evidence:
+
+- lanes remain the UX
+- cache remains the optimization
+- the prototype should tell us whether the optimization is material enough to
+  justify building it into `apply`

--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -233,7 +233,27 @@ Lease behavior is now explicit in the prototype:
 - the conflict matrix is deliberate:
   - `edit` conflicts with `edit`, `exec`, and `review`
   - `exec` conflicts with `edit` and `review`, but not `exec`
-  - `review` is exclusive
+- `review` is exclusive
+
+## Synapt Integration Prototype
+
+The lane prototype now includes a minimal Synapt-native event layer:
+
+- `enter-lane --notify-channel --recall`
+- `exit-lane --notify-channel --recall`
+- append-only event log at `.grip/events/lane_events.jsonl`
+- recall-compatible log at `.grip/events/recall_lane_history.jsonl`
+- `lane-history` to reconstruct a unit's lane timeline
+
+Unit `agent_id` can now flow from `WorkspaceSpec` into:
+
+- lane metadata
+- current-lane state
+- emitted lane events
+
+This is still prototype scope, but it tests the right product direction:
+lane transitions and lease changes should be observable workspace events rather
+than invisible local state.
 
 Bootstrap command:
 

--- a/gr2/prototypes/cache_materialization_probe.py
+++ b/gr2/prototypes/cache_materialization_probe.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Prototype cache-backed materialization for gr2 working clones.
+
+This is not a final implementation. It exists to answer a narrower question:
+
+- if `apply` seeds working clones from a local mirror/reference cache, does that
+  materially improve materialization speed while keeping the user-facing model
+  unchanged?
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+PLAYGROUND_REPOS = {
+    "app": {
+        "ssh": "git@github.com:synapt-dev/gr2-playground-app.git",
+        "https": "https://github.com/synapt-dev/gr2-playground-app.git",
+    },
+    "api": {
+        "ssh": "git@github.com:synapt-dev/gr2-playground-api.git",
+        "https": "https://github.com/synapt-dev/gr2-playground-api.git",
+    },
+    "web": {
+        "ssh": "git@github.com:synapt-dev/gr2-playground-web.git",
+        "https": "https://github.com/synapt-dev/gr2-playground-web.git",
+    },
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Measure direct clone vs cache-backed clone materialization"
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["ssh", "https"],
+        default="ssh",
+        help="remote transport to test",
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        dest="repos",
+        help="repo(s) to test; defaults to all playground repos",
+    )
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        help="optional persistent temp root; defaults to a temporary directory",
+    )
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def repo_url(repo_name: str, transport: str) -> str:
+    return PLAYGROUND_REPOS[repo_name][transport]
+
+
+def git_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env.setdefault(
+        "GIT_SSH_COMMAND",
+        "ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new",
+    )
+    return env
+
+
+def run(argv: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=True,
+        env=git_env(),
+    )
+
+
+def timed_clone(argv: list[str], *, cwd: Path | None = None) -> tuple[float, subprocess.CompletedProcess[str]]:
+    start = time.perf_counter()
+    result = run(argv, cwd=cwd)
+    elapsed = time.perf_counter() - start
+    return (elapsed, result)
+
+
+def verify_working_clone(path: Path) -> dict[str, object]:
+    head = run(["git", "-C", str(path), "rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+    status = run(["git", "-C", str(path), "status", "--short"]).stdout.strip()
+    alternates = path / ".git" / "objects" / "info" / "alternates"
+    return {
+        "head": head,
+        "clean": status == "",
+        "uses_alternates": alternates.exists(),
+        "alternates_path": str(alternates) if alternates.exists() else None,
+    }
+
+
+def probe_repo(root: Path, repo_name: str, transport: str) -> dict[str, object]:
+    url = repo_url(repo_name, transport)
+    repo_root = root / repo_name
+    direct_root = repo_root / "direct"
+    cached_root = repo_root / "cached"
+    cache_root = repo_root / "cache"
+    direct_root.mkdir(parents=True, exist_ok=True)
+    cached_root.mkdir(parents=True, exist_ok=True)
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    direct_target = direct_root / repo_name
+    cache_mirror = cache_root / f"{repo_name}.git"
+    cached_target = cached_root / repo_name
+
+    direct_seconds, _ = timed_clone(["git", "clone", url, str(direct_target)])
+    mirror_seconds, _ = timed_clone(["git", "clone", "--mirror", url, str(cache_mirror)])
+    cached_seconds, _ = timed_clone(
+        [
+            "git",
+            "clone",
+            "--reference-if-able",
+            str(cache_mirror),
+            url,
+            str(cached_target),
+        ]
+    )
+
+    direct_info = verify_working_clone(direct_target)
+    cached_info = verify_working_clone(cached_target)
+
+    return {
+        "repo": repo_name,
+        "transport": transport,
+        "direct_clone_seconds": round(direct_seconds, 3),
+        "mirror_seed_seconds": round(mirror_seconds, 3),
+        "cached_clone_seconds": round(cached_seconds, 3),
+        "delta_seconds": round(direct_seconds - cached_seconds, 3),
+        "direct_clone": direct_info,
+        "cached_clone": cached_info,
+        "mirror_path": str(cache_mirror),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    repos = args.repos or list(PLAYGROUND_REPOS.keys())
+    unknown = [repo for repo in repos if repo not in PLAYGROUND_REPOS]
+    if unknown:
+        raise SystemExit("unknown repos: " + ", ".join(unknown))
+
+    if args.workspace_root:
+        root = args.workspace_root.resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        cleanup = False
+    else:
+        root = Path(tempfile.mkdtemp(prefix="gr2-cache-probe."))
+        cleanup = True
+
+    try:
+        rows = [probe_repo(root, repo, args.transport) for repo in repos]
+        if args.json:
+            print(json.dumps({"root": str(root), "results": rows}, indent=2))
+        else:
+            print(f"root: {root}")
+            print("REPO\tTRANSPORT\tDIRECT_S\tMIRROR_S\tCACHED_S\tDELTA_S\tALTERNATES")
+            for row in rows:
+                print(
+                    f"{row['repo']}\t{row['transport']}\t{row['direct_clone_seconds']}\t"
+                    f"{row['mirror_seed_seconds']}\t{row['cached_clone_seconds']}\t"
+                    f"{row['delta_seconds']}\t{str(row['cached_clone']['uses_alternates']).lower()}"
+                )
+            print("notes:")
+            print("- direct clone is a normal working clone from remote")
+            print("- mirror seed is the one-time cache population cost")
+            print("- cached clone is a working clone using --reference-if-able from the local mirror")
+        return 0
+    finally:
+        if cleanup:
+            shutil.rmtree(root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gr2/prototypes/concurrent_lease_stress.py
+++ b/gr2/prototypes/concurrent_lease_stress.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Concurrent lease stress harness with before/after locking results."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run concurrent lease stress before and after file locking"
+    )
+    parser.add_argument("--rounds", type=int, default=50)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def lane_proto(root: Path) -> Path:
+    return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
+
+
+def run(argv: list[str], *, env: dict | None = None, check: bool = True, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, check=check, text=True, capture_output=capture, env=env)
+
+
+def init_workspace(workspace_root: Path) -> None:
+    (workspace_root / ".grip").mkdir(parents=True, exist_ok=True)
+    (workspace_root / "agents").mkdir(exist_ok=True)
+    spec = """schema_version = 1
+workspace_name = "concurrent-lease-stress"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://example.invalid/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+agent_id = "atlas-agent"
+repos = ["app"]
+"""
+    (workspace_root / ".grip" / "workspace_spec.toml").write_text(spec)
+
+
+def create_lane(root: Path, workspace_root: Path) -> None:
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "create-lane",
+            str(workspace_root),
+            "atlas",
+            "feat-race",
+            "--repos",
+            "app",
+            "--branch",
+            "feat/race",
+        ],
+        capture=True,
+    )
+
+
+def worker(workspace_root: str, actor: str, queue, disable_locking: bool) -> None:
+    root = repo_root()
+    env = os.environ.copy()
+    if disable_locking:
+        env["GR2_DISABLE_LEASE_LOCKING"] = "1"
+        env["GR2_LEASE_TEST_DELAY"] = "0.02"
+    proc = run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "acquire-lane-lease",
+            workspace_root,
+            "atlas",
+            "feat-race",
+            "--actor",
+            actor,
+            "--mode",
+            "edit",
+            "--ttl-seconds",
+            "900",
+        ],
+        env=env,
+        check=False,
+        capture=True,
+    )
+    queue.put(
+        {
+            "actor": actor,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+        }
+    )
+
+
+def read_leases(workspace_root: Path) -> tuple[bool, list[dict] | None]:
+    path = workspace_root / "agents" / "atlas" / "lanes" / "feat-race" / "leases.json"
+    if not path.exists():
+        return True, []
+    try:
+        return True, json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return False, None
+
+
+def release_all(root: Path, workspace_root: Path, disable_locking: bool) -> None:
+    env = os.environ.copy()
+    if disable_locking:
+        env["GR2_DISABLE_LEASE_LOCKING"] = "1"
+    for actor in ("worker:a", "worker:b"):
+        run(
+            [
+                "python3",
+                str(lane_proto(root)),
+                "release-lane-lease",
+                str(workspace_root),
+                "atlas",
+                "feat-race",
+                "--actor",
+                actor,
+            ],
+            env=env,
+            check=False,
+            capture=True,
+        )
+
+
+def run_phase(disable_locking: bool, rounds: int) -> dict:
+    root = repo_root()
+    with tempfile.TemporaryDirectory(prefix="gr2-concurrent-lease-") as tmp:
+        workspace_root = Path(tmp)
+        init_workspace(workspace_root)
+        create_lane(root, workspace_root)
+
+        corruption_count = 0
+        both_succeeded_count = 0
+        unexpected_lease_count = 0
+
+        for _ in range(rounds):
+            queue = multiprocessing.Queue()
+            p1 = multiprocessing.Process(
+                target=worker,
+                args=(str(workspace_root), "worker:a", queue, disable_locking),
+            )
+            p2 = multiprocessing.Process(
+                target=worker,
+                args=(str(workspace_root), "worker:b", queue, disable_locking),
+            )
+            p1.start()
+            p2.start()
+            p1.join()
+            p2.join()
+
+            results = [queue.get(), queue.get()]
+            success_count = sum(1 for item in results if item["returncode"] == 0)
+            if success_count == 2:
+                both_succeeded_count += 1
+
+            valid_json, leases = read_leases(workspace_root)
+            if not valid_json:
+                corruption_count += 1
+            else:
+                expected = 1 if success_count >= 1 else 0
+                if len(leases or []) != expected:
+                    unexpected_lease_count += 1
+
+            release_all(root, workspace_root, disable_locking)
+
+        return {
+            "locking": "disabled" if disable_locking else "enabled",
+            "rounds": rounds,
+            "corruption_count": corruption_count,
+            "both_succeeded_count": both_succeeded_count,
+            "unexpected_lease_count": unexpected_lease_count,
+        }
+
+
+def main() -> int:
+    args = parse_args()
+    before = run_phase(disable_locking=True, rounds=args.rounds)
+    after = run_phase(disable_locking=False, rounds=args.rounds)
+    payload = {"before_locking": before, "after_locking": after}
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print("gr2 concurrent lease stress")
+        print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/cross_mode_lane_stress.py
+++ b/gr2/prototypes/cross_mode_lane_stress.py
@@ -160,6 +160,45 @@ def plan_exec_json(root: Path, workspace_root: Path, owner_unit: str, lane_name:
     return json.loads(proc.stdout)
 
 
+def acquire_lease(root: Path, workspace_root: Path, owner_unit: str, lane_name: str, actor: str, mode: str, ttl_seconds: int = 900, force: bool = False, expect_ok: bool = True) -> subprocess.CompletedProcess[str]:
+    argv = [
+        "python3",
+        str(lane_proto(root)),
+        "acquire-lane-lease",
+        str(workspace_root),
+        owner_unit,
+        lane_name,
+        "--actor",
+        actor,
+        "--mode",
+        mode,
+        "--ttl-seconds",
+        str(ttl_seconds),
+    ]
+    if force:
+        argv.append("--force")
+    proc = subprocess.run(argv, check=False, text=True, capture_output=True)
+    if expect_ok and proc.returncode != 0:
+        raise SystemExit(f"lease acquisition failed unexpectedly: {' '.join(argv)}\n{proc.stdout}\n{proc.stderr}")
+    return proc
+
+
+def show_leases_json(root: Path, workspace_root: Path, owner_unit: str, lane_name: str) -> list[dict]:
+    proc = run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "show-lane-leases",
+            str(workspace_root),
+            owner_unit,
+            lane_name,
+            "--json",
+        ],
+        capture=True,
+    )
+    return json.loads(proc.stdout)
+
+
 def list_lanes_text(root: Path, workspace_root: Path, owner_unit: str | None = None) -> str:
     argv = [
         "python3",
@@ -213,20 +252,7 @@ def scenario_multi_agent_same_repo(root: Path, workspace_root: Path) -> Scenario
 
 def scenario_mixed_same_lane_exec(root: Path, workspace_root: Path) -> ScenarioResult:
     create_lane(root, workspace_root, "layne", "feat-blog", "app", "feat/blog")
-    run(
-        [
-            "python3",
-            str(lane_proto(root)),
-            "acquire-lane-lease",
-            str(workspace_root),
-            "layne",
-            "feat-blog",
-            "--actor",
-            "human:layne",
-            "--mode",
-            "edit",
-        ]
-    )
+    acquire_lease(root, workspace_root, "layne", "feat-blog", "human:layne", "edit")
 
     exec_rows = plan_exec_json(root, workspace_root, "layne", "feat-blog", "cargo test")
 
@@ -328,6 +354,120 @@ def scenario_single_agent_interrupt_recovery(root: Path, workspace_root: Path) -
     )
 
 
+def scenario_lease_conflict_matrix(root: Path, workspace_root: Path) -> ScenarioResult:
+    create_lane(root, workspace_root, "atlas", "feat-matrix", "app", "feat/matrix")
+
+    exec_one = acquire_lease(root, workspace_root, "atlas", "feat-matrix", "agent:atlas", "exec")
+    exec_two = acquire_lease(root, workspace_root, "atlas", "feat-matrix", "agent:apollo", "exec")
+    edit_conflict = acquire_lease(
+        root,
+        workspace_root,
+        "atlas",
+        "feat-matrix",
+        "human:layne",
+        "edit",
+        expect_ok=False,
+    )
+
+    create_lane(root, workspace_root, "atlas", "feat-review-lock", "app", "feat/review-lock")
+    acquire_lease(root, workspace_root, "atlas", "feat-review-lock", "agent:atlas", "review")
+    review_conflict = acquire_lease(
+        root,
+        workspace_root,
+        "atlas",
+        "feat-review-lock",
+        "agent:apollo",
+        "exec",
+        expect_ok=False,
+    )
+
+    holds = []
+    gaps = []
+    evidence = []
+
+    if exec_one.returncode == 0 and exec_two.returncode == 0:
+        holds.append("exec-vs-exec is allowed for the same lane")
+        evidence.append("two exec leases acquired successfully on atlas/feat-matrix")
+    else:
+        gaps.append("exec-vs-exec was blocked unexpectedly")
+
+    if edit_conflict.returncode != 0:
+        holds.append("edit-vs-exec conflicts as expected")
+        evidence.append(edit_conflict.stdout.strip())
+    else:
+        gaps.append("edit-vs-exec did not conflict")
+
+    if review_conflict.returncode != 0:
+        holds.append("review-vs-anything is exclusive")
+        evidence.append(review_conflict.stdout.strip())
+    else:
+        gaps.append("review-vs-exec did not conflict")
+
+    leases = show_leases_json(root, workspace_root, "atlas", "feat-matrix")
+    evidence.append(json.dumps(leases, indent=2))
+    verdict = "holds" if not gaps else "fails"
+    return ScenarioResult(
+        scenario_id="lease-conflict-matrix",
+        user_mode="cross-mode",
+        title="lease conflict matrix enforces edit/exec/review semantics",
+        verdict=verdict,
+        holds=holds,
+        gaps=gaps,
+        evidence=evidence,
+    )
+
+
+def scenario_stale_lease_force_break(root: Path, workspace_root: Path) -> ScenarioResult:
+    create_lane(root, workspace_root, "atlas", "feat-stale", "app", "feat/stale")
+    stale = acquire_lease(
+        root,
+        workspace_root,
+        "atlas",
+        "feat-stale",
+        "human:layne",
+        "edit",
+        ttl_seconds=0,
+    )
+    blocked_exec = plan_exec_json(root, workspace_root, "atlas", "feat-stale", "cargo test")
+    forced = acquire_lease(
+        root,
+        workspace_root,
+        "atlas",
+        "feat-stale",
+        "agent:atlas",
+        "exec",
+        ttl_seconds=900,
+        force=True,
+    )
+    leases_after = show_leases_json(root, workspace_root, "atlas", "feat-stale")
+
+    holds = []
+    gaps = []
+    evidence = [stale.stdout.strip(), json.dumps(blocked_exec, indent=2), forced.stdout.strip(), json.dumps(leases_after, indent=2)]
+
+    if isinstance(blocked_exec, dict) and blocked_exec.get("reason") == "stale-conflicting-lease":
+        holds.append("plan-exec detects stale conflicting leases")
+    else:
+        gaps.append("plan-exec did not flag stale conflicting leases")
+
+    actors_after = {lease["actor"] for lease in leases_after}
+    if "human:layne" not in actors_after and "agent:atlas" in actors_after:
+        holds.append("force acquisition breaks stale conflicting lease and installs new lease")
+    else:
+        gaps.append("force acquisition did not replace stale conflicting lease cleanly")
+
+    verdict = "holds" if not gaps else "fails"
+    return ScenarioResult(
+        scenario_id="stale-lease-force-break",
+        user_mode="cross-mode",
+        title="stale leases are detectable and force-breakable",
+        verdict=verdict,
+        holds=holds,
+        gaps=gaps,
+        evidence=evidence,
+    )
+
+
 def scenario_solo_human_forgets_lane(root: Path, workspace_root: Path) -> ScenarioResult:
     create_lane(root, workspace_root, "layne", "feat-auth", "app,api", "feat/auth")
     create_lane(root, workspace_root, "layne", "feat-web", "web", "feat/web")
@@ -406,6 +546,8 @@ def run_scenarios(workspace_root: Path) -> list[ScenarioResult]:
     root = repo_root()
     init_workspace(workspace_root)
     return [
+        scenario_lease_conflict_matrix(root, workspace_root),
+        scenario_stale_lease_force_break(root, workspace_root),
         scenario_multi_agent_same_repo(root, workspace_root),
         scenario_mixed_same_lane_exec(root, workspace_root),
         scenario_single_agent_interrupt_recovery(root, workspace_root),

--- a/gr2/prototypes/cross_mode_lane_stress.py
+++ b/gr2/prototypes/cross_mode_lane_stress.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Adversarial cross-mode stress harness for the gr2 lane model.
+
+This script pressures the lane prototype across the four primary user modes:
+
+1. solo human
+2. single agent
+3. multi-agent
+4. mixed human + agent
+
+It does not pretend the model is complete. It reports where the current
+prototype holds, where it only partially holds, and where it still falls over.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class ScenarioResult:
+    scenario_id: str
+    user_mode: str
+    title: str
+    verdict: str
+    holds: list[str]
+    gaps: list[str]
+    evidence: list[str]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run adversarial cross-mode lane stress checks"
+    )
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        help="optional workspace root; defaults to a temporary workspace",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit structured JSON instead of human-readable text",
+    )
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def lane_proto(root: Path) -> Path:
+    return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
+
+
+def run(argv: list[str], *, capture: bool = False, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def init_workspace(workspace_root: Path) -> None:
+    (workspace_root / ".grip").mkdir(parents=True, exist_ok=True)
+    (workspace_root / "agents").mkdir(exist_ok=True)
+    spec = """schema_version = 1
+workspace_name = "lane-cross-mode-stress"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://example.invalid/app.git"
+
+[[repos]]
+name = "api"
+path = "repos/api"
+url = "https://example.invalid/api.git"
+
+[[repos]]
+name = "web"
+path = "repos/web"
+url = "https://example.invalid/web.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app", "api", "web"]
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = ["app", "api", "web"]
+
+[[units]]
+name = "layne"
+path = "agents/layne"
+repos = ["app", "api", "web"]
+"""
+    (workspace_root / ".grip" / "workspace_spec.toml").write_text(spec)
+
+
+def create_lane(root: Path, workspace_root: Path, owner_unit: str, lane_name: str, repos: str, branch: str, lane_type: str = "feature") -> None:
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "create-lane",
+            str(workspace_root),
+            owner_unit,
+            lane_name,
+            "--type",
+            lane_type,
+            "--repos",
+            repos,
+            "--branch",
+            branch,
+        ]
+    )
+
+
+def create_review_lane(root: Path, workspace_root: Path, owner_unit: str, repo: str, pr_number: int) -> None:
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "create-review-lane",
+            str(workspace_root),
+            owner_unit,
+            repo,
+            str(pr_number),
+        ]
+    )
+
+
+def plan_exec_json(root: Path, workspace_root: Path, owner_unit: str, lane_name: str, command_text: str) -> list[dict]:
+    proc = run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "plan-exec",
+            str(workspace_root),
+            owner_unit,
+            lane_name,
+            command_text,
+            "--json",
+        ],
+        capture=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def list_lanes_text(root: Path, workspace_root: Path, owner_unit: str | None = None) -> str:
+    argv = [
+        "python3",
+        str(lane_proto(root)),
+        "list-lanes",
+        str(workspace_root),
+    ]
+    if owner_unit:
+        argv.extend(["--owner-unit", owner_unit])
+    proc = run(argv, capture=True)
+    return proc.stdout
+
+
+def scenario_multi_agent_same_repo(root: Path, workspace_root: Path) -> ScenarioResult:
+    create_lane(root, workspace_root, "atlas", "feat-router", "app", "feat/router")
+    create_lane(root, workspace_root, "apollo", "feat-materialize", "app", "feat/materialize")
+
+    atlas_lane = workspace_root / "agents" / "atlas" / "lanes" / "feat-router" / "lane.toml"
+    apollo_lane = workspace_root / "agents" / "apollo" / "lanes" / "feat-materialize" / "lane.toml"
+
+    holds = []
+    gaps = []
+    evidence = []
+
+    if atlas_lane.exists() and apollo_lane.exists():
+        holds.append("two units can create separate lanes touching the same repo without metadata collision")
+        evidence.append(f"lane files: {atlas_lane.relative_to(workspace_root)}, {apollo_lane.relative_to(workspace_root)}")
+    else:
+        gaps.append("unit-scoped lane metadata was not isolated cleanly")
+
+    atlas_exec = plan_exec_json(root, workspace_root, "atlas", "feat-router", "cargo test")
+    apollo_exec = plan_exec_json(root, workspace_root, "apollo", "feat-materialize", "cargo test")
+    if atlas_exec and apollo_exec and atlas_exec[0]["cwd"] != apollo_exec[0]["cwd"]:
+        holds.append("execution planning stays unit-scoped even when both lanes include the same repo")
+        evidence.append(f"exec cwd atlas={atlas_exec[0]['cwd']} apollo={apollo_exec[0]['cwd']}")
+        verdict = "holds"
+    else:
+        gaps.append("execution planning did not stay unit-scoped for same-repo parallel work")
+        verdict = "fails"
+
+    return ScenarioResult(
+        scenario_id="multi-agent-same-repo",
+        user_mode="multi-agent",
+        title="two agents create lanes that touch the same repo",
+        verdict=verdict,
+        holds=holds,
+        gaps=gaps,
+        evidence=evidence,
+    )
+
+
+def scenario_mixed_same_lane_exec(root: Path, workspace_root: Path) -> ScenarioResult:
+    create_lane(root, workspace_root, "layne", "feat-blog", "app", "feat/blog")
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "acquire-lane-lease",
+            str(workspace_root),
+            "layne",
+            "feat-blog",
+            "--actor",
+            "human:layne",
+            "--mode",
+            "edit",
+        ]
+    )
+
+    exec_rows = plan_exec_json(root, workspace_root, "layne", "feat-blog", "cargo test")
+
+    holds = []
+    gaps = []
+    evidence = [
+        "human edit lease acquired for layne/feat-blog",
+        json.dumps(exec_rows if isinstance(exec_rows, list) else exec_rows, indent=2),
+    ]
+
+    if isinstance(exec_rows, dict) and exec_rows.get("status") == "blocked":
+        holds.append("same-lane human-edit vs agent-exec is blocked by a lease")
+        holds.append("prototype now models occupancy instead of silently planning through it")
+        verdict = "holds"
+    else:
+        gaps.append("same-lane concurrent human-edit vs agent-exec is not modeled or blocked")
+        verdict = "fails"
+
+    return ScenarioResult(
+        scenario_id="mixed-same-lane-exec",
+        user_mode="mixed-human-agent",
+        title="human edits in a lane while an agent plans exec in the same lane",
+        verdict=verdict,
+        holds=holds,
+        gaps=gaps,
+        evidence=evidence,
+    )
+
+
+def scenario_single_agent_interrupt_recovery(root: Path, workspace_root: Path) -> ScenarioResult:
+    create_lane(root, workspace_root, "atlas", "feat-auth", "app,api", "feat/auth")
+    create_review_lane(root, workspace_root, "atlas", "app", 123)
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "enter-lane",
+            str(workspace_root),
+            "atlas",
+            "feat-auth",
+            "--actor",
+            "agent:atlas",
+        ]
+    )
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "enter-lane",
+            str(workspace_root),
+            "atlas",
+            "review-123",
+            "--actor",
+            "agent:atlas",
+        ]
+    )
+    lane_listing = list_lanes_text(root, workspace_root, "atlas")
+    current_lane_proc = run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "current-lane",
+            str(workspace_root),
+            "atlas",
+            "--json",
+        ],
+        capture=True,
+    )
+    current_lane_doc = json.loads(current_lane_proc.stdout)
+    holds = [
+        "agent can enumerate all of its lanes without guessing filesystem paths",
+        "lane metadata includes repos, type, and PR references",
+    ]
+    gaps = []
+    evidence = [lane_listing.strip(), json.dumps(current_lane_doc, indent=2)]
+
+    current = current_lane_doc.get("current", {})
+    recent = current_lane_doc.get("recent", [])
+    if current.get("lane_name") == "review-123":
+        holds.append("agent can recover current lane after an interruption")
+    else:
+        gaps.append("current-lane surface did not record the lane entered most recently")
+
+    if recent and recent[0].get("lane_name") == "feat-auth":
+        holds.append("agent can recover previous lane from recent history")
+        verdict = "holds"
+    else:
+        gaps.append("prototype still cannot recover previous lane deterministically")
+        verdict = "partial"
+
+    return ScenarioResult(
+        scenario_id="single-agent-interrupt-recovery",
+        user_mode="single-agent",
+        title="agent is interrupted mid-task and needs to recover lane context",
+        verdict=verdict,
+        holds=holds,
+        gaps=gaps,
+        evidence=evidence,
+    )
+
+
+def scenario_solo_human_forgets_lane(root: Path, workspace_root: Path) -> ScenarioResult:
+    create_lane(root, workspace_root, "layne", "feat-auth", "app,api", "feat/auth")
+    create_lane(root, workspace_root, "layne", "feat-web", "web", "feat/web")
+    create_lane(root, workspace_root, "layne", "feat-release", "app,web", "feat/release")
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "enter-lane",
+            str(workspace_root),
+            "layne",
+            "feat-release",
+            "--actor",
+            "human:layne",
+        ]
+    )
+    create_review_lane(root, workspace_root, "layne", "app", 456)
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "enter-lane",
+            str(workspace_root),
+            "layne",
+            "review-456",
+            "--actor",
+            "human:layne",
+        ]
+    )
+
+    lane_listing = list_lanes_text(root, workspace_root, "layne")
+    current_lane_proc = run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "current-lane",
+            str(workspace_root),
+            "layne",
+            "--json",
+        ],
+        capture=True,
+    )
+    current_lane_doc = json.loads(current_lane_proc.stdout)
+    holds = [
+        "user can see all lanes in one listing",
+        "review lane is isolated as its own lane type rather than overwriting feature state",
+    ]
+    gaps = []
+    evidence = [lane_listing.strip(), json.dumps(current_lane_doc, indent=2)]
+
+    if current_lane_doc.get("current", {}).get("lane_name") == "review-456":
+        holds.append("current review lane is visible after switching")
+    else:
+        gaps.append("current lane is not visible after switching to review")
+
+    recent = current_lane_doc.get("recent", [])
+    if recent and recent[0].get("lane_name") == "feat-release":
+        holds.append("previous feature lane is recoverable after entering review")
+        verdict = "holds"
+    else:
+        gaps.append("prototype lacks an obvious return-to-previous-lane recovery path")
+        verdict = "partial"
+
+    return ScenarioResult(
+        scenario_id="solo-human-lane-recovery",
+        user_mode="solo-human",
+        title="solo human has three feature lanes, switches to review, then forgets the prior lane",
+        verdict=verdict,
+        holds=holds,
+        gaps=gaps,
+        evidence=evidence,
+    )
+
+
+def run_scenarios(workspace_root: Path) -> list[ScenarioResult]:
+    root = repo_root()
+    init_workspace(workspace_root)
+    return [
+        scenario_multi_agent_same_repo(root, workspace_root),
+        scenario_mixed_same_lane_exec(root, workspace_root),
+        scenario_single_agent_interrupt_recovery(root, workspace_root),
+        scenario_solo_human_forgets_lane(root, workspace_root),
+    ]
+
+
+def print_human(results: list[ScenarioResult], workspace_root: Path) -> None:
+    print("gr2 cross-mode lane stress results")
+    print(f"workspace: {workspace_root}")
+    print()
+    for result in results:
+        print(f"[{result.verdict}] {result.user_mode}: {result.title}")
+        if result.holds:
+            print("  holds:")
+            for item in result.holds:
+                print(f"    - {item}")
+        if result.gaps:
+            print("  gaps:")
+            for item in result.gaps:
+                print(f"    - {item}")
+        if result.evidence:
+            print("  evidence:")
+            for item in result.evidence:
+                for line in item.splitlines():
+                    print(f"    {line}")
+        print()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.workspace_root:
+        workspace_root = args.workspace_root.resolve()
+        workspace_root.mkdir(parents=True, exist_ok=True)
+        results = run_scenarios(workspace_root)
+    else:
+        with tempfile.TemporaryDirectory(prefix="gr2-cross-mode-") as tmp:
+            workspace_root = Path(tmp)
+            results = run_scenarios(workspace_root)
+            if args.json:
+                print(json.dumps([asdict(result) for result in results], indent=2))
+                return 0
+            print_human(results, workspace_root)
+            return 0
+
+    if args.json:
+        print(json.dumps([asdict(result) for result in results], indent=2))
+    else:
+        print_human(results, workspace_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/cross_mode_lane_stress.py
+++ b/gr2/prototypes/cross_mode_lane_stress.py
@@ -95,16 +95,19 @@ url = "https://example.invalid/web.git"
 [[units]]
 name = "atlas"
 path = "agents/atlas"
+agent_id = "atlas-agent"
 repos = ["app", "api", "web"]
 
 [[units]]
 name = "apollo"
 path = "agents/apollo"
+agent_id = "apollo-agent"
 repos = ["app", "api", "web"]
 
 [[units]]
 name = "layne"
 path = "agents/layne"
+agent_id = "layne-human"
 repos = ["app", "api", "web"]
 """
     (workspace_root / ".grip" / "workspace_spec.toml").write_text(spec)
@@ -417,6 +420,96 @@ def scenario_lease_conflict_matrix(root: Path, workspace_root: Path) -> Scenario
     )
 
 
+def scenario_synapt_lane_events(root: Path, workspace_root: Path) -> ScenarioResult:
+    create_lane(root, workspace_root, "atlas", "feat-events", "app,api", "feat/events")
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "enter-lane",
+            str(workspace_root),
+            "atlas",
+            "feat-events",
+            "--actor",
+            "agent:atlas",
+            "--notify-channel",
+            "--recall",
+        ]
+    )
+    acquire_lease(root, workspace_root, "atlas", "feat-events", "agent:atlas", "exec")
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "release-lane-lease",
+            str(workspace_root),
+            "atlas",
+            "feat-events",
+            "--actor",
+            "agent:atlas",
+        ]
+    )
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "exit-lane",
+            str(workspace_root),
+            "atlas",
+            "--actor",
+            "agent:atlas",
+            "--notify-channel",
+            "--recall",
+        ]
+    )
+    history_proc = run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "lane-history",
+            str(workspace_root),
+            "atlas",
+            "--json",
+        ],
+        capture=True,
+    )
+    history_rows = json.loads(history_proc.stdout)
+    events_path = workspace_root / ".grip" / "events" / "lane_events.jsonl"
+    recall_path = workspace_root / ".grip" / "events" / "recall_lane_history.jsonl"
+
+    holds = []
+    gaps = []
+    evidence = [json.dumps(history_rows, indent=2)]
+
+    event_types = [row["type"] for row in history_rows]
+    expected = ["lane_enter", "lease_acquire", "lease_release", "lane_exit"]
+    if event_types == expected:
+        holds.append("lane event timeline is reconstructible from append-only event log")
+    else:
+        gaps.append(f"unexpected lane event order: {event_types}")
+
+    if all(row.get("agent_id") == "atlas-agent" for row in history_rows):
+        holds.append("agent_id flows from workspace spec into lane events")
+    else:
+        gaps.append("agent_id did not flow consistently into lane events")
+
+    if events_path.exists() and recall_path.exists():
+        holds.append("channel-compatible and recall-compatible event logs are both written")
+    else:
+        gaps.append("expected event logs were not both written")
+
+    verdict = "holds" if not gaps else "fails"
+    return ScenarioResult(
+        scenario_id="synapt-lane-events",
+        user_mode="single-agent",
+        title="lane enter/lease/exit emits reconstructible synapt-compatible events",
+        verdict=verdict,
+        holds=holds,
+        gaps=gaps,
+        evidence=evidence,
+    )
+
+
 def scenario_stale_lease_force_break(root: Path, workspace_root: Path) -> ScenarioResult:
     create_lane(root, workspace_root, "atlas", "feat-stale", "app", "feat/stale")
     stale = acquire_lease(
@@ -546,6 +639,7 @@ def run_scenarios(workspace_root: Path) -> list[ScenarioResult]:
     root = repo_root()
     init_workspace(workspace_root)
     return [
+        scenario_synapt_lane_events(root, workspace_root),
         scenario_lease_conflict_matrix(root, workspace_root),
         scenario_stale_lease_force_break(root, workspace_root),
         scenario_multi_agent_same_repo(root, workspace_root),

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-"""Prototype lane metadata and lane-aware execution planning for gr2.
+"""Prototype lane metadata, execution planning, and shared scratchpads for gr2.
 
-This prototype does not mutate git state. It proves the lane model is useful by
-persisting explicit lane metadata and generating execution plans scoped by lane.
+This prototype does not mutate git state. It explores three UX questions:
+
+1. are lane records legible enough to guide multi-repo work?
+2. can lightweight shared scratchpads fill the collaboration gap without
+   violating private-workspace rules?
+3. can the tool tell the user what to do next instead of forcing them to infer
+   the workflow?
 """
 
 from __future__ import annotations
@@ -17,6 +22,7 @@ from pathlib import Path
 
 
 LANE_SCHEMA_VERSION = 1
+SCRATCHPAD_SCHEMA_VERSION = 1
 
 
 @dataclasses.dataclass
@@ -48,32 +54,14 @@ class LaneMetadata:
         for repo, branch in sorted(self.branch_map.items()):
             lines.append(f'{repo} = "{branch}"')
 
-        lines.extend(
-            [
-                "",
-                "[context]",
-                "shared_roots = ["
-            ]
-        )
+        lines.extend(["", "[context]", "shared_roots = ["])
         for root in self.shared_context_roots:
             lines.append(f'  "{root}",')
-
-        lines.extend(
-            [
-                "]",
-                "private_roots = [",
-            ]
-        )
+        lines.extend(["]", "private_roots = ["])
         for root in self.private_context_roots:
             lines.append(f'  "{root}",')
 
-        lines.extend(
-            [
-                "]",
-                "",
-                "[exec_defaults]",
-            ]
-        )
+        lines.extend(["]", "", "[exec_defaults]"])
         for key, value in self.exec_defaults.items():
             if isinstance(value, bool):
                 encoded = str(value).lower()
@@ -85,16 +73,50 @@ class LaneMetadata:
                 encoded = f'"{value}"'
             lines.append(f"{key} = {encoded}")
 
-        if self.pr_associations:
-            lines.extend(["", "[[pr_associations]]"])
-            for assoc in self.pr_associations:
-                lines.append(f'ref = "{assoc}"')
+        for assoc in self.pr_associations:
+            lines.extend(["", "[[pr_associations]]", f'ref = "{assoc}"'])
 
         return "\n".join(lines) + "\n"
 
 
+@dataclasses.dataclass
+class SharedScratchpad:
+    schema_version: int
+    name: str
+    kind: str
+    purpose: str
+    participants: list[str]
+    linked_refs: list[str]
+    lifecycle: str
+    creation_source: str
+    docs_root: str
+    notes_root: str
+    context_root: str
+
+    def as_toml(self) -> str:
+        lines = [
+            f"schema_version = {self.schema_version}",
+            f'name = "{self.name}"',
+            f'kind = "{self.kind}"',
+            f'purpose = "{self.purpose}"',
+            f'lifecycle = "{self.lifecycle}"',
+            f'creation_source = "{self.creation_source}"',
+            "",
+            f'participants = [{", ".join(f"\"{p}\"" for p in self.participants)}]',
+            f'linked_refs = [{", ".join(f"\"{r}\"" for r in self.linked_refs)}]',
+            "",
+            "[paths]",
+            f'docs_root = "{self.docs_root}"',
+            f'notes_root = "{self.notes_root}"',
+            f'context_root = "{self.context_root}"',
+        ]
+        return "\n".join(lines) + "\n"
+
+
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Prototype gr2 lane metadata + exec planner")
+    parser = argparse.ArgumentParser(
+        description="Prototype gr2 lanes + shared scratchpads"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     create = sub.add_parser("create-lane")
@@ -103,13 +125,41 @@ def parse_args() -> argparse.Namespace:
     create.add_argument("lane_name")
     create.add_argument("--type", default="feature")
     create.add_argument("--repos", required=True, help="comma-separated repo names")
-    create.add_argument("--branch", required=True, help="default branch for included repos")
+    create.add_argument(
+        "--branch",
+        required=True,
+        help="default branch or repo=branch mappings separated by commas",
+    )
     create.add_argument("--source", default="manual")
+    create.add_argument(
+        "--command",
+        dest="default_commands",
+        action="append",
+        default=[],
+        help="default lane command",
+    )
+
+    review = sub.add_parser("create-review-lane")
+    review.add_argument("workspace_root", type=Path)
+    review.add_argument("owner_unit")
+    review.add_argument("repo")
+    review.add_argument("pr_number", type=int)
+    review.add_argument("--lane-name")
+    review.add_argument("--branch")
 
     show = sub.add_parser("show-lane")
     show.add_argument("workspace_root", type=Path)
     show.add_argument("owner_unit")
     show.add_argument("lane_name")
+
+    lane_list = sub.add_parser("list-lanes")
+    lane_list.add_argument("workspace_root", type=Path)
+    lane_list.add_argument("--owner-unit")
+
+    next_step = sub.add_parser("next-step")
+    next_step.add_argument("workspace_root", type=Path)
+    next_step.add_argument("owner_unit")
+    next_step.add_argument("lane_name")
 
     plan = sub.add_parser("plan-exec")
     plan.add_argument("workspace_root", type=Path)
@@ -118,6 +168,22 @@ def parse_args() -> argparse.Namespace:
     plan.add_argument("command_text")
     plan.add_argument("--repos", help="optional comma-separated repo subset")
     plan.add_argument("--json", action="store_true")
+
+    scratch = sub.add_parser("create-shared-scratchpad")
+    scratch.add_argument("workspace_root", type=Path)
+    scratch.add_argument("name")
+    scratch.add_argument("--kind", default="doc")
+    scratch.add_argument("--purpose", required=True)
+    scratch.add_argument("--participant", action="append", default=[])
+    scratch.add_argument("--ref", action="append", default=[])
+    scratch.add_argument("--source", default="manual")
+
+    scratch_show = sub.add_parser("show-shared-scratchpad")
+    scratch_show.add_argument("workspace_root", type=Path)
+    scratch_show.add_argument("name")
+
+    scratch_list = sub.add_parser("list-shared-scratchpads")
+    scratch_list.add_argument("workspace_root", type=Path)
 
     return parser.parse_args()
 
@@ -130,16 +196,89 @@ def lane_file(workspace_root: Path, owner_unit: str, lane_name: str) -> Path:
     return lane_dir(workspace_root, owner_unit, lane_name) / "lane.toml"
 
 
+def shared_scratchpad_dir(workspace_root: Path, name: str) -> Path:
+    return workspace_root / "shared" / "scratchpads" / name
+
+
+def shared_scratchpad_file(workspace_root: Path, name: str) -> Path:
+    return shared_scratchpad_dir(workspace_root, name) / "scratchpad.toml"
+
+
 def load_workspace_spec(workspace_root: Path) -> dict:
     with (workspace_root / ".grip" / "workspace_spec.toml").open("rb") as fh:
         return tomllib.load(fh)
+
+
+def load_lane_doc(workspace_root: Path, owner_unit: str, lane_name: str) -> dict:
+    path = lane_file(workspace_root, owner_unit, lane_name)
+    if not path.exists():
+        raise SystemExit(f"lane not found: {owner_unit}/{lane_name}")
+    return tomllib.loads(path.read_text())
+
+
+def load_shared_scratchpad_doc(workspace_root: Path, name: str) -> dict:
+    path = shared_scratchpad_file(workspace_root, name)
+    if not path.exists():
+        raise SystemExit(f"shared scratchpad not found: {name}")
+    return tomllib.loads(path.read_text())
+
+
+def iter_lane_files(workspace_root: Path, owner_unit: str | None = None) -> list[Path]:
+    agents_root = workspace_root / "agents"
+    if owner_unit:
+        lane_roots = [agents_root / owner_unit / "lanes"]
+    else:
+        lane_roots = [path / "lanes" for path in agents_root.iterdir() if path.is_dir()]
+
+    files: list[Path] = []
+    for root in lane_roots:
+        if not root.exists():
+            continue
+        files.extend(sorted(root.glob("*/lane.toml")))
+    return files
+
+
+def iter_shared_scratchpad_files(workspace_root: Path) -> list[Path]:
+    root = workspace_root / "shared" / "scratchpads"
+    if not root.exists():
+        return []
+    return sorted(root.glob("*/scratchpad.toml"))
+
+
+def parse_repo_list(raw: str) -> list[str]:
+    return [repo.strip() for repo in raw.split(",") if repo.strip()]
+
+
+def parse_branch_arg(raw: str, repos: list[str]) -> dict[str, str]:
+    if "=" not in raw:
+        return {repo: raw for repo in repos}
+
+    branch_map: dict[str, str] = {}
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        repo, branch = item.split("=", 1)
+        repo = repo.strip()
+        branch = branch.strip()
+        if repo not in repos:
+            raise SystemExit(f"branch mapping references repo outside lane: {repo}")
+        if not branch:
+            raise SystemExit(f"empty branch in mapping: {item}")
+        branch_map[repo] = branch
+
+    missing = [repo for repo in repos if repo not in branch_map]
+    if missing:
+        raise SystemExit("missing branch mapping for repos: " + ", ".join(missing))
+
+    return branch_map
 
 
 def create_lane(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     spec = load_workspace_spec(workspace_root)
     repo_names = [item["name"] for item in spec.get("repos", [])]
-    repos = [repo.strip() for repo in args.repos.split(",") if repo.strip()]
+    repos = parse_repo_list(args.repos)
 
     missing = [repo for repo in repos if repo not in repo_names]
     if missing:
@@ -156,7 +295,7 @@ def create_lane(args: argparse.Namespace) -> int:
         owner_unit=args.owner_unit,
         lane_type=args.type,
         repos=repos,
-        branch_map={repo: args.branch for repo in repos},
+        branch_map=parse_branch_arg(args.branch, repos),
         pr_associations=[],
         shared_context_roots=["config", ".grip/context/shared"],
         private_context_roots=[
@@ -167,6 +306,7 @@ def create_lane(args: argparse.Namespace) -> int:
             "parallelism": "workspace-default",
             "fail_fast": True,
             "default_command_family": ["build", "test"],
+            "commands": args.default_commands,
         },
         creation_source=args.source,
     )
@@ -175,20 +315,134 @@ def create_lane(args: argparse.Namespace) -> int:
     return 0
 
 
+def create_review_lane(args: argparse.Namespace) -> int:
+    lane_name = args.lane_name or f"review-{args.pr_number}"
+    branch = args.branch or f"pr/{args.pr_number}"
+    create_args = argparse.Namespace(
+        workspace_root=args.workspace_root,
+        owner_unit=args.owner_unit,
+        lane_name=lane_name,
+        type="review",
+        repos=args.repo,
+        branch=f"{args.repo}={branch}",
+        source="pull-request",
+        default_commands=[],
+    )
+    create_lane(create_args)
+    lane_path = lane_file(args.workspace_root.resolve(), args.owner_unit, lane_name)
+    content = lane_path.read_text().rstrip()
+    content += f'\n\n[[pr_associations]]\nref = "{args.repo}#{args.pr_number}"\n'
+    lane_path.write_text(content)
+    print(f"created review lane {args.owner_unit}/{lane_name} for {args.repo}#{args.pr_number}")
+    return 0
+
+
+def create_shared_scratchpad(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    root = shared_scratchpad_dir(workspace_root, args.name)
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "docs").mkdir(exist_ok=True)
+    (root / "notes").mkdir(exist_ok=True)
+    (root / "context").mkdir(exist_ok=True)
+
+    scratchpad = SharedScratchpad(
+        schema_version=SCRATCHPAD_SCHEMA_VERSION,
+        name=args.name,
+        kind=args.kind,
+        purpose=args.purpose,
+        participants=sorted(set(args.participant)),
+        linked_refs=args.ref,
+        lifecycle="draft",
+        creation_source=args.source,
+        docs_root=f"shared/scratchpads/{args.name}/docs",
+        notes_root=f"shared/scratchpads/{args.name}/notes",
+        context_root=f"shared/scratchpads/{args.name}/context",
+    )
+    shared_scratchpad_file(workspace_root, args.name).write_text(scratchpad.as_toml())
+    readme = root / "docs" / "README.md"
+    if not readme.exists():
+        readme.write_text(
+            f"# {args.name}\n\nPurpose: {args.purpose}\n\nParticipants: "
+            + (", ".join(scratchpad.participants) if scratchpad.participants else "unassigned")
+            + "\n"
+        )
+    print(shared_scratchpad_file(workspace_root, args.name))
+    return 0
+
+
+def list_lanes(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    print("OWNER\tLANE\tTYPE\tREPOS\tPRS")
+    for path in iter_lane_files(workspace_root, args.owner_unit):
+        doc = tomllib.loads(path.read_text())
+        refs = ",".join(item["ref"] for item in doc.get("pr_associations", [])) or "-"
+        print(
+            f'{doc["owner_unit"]}\t{doc["lane_name"]}\t{doc["lane_type"]}\t{len(doc.get("repos", []))}\t{refs}'
+        )
+    return 0
+
+
 def show_lane(args: argparse.Namespace) -> int:
     print(lane_file(args.workspace_root.resolve(), args.owner_unit, args.lane_name).read_text())
     return 0
 
 
+def show_shared_scratchpad(args: argparse.Namespace) -> int:
+    print(shared_scratchpad_file(args.workspace_root.resolve(), args.name).read_text())
+    return 0
+
+
+def list_shared_scratchpads(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    print("NAME\tKIND\tLIFECYCLE\tPARTICIPANTS\tPURPOSE")
+    for path in iter_shared_scratchpad_files(workspace_root):
+        doc = tomllib.loads(path.read_text())
+        participants = ",".join(doc.get("participants", [])) or "-"
+        print(
+            f'{doc["name"]}\t{doc["kind"]}\t{doc["lifecycle"]}\t{participants}\t{doc["purpose"]}'
+        )
+    return 0
+
+
+def next_step(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    print("gr2 prototype next-step")
+    print(f'lane: {args.owner_unit}/{lane_doc["lane_name"]}')
+    print(f'type: {lane_doc["lane_type"]}')
+    print(f'repos: {", ".join(lane_doc["repos"])}')
+    if lane_doc.get("pr_associations"):
+        print("mode: review")
+        print("recommended:")
+        print(
+            f"  python3 gr2/prototypes/lane_workspace_prototype.py plan-exec {workspace_root} {args.owner_unit} {args.lane_name} 'cargo test'"
+        )
+        print("  inspect the review lane, then return to your feature or home lane")
+    elif lane_doc["lane_type"] == "feature":
+        print("mode: feature")
+        print("recommended:")
+        print(
+            f"  python3 gr2/prototypes/lane_workspace_prototype.py plan-exec {workspace_root} {args.owner_unit} {args.lane_name} 'cargo test'"
+        )
+        print(
+            f"  python3 gr2/prototypes/lane_workspace_prototype.py list-shared-scratchpads {workspace_root}"
+        )
+    else:
+        print("mode: general")
+        print("recommended:")
+        print(
+            f"  python3 gr2/prototypes/lane_workspace_prototype.py show-lane {workspace_root} {args.owner_unit} {args.lane_name}"
+        )
+    return 0
+
+
 def plan_exec(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
-    lane_doc = tomllib.loads(
-        lane_file(workspace_root, args.owner_unit, args.lane_name).read_text()
-    )
+    lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
 
     selected_repos = lane_doc["repos"]
     if args.repos:
-        requested = [repo.strip() for repo in args.repos.split(",") if repo.strip()]
+        requested = parse_repo_list(args.repos)
         selected_repos = [repo for repo in selected_repos if repo in requested]
 
     command_argv = shlex.split(args.command_text)
@@ -200,7 +454,15 @@ def plan_exec(args: argparse.Namespace) -> int:
                 "owner_unit": lane_doc["owner_unit"],
                 "repo": repo,
                 "branch": lane_doc["branch_map"].get(repo),
-                "cwd": str(workspace_root / "agents" / args.owner_unit / "lanes" / args.lane_name / "repos" / repo),
+                "cwd": str(
+                    workspace_root
+                    / "agents"
+                    / args.owner_unit
+                    / "lanes"
+                    / args.lane_name
+                    / "repos"
+                    / repo
+                ),
                 "command": command_argv,
                 "shared_context_roots": lane_doc.get("context", {}).get("shared_roots", []),
                 "private_context_roots": lane_doc.get("context", {}).get("private_roots", []),
@@ -212,10 +474,13 @@ def plan_exec(args: argparse.Namespace) -> int:
         print(json.dumps(rows, indent=2))
     else:
         print("gr2 lane-exec prototype")
+        print(
+            f'owner={lane_doc["owner_unit"]} lane={lane_doc["lane_name"]} type={lane_doc["lane_type"]} fail_fast={lane_doc["exec_defaults"]["fail_fast"]}'
+        )
         print("LANE\tREPO\tBRANCH\tCWD\tCOMMAND")
         for row in rows:
             print(
-                f"{row['lane']}\t{row['repo']}\t{row['branch']}\t{row['cwd']}\t{' '.join(row['command'])}"
+                f'{row["lane"]}\t{row["repo"]}\t{row["branch"]}\t{row["cwd"]}\t{" ".join(row["command"])}'
             )
     return 0
 
@@ -224,10 +489,22 @@ def main() -> int:
     args = parse_args()
     if args.command == "create-lane":
         return create_lane(args)
+    if args.command == "create-review-lane":
+        return create_review_lane(args)
     if args.command == "show-lane":
         return show_lane(args)
+    if args.command == "list-lanes":
+        return list_lanes(args)
+    if args.command == "next-step":
+        return next_step(args)
     if args.command == "plan-exec":
         return plan_exec(args)
+    if args.command == "create-shared-scratchpad":
+        return create_shared_scratchpad(args)
+    if args.command == "show-shared-scratchpad":
+        return show_shared_scratchpad(args)
+    if args.command == "list-shared-scratchpads":
+        return list_shared_scratchpads(args)
     raise SystemExit(f"unknown command: {args.command}")
 
 

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -18,7 +18,7 @@ import json
 import shlex
 import sys
 import tomllib
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 
@@ -191,6 +191,17 @@ def parse_args() -> argparse.Namespace:
     lease.add_argument("lane_name")
     lease.add_argument("--actor", required=True)
     lease.add_argument("--mode", choices=["edit", "exec", "review"], required=True)
+    lease.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=900,
+        help="lease TTL in seconds before it is considered stale",
+    )
+    lease.add_argument(
+        "--force",
+        action="store_true",
+        help="break conflicting stale leases with a warning",
+    )
 
     release = sub.add_parser("release-lane-lease")
     release.add_argument("workspace_root", type=Path)
@@ -335,6 +346,53 @@ def now_utc() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat()
 
 
+def parse_utc(raw: str) -> datetime:
+    return datetime.fromisoformat(raw)
+
+
+def is_stale_lease(lease: dict) -> bool:
+    expires_at = lease.get("expires_at")
+    if not expires_at:
+        return False
+    return parse_utc(expires_at) <= datetime.now(UTC)
+
+
+def build_lease(actor: str, mode: str, ttl_seconds: int) -> dict:
+    acquired = datetime.now(UTC).replace(microsecond=0)
+    expires = acquired + timedelta(seconds=ttl_seconds)
+    return {
+        "actor": actor,
+        "mode": mode,
+        "ttl_seconds": ttl_seconds,
+        "acquired_at": acquired.isoformat(),
+        "expires_at": expires.isoformat(),
+    }
+
+
+def lease_conflicts(existing_mode: str, requested_mode: str) -> bool:
+    matrix = {
+        "edit": {"edit", "exec", "review"},
+        "exec": {"edit", "review"},
+        "review": {"edit", "exec", "review"},
+    }
+    return requested_mode in matrix.get(existing_mode, set())
+
+
+def conflicting_leases(leases: list[dict], actor: str, requested_mode: str) -> tuple[list[dict], list[dict]]:
+    active: list[dict] = []
+    stale: list[dict] = []
+    for lease in leases:
+        if lease["actor"] == actor:
+            continue
+        if not lease_conflicts(lease["mode"], requested_mode):
+            continue
+        if is_stale_lease(lease):
+            stale.append(lease)
+        else:
+            active.append(lease)
+    return active, stale
+
+
 def age_days(path: Path) -> int:
     modified = datetime.fromtimestamp(path.stat().st_mtime, UTC)
     return max(0, int((datetime.now(UTC) - modified).total_seconds() // 86400))
@@ -472,13 +530,48 @@ def acquire_lane_lease(args: argparse.Namespace) -> int:
     load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
     leases = load_lane_leases(workspace_root, args.owner_unit, args.lane_name)
     retained = [lease for lease in leases if lease["actor"] != args.actor]
-    retained.append(
-        {
-            "actor": args.actor,
-            "mode": args.mode,
-            "acquired_at": now_utc(),
+    active_conflicts, stale_conflicts = conflicting_leases(retained, args.actor, args.mode)
+
+    if active_conflicts:
+        payload = {
+            "status": "blocked",
+            "reason": "conflicting-active-lease",
+            "lane": args.lane_name,
+            "owner_unit": args.owner_unit,
+            "requested": {"actor": args.actor, "mode": args.mode},
+            "conflicting_leases": active_conflicts,
         }
-    )
+        print(json.dumps(payload, indent=2))
+        return 1
+
+    if stale_conflicts and not args.force:
+        payload = {
+            "status": "blocked",
+            "reason": "stale-conflicting-lease",
+            "lane": args.lane_name,
+            "owner_unit": args.owner_unit,
+            "requested": {"actor": args.actor, "mode": args.mode},
+            "conflicting_leases": stale_conflicts,
+            "hint": "rerun with --force to break stale conflicting leases",
+        }
+        print(json.dumps(payload, indent=2))
+        return 1
+
+    if stale_conflicts and args.force:
+        print(
+            json.dumps(
+                {
+                    "status": "warning",
+                    "reason": "breaking-stale-conflicting-leases",
+                    "broken_leases": stale_conflicts,
+                },
+                indent=2,
+            )
+        )
+        stale_actors = {lease["actor"] for lease in stale_conflicts}
+        retained = [lease for lease in retained if lease["actor"] not in stale_actors]
+
+    retained.append(build_lease(args.actor, args.mode, args.ttl_seconds))
     write_lane_leases(workspace_root, args.owner_unit, args.lane_name, retained)
     print(lane_leases_file(workspace_root, args.owner_unit, args.lane_name))
     return 0
@@ -498,9 +591,12 @@ def show_lane_leases(args: argparse.Namespace) -> int:
     if args.json:
         print(json.dumps(leases, indent=2))
         return 0
-    print("ACTOR\tMODE\tACQUIRED_AT")
+    print("ACTOR\tMODE\tTTL\tACQUIRED_AT\tEXPIRES_AT\tSTATE")
     for lease in leases:
-        print(f'{lease["actor"]}\t{lease["mode"]}\t{lease["acquired_at"]}')
+        state = "stale" if is_stale_lease(lease) else "active"
+        print(
+            f'{lease["actor"]}\t{lease["mode"]}\t{lease.get("ttl_seconds", "-")}\t{lease["acquired_at"]}\t{lease.get("expires_at", "-")}\t{state}'
+        )
     return 0
 
 
@@ -722,27 +818,41 @@ def plan_exec(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
     leases = load_lane_leases(workspace_root, args.owner_unit, args.lane_name)
-
-    conflicting = [
-        lease
-        for lease in leases
-        if lease["mode"] == "edit" and not lease["actor"].startswith("agent:")
-    ]
-    if conflicting:
+    active_conflicts, stale_conflicts = conflicting_leases(leases, "agent:exec-planner", "exec")
+    if active_conflicts:
         payload = {
             "status": "blocked",
-            "reason": "human-edit-lease",
+            "reason": "conflicting-active-lease",
             "lane": lane_doc["lane_name"],
             "owner_unit": lane_doc["owner_unit"],
-            "conflicting_leases": conflicting,
+            "requested_mode": "exec",
+            "conflicting_leases": active_conflicts,
         }
         if args.json:
             print(json.dumps(payload, indent=2))
         else:
             print("gr2 lane-exec prototype")
-            print("status=blocked reason=human-edit-lease")
-            for lease in conflicting:
+            print("status=blocked reason=conflicting-active-lease")
+            for lease in active_conflicts:
                 print(f'conflict: actor={lease["actor"]} mode={lease["mode"]} acquired_at={lease["acquired_at"]}')
+        return 0
+    if stale_conflicts:
+        payload = {
+            "status": "blocked",
+            "reason": "stale-conflicting-lease",
+            "lane": lane_doc["lane_name"],
+            "owner_unit": lane_doc["owner_unit"],
+            "requested_mode": "exec",
+            "conflicting_leases": stale_conflicts,
+            "hint": "break stale leases with acquire-lane-lease --force or clean them up first",
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print("gr2 lane-exec prototype")
+            print("status=blocked reason=stale-conflicting-lease")
+            for lease in stale_conflicts:
+                print(f'stale-conflict: actor={lease["actor"]} mode={lease["mode"]} expires_at={lease.get("expires_at", "-")}')
         return 0
 
     selected_repos = lane_doc["repos"]

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -31,6 +31,7 @@ class LaneMetadata:
     schema_version: int
     lane_name: str
     owner_unit: str
+    agent_id: str | None
     lane_type: str
     repos: list[str]
     branch_map: dict[str, str]
@@ -45,6 +46,7 @@ class LaneMetadata:
             f"schema_version = {self.schema_version}",
             f'lane_name = "{self.lane_name}"',
             f'owner_unit = "{self.owner_unit}"',
+            f'agent_id = "{self.agent_id or ""}"',
             f'lane_type = "{self.lane_type}"',
             f'creation_source = "{self.creation_source}"',
             "",
@@ -179,11 +181,25 @@ def parse_args() -> argparse.Namespace:
     enter.add_argument("owner_unit")
     enter.add_argument("lane_name")
     enter.add_argument("--actor", required=True, help="actor label, e.g. human:layne or agent:atlas")
+    enter.add_argument("--notify-channel", action="store_true")
+    enter.add_argument("--recall", action="store_true")
+
+    exit_lane = sub.add_parser("exit-lane")
+    exit_lane.add_argument("workspace_root", type=Path)
+    exit_lane.add_argument("owner_unit")
+    exit_lane.add_argument("--actor", required=True)
+    exit_lane.add_argument("--notify-channel", action="store_true")
+    exit_lane.add_argument("--recall", action="store_true")
 
     current = sub.add_parser("current-lane")
     current.add_argument("workspace_root", type=Path)
     current.add_argument("owner_unit")
     current.add_argument("--json", action="store_true")
+
+    history = sub.add_parser("lane-history")
+    history.add_argument("workspace_root", type=Path)
+    history.add_argument("owner_unit")
+    history.add_argument("--json", action="store_true")
 
     lease = sub.add_parser("acquire-lane-lease")
     lease.add_argument("workspace_root", type=Path)
@@ -282,9 +298,29 @@ def lane_leases_file(workspace_root: Path, owner_unit: str, lane_name: str) -> P
     return lane_dir(workspace_root, owner_unit, lane_name) / "leases.json"
 
 
+def events_dir(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "events"
+
+
+def lane_events_file(workspace_root: Path) -> Path:
+    return events_dir(workspace_root) / "lane_events.jsonl"
+
+
+def recall_lane_events_file(workspace_root: Path) -> Path:
+    return events_dir(workspace_root) / "recall_lane_history.jsonl"
+
+
 def load_workspace_spec(workspace_root: Path) -> dict:
     with (workspace_root / ".grip" / "workspace_spec.toml").open("rb") as fh:
         return tomllib.load(fh)
+
+
+def find_unit_spec(workspace_root: Path, owner_unit: str) -> dict:
+    spec = load_workspace_spec(workspace_root)
+    for unit in spec.get("units", []):
+        if unit.get("name") == owner_unit:
+            return unit
+    raise SystemExit(f"unit not found in workspace spec: {owner_unit}")
 
 
 def load_lane_doc(workspace_root: Path, owner_unit: str, lane_name: str) -> dict:
@@ -306,6 +342,33 @@ def load_current_lane_doc(workspace_root: Path, owner_unit: str) -> dict:
     if not path.exists():
         raise SystemExit(f"no current lane recorded for unit: {owner_unit}")
     return json.loads(path.read_text())
+
+
+def append_jsonl(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload) + "\n")
+
+
+def emit_lane_event(workspace_root: Path, payload: dict) -> None:
+    append_jsonl(lane_events_file(workspace_root), payload)
+
+
+def emit_recall_lane_event(workspace_root: Path, payload: dict) -> None:
+    append_jsonl(recall_lane_events_file(workspace_root), payload)
+
+
+def iter_lane_events(workspace_root: Path) -> list[dict]:
+    path = lane_events_file(workspace_root)
+    if not path.exists():
+        return []
+    items: list[dict] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        items.append(json.loads(line))
+    return items
 
 
 def load_lane_leases(workspace_root: Path, owner_unit: str, lane_name: str) -> list[dict]:
@@ -430,6 +493,7 @@ def parse_branch_arg(raw: str, repos: list[str]) -> dict[str, str]:
 def create_lane(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     spec = load_workspace_spec(workspace_root)
+    unit_spec = find_unit_spec(workspace_root, args.owner_unit)
     repo_names = [item["name"] for item in spec.get("repos", [])]
     repos = parse_repo_list(args.repos)
 
@@ -446,6 +510,7 @@ def create_lane(args: argparse.Namespace) -> int:
         schema_version=LANE_SCHEMA_VERSION,
         lane_name=args.lane_name,
         owner_unit=args.owner_unit,
+        agent_id=unit_spec.get("agent_id"),
         lane_type=args.type,
         repos=repos,
         branch_map=parse_branch_arg(args.branch, repos),
@@ -471,6 +536,7 @@ def create_lane(args: argparse.Namespace) -> int:
 def enter_lane(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    unit_spec = find_unit_spec(workspace_root, args.owner_unit)
     path = current_lane_file(workspace_root, args.owner_unit)
     path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -495,6 +561,7 @@ def enter_lane(args: argparse.Namespace) -> int:
     doc = {
         "current": {
             "owner_unit": args.owner_unit,
+            "agent_id": unit_spec.get("agent_id"),
             "lane_name": args.lane_name,
             "lane_type": lane_doc["lane_type"],
             "repos": lane_doc.get("repos", []),
@@ -504,7 +571,87 @@ def enter_lane(args: argparse.Namespace) -> int:
         "recent": deduped,
     }
     path.write_text(json.dumps(doc, indent=2) + "\n")
+    event = {
+        "type": "lane_enter",
+        "agent": args.actor,
+        "agent_id": unit_spec.get("agent_id"),
+        "owner_unit": args.owner_unit,
+        "lane": args.lane_name,
+        "lane_type": lane_doc["lane_type"],
+        "repos": lane_doc.get("repos", []),
+        "timestamp": now_utc(),
+    }
+    emit_lane_event(workspace_root, event)
+    if args.notify_channel:
+        event["channel_message"] = (
+            f'{args.actor} entered {args.owner_unit}/{args.lane_name} '
+            f'[{lane_doc["lane_type"]}] repos={",".join(lane_doc.get("repos", []))}'
+        )
+    if args.recall:
+        emit_recall_lane_event(
+            workspace_root,
+            {
+                "kind": "lane_transition",
+                "action": "enter",
+                "owner_unit": args.owner_unit,
+                "agent_id": unit_spec.get("agent_id"),
+                "actor": args.actor,
+                "lane": args.lane_name,
+                "lane_type": lane_doc["lane_type"],
+                "repos": lane_doc.get("repos", []),
+                "timestamp": event["timestamp"],
+            },
+        )
     print(path)
+    return 0
+
+
+def exit_lane(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    doc = load_current_lane_doc(workspace_root, args.owner_unit)
+    current_doc = doc.get("current")
+    if not current_doc:
+        raise SystemExit(f"no current lane to exit for unit: {args.owner_unit}")
+    event = {
+        "type": "lane_exit",
+        "agent": args.actor,
+        "agent_id": current_doc.get("agent_id"),
+        "owner_unit": args.owner_unit,
+        "lane": current_doc["lane_name"],
+        "lane_type": current_doc["lane_type"],
+        "repos": current_doc.get("repos", []),
+        "timestamp": now_utc(),
+    }
+    emit_lane_event(workspace_root, event)
+    if args.notify_channel:
+        event["channel_message"] = (
+            f'{args.actor} exited {args.owner_unit}/{current_doc["lane_name"]} '
+            f'[{current_doc["lane_type"]}]'
+        )
+    if args.recall:
+        emit_recall_lane_event(
+            workspace_root,
+            {
+                "kind": "lane_transition",
+                "action": "exit",
+                "owner_unit": args.owner_unit,
+                "agent_id": current_doc.get("agent_id"),
+                "actor": args.actor,
+                "lane": current_doc["lane_name"],
+                "lane_type": current_doc["lane_type"],
+                "repos": current_doc.get("repos", []),
+                "timestamp": event["timestamp"],
+            },
+        )
+
+    recent = doc.get("recent", [])
+    next_current = recent[0] if recent else None
+    updated = {
+        "current": next_current,
+        "recent": recent[1:] if next_current else [],
+    }
+    current_lane_file(workspace_root, args.owner_unit).write_text(json.dumps(updated, indent=2) + "\n")
+    print(current_lane_file(workspace_root, args.owner_unit))
     return 0
 
 
@@ -522,6 +669,22 @@ def current_lane(args: argparse.Namespace) -> int:
         print("recent:")
         for item in recent:
             print(f'  - {item["owner_unit"]}/{item["lane_name"]} ({item["lane_type"]})')
+    return 0
+
+
+def lane_history(args: argparse.Namespace) -> int:
+    rows = [
+        event for event in iter_lane_events(args.workspace_root.resolve())
+        if event.get("owner_unit") == args.owner_unit
+    ]
+    if args.json:
+        print(json.dumps(rows, indent=2))
+        return 0
+    print("TIMESTAMP\tTYPE\tACTOR\tAGENT_ID\tLANE\tREPOS")
+    for row in rows:
+        print(
+            f'{row.get("timestamp","-")}\t{row.get("type","-")}\t{row.get("agent","-")}\t{row.get("agent_id","-")}\t{row.get("lane","-")}\t{",".join(row.get("repos", []))}'
+        )
     return 0
 
 
@@ -573,15 +736,47 @@ def acquire_lane_lease(args: argparse.Namespace) -> int:
 
     retained.append(build_lease(args.actor, args.mode, args.ttl_seconds))
     write_lane_leases(workspace_root, args.owner_unit, args.lane_name, retained)
+    lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    unit_spec = find_unit_spec(workspace_root, args.owner_unit)
+    emit_lane_event(
+        workspace_root,
+        {
+            "type": "lease_acquire",
+            "agent": args.actor,
+            "agent_id": unit_spec.get("agent_id"),
+            "owner_unit": args.owner_unit,
+            "lane": args.lane_name,
+            "lane_type": lane_doc["lane_type"],
+            "lease_mode": args.mode,
+            "ttl_seconds": args.ttl_seconds,
+            "repos": lane_doc.get("repos", []),
+            "timestamp": now_utc(),
+        },
+    )
     print(lane_leases_file(workspace_root, args.owner_unit, args.lane_name))
     return 0
 
 
 def release_lane_lease(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
+    lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    unit_spec = find_unit_spec(workspace_root, args.owner_unit)
     leases = load_lane_leases(workspace_root, args.owner_unit, args.lane_name)
     retained = [lease for lease in leases if lease["actor"] != args.actor]
     write_lane_leases(workspace_root, args.owner_unit, args.lane_name, retained)
+    emit_lane_event(
+        workspace_root,
+        {
+            "type": "lease_release",
+            "agent": args.actor,
+            "agent_id": unit_spec.get("agent_id"),
+            "owner_unit": args.owner_unit,
+            "lane": args.lane_name,
+            "lane_type": lane_doc["lane_type"],
+            "repos": lane_doc.get("repos", []),
+            "timestamp": now_utc(),
+        },
+    )
     print(lane_leases_file(workspace_root, args.owner_unit, args.lane_name))
     return 0
 
@@ -906,8 +1101,12 @@ def main() -> int:
         return create_lane(args)
     if args.command == "enter-lane":
         return enter_lane(args)
+    if args.command == "exit-lane":
+        return exit_lane(args)
     if args.command == "current-lane":
         return current_lane(args)
+    if args.command == "lane-history":
+        return lane_history(args)
     if args.command == "create-review-lane":
         return create_review_lane(args)
     if args.command == "show-lane":

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -18,6 +18,7 @@ import json
 import shlex
 import sys
 import tomllib
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -92,6 +93,8 @@ class SharedScratchpad:
     docs_root: str
     notes_root: str
     context_root: str
+    created_at: str
+    updated_at: str
 
     def as_toml(self) -> str:
         lines = [
@@ -101,6 +104,8 @@ class SharedScratchpad:
             f'purpose = "{self.purpose}"',
             f'lifecycle = "{self.lifecycle}"',
             f'creation_source = "{self.creation_source}"',
+            f'created_at = "{self.created_at}"',
+            f'updated_at = "{self.updated_at}"',
             "",
             f'participants = [{", ".join(f"\"{p}\"" for p in self.participants)}]',
             f'linked_refs = [{", ".join(f"\"{r}\"" for r in self.linked_refs)}]',
@@ -185,6 +190,30 @@ def parse_args() -> argparse.Namespace:
     scratch_list = sub.add_parser("list-shared-scratchpads")
     scratch_list.add_argument("workspace_root", type=Path)
 
+    scratch_audit = sub.add_parser("audit-shared-scratchpads")
+    scratch_audit.add_argument("workspace_root", type=Path)
+    scratch_audit.add_argument(
+        "--stale-days",
+        type=int,
+        default=7,
+        help="mark scratchpads as stale when untouched for this many days",
+    )
+
+    promote = sub.add_parser("plan-promote-scratchpad")
+    promote.add_argument("workspace_root", type=Path)
+    promote.add_argument("name")
+    promote.add_argument("--target-repo", required=True)
+    promote.add_argument("--target-path", required=True)
+    promote.add_argument("--owner-unit", required=True)
+    promote.add_argument("--lane", help="optional lane that should carry the promotion")
+
+    recommend = sub.add_parser("recommend-surface")
+    recommend.add_argument("--kind", choices=["code", "doc", "review", "planning"], required=True)
+    recommend.add_argument("--collaborative", action="store_true")
+    recommend.add_argument("--formal-review", action="store_true")
+    recommend.add_argument("--repos", type=int, default=1)
+    recommend.add_argument("--shared-draft", action="store_true")
+
     return parser.parse_args()
 
 
@@ -243,6 +272,15 @@ def iter_shared_scratchpad_files(workspace_root: Path) -> list[Path]:
     if not root.exists():
         return []
     return sorted(root.glob("*/scratchpad.toml"))
+
+
+def now_utc() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def age_days(path: Path) -> int:
+    modified = datetime.fromtimestamp(path.stat().st_mtime, UTC)
+    return max(0, int((datetime.now(UTC) - modified).total_seconds() // 86400))
 
 
 def parse_repo_list(raw: str) -> list[str]:
@@ -357,6 +395,8 @@ def create_shared_scratchpad(args: argparse.Namespace) -> int:
         docs_root=f"shared/scratchpads/{args.name}/docs",
         notes_root=f"shared/scratchpads/{args.name}/notes",
         context_root=f"shared/scratchpads/{args.name}/context",
+        created_at=now_utc(),
+        updated_at=now_utc(),
     )
     shared_scratchpad_file(workspace_root, args.name).write_text(scratchpad.as_toml())
     readme = root / "docs" / "README.md"
@@ -394,13 +434,104 @@ def show_shared_scratchpad(args: argparse.Namespace) -> int:
 
 def list_shared_scratchpads(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
-    print("NAME\tKIND\tLIFECYCLE\tPARTICIPANTS\tPURPOSE")
+    print("NAME\tKIND\tLIFECYCLE\tAGE_DAYS\tPARTICIPANTS\tPURPOSE")
     for path in iter_shared_scratchpad_files(workspace_root):
         doc = tomllib.loads(path.read_text())
         participants = ",".join(doc.get("participants", [])) or "-"
         print(
-            f'{doc["name"]}\t{doc["kind"]}\t{doc["lifecycle"]}\t{participants}\t{doc["purpose"]}'
+            f'{doc["name"]}\t{doc["kind"]}\t{doc["lifecycle"]}\t{age_days(path)}\t{participants}\t{doc["purpose"]}'
         )
+    return 0
+
+
+def audit_shared_scratchpads(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    print("NAME\tSTATUS\tAGE_DAYS\tISSUES")
+    for path in iter_shared_scratchpad_files(workspace_root):
+        doc = tomllib.loads(path.read_text())
+        root = path.parent
+        issues: list[str] = []
+        days = age_days(path)
+        docs_root = root / "docs"
+        notes_root = root / "notes"
+        context_root = root / "context"
+
+        if days >= args.stale_days and doc.get("lifecycle") not in {"done", "paused"}:
+            issues.append("stale-active")
+        if not doc.get("participants"):
+            issues.append("no-participants")
+        if not doc.get("linked_refs"):
+            issues.append("no-refs")
+        if not docs_root.exists():
+            issues.append("missing-docs-root")
+        if not notes_root.exists():
+            issues.append("missing-notes-root")
+        if not context_root.exists():
+            issues.append("missing-context-root")
+        if doc.get("kind") == "doc" and not any(docs_root.iterdir()):
+            issues.append("empty-docs")
+
+        status = "ok" if not issues else "needs-attention"
+        print(f'{doc["name"]}\t{status}\t{days}\t{",".join(issues) or "-"}')
+    return 0
+
+
+def plan_promote_scratchpad(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    doc = load_shared_scratchpad_doc(workspace_root, args.name)
+    lane_name = args.lane or f"promote-{args.name}"
+    print("gr2 prototype scratchpad-promotion plan")
+    print(f'scratchpad: {doc["name"]}')
+    print(f'kind: {doc["kind"]}')
+    print(f'lifecycle: {doc["lifecycle"]}')
+    print(f'target repo: {args.target_repo}')
+    print(f'target path: {args.target_path}')
+    print(f'owner unit: {args.owner_unit}')
+    print(f'suggested lane: {lane_name}')
+    print("recommended:")
+    print(
+        f"  1. create or reuse a feature lane for {args.target_repo} under {args.owner_unit}"
+    )
+    print(
+        f"  2. copy content from shared/scratchpads/{doc['name']}/docs into {args.target_repo}:{args.target_path}"
+    )
+    print(f"  3. branch and commit in lane {lane_name}")
+    print("  4. open a PR once the artifact is ready for formal review")
+    if not doc.get("linked_refs"):
+        print("warning: scratchpad has no linked refs; traceability should be added before promotion")
+    return 0
+
+
+def recommend_surface(args: argparse.Namespace) -> int:
+    recommendation = "feature-lane"
+    rationale: list[str] = []
+
+    if args.kind == "review" or args.formal_review:
+        recommendation = "review-lane"
+        rationale.append("formal review or PR inspection should stay isolated")
+    elif args.kind in {"doc", "planning"} and args.collaborative:
+        recommendation = "shared-scratchpad"
+        rationale.append("shared drafting is lighter than a PR and should not invade private lanes")
+    elif args.shared_draft:
+        recommendation = "shared-scratchpad"
+        rationale.append("explicit shared draft requested")
+    elif args.kind == "code" and args.repos > 1:
+        recommendation = "feature-lane"
+        rationale.append("cross-repo implementation needs one named task context")
+    elif args.kind == "code":
+        recommendation = "feature-lane"
+        rationale.append("private implementation should start in an isolated lane")
+    else:
+        recommendation = "feature-lane"
+        rationale.append("default safe choice is an isolated lane")
+
+    print("gr2 prototype surface recommendation")
+    print(f"recommended: {recommendation}")
+    print(f"why: {'; '.join(rationale)}")
+    print("rules:")
+    print("  - use a review lane for formal PR inspection")
+    print("  - use a shared scratchpad for collaborative drafting")
+    print("  - use a feature lane for implementation work")
     return 0
 
 
@@ -505,6 +636,12 @@ def main() -> int:
         return show_shared_scratchpad(args)
     if args.command == "list-shared-scratchpads":
         return list_shared_scratchpads(args)
+    if args.command == "audit-shared-scratchpads":
+        return audit_shared_scratchpads(args)
+    if args.command == "plan-promote-scratchpad":
+        return plan_promote_scratchpad(args)
+    if args.command == "recommend-surface":
+        return recommend_surface(args)
     raise SystemExit(f"unknown command: {args.command}")
 
 

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import os
 import json
 import shlex
 import sys
+import time
 import tomllib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+import fcntl
 
 
 LANE_SCHEMA_VERSION = 1
@@ -298,6 +301,10 @@ def lane_leases_file(workspace_root: Path, owner_unit: str, lane_name: str) -> P
     return lane_dir(workspace_root, owner_unit, lane_name) / "leases.json"
 
 
+def lane_leases_lock_file(workspace_root: Path, owner_unit: str, lane_name: str) -> Path:
+    return lane_dir(workspace_root, owner_unit, lane_name) / "leases.lock"
+
+
 def events_dir(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "events"
 
@@ -378,9 +385,71 @@ def load_lane_leases(workspace_root: Path, owner_unit: str, lane_name: str) -> l
     return json.loads(path.read_text())
 
 
-def write_lane_leases(workspace_root: Path, owner_unit: str, lane_name: str, leases: list[dict]) -> None:
+def lease_locking_enabled() -> bool:
+    return os.environ.get("GR2_DISABLE_LEASE_LOCKING") != "1"
+
+
+def write_lane_leases(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: str,
+    leases: list[dict],
+    *,
+    lock_fh=None,
+) -> None:
     path = lane_leases_file(workspace_root, owner_unit, lane_name)
-    path.write_text(json.dumps(leases, indent=2) + "\n")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if lock_fh is None:
+        lock_path = lane_leases_lock_file(workspace_root, owner_unit, lane_name)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+", encoding="utf-8") as owned_lock_fh:
+            if lease_locking_enabled():
+                fcntl.flock(owned_lock_fh.fileno(), fcntl.LOCK_EX)
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(leases, indent=2) + "\n")
+            os.replace(tmp, path)
+            if lease_locking_enabled():
+                fcntl.flock(owned_lock_fh.fileno(), fcntl.LOCK_UN)
+        return
+
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(leases, indent=2) + "\n")
+    os.replace(tmp, path)
+
+
+def mutate_lane_leases(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: str,
+    mutator,
+):
+    lock_path = lane_leases_lock_file(workspace_root, owner_unit, lane_name)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_fh:
+        if lease_locking_enabled():
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        path = lane_leases_file(workspace_root, owner_unit, lane_name)
+        if path.exists():
+            leases = json.loads(path.read_text())
+        else:
+            leases = []
+        if not lease_locking_enabled():
+            delay = float(os.environ.get("GR2_LEASE_TEST_DELAY", "0"))
+            if delay > 0:
+                time.sleep(delay)
+        result = mutator(leases)
+        if result.get("write"):
+            write_lane_leases(
+                workspace_root,
+                owner_unit,
+                lane_name,
+                result["leases"],
+                lock_fh=lock_fh,
+            )
+        if lease_locking_enabled():
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+        return result
 
 
 def iter_lane_files(workspace_root: Path, owner_unit: str | None = None) -> list[Path]:
@@ -691,51 +760,17 @@ def lane_history(args: argparse.Namespace) -> int:
 def acquire_lane_lease(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
-    leases = load_lane_leases(workspace_root, args.owner_unit, args.lane_name)
-    retained = [lease for lease in leases if lease["actor"] != args.actor]
-    active_conflicts, stale_conflicts = conflicting_leases(retained, args.actor, args.mode)
-
-    if active_conflicts:
-        payload = {
-            "status": "blocked",
-            "reason": "conflicting-active-lease",
-            "lane": args.lane_name,
-            "owner_unit": args.owner_unit,
-            "requested": {"actor": args.actor, "mode": args.mode},
-            "conflicting_leases": active_conflicts,
-        }
-        print(json.dumps(payload, indent=2))
+    result = mutate_lane_leases(
+        workspace_root,
+        args.owner_unit,
+        args.lane_name,
+        lambda leases: _acquire_lane_lease_mutation(leases, args),
+    )
+    if result["status"] == "blocked":
+        print(json.dumps(result["payload"], indent=2))
         return 1
-
-    if stale_conflicts and not args.force:
-        payload = {
-            "status": "blocked",
-            "reason": "stale-conflicting-lease",
-            "lane": args.lane_name,
-            "owner_unit": args.owner_unit,
-            "requested": {"actor": args.actor, "mode": args.mode},
-            "conflicting_leases": stale_conflicts,
-            "hint": "rerun with --force to break stale conflicting leases",
-        }
-        print(json.dumps(payload, indent=2))
-        return 1
-
-    if stale_conflicts and args.force:
-        print(
-            json.dumps(
-                {
-                    "status": "warning",
-                    "reason": "breaking-stale-conflicting-leases",
-                    "broken_leases": stale_conflicts,
-                },
-                indent=2,
-            )
-        )
-        stale_actors = {lease["actor"] for lease in stale_conflicts}
-        retained = [lease for lease in retained if lease["actor"] not in stale_actors]
-
-    retained.append(build_lease(args.actor, args.mode, args.ttl_seconds))
-    write_lane_leases(workspace_root, args.owner_unit, args.lane_name, retained)
+    if result["status"] == "warning":
+        print(json.dumps(result["warning"], indent=2))
     lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
     unit_spec = find_unit_spec(workspace_root, args.owner_unit)
     emit_lane_event(
@@ -757,13 +792,72 @@ def acquire_lane_lease(args: argparse.Namespace) -> int:
     return 0
 
 
+def _acquire_lane_lease_mutation(leases: list[dict], args: argparse.Namespace) -> dict:
+    retained = [lease for lease in leases if lease["actor"] != args.actor]
+    active_conflicts, stale_conflicts = conflicting_leases(retained, args.actor, args.mode)
+
+    if active_conflicts:
+        return {
+            "status": "blocked",
+            "payload": {
+                "status": "blocked",
+                "reason": "conflicting-active-lease",
+                "lane": args.lane_name,
+                "owner_unit": args.owner_unit,
+                "requested": {"actor": args.actor, "mode": args.mode},
+                "conflicting_leases": active_conflicts,
+            },
+            "write": False,
+        }
+
+    if stale_conflicts and not args.force:
+        return {
+            "status": "blocked",
+            "payload": {
+                "status": "blocked",
+                "reason": "stale-conflicting-lease",
+                "lane": args.lane_name,
+                "owner_unit": args.owner_unit,
+                "requested": {"actor": args.actor, "mode": args.mode},
+                "conflicting_leases": stale_conflicts,
+                "hint": "rerun with --force to break stale conflicting leases",
+            },
+            "write": False,
+        }
+
+    warning = None
+    if stale_conflicts and args.force:
+        warning = {
+            "status": "warning",
+            "reason": "breaking-stale-conflicting-leases",
+            "broken_leases": stale_conflicts,
+        }
+        stale_actors = {lease["actor"] for lease in stale_conflicts}
+        retained = [lease for lease in retained if lease["actor"] not in stale_actors]
+
+    retained.append(build_lease(args.actor, args.mode, args.ttl_seconds))
+    return {
+        "status": "warning" if warning else "ok",
+        "warning": warning,
+        "leases": retained,
+        "write": True,
+    }
+
+
 def release_lane_lease(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
     unit_spec = find_unit_spec(workspace_root, args.owner_unit)
-    leases = load_lane_leases(workspace_root, args.owner_unit, args.lane_name)
-    retained = [lease for lease in leases if lease["actor"] != args.actor]
-    write_lane_leases(workspace_root, args.owner_unit, args.lane_name, retained)
+    mutate_lane_leases(
+        workspace_root,
+        args.owner_unit,
+        args.lane_name,
+        lambda leases: {
+            "status": "ok",
+            "leases": [lease for lease in leases if lease["actor"] != args.actor],
+            "write": True,
+        },
+    )
     emit_lane_event(
         workspace_root,
         {

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -174,6 +174,36 @@ def parse_args() -> argparse.Namespace:
     plan.add_argument("--repos", help="optional comma-separated repo subset")
     plan.add_argument("--json", action="store_true")
 
+    enter = sub.add_parser("enter-lane")
+    enter.add_argument("workspace_root", type=Path)
+    enter.add_argument("owner_unit")
+    enter.add_argument("lane_name")
+    enter.add_argument("--actor", required=True, help="actor label, e.g. human:layne or agent:atlas")
+
+    current = sub.add_parser("current-lane")
+    current.add_argument("workspace_root", type=Path)
+    current.add_argument("owner_unit")
+    current.add_argument("--json", action="store_true")
+
+    lease = sub.add_parser("acquire-lane-lease")
+    lease.add_argument("workspace_root", type=Path)
+    lease.add_argument("owner_unit")
+    lease.add_argument("lane_name")
+    lease.add_argument("--actor", required=True)
+    lease.add_argument("--mode", choices=["edit", "exec", "review"], required=True)
+
+    release = sub.add_parser("release-lane-lease")
+    release.add_argument("workspace_root", type=Path)
+    release.add_argument("owner_unit")
+    release.add_argument("lane_name")
+    release.add_argument("--actor", required=True)
+
+    show_leases = sub.add_parser("show-lane-leases")
+    show_leases.add_argument("workspace_root", type=Path)
+    show_leases.add_argument("owner_unit")
+    show_leases.add_argument("lane_name")
+    show_leases.add_argument("--json", action="store_true")
+
     scratch = sub.add_parser("create-shared-scratchpad")
     scratch.add_argument("workspace_root", type=Path)
     scratch.add_argument("name")
@@ -233,6 +263,14 @@ def shared_scratchpad_file(workspace_root: Path, name: str) -> Path:
     return shared_scratchpad_dir(workspace_root, name) / "scratchpad.toml"
 
 
+def current_lane_file(workspace_root: Path, owner_unit: str) -> Path:
+    return workspace_root / ".grip" / "state" / "current_lane" / f"{owner_unit}.json"
+
+
+def lane_leases_file(workspace_root: Path, owner_unit: str, lane_name: str) -> Path:
+    return lane_dir(workspace_root, owner_unit, lane_name) / "leases.json"
+
+
 def load_workspace_spec(workspace_root: Path) -> dict:
     with (workspace_root / ".grip" / "workspace_spec.toml").open("rb") as fh:
         return tomllib.load(fh)
@@ -250,6 +288,25 @@ def load_shared_scratchpad_doc(workspace_root: Path, name: str) -> dict:
     if not path.exists():
         raise SystemExit(f"shared scratchpad not found: {name}")
     return tomllib.loads(path.read_text())
+
+
+def load_current_lane_doc(workspace_root: Path, owner_unit: str) -> dict:
+    path = current_lane_file(workspace_root, owner_unit)
+    if not path.exists():
+        raise SystemExit(f"no current lane recorded for unit: {owner_unit}")
+    return json.loads(path.read_text())
+
+
+def load_lane_leases(workspace_root: Path, owner_unit: str, lane_name: str) -> list[dict]:
+    path = lane_leases_file(workspace_root, owner_unit, lane_name)
+    if not path.exists():
+        return []
+    return json.loads(path.read_text())
+
+
+def write_lane_leases(workspace_root: Path, owner_unit: str, lane_name: str, leases: list[dict]) -> None:
+    path = lane_leases_file(workspace_root, owner_unit, lane_name)
+    path.write_text(json.dumps(leases, indent=2) + "\n")
 
 
 def iter_lane_files(workspace_root: Path, owner_unit: str | None = None) -> list[Path]:
@@ -350,6 +407,100 @@ def create_lane(args: argparse.Namespace) -> int:
     )
     lane_file(workspace_root, args.owner_unit, args.lane_name).write_text(metadata.as_toml())
     print(lane_file(workspace_root, args.owner_unit, args.lane_name))
+    return 0
+
+
+def enter_lane(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    path = current_lane_file(workspace_root, args.owner_unit)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    previous: list[dict] = []
+    if path.exists():
+        old = json.loads(path.read_text())
+        previous = old.get("recent", [])
+        current = old.get("current")
+        if current:
+            previous.insert(0, current)
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for item in previous:
+        key = (item["owner_unit"], item["lane_name"])
+        if key in seen or key == (args.owner_unit, args.lane_name):
+            continue
+        seen.add(key)
+        deduped.append(item)
+    deduped = deduped[:5]
+
+    doc = {
+        "current": {
+            "owner_unit": args.owner_unit,
+            "lane_name": args.lane_name,
+            "lane_type": lane_doc["lane_type"],
+            "repos": lane_doc.get("repos", []),
+            "actor": args.actor,
+            "entered_at": now_utc(),
+        },
+        "recent": deduped,
+    }
+    path.write_text(json.dumps(doc, indent=2) + "\n")
+    print(path)
+    return 0
+
+
+def current_lane(args: argparse.Namespace) -> int:
+    doc = load_current_lane_doc(args.workspace_root.resolve(), args.owner_unit)
+    if args.json:
+        print(json.dumps(doc, indent=2))
+        return 0
+    current_doc = doc["current"]
+    print("gr2 prototype current-lane")
+    print(f'owner={current_doc["owner_unit"]} lane={current_doc["lane_name"]} type={current_doc["lane_type"]} actor={current_doc["actor"]}')
+    print(f'entered_at={current_doc["entered_at"]}')
+    recent = doc.get("recent", [])
+    if recent:
+        print("recent:")
+        for item in recent:
+            print(f'  - {item["owner_unit"]}/{item["lane_name"]} ({item["lane_type"]})')
+    return 0
+
+
+def acquire_lane_lease(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    leases = load_lane_leases(workspace_root, args.owner_unit, args.lane_name)
+    retained = [lease for lease in leases if lease["actor"] != args.actor]
+    retained.append(
+        {
+            "actor": args.actor,
+            "mode": args.mode,
+            "acquired_at": now_utc(),
+        }
+    )
+    write_lane_leases(workspace_root, args.owner_unit, args.lane_name, retained)
+    print(lane_leases_file(workspace_root, args.owner_unit, args.lane_name))
+    return 0
+
+
+def release_lane_lease(args: argparse.Namespace) -> int:
+    workspace_root = args.workspace_root.resolve()
+    leases = load_lane_leases(workspace_root, args.owner_unit, args.lane_name)
+    retained = [lease for lease in leases if lease["actor"] != args.actor]
+    write_lane_leases(workspace_root, args.owner_unit, args.lane_name, retained)
+    print(lane_leases_file(workspace_root, args.owner_unit, args.lane_name))
+    return 0
+
+
+def show_lane_leases(args: argparse.Namespace) -> int:
+    leases = load_lane_leases(args.workspace_root.resolve(), args.owner_unit, args.lane_name)
+    if args.json:
+        print(json.dumps(leases, indent=2))
+        return 0
+    print("ACTOR\tMODE\tACQUIRED_AT")
+    for lease in leases:
+        print(f'{lease["actor"]}\t{lease["mode"]}\t{lease["acquired_at"]}')
     return 0
 
 
@@ -570,6 +721,29 @@ def next_step(args: argparse.Namespace) -> int:
 def plan_exec(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     lane_doc = load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    leases = load_lane_leases(workspace_root, args.owner_unit, args.lane_name)
+
+    conflicting = [
+        lease
+        for lease in leases
+        if lease["mode"] == "edit" and not lease["actor"].startswith("agent:")
+    ]
+    if conflicting:
+        payload = {
+            "status": "blocked",
+            "reason": "human-edit-lease",
+            "lane": lane_doc["lane_name"],
+            "owner_unit": lane_doc["owner_unit"],
+            "conflicting_leases": conflicting,
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print("gr2 lane-exec prototype")
+            print("status=blocked reason=human-edit-lease")
+            for lease in conflicting:
+                print(f'conflict: actor={lease["actor"]} mode={lease["mode"]} acquired_at={lease["acquired_at"]}')
+        return 0
 
     selected_repos = lane_doc["repos"]
     if args.repos:
@@ -620,6 +794,10 @@ def main() -> int:
     args = parse_args()
     if args.command == "create-lane":
         return create_lane(args)
+    if args.command == "enter-lane":
+        return enter_lane(args)
+    if args.command == "current-lane":
+        return current_lane(args)
     if args.command == "create-review-lane":
         return create_review_lane(args)
     if args.command == "show-lane":
@@ -630,6 +808,12 @@ def main() -> int:
         return next_step(args)
     if args.command == "plan-exec":
         return plan_exec(args)
+    if args.command == "acquire-lane-lease":
+        return acquire_lane_lease(args)
+    if args.command == "release-lane-lease":
+        return release_lane_lease(args)
+    if args.command == "show-lane-leases":
+        return show_lane_leases(args)
     if args.command == "create-shared-scratchpad":
         return create_shared_scratchpad(args)
     if args.command == "show-shared-scratchpad":

--- a/gr2/prototypes/layout_model_probe.py
+++ b/gr2/prototypes/layout_model_probe.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Assess which workspace layout model best matches the observed gr2 behavior.
+
+This is a UX prototype. It does not prescribe the final architecture on its own.
+It makes the current mismatch explicit so we can iterate with evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tomllib
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Probe observed gr2 layout vs candidate models")
+    parser.add_argument("workspace_root", type=Path)
+    parser.add_argument("--owner-unit", required=True)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def load_spec(workspace_root: Path) -> dict:
+    with (workspace_root / ".grip" / "workspace_spec.toml").open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def repo_names(spec: dict) -> list[str]:
+    return [repo["name"] for repo in spec.get("repos", [])]
+
+
+def probe(workspace_root: Path, owner_unit: str) -> dict:
+    spec = load_spec(workspace_root)
+    repos = repo_names(spec)
+    observations: list[dict[str, object]] = []
+    shared_git_count = 0
+    unit_git_count = 0
+
+    for repo in repos:
+        shared_root = workspace_root / "repos" / repo
+        unit_root = workspace_root / "agents" / owner_unit / repo
+        lane_root = workspace_root / "agents" / owner_unit / "lanes" / "feat-auth" / "repos" / repo
+
+        shared_git = (shared_root / ".git").exists()
+        unit_git = (unit_root / ".git").exists()
+        lane_git = (lane_root / ".git").exists()
+        shared_exists = shared_root.exists()
+        unit_exists = unit_root.exists()
+
+        if shared_git:
+            shared_git_count += 1
+        if unit_git:
+            unit_git_count += 1
+
+        observations.append(
+            {
+                "repo": repo,
+                "shared_path_exists": shared_exists,
+                "shared_git": shared_git,
+                "unit_path_exists": unit_exists,
+                "unit_git": unit_git,
+                "lane_git": lane_git,
+            }
+        )
+
+    shared_first_score = 0
+    unit_first_score = 0
+    reasons: list[str] = []
+
+    if unit_git_count == len(repos):
+        unit_first_score += 3
+        reasons.append("all repos materialized as unit-local git checkouts")
+    if shared_git_count == len(repos):
+        shared_first_score += 3
+        reasons.append("all repos materialized as shared git checkouts")
+    if shared_git_count == 0 and any(item["shared_path_exists"] for item in observations):
+        unit_first_score += 2
+        reasons.append("shared repo paths exist as placeholders rather than active checkouts")
+    if any(item["lane_git"] for item in observations):
+        shared_first_score += 1
+        unit_first_score += 1
+        reasons.append("lane-local repo materialization exists, so a routed model may be emerging")
+    else:
+        unit_first_score += 1
+        reasons.append("lane-local repos are not yet materialized")
+
+    if unit_first_score > shared_first_score:
+        recommendation = "ratify-unit-local-first"
+        summary = (
+            "Current behavior matches a unit-local-first model more closely than a shared-repo-first model."
+        )
+    elif shared_first_score > unit_first_score:
+        recommendation = "push-shared-repo-model"
+        summary = (
+            "Current behavior already resembles a shared-repo-first model strongly enough to continue that direction."
+        )
+    else:
+        recommendation = "hybrid-needs-clarification"
+        summary = "Observed behavior is split enough that the model should be clarified explicitly."
+
+    return {
+        "owner_unit": owner_unit,
+        "recommendation": recommendation,
+        "summary": summary,
+        "shared_first_score": shared_first_score,
+        "unit_first_score": unit_first_score,
+        "reasons": reasons,
+        "observations": observations,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    result = probe(args.workspace_root.resolve(), args.owner_unit)
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    print("gr2 prototype layout-model probe")
+    print(f"owner: {result['owner_unit']}")
+    print(f"recommendation: {result['recommendation']}")
+    print(f"summary: {result['summary']}")
+    print(f"score shared-first={result['shared_first_score']} unit-local-first={result['unit_first_score']}")
+    print("reasons:")
+    for reason in result["reasons"]:
+        print(f"- {reason}")
+    print("observations:")
+    print("REPO\tSHARED_PATH\tSHARED_GIT\tUNIT_PATH\tUNIT_GIT\tLANE_GIT")
+    for row in result["observations"]:
+        print(
+            f"{row['repo']}\t{str(row['shared_path_exists']).lower()}\t{str(row['shared_git']).lower()}\t"
+            f"{str(row['unit_path_exists']).lower()}\t{str(row['unit_git']).lower()}\t{str(row['lane_git']).lower()}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/real_git_lane_materialization.py
+++ b/gr2/prototypes/real_git_lane_materialization.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Prototype real-git same-repo multi-agent lane materialization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify real-git same-repo lane materialization"
+    )
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        help="optional workspace root; defaults to a temporary workspace",
+    )
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def lane_proto(root: Path) -> Path:
+    return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
+
+
+def run(
+    argv: list[str],
+    *,
+    cwd: Path | None = None,
+    capture: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        check=check,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def init_workspace(workspace_root: Path, bare_remote: Path) -> None:
+    (workspace_root / ".grip").mkdir(parents=True, exist_ok=True)
+    (workspace_root / "agents").mkdir(exist_ok=True)
+    spec = f"""schema_version = 1
+workspace_name = "real-git-lane-materialization"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{bare_remote}"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+agent_id = "atlas-agent"
+repos = ["app"]
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+agent_id = "apollo-agent"
+repos = ["app"]
+"""
+    (workspace_root / ".grip" / "workspace_spec.toml").write_text(spec)
+
+
+def seed_bare_remote(root: Path) -> Path:
+    remotes = root / "remotes"
+    work = root / "seed-work"
+    remotes.mkdir(parents=True, exist_ok=True)
+    run(["git", "init", "--bare", str(remotes / "app.git")])
+    run(["git", "init", str(work)])
+    run(["git", "config", "user.name", "Playground User"], cwd=work)
+    run(["git", "config", "user.email", "playground@example.com"], cwd=work)
+    (work / "README.md").write_text("# app\n")
+    run(["git", "add", "README.md"], cwd=work)
+    run(["git", "commit", "-m", "Initial commit"], cwd=work)
+    run(["git", "branch", "-M", "main"], cwd=work)
+    run(["git", "remote", "add", "origin", str(remotes / "app.git")], cwd=work)
+    run(["git", "push", "-u", "origin", "main"], cwd=work)
+    return remotes / "app.git"
+
+
+def create_lane(
+    root: Path, workspace_root: Path, owner_unit: str, lane_name: str, branch: str
+) -> None:
+    run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "create-lane",
+            str(workspace_root),
+            owner_unit,
+            lane_name,
+            "--repos",
+            "app",
+            "--branch",
+            branch,
+        ]
+    )
+
+
+def plan_exec_json(
+    root: Path, workspace_root: Path, owner_unit: str, lane_name: str
+) -> list[dict]:
+    proc = run(
+        [
+            "python3",
+            str(lane_proto(root)),
+            "plan-exec",
+            str(workspace_root),
+            owner_unit,
+            lane_name,
+            "git status",
+            "--json",
+        ],
+        capture=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def configure_checkout(repo_path: Path, user_name: str, user_email: str) -> None:
+    run(["git", "config", "user.name", user_name], cwd=repo_path)
+    run(["git", "config", "user.email", user_email], cwd=repo_path)
+
+
+def clone_into_lane(
+    remote: Path, cwd_path: Path, branch: str, user_name: str, user_email: str
+) -> None:
+    cwd_path.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "clone", str(remote), str(cwd_path)])
+    configure_checkout(cwd_path, user_name, user_email)
+    run(["git", "checkout", "-b", branch], cwd=cwd_path)
+
+
+def commit_lane_change(
+    repo_path: Path, filename: str, contents: str, message: str
+) -> str:
+    (repo_path / filename).write_text(contents)
+    run(["git", "add", filename], cwd=repo_path)
+    run(["git", "commit", "-m", message], cwd=repo_path)
+    proc = run(["git", "rev-parse", "HEAD"], cwd=repo_path, capture=True)
+    return proc.stdout.strip()
+
+
+def verify(workspace_root: Path) -> dict:
+    root = repo_root()
+    remote = seed_bare_remote(workspace_root / ".tmp")
+    init_workspace(workspace_root, remote)
+
+    create_lane(root, workspace_root, "atlas", "feat-router", "feat/router")
+    create_lane(root, workspace_root, "apollo", "feat-materialize", "feat/materialize")
+
+    atlas_plan = plan_exec_json(root, workspace_root, "atlas", "feat-router")
+    apollo_plan = plan_exec_json(root, workspace_root, "apollo", "feat-materialize")
+
+    atlas_cwd = Path(atlas_plan[0]["cwd"])
+    apollo_cwd = Path(apollo_plan[0]["cwd"])
+
+    clone_into_lane(remote, atlas_cwd, "feat/router", "Atlas User", "atlas@example.com")
+    clone_into_lane(
+        remote,
+        apollo_cwd,
+        "feat/materialize",
+        "Apollo User",
+        "apollo@example.com",
+    )
+
+    atlas_commit = commit_lane_change(
+        atlas_cwd, "atlas.txt", "atlas lane change\n", "atlas lane commit"
+    )
+    apollo_commit = commit_lane_change(
+        apollo_cwd, "apollo.txt", "apollo lane change\n", "apollo lane commit"
+    )
+
+    atlas_status = run(["git", "status", "--short"], cwd=atlas_cwd, capture=True).stdout.strip()
+    apollo_status = run(["git", "status", "--short"], cwd=apollo_cwd, capture=True).stdout.strip()
+
+    result = {
+        "atlas_cwd": str(atlas_cwd),
+        "apollo_cwd": str(apollo_cwd),
+        "cwd_collision": atlas_cwd == apollo_cwd,
+        "atlas_commit": atlas_commit,
+        "apollo_commit": apollo_commit,
+        "commit_collision": atlas_commit == apollo_commit,
+        "atlas_has_apollo_file": (atlas_cwd / "apollo.txt").exists(),
+        "apollo_has_atlas_file": (apollo_cwd / "atlas.txt").exists(),
+        "atlas_clean": atlas_status == "",
+        "apollo_clean": apollo_status == "",
+    }
+    result["verdict"] = (
+        "holds"
+        if not result["cwd_collision"]
+        and not result["commit_collision"]
+        and not result["atlas_has_apollo_file"]
+        and not result["apollo_has_atlas_file"]
+        and result["atlas_clean"]
+        and result["apollo_clean"]
+        else "fails"
+    )
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+    if args.workspace_root:
+        workspace_root = args.workspace_root.resolve()
+        if workspace_root.exists():
+            shutil.rmtree(workspace_root)
+        workspace_root.mkdir(parents=True, exist_ok=True)
+        result = verify(workspace_root)
+    else:
+        with tempfile.TemporaryDirectory(prefix="gr2-real-git-lanes-") as tmp:
+            workspace_root = Path(tmp)
+            result = verify(workspace_root)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print("gr2 real-git same-repo lane materialization")
+        print(f'workspace: {workspace_root}')
+        print(f'verdict: {result["verdict"]}')
+        print(f'atlas cwd: {result["atlas_cwd"]}')
+        print(f'apollo cwd: {result["apollo_cwd"]}')
+        print(f'cwd collision: {result["cwd_collision"]}')
+        print(f'commit collision: {result["commit_collision"]}')
+        print(f'atlas sees apollo file: {result["atlas_has_apollo_file"]}')
+        print(f'apollo sees atlas file: {result["apollo_has_atlas_file"]}')
+        print(f'atlas clean: {result["atlas_clean"]}')
+        print(f'apollo clean: {result["apollo_clean"]}')
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/real_git_playground.py
+++ b/gr2/prototypes/real_git_playground.py
@@ -77,6 +77,10 @@ def transport_probe(root: Path) -> Path:
     return root / "gr2" / "prototypes" / "repo_transport_probe.py"
 
 
+def layout_probe(root: Path) -> Path:
+    return root / "gr2" / "prototypes" / "layout_model_probe.py"
+
+
 def repo_url(repo_name: str, transport: str) -> str:
     return PLAYGROUND_REPOS[repo_name][transport]
 
@@ -175,6 +179,7 @@ def main() -> int:
     gr2 = gr2_binary(root)
     lane_script = lane_proto(root)
     probe_script = transport_probe(root)
+    layout_script = layout_probe(root)
     has_exec = gr2_supports_exec(gr2)
 
     if not workspace_root.exists():
@@ -419,6 +424,19 @@ def main() -> int:
     )
     print(promotion_plan.stdout)
 
+    layout_assessment = run(
+        [
+            sys.executable,
+            str(layout_script),
+            str(workspace_root),
+            "--owner-unit",
+            args.owner_unit,
+        ],
+        cwd=root,
+        capture=True,
+    )
+    print(layout_assessment.stdout)
+
     verify_paths(workspace_root, args.owner_unit)
 
     print("\nreal-git playground bootstrap complete")
@@ -430,6 +448,7 @@ def main() -> int:
     print("- the prototype can recommend lane vs review vs shared scratchpad")
     print("- the prototype can audit scratchpads for stale or weak tracking")
     print("- the prototype can show a promotion path from scratchpad to repo artifact")
+    print("- the prototype can assess whether the observed layout matches the intended model")
     if has_exec:
         print("- exec status stays lane-scoped")
     else:

--- a/gr2/prototypes/real_git_playground.py
+++ b/gr2/prototypes/real_git_playground.py
@@ -73,6 +73,10 @@ def lane_proto(root: Path) -> Path:
     return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
 
 
+def transport_probe(root: Path) -> Path:
+    return root / "gr2" / "prototypes" / "repo_transport_probe.py"
+
+
 def repo_url(repo_name: str, transport: str) -> str:
     return PLAYGROUND_REPOS[repo_name][transport]
 
@@ -170,6 +174,7 @@ def main() -> int:
 
     gr2 = gr2_binary(root)
     lane_script = lane_proto(root)
+    probe_script = transport_probe(root)
     has_exec = gr2_supports_exec(gr2)
 
     if not workspace_root.exists():
@@ -196,6 +201,27 @@ def main() -> int:
         workspace_root, args.owner_unit, args.workspace_name, args.transport
     )
 
+    try:
+        probe = run(
+            [
+                sys.executable,
+                str(probe_script),
+                str(workspace_root / ".grip" / "workspace_spec.toml"),
+            ],
+            cwd=root,
+            capture=True,
+        )
+        print(probe.stdout)
+    except subprocess.CalledProcessError as exc:
+        if exc.stdout:
+            print(exc.stdout)
+        raise SystemExit(
+            f"repo transport probe failed before apply.\n"
+            f"transport={args.transport}\n"
+            "The selected remotes are not ready to clone from this environment.\n"
+            "Fix auth/transport first or rerun with a different `--transport`."
+        ) from exc
+
     run([str(gr2), "spec", "validate"], cwd=workspace_root)
     run([str(gr2), "plan", "--yes"], cwd=workspace_root)
     try:
@@ -204,6 +230,8 @@ def main() -> int:
         raise SystemExit(
             f"gr2 apply failed during real-git bootstrap.\n"
             f"transport={args.transport}\n"
+            "Probe output above should indicate whether the failure is due to "
+            "transport reachability or authentication.\n"
             "This usually means the selected Git transport is not reachable or "
             "authenticated in the current environment.\n"
             "Try rerunning with `--transport https` or `--transport ssh` as appropriate."

--- a/gr2/prototypes/real_git_playground.py
+++ b/gr2/prototypes/real_git_playground.py
@@ -21,9 +21,18 @@ from pathlib import Path
 
 
 PLAYGROUND_REPOS = {
-    "app": "git@github.com:synapt-dev/gr2-playground-app.git",
-    "api": "git@github.com:synapt-dev/gr2-playground-api.git",
-    "web": "git@github.com:synapt-dev/gr2-playground-web.git",
+    "app": {
+        "ssh": "git@github.com:synapt-dev/gr2-playground-app.git",
+        "https": "https://github.com/synapt-dev/gr2-playground-app.git",
+    },
+    "api": {
+        "ssh": "git@github.com:synapt-dev/gr2-playground-api.git",
+        "https": "https://github.com/synapt-dev/gr2-playground-api.git",
+    },
+    "web": {
+        "ssh": "git@github.com:synapt-dev/gr2-playground-web.git",
+        "https": "https://github.com/synapt-dev/gr2-playground-web.git",
+    },
 }
 
 
@@ -38,6 +47,12 @@ def parse_args() -> argparse.Namespace:
         "--keep-existing",
         action="store_true",
         help="reuse an existing workspace root instead of failing",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["ssh", "https"],
+        default="ssh",
+        help="git remote transport to use for playground repos",
     )
     return parser.parse_args()
 
@@ -56,6 +71,10 @@ def gr2_binary(root: Path) -> Path:
 
 def lane_proto(root: Path) -> Path:
     return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
+
+
+def repo_url(repo_name: str, transport: str) -> str:
+    return PLAYGROUND_REPOS[repo_name][transport]
 
 
 def run(
@@ -79,7 +98,9 @@ def gr2_supports_exec(gr2: Path) -> bool:
     return "\n  exec" in help_out.stdout
 
 
-def write_workspace_spec(workspace_root: Path, owner_unit: str, workspace_name: str) -> None:
+def write_workspace_spec(
+    workspace_root: Path, owner_unit: str, workspace_name: str, transport: str
+) -> None:
     spec = f"""schema_version = 1
 workspace_name = "{workspace_name}"
 
@@ -89,17 +110,17 @@ root = ".grip/cache"
 [[repos]]
 name = "app"
 path = "repos/app"
-url = "{PLAYGROUND_REPOS["app"]}"
+url = "{repo_url("app", transport)}"
 
 [[repos]]
 name = "api"
 path = "repos/api"
-url = "{PLAYGROUND_REPOS["api"]}"
+url = "{repo_url("api", transport)}"
 
 [[repos]]
 name = "web"
 path = "repos/web"
-url = "{PLAYGROUND_REPOS["web"]}"
+url = "{repo_url("web", transport)}"
 
 [[units]]
 name = "{owner_unit}"
@@ -165,14 +186,28 @@ def main() -> int:
 
     run([str(gr2), "unit", "add", args.owner_unit], cwd=workspace_root)
 
-    for repo_name, repo_url in PLAYGROUND_REPOS.items():
-        run([str(gr2), "repo", "add", repo_name, repo_url], cwd=workspace_root)
+    for repo_name in PLAYGROUND_REPOS:
+        run(
+            [str(gr2), "repo", "add", repo_name, repo_url(repo_name, args.transport)],
+            cwd=workspace_root,
+        )
 
-    write_workspace_spec(workspace_root, args.owner_unit, args.workspace_name)
+    write_workspace_spec(
+        workspace_root, args.owner_unit, args.workspace_name, args.transport
+    )
 
     run([str(gr2), "spec", "validate"], cwd=workspace_root)
     run([str(gr2), "plan", "--yes"], cwd=workspace_root)
-    run([str(gr2), "apply", "--yes"], cwd=workspace_root)
+    try:
+        run([str(gr2), "apply", "--yes"], cwd=workspace_root)
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(
+            f"gr2 apply failed during real-git bootstrap.\n"
+            f"transport={args.transport}\n"
+            "This usually means the selected Git transport is not reachable or "
+            "authenticated in the current environment.\n"
+            "Try rerunning with `--transport https` or `--transport ssh` as appropriate."
+        ) from exc
 
     run(["git", "-C", str(unit_repo_path(workspace_root, args.owner_unit, "app")), "checkout", "-b", "feat/auth"])
     run(["git", "-C", str(unit_repo_path(workspace_root, args.owner_unit, "api")), "checkout", "-b", "feat/auth"])
@@ -306,6 +341,56 @@ def main() -> int:
     )
     print(scratchpads.stdout)
 
+    recommendation = run(
+        [
+            sys.executable,
+            str(lane_script),
+            "recommend-surface",
+            "--kind",
+            "doc",
+            "--collaborative",
+            "--shared-draft",
+            "--repos",
+            "1",
+        ],
+        cwd=root,
+        capture=True,
+    )
+    print(recommendation.stdout)
+
+    scratchpad_audit = run(
+        [
+            sys.executable,
+            str(lane_script),
+            "audit-shared-scratchpads",
+            str(workspace_root),
+            "--stale-days",
+            "1",
+        ],
+        cwd=root,
+        capture=True,
+    )
+    print(scratchpad_audit.stdout)
+
+    promotion_plan = run(
+        [
+            sys.executable,
+            str(lane_script),
+            "plan-promote-scratchpad",
+            str(workspace_root),
+            "blog-draft",
+            "--target-repo",
+            "app",
+            "--target-path",
+            "docs/blog/blog-draft.md",
+            "--owner-unit",
+            args.owner_unit,
+        ],
+        cwd=root,
+        capture=True,
+    )
+    print(promotion_plan.stdout)
+
     verify_paths(workspace_root, args.owner_unit)
 
     print("\nreal-git playground bootstrap complete")
@@ -314,6 +399,9 @@ def main() -> int:
     print("- real remotes cloned into unit-local repo paths")
     print("- dirty local git state can be observed")
     print("- multiple lanes can coexist in metadata")
+    print("- the prototype can recommend lane vs review vs shared scratchpad")
+    print("- the prototype can audit scratchpads for stale or weak tracking")
+    print("- the prototype can show a promotion path from scratchpad to repo artifact")
     if has_exec:
         print("- exec status stays lane-scoped")
     else:

--- a/gr2/prototypes/real_git_playground.py
+++ b/gr2/prototypes/real_git_playground.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Bootstrap and verify a real-git gr2 playground workspace.
+
+This harness is intentionally pragmatic:
+
+- it uses actual GitHub repos in synapt-dev
+- it exercises the current shipped gr2 surfaces against real remotes
+- it combines current gr2 commands with prototype-only scratchpad commands
+
+The goal is not to pretend gr2 is further along than it is. The goal is to
+pressure the UX against real git state so we can iterate with data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PLAYGROUND_REPOS = {
+    "app": "git@github.com:synapt-dev/gr2-playground-app.git",
+    "api": "git@github.com:synapt-dev/gr2-playground-api.git",
+    "web": "git@github.com:synapt-dev/gr2-playground-web.git",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap a real-git gr2 playground workspace"
+    )
+    parser.add_argument("workspace_root", type=Path)
+    parser.add_argument("--owner-unit", default="atlas")
+    parser.add_argument("--workspace-name", default="gr2-real-git-playground")
+    parser.add_argument(
+        "--keep-existing",
+        action="store_true",
+        help="reuse an existing workspace root instead of failing",
+    )
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def gr2_binary(root: Path) -> Path:
+    binary = root / "target" / "debug" / "gr2"
+    if binary.exists():
+        return binary
+    run(["cargo", "build", "--quiet", "--bin", "gr2"], cwd=root)
+    return binary
+
+
+def lane_proto(root: Path) -> Path:
+    return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
+
+
+def run(
+    argv: list[str],
+    *,
+    cwd: Path | None = None,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    print("+", " ".join(argv))
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def gr2_supports_exec(gr2: Path) -> bool:
+    help_out = run([str(gr2), "--help"], capture=True)
+    return "\n  exec" in help_out.stdout
+
+
+def write_workspace_spec(workspace_root: Path, owner_unit: str, workspace_name: str) -> None:
+    spec = f"""schema_version = 1
+workspace_name = "{workspace_name}"
+
+[cache]
+root = ".grip/cache"
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "{PLAYGROUND_REPOS["app"]}"
+
+[[repos]]
+name = "api"
+path = "repos/api"
+url = "{PLAYGROUND_REPOS["api"]}"
+
+[[repos]]
+name = "web"
+path = "repos/web"
+url = "{PLAYGROUND_REPOS["web"]}"
+
+[[units]]
+name = "{owner_unit}"
+path = "agents/{owner_unit}"
+repos = ["app", "api", "web"]
+"""
+    spec_path = workspace_root / ".grip" / "workspace_spec.toml"
+    spec_path.write_text(spec)
+
+
+def ensure(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def unit_repo_path(workspace_root: Path, owner_unit: str, repo_name: str) -> Path:
+    return workspace_root / "agents" / owner_unit / repo_name
+
+
+def verify_paths(workspace_root: Path, owner_unit: str) -> None:
+    for rel in [
+        ".grip/workspace.toml",
+        ".grip/workspace_spec.toml",
+        f"agents/{owner_unit}/app/.git",
+        f"agents/{owner_unit}/api/.git",
+        f"agents/{owner_unit}/web/.git",
+        f".grip/state/lanes/{owner_unit}/feat-auth.toml",
+        f".grip/state/lanes/{owner_unit}/feat-web.toml",
+        f".grip/state/lanes/{owner_unit}/review-app-123.toml",
+        "shared/scratchpads/blog-draft/scratchpad.toml",
+    ]:
+        ensure((workspace_root / rel).exists(), f"expected path missing: {rel}")
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root()
+    workspace_root = args.workspace_root.resolve()
+
+    if workspace_root.exists() and not args.keep_existing:
+        if any(workspace_root.iterdir()):
+            raise SystemExit(
+                f"workspace root already exists and is not empty: {workspace_root} "
+                "(pass --keep-existing to reuse)"
+            )
+        workspace_root.rmdir()
+
+    gr2 = gr2_binary(root)
+    lane_script = lane_proto(root)
+    has_exec = gr2_supports_exec(gr2)
+
+    if not workspace_root.exists():
+        run(
+            [
+                str(gr2),
+                "init",
+                str(workspace_root),
+                "--name",
+                args.workspace_name,
+            ],
+            cwd=root,
+        )
+
+    run([str(gr2), "unit", "add", args.owner_unit], cwd=workspace_root)
+
+    for repo_name, repo_url in PLAYGROUND_REPOS.items():
+        run([str(gr2), "repo", "add", repo_name, repo_url], cwd=workspace_root)
+
+    write_workspace_spec(workspace_root, args.owner_unit, args.workspace_name)
+
+    run([str(gr2), "spec", "validate"], cwd=workspace_root)
+    run([str(gr2), "plan", "--yes"], cwd=workspace_root)
+    run([str(gr2), "apply", "--yes"], cwd=workspace_root)
+
+    run(["git", "-C", str(unit_repo_path(workspace_root, args.owner_unit, "app")), "checkout", "-b", "feat/auth"])
+    run(["git", "-C", str(unit_repo_path(workspace_root, args.owner_unit, "api")), "checkout", "-b", "feat/auth"])
+    run(["git", "-C", str(unit_repo_path(workspace_root, args.owner_unit, "web")), "checkout", "-b", "feat/web"])
+
+    app_readme = unit_repo_path(workspace_root, args.owner_unit, "app") / "README.md"
+    app_readme.write_text(app_readme.read_text() + "\nDirty playground change.\n")
+
+    repo_status = run(
+        [str(gr2), "repo", "status"],
+        cwd=workspace_root,
+        capture=True,
+    )
+    print(repo_status.stdout)
+
+    run(
+        [
+            str(gr2),
+            "lane",
+            "create",
+            "feat-auth",
+            "--owner-unit",
+            args.owner_unit,
+            "--repo",
+            "app",
+            "--repo",
+            "api",
+            "--branch",
+            "app=feat/auth",
+            "--branch",
+            "api=feat/auth",
+            "--exec",
+            "cargo test -p app",
+            "--exec",
+            "cargo test -p api",
+        ],
+        cwd=workspace_root,
+    )
+    run(
+        [
+            str(gr2),
+            "lane",
+            "create",
+            "feat-web",
+            "--owner-unit",
+            args.owner_unit,
+            "--repo",
+            "web",
+            "--branch",
+            "web=feat/web",
+            "--exec",
+            "npm test",
+        ],
+        cwd=workspace_root,
+    )
+    run(
+        [
+            str(gr2),
+            "lane",
+            "create",
+            "review-app-123",
+            "--owner-unit",
+            args.owner_unit,
+            "--type",
+            "review",
+            "--repo",
+            "app",
+            "--pr",
+            "app:123",
+            "--branch",
+            "app=review/pr-123",
+        ],
+        cwd=workspace_root,
+    )
+
+    lane_list = run(
+        [str(gr2), "lane", "list", "--owner-unit", args.owner_unit],
+        cwd=workspace_root,
+        capture=True,
+    )
+    print(lane_list.stdout)
+
+    if has_exec:
+        exec_status = run(
+            [
+                str(gr2),
+                "exec",
+                "status",
+                "--lane",
+                "feat-auth",
+                "--owner-unit",
+                args.owner_unit,
+            ],
+            cwd=workspace_root,
+            capture=True,
+        )
+        print(exec_status.stdout)
+    else:
+        print(
+            "note: this branch does not ship `gr2 exec status`; "
+            "real-git exec verification is deferred until the exec surface lands "
+            "on the same branch as the playground flow"
+        )
+
+    run(
+        [
+            sys.executable,
+            str(lane_script),
+            "create-shared-scratchpad",
+            str(workspace_root),
+            "blog-draft",
+            "--kind",
+            "doc",
+            "--purpose",
+            "Real-git shared drafting verification",
+            "--participant",
+            args.owner_unit,
+            "--participant",
+            "layne",
+            "--ref",
+            "grip#552",
+            "--ref",
+            "grip#555",
+        ],
+        cwd=root,
+    )
+    scratchpads = run(
+        [sys.executable, str(lane_script), "list-shared-scratchpads", str(workspace_root)],
+        cwd=root,
+        capture=True,
+    )
+    print(scratchpads.stdout)
+
+    verify_paths(workspace_root, args.owner_unit)
+
+    print("\nreal-git playground bootstrap complete")
+    print(f"workspace: {workspace_root}")
+    print("verified:")
+    print("- real remotes cloned into unit-local repo paths")
+    print("- dirty local git state can be observed")
+    print("- multiple lanes can coexist in metadata")
+    if has_exec:
+        print("- exec status stays lane-scoped")
+    else:
+        print("- exec verification is still pending branch convergence with the shipped exec surface")
+    print("- shared scratchpad can exist beside private lanes")
+    print("observation:")
+    print("- current apply converges unit-local checkouts under agents/<unit>/..., not repos/<repo>")
+    if not has_exec:
+        print("- current prototype and shipped lane metadata are not yet unified enough for one exec harness")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/repo_transport_probe.py
+++ b/gr2/prototypes/repo_transport_probe.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Probe whether repo remotes are reachable/authenticated before gr2 apply.
+
+This is a UX prototype, not a full transport manager. Its job is to answer:
+
+- will this remote likely clone successfully from this environment?
+- if not, is the problem transport reachability or authentication?
+- what should the user try next?
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+SSH_TIMEOUT_SECONDS = 5
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Probe repo transport/auth readiness")
+    parser.add_argument("workspace_spec", type=Path, help="path to workspace_spec.toml")
+    parser.add_argument("--json", action="store_true", help="emit structured JSON")
+    return parser.parse_args()
+
+
+def detect_transport(url: str) -> str:
+    if url.startswith("git@") or url.startswith("ssh://"):
+        return "ssh"
+    if url.startswith("https://") or url.startswith("http://"):
+        return "https"
+    return "unknown"
+
+
+def classify_failure(stderr: str, transport: str) -> tuple[str, str]:
+    text = stderr.lower()
+    if "operation timed out" in text or "connection timed out" in text:
+        return ("transport-unreachable", f"{transport} transport timed out")
+    if "connection refused" in text:
+        return ("transport-unreachable", f"{transport} transport refused connection")
+    if "permission denied (publickey)" in text:
+        return ("auth-failed", "ssh key was rejected")
+    if "could not read username" in text or "authentication failed" in text:
+        return ("auth-failed", "https authentication is missing or invalid")
+    if "repository not found" in text:
+        return ("repo-not-found", "repository not found or not visible to current auth")
+    if "could not resolve host" in text:
+        return ("dns-failed", "host could not be resolved")
+    return ("probe-failed", stderr.strip().splitlines()[-1] if stderr.strip() else "unknown error")
+
+
+def recommendation(status: str, transport: str) -> str:
+    if status == "ok":
+        return "selected transport looks usable"
+    if status == "transport-unreachable" and transport == "ssh":
+        return "try HTTPS or fix SSH network reachability"
+    if status == "transport-unreachable":
+        return "check network access or remote availability"
+    if status == "auth-failed" and transport == "ssh":
+        return "load the correct SSH key or switch to HTTPS"
+    if status == "auth-failed":
+        return "configure GitHub HTTPS auth or switch to SSH"
+    if status == "repo-not-found":
+        return "verify repo visibility and credentials"
+    if status == "dns-failed":
+        return "fix host resolution before retrying"
+    return "inspect stderr and retry with an explicit transport"
+
+
+def probe_url(url: str) -> tuple[str, str]:
+    transport = detect_transport(url)
+    env = None
+    if transport == "ssh":
+        env = {
+            **dict(os.environ),
+            "GIT_SSH_COMMAND": (
+                f"ssh -o BatchMode=yes -o ConnectTimeout={SSH_TIMEOUT_SECONDS} "
+                "-o StrictHostKeyChecking=accept-new"
+            ),
+        }
+
+    result = subprocess.run(
+        ["git", "ls-remote", "--symref", url, "HEAD"],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    if result.returncode == 0:
+        head_ref = ""
+        for line in result.stdout.splitlines():
+            match = re.match(r"ref: refs/heads/(.+)\s+HEAD", line)
+            if match:
+                head_ref = match.group(1)
+                break
+        return ("ok", head_ref or "HEAD reachable")
+    status, detail = classify_failure(result.stderr, transport)
+    return (status, detail)
+
+
+def load_spec(path: Path) -> list[dict[str, str]]:
+    with path.open("rb") as fh:
+        doc = tomllib.load(fh)
+    return list(doc.get("repos", []))
+
+
+def main() -> int:
+    args = parse_args()
+    repos = load_spec(args.workspace_spec)
+    rows: list[dict[str, str]] = []
+    exit_code = 0
+    for repo in repos:
+        url = repo["url"]
+        transport = detect_transport(url)
+        status, detail = probe_url(url)
+        if status != "ok":
+            exit_code = 1
+        rows.append(
+            {
+                "repo": repo["name"],
+                "url": url,
+                "transport": transport,
+                "status": status,
+                "detail": detail,
+                "recommendation": recommendation(status, transport),
+            }
+        )
+
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print("REPO\tTRANSPORT\tSTATUS\tDETAIL\tNEXT")
+        for row in rows:
+            print(
+                f'{row["repo"]}\t{row["transport"]}\t{row["status"]}\t'
+                f'{row["detail"]}\t{row["recommendation"]}'
+            )
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- stack the shared scratchpad + real-git playground prototype work on top of `atlas/gr2-exec`
- verify the prototype against the shipped `gr2 exec status` surface before `#550` lands on `main`
- capture integrated UX findings from a real-git run against actual org repos

## Why
Waiting for `#550` to merge to `main` would stall useful prototype iteration. This stacked PR gives us a real review surface now.

## Real-git verification run
Executed `gr2/prototypes/real_git_playground.py` on this stacked branch against:
- `synapt-dev/gr2-playground-app`
- `synapt-dev/gr2-playground-api`
- `synapt-dev/gr2-playground-web`

Integrated findings:
- current `apply` converges unit-local checkouts under `agents/<unit>/...`
- `repo status` still reports `repos/<repo>` as `block_path_conflict` placeholders rather than real shared clones
- dirty local git state is detected correctly on unit-local repos
- multiple feature/review lanes can coexist in metadata
- `exec status` stays lane-scoped and reports lane-local repos as `missing` when not materialized under the lane root
- shared scratchpads can coexist beside private lanes

## Notes
- this is intentionally a stacked review surface on top of `atlas/gr2-exec`
- once `#550` lands on `main`, this branch should be rebased or restacked onto `main`
