### PR TITLE
feat: add python-first gr2 workspace orchestration

### DIFF
--- a/gr2/prototypes/python_exec_playground.py
+++ b/gr2/prototypes/python_exec_playground.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(args: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    proc = subprocess.run(args, cwd=cwd, env=env, text=True, capture_output=True)
+    if check and proc.returncode != 0:
+        raise SystemExit(f"command failed: {args}\nstdout={proc.stdout}\nstderr={proc.stderr}")
+    return proc
+
+
+def pygr2(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["python3", "-m", "gr2.python_cli", *args], cwd=cwd, check=check)
+
+
+def git(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["git", *args], cwd=cwd, check=check)
+
+
+def seed_remote(remote: Path) -> None:
+    git("init", "--bare", str(remote))
+    with tempfile.TemporaryDirectory(prefix="gr2-exec-seed-") as td:
+        seed = Path(td) / "seed"
+        git("clone", str(remote), str(seed))
+        git("config", "user.name", "Atlas", cwd=seed)
+        git("config", "user.email", "atlas@example.com", cwd=seed)
+        (seed / "README.md").write_text("# demo\n")
+        git("add", "README.md", cwd=seed)
+        git("commit", "-m", "seed", cwd=seed)
+        git("push", "origin", "HEAD:main", cwd=seed)
+    git("--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main")
+
+
+def write_spec(workspace_root: Path, remote: Path) -> None:
+    grip_dir = workspace_root / ".grip"
+    grip_dir.mkdir(parents=True, exist_ok=True)
+    (grip_dir / "workspace_spec.toml").write_text(
+        "\n".join(
+            [
+                'workspace_name = "exec-playground"',
+                "",
+                "[[repos]]",
+                'name = "demo"',
+                'path = "repos/demo"',
+                f'url = "{remote.as_posix()}"',
+                "",
+                "[[units]]",
+                'name = "atlas"',
+                'path = "agents/atlas/home"',
+                'repos = ["demo"]',
+                "",
+            ]
+        )
+    )
+
+
+def base_workspace() -> Path:
+    workspace_root = Path(tempfile.mkdtemp(prefix="gr2-exec-playground-"))
+    remote = workspace_root / "demo-remote.git"
+    seed_remote(remote)
+    write_spec(workspace_root, remote)
+    pygr2("apply", str(workspace_root), "--yes")
+    pygr2(
+        "lane",
+        "create",
+        str(workspace_root),
+        "atlas",
+        "feat-auth",
+        "--repos",
+        "demo",
+        "--branch",
+        "feat/auth",
+    )
+    pygr2("lane", "enter", str(workspace_root), "atlas", "feat-auth", "--actor", "agent:atlas")
+    return workspace_root
+
+
+def scenario_exec_status_ready() -> dict[str, object]:
+    workspace_root = base_workspace()
+    payload = json.loads(pygr2("exec", "status", str(workspace_root), "atlas", "--json").stdout)
+    row = payload["rows"][0]
+    return {
+        "name": "exec-status-ready",
+        "holds": payload["status"] == "ready"
+        and payload["lane"] == "feat-auth"
+        and row["repo"] == "demo"
+        and row["exists"] is True
+        and row["cwd"].endswith("/agents/atlas/lanes/feat-auth/repos/demo"),
+        "payload": payload,
+    }
+
+
+def scenario_exec_run_success() -> dict[str, object]:
+    workspace_root = base_workspace()
+    payload = json.loads(
+        pygr2(
+            "exec",
+            "run",
+            str(workspace_root),
+            "atlas",
+            "python3",
+            "-c",
+            "from pathlib import Path; Path('EXEC_OK').write_text('ok\\n')",
+            "--actor",
+            "agent:atlas",
+            "--json",
+        ).stdout
+    )
+    repo_root = workspace_root / "agents" / "atlas" / "lanes" / "feat-auth" / "repos" / "demo"
+    leases_path = workspace_root / "agents" / "atlas" / "lanes" / "feat-auth" / "leases.json"
+    leases = json.loads(leases_path.read_text()) if leases_path.exists() else []
+    return {
+        "name": "exec-run-success",
+        "holds": payload["status"] == "success"
+        and payload["results"][0]["status"] == "ok"
+        and repo_root.joinpath("EXEC_OK").exists()
+        and leases == [],
+        "payload": payload,
+    }
+
+
+def scenario_exec_blocked_by_edit() -> dict[str, object]:
+    workspace_root = base_workspace()
+    pygr2(
+        "lane",
+        "lease",
+        "acquire",
+        str(workspace_root),
+        "atlas",
+        "feat-auth",
+        "--actor",
+        "human:layne",
+        "--mode",
+        "edit",
+    )
+    proc = pygr2(
+        "exec",
+        "run",
+        str(workspace_root),
+        "atlas",
+        "pwd",
+        "--actor",
+        "agent:atlas",
+        "--json",
+        check=False,
+    )
+    payload = json.loads(proc.stdout)
+    return {
+        "name": "exec-blocked-by-edit",
+        "holds": proc.returncode == 1
+        and payload["status"] == "blocked"
+        and payload["reason"] == "conflicting-active-lease",
+        "payload": payload,
+    }
+
+
+SCENARIOS = [
+    scenario_exec_status_ready,
+    scenario_exec_run_success,
+    scenario_exec_blocked_by_edit,
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Playground verification for Python gr2 exec status/run.")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    results = [scenario() for scenario in SCENARIOS]
+    verdict = "holds" if all(item["holds"] for item in results) else "gaps"
+    payload = {"verdict": verdict, "results": results}
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"python exec playground verdict: {verdict}")
+        for item in results:
+            print(f"- {item['name']}: {'holds' if item['holds'] else 'gaps'}")
+    return 0 if verdict == "holds" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/python_hook_runtime_playground.py
+++ b/gr2/prototypes/python_hook_runtime_playground.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(args: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    proc = subprocess.run(args, cwd=cwd, env=env, text=True, capture_output=True)
+    if check and proc.returncode != 0:
+        raise SystemExit(f"command failed: {args}\nstdout={proc.stdout}\nstderr={proc.stderr}")
+    return proc
+
+
+def pygr2(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["python3", "-m", "gr2.python_cli", *args], cwd=cwd, check=check)
+
+
+def git(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["git", *args], cwd=cwd, check=check)
+
+
+def seed_remote(remote: Path) -> None:
+    git("init", "--bare", str(remote))
+    with tempfile.TemporaryDirectory(prefix="gr2-hooks-seed-") as td:
+        seed = Path(td) / "seed"
+        git("clone", str(remote), str(seed))
+        git("config", "user.name", "Atlas", cwd=seed)
+        git("config", "user.email", "atlas@example.com", cwd=seed)
+        (seed / "README.md").write_text("# demo\n")
+        hooks_dir = seed / ".gr2"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        (hooks_dir / "hooks.toml").write_text(
+            "\n".join(
+                [
+                    "[[files.copy]]",
+                    'src = "{workspace_root}/shared.txt"',
+                    'dest = "{repo_root}/COPY_SKIP.txt"',
+                    'if_exists = "skip"',
+                    "",
+                    "[[files.copy]]",
+                    'src = "{workspace_root}/shared.txt"',
+                    'dest = "{repo_root}/COPY_OVERWRITE.txt"',
+                    'if_exists = "overwrite"',
+                    "",
+                    "[[lifecycle.on_enter]]",
+                    'name = "manual-write"',
+                    "command = \"python3 -c \\\"from pathlib import Path; Path('MANUAL.txt').write_text('manual\\\\n')\\\"\"",
+                    'cwd = "{repo_root}"',
+                    'when = "manual"',
+                    'on_failure = "warn"',
+                    "",
+                    "[[lifecycle.on_enter]]",
+                    'name = "warn-fail"',
+                    'command = "python3 -c \\"import sys; sys.exit(3)\\""',
+                    'cwd = "{repo_root}"',
+                    'when = "always"',
+                    'on_failure = "warn"',
+                    "",
+                    "[[lifecycle.on_enter]]",
+                    'name = "skip-fail"',
+                    'command = "python3 -c \\"import sys; sys.exit(5)\\""',
+                    'cwd = "{repo_root}"',
+                    'when = "always"',
+                    'on_failure = "skip"',
+                    "",
+                    "[[lifecycle.on_exit]]",
+                    'name = "block-fail"',
+                    'command = "python3 -c \\"import sys; sys.exit(7)\\""',
+                    'cwd = "{repo_root}"',
+                    'when = "always"',
+                    'on_failure = "block"',
+                    "",
+                ]
+            )
+        )
+        git("add", "README.md", ".gr2/hooks.toml", cwd=seed)
+        git("commit", "-m", "seed", cwd=seed)
+        git("push", "origin", "HEAD:main", cwd=seed)
+    git("--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main")
+
+
+def write_spec(workspace_root: Path, remote: Path) -> None:
+    (workspace_root / ".grip").mkdir(parents=True, exist_ok=True)
+    (workspace_root / ".grip" / "workspace_spec.toml").write_text(
+        "\n".join(
+            [
+                'workspace_name = "hooks-playground"',
+                "",
+                "[[repos]]",
+                'name = "demo"',
+                'path = "repos/demo"',
+                f'url = "{remote.as_posix()}"',
+                "",
+                "[[units]]",
+                'name = "atlas"',
+                'path = "agents/atlas/home"',
+                'repos = ["demo"]',
+                "",
+            ]
+        )
+    )
+
+
+def base_workspace() -> Path:
+    workspace_root = Path(tempfile.mkdtemp(prefix="gr2-hooks-playground-"))
+    (workspace_root / "shared.txt").write_text("shared\n")
+    remote = workspace_root / "demo-remote.git"
+    seed_remote(remote)
+    write_spec(workspace_root, remote)
+    pygr2("apply", str(workspace_root), "--yes")
+    repo_root = workspace_root / "repos" / "demo"
+    repo_root.joinpath("COPY_SKIP.txt").write_text("original\n")
+    repo_root.joinpath("COPY_OVERWRITE.txt").write_text("old\n")
+    pygr2(
+        "lane",
+        "create",
+        str(workspace_root),
+        "atlas",
+        "feat-hooks",
+        "--repos",
+        "demo",
+        "--branch",
+        "feat/hooks",
+    )
+    return workspace_root
+
+
+def scenario_manual_hook_flag() -> dict[str, object]:
+    workspace_root = base_workspace()
+    repo_root = workspace_root / "agents" / "atlas" / "lanes" / "feat-hooks" / "repos" / "demo"
+    pygr2("lane", "enter", str(workspace_root), "atlas", "feat-hooks", "--actor", "agent:atlas")
+    without_manual = not repo_root.joinpath("MANUAL.txt").exists()
+    with_manual = json.loads(
+        pygr2(
+            "repo",
+            "hook-run",
+            str(workspace_root),
+            str(repo_root),
+            "on_enter",
+            "--manual",
+            "--json",
+        ).stdout
+    )
+    return {
+        "name": "manual-hook-flag",
+        "holds": without_manual
+        and repo_root.joinpath("MANUAL.txt").exists()
+        and any(item["name"] == "manual-write" and item["status"] == "applied" for item in with_manual["results"]),
+        "payload": with_manual,
+    }
+
+
+def scenario_warn_skip_and_block() -> dict[str, object]:
+    workspace_root = base_workspace()
+    repo_root = workspace_root / "agents" / "atlas" / "lanes" / "feat-hooks" / "repos" / "demo"
+    warn_skip = json.loads(
+        pygr2(
+            "repo",
+            "hook-run",
+            str(workspace_root),
+            str(repo_root),
+            "on_enter",
+            "--json",
+        ).stdout
+    )
+    block = pygr2(
+        "repo",
+        "hook-run",
+        str(workspace_root),
+        str(repo_root),
+        "on_exit",
+        "--json",
+        check=False,
+    )
+    return {
+        "name": "warn-skip-block",
+        "holds": any(item["name"] == "warn-fail" and item["status"] == "warned" for item in warn_skip["results"])
+        and any(item["name"] == "skip-fail" and item["status"] == "skipped" for item in warn_skip["results"])
+        and block.returncode != 0
+        and '"on_failure": "block"' in (block.stderr + block.stdout),
+    }
+
+
+def scenario_projection_if_exists() -> dict[str, object]:
+    workspace_root = base_workspace()
+    repo_root = workspace_root / "repos" / "demo"
+    payload = json.loads(
+        pygr2(
+            "repo",
+            "projection-run",
+            str(workspace_root),
+            str(repo_root),
+            "--json",
+        ).stdout
+    )
+    return {
+        "name": "projection-if-exists",
+        "holds": repo_root.joinpath("COPY_SKIP.txt").read_text() == "original\n"
+        and repo_root.joinpath("COPY_OVERWRITE.txt").read_text() == "shared\n"
+        and any(item["status"] == "skipped" for item in payload["results"])
+        and any(item["status"] == "applied" for item in payload["results"]),
+    }
+
+
+SCENARIOS = [
+    scenario_manual_hook_flag,
+    scenario_warn_skip_and_block,
+    scenario_projection_if_exists,
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Playground verification for Python gr2 hook runtime semantics.")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    results = [scenario() for scenario in SCENARIOS]
+    verdict = "holds" if all(item["holds"] for item in results) else "gaps"
+    payload = {"verdict": verdict, "results": results}
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"python hook runtime verdict: {verdict}")
+        for item in results:
+            print(f"- {item['name']}: {'holds' if item['holds'] else 'gaps'}")
+    return 0 if verdict == "holds" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/python_migration_playground.py
+++ b/gr2/prototypes/python_migration_playground.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(args: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    proc = subprocess.run(args, cwd=cwd, env=env, text=True, capture_output=True)
+    if check and proc.returncode != 0:
+        raise SystemExit(f"command failed: {args}\nstdout={proc.stdout}\nstderr={proc.stderr}")
+    return proc
+
+
+def pygr2(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["python3", "-m", "gr2.python_cli", *args], cwd=cwd, check=check)
+
+
+def write_gr1_workspace(workspace_root: Path) -> None:
+    gitgrip = workspace_root / ".gitgrip"
+    (gitgrip / "spaces" / "main").mkdir(parents=True, exist_ok=True)
+    (gitgrip / "spaces" / "main" / "gripspace.yml").write_text(
+        "\n".join(
+            [
+                "version: 2",
+                "manifest:",
+                "  url: git@github.com:synapt-dev/synapt-gripspace.git",
+                "repos:",
+                "  grip:",
+                "    url: git@github.com:synapt-dev/grip.git",
+                "    path: ./gitgrip",
+                "    revision: main",
+                "  synapt:",
+                "    url: git@github.com:synapt-dev/synapt.git",
+                "    path: ./synapt",
+                "    revision: main",
+                "  mem0:",
+                "    url: https://github.com/mem0ai/mem0.git",
+                "    path: reference/mem0",
+                "    default_branch: main",
+                "    reference: true",
+                "",
+            ]
+        )
+    )
+    (gitgrip / "agents.toml").write_text(
+        "\n".join(
+            [
+                "[agents.atlas]",
+                'worktree = "main"',
+                'channel = "dev"',
+                "",
+                "[agents.apollo]",
+                'worktree = "main"',
+                'channel = "dev"',
+                "",
+            ]
+        )
+    )
+    (gitgrip / "state.json").write_text(json.dumps({"branchToPr": {"feat/auth": 123}}, indent=2))
+    (gitgrip / "sync-state.json").write_text(json.dumps({"timestamp": "2026-04-14T12:00:00Z"}, indent=2))
+    (gitgrip / "griptrees.json").write_text(json.dumps({"griptrees": {"review-pr1": {"path": "/tmp/review-pr1", "branch": "review-pr1"}}}, indent=2))
+
+
+def scenario_detect_and_migrate() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-migration-") as td:
+        workspace_root = Path(td)
+        write_gr1_workspace(workspace_root)
+        manifest_before = (workspace_root / ".gitgrip" / "spaces" / "main" / "gripspace.yml").read_text()
+
+        detect = json.loads(pygr2("workspace", "detect-gr1", str(workspace_root), "--json").stdout)
+        migrate = json.loads(pygr2("workspace", "migrate-gr1", str(workspace_root), "--json").stdout)
+        spec_text = (workspace_root / ".grip" / "workspace_spec.toml").read_text()
+        manifest_after = (workspace_root / ".gitgrip" / "spaces" / "main" / "gripspace.yml").read_text()
+
+        return {
+            "name": "detect-and-migrate-gr1",
+            "holds": detect["detected"] is True
+            and detect["repo_count"] == 3
+            and set(detect["agents"]) == {"apollo", "atlas"}
+            and "gitgrip" in spec_text
+            and 'name = "atlas"' in spec_text
+            and 'name = "apollo"' in spec_text
+            and (workspace_root / ".grip" / "migrations" / "gr1" / "state.json").exists()
+            and (workspace_root / ".grip" / "migrations" / "gr1" / "sync-state.json").exists()
+            and (workspace_root / ".grip" / "migrations" / "gr1" / "griptrees.json").exists()
+            and manifest_before == manifest_after,
+            "detect": detect,
+            "migrate": migrate,
+        }
+
+
+def scenario_existing_gr2_blocks_without_force() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-migration-force-") as td:
+        workspace_root = Path(td)
+        write_gr1_workspace(workspace_root)
+        grip_dir = workspace_root / ".grip"
+        grip_dir.mkdir(parents=True, exist_ok=True)
+        (grip_dir / "workspace_spec.toml").write_text('workspace_name = "existing"\n')
+        blocked = pygr2("workspace", "migrate-gr1", str(workspace_root), "--json", check=False)
+        forced = pygr2("workspace", "migrate-gr1", str(workspace_root), "--json", "--force")
+        forced_payload = json.loads(forced.stdout)
+        return {
+            "name": "migrate-force-guard",
+            "holds": blocked.returncode != 0
+            and "refusing to overwrite existing gr2 workspace spec" in (blocked.stderr + blocked.stdout)
+            and forced_payload["unit_count"] == 2,
+        }
+
+
+SCENARIOS = [
+    scenario_detect_and_migrate,
+    scenario_existing_gr2_blocks_without_force,
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Playground verification for gr1 -> Python gr2 migration.")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    results = [scenario() for scenario in SCENARIOS]
+    verdict = "holds" if all(item["holds"] for item in results) else "gaps"
+    payload = {"verdict": verdict, "results": results}
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"python migration playground verdict: {verdict}")
+        for item in results:
+            print(f"- {item['name']}: {'holds' if item['holds'] else 'gaps'}")
+    return 0 if verdict == "holds" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/python_review_checkout_playground.py
+++ b/gr2/prototypes/python_review_checkout_playground.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(args: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    proc = subprocess.run(args, cwd=cwd, env=env, text=True, capture_output=True)
+    if check and proc.returncode != 0:
+        raise SystemExit(f"command failed: {args}\nstdout={proc.stdout}\nstderr={proc.stderr}")
+    return proc
+
+
+def pygr2(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["python3", "-m", "gr2.python_cli", *args], cwd=cwd, check=check)
+
+
+def git(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["git", *args], cwd=cwd, check=check)
+
+
+def seed_remote_with_review_branch(remote: Path, branch_name: str) -> None:
+    git("init", "--bare", str(remote))
+    with tempfile.TemporaryDirectory(prefix="gr2-review-seed-") as td:
+        seed = Path(td) / "seed"
+        git("clone", str(remote), str(seed))
+        git("config", "user.name", "Atlas", cwd=seed)
+        git("config", "user.email", "atlas@example.com", cwd=seed)
+        (seed / "README.md").write_text("# demo\n")
+        git("add", "README.md", cwd=seed)
+        git("commit", "-m", "seed", cwd=seed)
+        git("push", "origin", "HEAD:main", cwd=seed)
+        git("checkout", "-b", branch_name, cwd=seed)
+        (seed / "REVIEW.txt").write_text("review branch\n")
+        git("add", "REVIEW.txt", cwd=seed)
+        git("commit", "-m", "review branch", cwd=seed)
+        git("push", "origin", f"HEAD:{branch_name}", cwd=seed)
+    git("--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main")
+
+
+def advance_review_branch(remote: Path, branch_name: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="gr2-review-advance-") as td:
+        seed = Path(td) / "seed"
+        git("clone", str(remote), str(seed))
+        git("config", "user.name", "Atlas", cwd=seed)
+        git("config", "user.email", "atlas@example.com", cwd=seed)
+        git("checkout", branch_name, cwd=seed)
+        (seed / "REVIEW_2.txt").write_text("updated review branch\n")
+        git("add", "REVIEW_2.txt", cwd=seed)
+        git("commit", "-m", "review branch update", cwd=seed)
+        git("push", "origin", f"HEAD:{branch_name}", cwd=seed)
+
+
+def remove_lane_checkout(shared_repo_root: Path, lane_repo_root: Path) -> None:
+    git("-C", str(shared_repo_root), "worktree", "remove", "--force", str(lane_repo_root))
+
+
+def write_spec(workspace_root: Path, remote: Path) -> None:
+    (workspace_root / ".grip").mkdir(parents=True, exist_ok=True)
+    (workspace_root / ".grip" / "workspace_spec.toml").write_text(
+        "\n".join(
+            [
+                'workspace_name = "review-playground"',
+                "",
+                "[[repos]]",
+                'name = "demo"',
+                'path = "repos/demo"',
+                f'url = "{remote.as_posix()}"',
+                "",
+                "[[units]]",
+                'name = "atlas"',
+                'path = "agents/atlas/home"',
+                'repos = ["demo"]',
+                "",
+            ]
+        )
+    )
+
+
+def scenario_review_checkout_and_enter() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-review-playground-") as td:
+        workspace_root = Path(td)
+        remote = workspace_root / "demo-remote.git"
+        review_branch = "review/demo-42"
+        seed_remote_with_review_branch(remote, review_branch)
+        write_spec(workspace_root, remote)
+        pygr2("apply", str(workspace_root), "--yes")
+
+        payload = json.loads(
+            pygr2(
+                "review",
+                "checkout-pr",
+                str(workspace_root),
+                "atlas",
+                "demo",
+                "42",
+                "--branch",
+                review_branch,
+                "--enter",
+                "--actor",
+                "agent:atlas",
+                "--json",
+            ).stdout
+        )
+
+        lane_repo_root = Path(payload["lane_repo_root"])
+        lane_file = workspace_root / "agents" / "atlas" / "lanes" / "review-42" / "lane.toml"
+        current_file = workspace_root / ".grip" / "state" / "current_lane" / "atlas.json"
+        current = json.loads(current_file.read_text())
+        lane_doc = tomllib.loads(lane_file.read_text())
+        branch = git("branch", "--show-current", cwd=lane_repo_root).stdout.strip()
+
+        return {
+            "name": "review-checkout-and-enter",
+            "holds": payload["lane_name"] == "review-42"
+            and payload["branch"] == review_branch
+            and payload["entered"] is True
+            and lane_repo_root.joinpath(".git").exists()
+            and lane_repo_root.joinpath("REVIEW.txt").exists()
+            and branch == review_branch
+            and current["current"]["lane_name"] == "review-42"
+            and lane_doc["lane_type"] == "review"
+            and lane_doc["pr_associations"][0]["ref"] == "demo#42",
+            "payload": payload,
+        }
+
+
+def scenario_missing_shared_repo_blocks() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-review-missing-shared-") as td:
+        workspace_root = Path(td)
+        remote = workspace_root / "demo-remote.git"
+        review_branch = "review/demo-42"
+        seed_remote_with_review_branch(remote, review_branch)
+        write_spec(workspace_root, remote)
+        proc = pygr2(
+            "review",
+            "checkout-pr",
+            str(workspace_root),
+            "atlas",
+            "demo",
+            "42",
+            "--branch",
+            review_branch,
+            "--json",
+            check=False,
+        )
+        return {
+            "name": "missing-shared-repo-blocks",
+            "holds": proc.returncode != 0 and "shared repo missing for review checkout" in (proc.stderr + proc.stdout),
+        }
+
+
+def scenario_existing_local_branch_refetches() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-review-refetch-") as td:
+        workspace_root = Path(td)
+        remote = workspace_root / "demo-remote.git"
+        review_branch = "review/demo-42"
+        seed_remote_with_review_branch(remote, review_branch)
+        write_spec(workspace_root, remote)
+        pygr2("apply", str(workspace_root), "--yes")
+
+        pygr2(
+            "review",
+            "checkout-pr",
+            str(workspace_root),
+            "atlas",
+            "demo",
+            "42",
+            "--lane",
+            "review-42-old",
+            "--branch",
+            review_branch,
+            "--json",
+        )
+
+        shared_repo_root = workspace_root / "repos" / "demo"
+        old_lane_repo_root = workspace_root / "agents" / "atlas" / "lanes" / "review-42-old" / "repos" / "demo"
+        remove_lane_checkout(shared_repo_root, old_lane_repo_root)
+
+        advance_review_branch(remote, review_branch)
+
+        payload = json.loads(
+            pygr2(
+                "review",
+                "checkout-pr",
+                str(workspace_root),
+                "atlas",
+                "demo",
+                "42",
+                "--lane",
+                "review-42-new",
+                "--branch",
+                review_branch,
+                "--json",
+            ).stdout
+        )
+
+        lane_repo_root = Path(payload["lane_repo_root"])
+        return {
+            "name": "existing-local-branch-refetches",
+            "holds": lane_repo_root.joinpath("REVIEW_2.txt").exists(),
+            "payload": payload,
+        }
+
+
+SCENARIOS = [
+    scenario_review_checkout_and_enter,
+    scenario_missing_shared_repo_blocks,
+    scenario_existing_local_branch_refetches,
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Playground verification for Python gr2 review checkout-pr.")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    results = [scenario() for scenario in SCENARIOS]
+    verdict = "holds" if all(item["holds"] for item in results) else "gaps"
+    payload = {"verdict": verdict, "results": results}
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"python review checkout verdict: {verdict}")
+        for item in results:
+            print(f"- {item['name']}: {'holds' if item['holds'] else 'gaps'}")
+    return 0 if verdict == "holds" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/python_spec_apply_playground.py
+++ b/gr2/prototypes/python_spec_apply_playground.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(args: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    proc = subprocess.run(args, cwd=cwd, env=env, text=True, capture_output=True)
+    if check and proc.returncode != 0:
+        raise SystemExit(f"command failed: {args}\nstdout={proc.stdout}\nstderr={proc.stderr}")
+    return proc
+
+
+def pygr2(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["python3", "-m", "gr2.python_cli", *args], cwd=cwd, check=check)
+
+
+def git(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["git", *args], cwd=cwd, check=check)
+
+
+def write_workspace_spec(workspace_root: Path, remote: Path) -> None:
+    grip_dir = workspace_root / ".grip"
+    grip_dir.mkdir(parents=True, exist_ok=True)
+    (grip_dir / "workspace_spec.toml").write_text(
+        "\n".join(
+            [
+                'workspace_name = "playground"',
+                "",
+                "[[repos]]",
+                'name = "demo"',
+                'path = "repos/demo"',
+                f'url = "{remote.as_posix()}"',
+                "",
+                "[[units]]",
+                'name = "atlas"',
+                'path = "agents/atlas/home"',
+                'repos = ["demo"]',
+                "",
+                "[[units]]",
+                'name = "apollo"',
+                'path = "agents/apollo/home"',
+                'repos = ["demo"]',
+                "",
+            ]
+        )
+    )
+
+
+def seed_bare_remote(remote: Path, *, with_hooks: bool = False) -> None:
+    git("init", "--bare", str(remote))
+    with tempfile.TemporaryDirectory(prefix="gr2-playground-seed-") as td:
+        seed = Path(td) / "seed"
+        git("clone", str(remote), str(seed))
+        git("config", "user.name", "Atlas", cwd=seed)
+        git("config", "user.email", "atlas@example.com", cwd=seed)
+        (seed / "README.md").write_text("# demo\n")
+        if with_hooks:
+            hooks_dir = seed / ".gr2"
+            hooks_dir.mkdir(parents=True, exist_ok=True)
+            (hooks_dir / "hooks.toml").write_text(
+                "\n".join(
+                    [
+                        "[[files.link]]",
+                        'src = "{workspace_root}/config/claude.md"',
+                        'dest = "{repo_root}/CLAUDE.md"',
+                        'if_exists = "overwrite"',
+                        "",
+                        "[[lifecycle.on_materialize]]",
+                        'name = "materialize-marker"',
+                        "command = \"python3 -c \\\"from pathlib import Path; Path('MATERIALIZED').write_text('ok\\\\n')\\\"\"",
+                        'cwd = "{repo_root}"',
+                        'when = "first_materialize"',
+                        'on_failure = "block"',
+                        "",
+                    ]
+                )
+            )
+        git("add", "README.md", cwd=seed)
+        if with_hooks:
+            git("add", ".gr2/hooks.toml", cwd=seed)
+        git("commit", "-m", "seed", cwd=seed)
+        git("push", "origin", "HEAD:main", cwd=seed)
+
+
+def create_demo_lane_state(workspace_root: Path) -> None:
+    lane_root = workspace_root / "agents" / "atlas" / "lanes" / "feat-auth"
+    (lane_root / "repos" / "demo").mkdir(parents=True, exist_ok=True)
+    current_dir = workspace_root / ".grip" / "state" / "lanes" / "atlas"
+    current_dir.mkdir(parents=True, exist_ok=True)
+    (current_dir / "current.json").write_text(
+        json.dumps(
+            {
+                "current": {
+                    "lane_name": "feat-auth",
+                    "entered_at": "2026-04-14T12:00:00Z",
+                }
+            },
+            indent=2,
+        )
+    )
+
+
+def scenario_missing_spec() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-spec-missing-") as td:
+        workspace_root = Path(td)
+        proc = pygr2("plan", str(workspace_root), check=False)
+        return {
+            "name": "missing-spec",
+            "holds": proc.returncode != 0 and "workspace spec not found" in (proc.stderr + proc.stdout),
+            "returncode": proc.returncode,
+        }
+
+
+def scenario_path_conflict() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-path-conflict-") as td:
+        workspace_root = Path(td)
+        remote = workspace_root / "demo-remote.git"
+        seed_bare_remote(remote)
+        write_workspace_spec(workspace_root, remote)
+        (workspace_root / "repos" / "demo").mkdir(parents=True, exist_ok=True)
+        proc = pygr2("spec", "validate", str(workspace_root), "--json", check=False)
+        payload = json.loads(proc.stdout)
+        return {
+            "name": "path-conflict",
+            "holds": proc.returncode == 1 and any(item["code"] == "repo_path_conflict" for item in payload["issues"]),
+            "issues": payload["issues"],
+        }
+
+
+def scenario_fresh_workspace() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-fresh-workspace-") as td:
+        workspace_root = Path(td)
+        remote = workspace_root / "demo-remote.git"
+        (workspace_root / "config").mkdir(parents=True, exist_ok=True)
+        (workspace_root / "config" / "claude.md").write_text("shared claude\n")
+        seed_bare_remote(remote, with_hooks=True)
+        write_workspace_spec(workspace_root, remote)
+
+        plan_before = json.loads(pygr2("plan", str(workspace_root), "--json").stdout)
+        apply_payload = json.loads(pygr2("apply", str(workspace_root), "--yes", "--json").stdout)
+        plan_after = json.loads(pygr2("plan", str(workspace_root), "--json").stdout)
+        repo_root = workspace_root / "repos" / "demo"
+        cache_root = workspace_root / ".grip" / "cache" / "repos" / "demo.git"
+        alternates = repo_root / ".git" / "objects" / "info" / "alternates"
+
+        expected_kinds = [
+            "seed_repo_cache",
+            "clone_repo",
+            "create_unit_root",
+            "write_unit_metadata",
+            "create_unit_root",
+            "write_unit_metadata",
+        ]
+
+        return {
+            "name": "fresh-workspace",
+            "holds": [item["kind"] for item in plan_before] == expected_kinds
+            and apply_payload["operation_count"] == 6
+            and plan_after == []
+            and repo_root.joinpath(".git").exists()
+            and (workspace_root / "agents" / "atlas" / "home" / "unit.toml").exists()
+            and (workspace_root / "agents" / "apollo" / "home" / "unit.toml").exists()
+            and cache_root.exists()
+            and alternates.exists()
+            and repo_root.joinpath("CLAUDE.md").exists()
+            and repo_root.joinpath("MATERIALIZED").exists(),
+            "plan_before": plan_before,
+            "apply_payload": apply_payload,
+            "cache_root_exists": cache_root.exists(),
+            "alternates_exists": alternates.exists(),
+            "claude_link_exists": repo_root.joinpath("CLAUDE.md").exists(),
+            "materialize_marker_exists": repo_root.joinpath("MATERIALIZED").exists(),
+        }
+
+
+def scenario_dirty_shared_repo_preserved() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-dirty-shared-") as td:
+        workspace_root = Path(td)
+        remote = workspace_root / "demo-remote.git"
+        seed_bare_remote(remote)
+        write_workspace_spec(workspace_root, remote)
+        pygr2("apply", str(workspace_root), "--yes")
+        repo_root = workspace_root / "repos" / "demo"
+        (repo_root / "LOCAL.txt").write_text("dirty\n")
+        plan_payload = json.loads(pygr2("plan", str(workspace_root), "--json").stdout)
+        apply_payload = json.loads(pygr2("apply", str(workspace_root), "--json").stdout)
+        preserved = (repo_root / "LOCAL.txt").exists()
+        return {
+            "name": "dirty-shared-repo-preserved",
+            "holds": plan_payload == [] and apply_payload["operation_count"] == 0 and preserved,
+            "plan_payload": plan_payload,
+            "apply_payload": apply_payload,
+        }
+
+
+def scenario_lane_state_untouched() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-lane-state-") as td:
+        workspace_root = Path(td)
+        remote = workspace_root / "demo-remote.git"
+        seed_bare_remote(remote)
+        write_workspace_spec(workspace_root, remote)
+        create_demo_lane_state(workspace_root)
+        before = (workspace_root / ".grip" / "state" / "lanes" / "atlas" / "current.json").read_text()
+        pygr2("apply", str(workspace_root), "--yes")
+        after = (workspace_root / ".grip" / "state" / "lanes" / "atlas" / "current.json").read_text()
+        lane_checkout_still_absent = not (workspace_root / "agents" / "atlas" / "lanes" / "feat-auth" / "repos" / "demo" / ".git").exists()
+        return {
+            "name": "lane-state-untouched",
+            "holds": before == after and lane_checkout_still_absent,
+        }
+
+
+def scenario_invalid_repo_hooks() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-invalid-hooks-") as td:
+        workspace_root = Path(td)
+        remote = workspace_root / "demo-remote.git"
+        seed_bare_remote(remote)
+        write_workspace_spec(workspace_root, remote)
+        pygr2("apply", str(workspace_root), "--yes")
+        hooks_dir = workspace_root / "repos" / "demo" / ".gr2"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        (hooks_dir / "hooks.toml").write_text(
+            "\n".join(
+                [
+                    "[[lifecycle.on_enter]]",
+                    'name = "broken"',
+                    'command = "true"',
+                    'when = "not-a-real-when"',
+                    "",
+                ]
+            )
+        )
+        proc = pygr2("spec", "validate", str(workspace_root), "--json", check=False)
+        payload = json.loads(proc.stdout)
+        return {
+            "name": "invalid-repo-hooks",
+            "holds": proc.returncode == 1 and any(item["code"] == "invalid_repo_hooks" for item in payload["issues"]),
+            "issues": payload["issues"],
+        }
+
+
+SCENARIOS = [
+    scenario_missing_spec,
+    scenario_path_conflict,
+    scenario_fresh_workspace,
+    scenario_dirty_shared_repo_preserved,
+    scenario_lane_state_untouched,
+    scenario_invalid_repo_hooks,
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Playground verification for Python gr2 spec/plan/apply.")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    results = [scenario() for scenario in SCENARIOS]
+    verdict = "holds" if all(item["holds"] for item in results) else "gaps"
+    payload = {"verdict": verdict, "results": results}
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"python spec/apply playground verdict: {verdict}")
+        for item in results:
+            print(f"- {item['name']}: {'holds' if item['holds'] else 'gaps'}")
+    return 0 if verdict == "holds" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -7,8 +9,21 @@ from typing import Optional
 
 import typer
 
-from .gitops import checkout_branch, clone_repo, ensure_lane_checkout, is_git_repo, remote_origin_url, repo_dirty, stash_if_dirty
+from . import execops
+from . import migration
+from .gitops import (
+    branch_exists,
+    checkout_branch,
+    ensure_lane_checkout,
+    fetch_ref,
+    is_git_repo,
+    refresh_existing_branch,
+    remote_origin_url,
+    repo_dirty,
+    stash_if_dirty,
+)
 from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
+from . import spec_apply
 from gr2.prototypes import lane_workspace_prototype as lane_proto
 from gr2.prototypes import repo_maintenance_prototype as repo_proto
 
@@ -21,12 +36,16 @@ lane_app = typer.Typer(help="Lane creation and navigation")
 lease_app = typer.Typer(help="Lane lease operations")
 review_app = typer.Typer(help="Review and reviewer requirement operations")
 workspace_app = typer.Typer(help="Workspace bootstrap and materialization")
+spec_app = typer.Typer(help="Declarative workspace spec operations")
+exec_app = typer.Typer(help="Lane-aware execution planning and execution")
 
 app.add_typer(repo_app, name="repo")
 app.add_typer(lane_app, name="lane")
 lane_app.add_typer(lease_app, name="lease")
 app.add_typer(review_app, name="review")
 app.add_typer(workspace_app, name="workspace")
+app.add_typer(spec_app, name="spec")
+app.add_typer(exec_app, name="exec")
 
 
 def _workspace_repo_spec(workspace_root: Path, repo_name: str) -> dict[str, object]:
@@ -45,7 +64,7 @@ def _lane_repo_root(workspace_root: Path, owner_unit: str, lane_name: str, repo_
     return lane_proto.lane_dir(workspace_root, owner_unit, lane_name) / "repos" / repo_name
 
 
-def _materialize_lane_repos(workspace_root: Path, owner_unit: str, lane_name: str) -> None:
+def _materialize_lane_repos(workspace_root: Path, owner_unit: str, lane_name: str, *, manual_hooks: bool = False) -> None:
     lane_doc = lane_proto.load_lane_doc(workspace_root, owner_unit, lane_name)
     branch_map = dict(lane_doc.get("branch_map", {}))
     lane_root = lane_proto.lane_dir(workspace_root, owner_unit, lane_name)
@@ -80,10 +99,11 @@ def _materialize_lane_repos(workspace_root: Path, owner_unit: str, lane_name: st
             ctx,
             repo_dirty=repo_dirty(target_repo_root),
             first_materialize=first_materialize,
+            allow_manual=manual_hooks,
         )
 
 
-def _run_lane_stage(workspace_root: Path, owner_unit: str, lane_name: str, stage: str) -> None:
+def _run_lane_stage(workspace_root: Path, owner_unit: str, lane_name: str, stage: str, *, manual_hooks: bool = False) -> None:
     lane_doc = lane_proto.load_lane_doc(workspace_root, owner_unit, lane_name)
     lane_root = lane_proto.lane_dir(workspace_root, owner_unit, lane_name)
     for repo_name in lane_doc.get("repos", []):
@@ -111,40 +131,64 @@ def _run_lane_stage(workspace_root: Path, owner_unit: str, lane_name: str, stage
             ctx,
             repo_dirty=repo_dirty(repo_root),
             first_materialize=False,
+            allow_manual=manual_hooks,
         )
 
 
-def _materialize_workspace_repo(workspace_root: Path, repo_spec: dict[str, object]) -> None:
-    repo_name = str(repo_spec["name"])
+def _prepare_review_branch(workspace_root: Path, repo: str, pr_number: int, branch: str | None) -> str:
+    repo_spec = _workspace_repo_spec(workspace_root, repo)
     repo_root = (workspace_root / str(repo_spec["path"])).resolve()
-    url = str(repo_spec.get("url", "")).strip()
-    first_materialize = False
     if not repo_root.exists():
-        if not url:
-            raise SystemExit(f"repo missing and no url configured for workspace materialization: {repo_name}")
-        first_materialize = clone_repo(url, repo_root)
-    elif not is_git_repo(repo_root):
-        raise SystemExit(f"workspace repo path exists but is not a git repo: {repo_root}")
+        raise SystemExit(f"shared repo missing for review checkout: {repo_root}\nrun `gr2 apply {workspace_root} --yes` first")
 
-    hooks = load_repo_hooks(repo_root)
-    if not hooks:
-        return
-    ctx = HookContext(
+    target_branch = branch or f"pr/{pr_number}"
+    source_ref = f"refs/heads/{branch}" if branch else f"refs/pull/{pr_number}/head"
+
+    if branch_exists(repo_root, target_branch):
+        refresh_existing_branch(repo_root, "origin", source_ref, target_branch)
+        return target_branch
+
+    if branch:
+        fetch_ref(repo_root, "origin", source_ref, target_branch)
+        return target_branch
+
+    fetch_ref(repo_root, "origin", source_ref, target_branch)
+    return target_branch
+
+
+def _create_review_lane_metadata(
+    workspace_root: Path,
+    owner_unit: str,
+    repo: str,
+    pr_number: int,
+    *,
+    lane_name: str | None = None,
+    branch: str | None = None,
+) -> str:
+    review_lane = lane_name or f"review-{pr_number}"
+    review_branch = branch or f"pr/{pr_number}"
+    ns = SimpleNamespace(
+        workspace_root=workspace_root,
+        owner_unit=owner_unit,
+        repo=repo,
+        pr_number=pr_number,
+        lane_name=review_lane,
+        branch=review_branch,
+    )
+    with contextlib.redirect_stdout(io.StringIO()):
+        _exit(lane_proto.create_review_lane(ns))
+    return review_lane
+
+
+def _repo_hook_context(workspace_root: Path, repo_root: Path) -> HookContext:
+    return HookContext(
         workspace_root=workspace_root,
         lane_root=repo_root,
         repo_root=repo_root,
-        repo_name=repo_name,
+        repo_name=repo_root.name,
         lane_owner="workspace",
-        lane_subject=repo_name,
+        lane_subject=repo_root.name,
         lane_name="workspace",
-    )
-    apply_file_projections(hooks, ctx)
-    run_lifecycle_stage(
-        hooks,
-        "on_materialize",
-        ctx,
-        repo_dirty=repo_dirty(repo_root),
-        first_materialize=first_materialize,
     )
 
 
@@ -227,30 +271,176 @@ def workspace_init(
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:
-        typer.echo(json.dumps(payload, indent=2))
+        lines = [
+            "WorkspaceInit",
+            f"workspace_root = {workspace_root}",
+            f"spec_path = {spec_path}",
+            f"default_unit = {default_unit}",
+            f"repo_count = {len(repos)}",
+            "REPOS",
+        ]
+        lines.extend(f"- {repo['name']}\t{repo['path']}\t{repo['url'] or '-'}" for repo in repos)
+        typer.echo("\n".join(lines))
 
 
 @workspace_app.command("materialize")
 def workspace_materialize(
     workspace_root: Path,
+    yes: bool = typer.Option(False, "--yes", help="Pre-approve plans with more than 3 operations"),
+    manual_hooks: bool = typer.Option(False, "--manual-hooks", help="Also run lifecycle hooks marked when=manual"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
-    """Read workspace_spec.toml, clone any missing repos, and run on_materialize hooks."""
+    """Read workspace_spec.toml and apply the current workspace materialization plan."""
     workspace_root = workspace_root.resolve()
-    spec = lane_proto.load_workspace_spec(workspace_root)
-    materialized: list[dict[str, object]] = []
-    for repo_spec in spec.get("repos", []):
-        _materialize_workspace_repo(workspace_root, repo_spec)
-        materialized.append(
-            {
-                "name": repo_spec["name"],
-                "path": str((workspace_root / str(repo_spec["path"])).resolve()),
-            }
-        )
+    payload = spec_apply.apply_plan(workspace_root, yes=yes, manual_hooks=manual_hooks)
     if json_output:
-        typer.echo(json.dumps({"workspace_root": str(workspace_root), "repos": materialized}, indent=2))
+        typer.echo(json.dumps(payload, indent=2))
     else:
-        typer.echo(json.dumps({"workspace_root": str(workspace_root), "repos": materialized}, indent=2))
+        typer.echo(spec_apply.render_apply_result(payload))
+
+
+@workspace_app.command("detect-gr1")
+def workspace_detect_gr1(
+    workspace_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Detect whether a workspace is using the gr1 (.gitgrip) layout."""
+    workspace_root = workspace_root.resolve()
+    payload = migration.detect_gr1_workspace(workspace_root)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(migration.render_detection(payload))
+    if not payload["detected"]:
+        raise typer.Exit(code=1)
+
+
+@workspace_app.command("migrate-gr1")
+def workspace_migrate_gr1(
+    workspace_root: Path,
+    force: bool = typer.Option(False, "--force", help="Allow overwrite of an existing .grip/workspace_spec.toml"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Convert an existing gr1 (.gitgrip) workspace into parallel gr2 (.grip) layout."""
+    workspace_root = workspace_root.resolve()
+    payload = migration.migrate_gr1_workspace(workspace_root, force=force)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(migration.render_migration(payload))
+
+
+@spec_app.command("show")
+def spec_show(
+    workspace_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show the current workspace spec."""
+    workspace_root = workspace_root.resolve()
+    typer.echo(spec_apply.show_spec(workspace_root, json_output=json_output))
+
+
+@spec_app.command("validate")
+def spec_validate(
+    workspace_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Validate the current workspace spec."""
+    workspace_root = workspace_root.resolve()
+    issues = spec_apply.validate_spec(workspace_root)
+    payload = {
+        "workspace_root": str(workspace_root),
+        "valid": not any(issue.level == "error" for issue in issues),
+        "issues": [issue.as_dict() for issue in issues],
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(spec_apply.render_validation(issues))
+    if not payload["valid"]:
+        raise typer.Exit(code=1)
+
+
+@app.command("plan")
+def workspace_plan(
+    workspace_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Build a Python gr2 execution plan from the workspace spec."""
+    workspace_root = workspace_root.resolve()
+    _, operations = spec_apply.build_plan(workspace_root)
+    if json_output:
+        typer.echo(json.dumps([item.as_dict() for item in operations], indent=2))
+    else:
+        typer.echo(spec_apply.render_plan(operations))
+
+
+@app.command("apply")
+def workspace_apply(
+    workspace_root: Path,
+    yes: bool = typer.Option(False, "--yes", help="Pre-approve plans with more than 3 operations"),
+    manual_hooks: bool = typer.Option(False, "--manual-hooks", help="Also run lifecycle hooks marked when=manual"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Apply the Python gr2 execution plan."""
+    workspace_root = workspace_root.resolve()
+    payload = spec_apply.apply_plan(workspace_root, yes=yes, manual_hooks=manual_hooks)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(spec_apply.render_apply_result(payload))
+
+
+@exec_app.command("status")
+def exec_status(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: Optional[str] = typer.Argument(None, help="Lane name. Defaults to the unit's current lane."),
+    repos: Optional[str] = typer.Option(None, help="Optional comma-separated repo subset"),
+    actor: str = typer.Option("agent:exec-status", help="Actor label for lease conflict evaluation"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show lane-aware execution status for a lane."""
+    workspace_root = workspace_root.resolve()
+    payload = execops.exec_status_payload(workspace_root, owner_unit, lane_name, repos=repos, actor=actor)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(execops.render_exec_status(payload))
+
+
+@exec_app.command("run", context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def exec_run(
+    ctx: typer.Context,
+    workspace_root: Path,
+    owner_unit: str,
+    command: list[str] = typer.Argument(None, help="Command to run inside each selected lane repo"),
+    lane_name: Optional[str] = typer.Option(None, "--lane", help="Lane name. Defaults to the unit's current lane."),
+    repos: Optional[str] = typer.Option(None, help="Optional comma-separated repo subset"),
+    actor: str = typer.Option(..., help="Actor label, e.g. agent:atlas"),
+    ttl_seconds: int = typer.Option(900, "--ttl-seconds", help="TTL for the temporary exec lease"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Run a command across the repos in a lane."""
+    workspace_root = workspace_root.resolve()
+    full_command = list(command or []) + list(ctx.args)
+    if not full_command:
+        raise typer.BadParameter("missing command to run")
+    payload = execops.run_exec(
+        workspace_root,
+        owner_unit,
+        lane_name,
+        actor=actor,
+        command=full_command,
+        repos=repos,
+        ttl_seconds=ttl_seconds,
+    )
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(execops.render_exec_run(payload))
+    if payload.get("status") in {"blocked", "failed"}:
+        raise typer.Exit(code=1)
 
 
 @repo_app.command("status")
@@ -293,6 +483,69 @@ def repo_hooks_show(
         typer.echo(json.dumps(hooks.as_dict(), indent=2))
 
 
+@repo_app.command("hook-run")
+def repo_hook_run(
+    workspace_root: Path,
+    repo_root: Path,
+    stage: str = typer.Argument(..., help="Lifecycle stage: on_materialize | on_enter | on_exit"),
+    manual: bool = typer.Option(False, "--manual", help="Allow hooks with when=manual to run"),
+    first_materialize: bool = typer.Option(False, "--first-materialize", help="Treat this invocation as first materialization"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Run repo hooks explicitly for one lifecycle stage."""
+    workspace_root = workspace_root.resolve()
+    repo_root = repo_root.resolve()
+    if stage not in {"on_materialize", "on_enter", "on_exit"}:
+        raise typer.BadParameter("stage must be one of: on_materialize, on_enter, on_exit")
+    hooks = load_repo_hooks(repo_root)
+    if hooks is None:
+        raise SystemExit(f"no .gr2/hooks.toml found in repo: {repo_root}")
+    ctx = _repo_hook_context(workspace_root, repo_root)
+    results = run_lifecycle_stage(
+        hooks,
+        stage,
+        ctx,
+        repo_dirty=repo_dirty(repo_root),
+        first_materialize=first_materialize,
+        allow_manual=manual,
+    )
+    payload = {
+        "workspace_root": str(workspace_root),
+        "repo_root": str(repo_root),
+        "stage": stage,
+        "results": [item.as_dict() for item in results],
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(json.dumps(payload, indent=2))
+
+
+@repo_app.command("projection-run")
+def repo_projection_run(
+    workspace_root: Path,
+    repo_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Apply file projections explicitly for one repo."""
+    workspace_root = workspace_root.resolve()
+    repo_root = repo_root.resolve()
+    hooks = load_repo_hooks(repo_root)
+    if hooks is None:
+        raise SystemExit(f"no .gr2/hooks.toml found in repo: {repo_root}")
+    ctx = _repo_hook_context(workspace_root, repo_root)
+    results = apply_file_projections(hooks, ctx)
+    payload = {
+        "workspace_root": str(workspace_root),
+        "repo_root": str(repo_root),
+        "results": [item.as_dict() for item in results],
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(json.dumps(payload, indent=2))
+
+
 @lane_app.command("create")
 def lane_create(
     workspace_root: Path,
@@ -303,6 +556,7 @@ def lane_create(
     lane_type: str = typer.Option("feature", "--type", help="Lane type"),
     source: str = typer.Option("manual", help="Creation source label"),
     command: list[str] = typer.Option(None, "--command", help="Default command for the lane"),
+    manual_hooks: bool = typer.Option(False, "--manual-hooks", help="Also run lifecycle hooks marked when=manual during lane materialization"),
 ) -> None:
     """Create a lane."""
     workspace_root = workspace_root.resolve()
@@ -317,7 +571,7 @@ def lane_create(
         default_commands=command or [],
     )
     _exit(lane_proto.create_lane(ns))
-    _materialize_lane_repos(workspace_root, owner_unit, lane_name)
+    _materialize_lane_repos(workspace_root, owner_unit, lane_name, manual_hooks=manual_hooks)
 
 
 @lane_app.command("enter")
@@ -328,10 +582,11 @@ def lane_enter(
     actor: str = typer.Option(..., help="Actor label, e.g. agent:atlas"),
     notify_channel: bool = typer.Option(False, "--notify-channel"),
     recall: bool = typer.Option(False, "--recall"),
+    manual_hooks: bool = typer.Option(False, "--manual-hooks", help="Also run lifecycle hooks marked when=manual"),
 ) -> None:
     """Enter a lane and optionally emit channel/recall-compatible events."""
     workspace_root = workspace_root.resolve()
-    _run_lane_stage(workspace_root, owner_unit, lane_name, "on_enter")
+    _run_lane_stage(workspace_root, owner_unit, lane_name, "on_enter", manual_hooks=manual_hooks)
     ns = SimpleNamespace(
         workspace_root=workspace_root,
         owner_unit=owner_unit,
@@ -350,6 +605,7 @@ def lane_exit(
     actor: str = typer.Option(..., help="Actor label, e.g. human:layne"),
     notify_channel: bool = typer.Option(False, "--notify-channel"),
     recall: bool = typer.Option(False, "--recall"),
+    manual_hooks: bool = typer.Option(False, "--manual-hooks", help="Also run lifecycle hooks marked when=manual"),
 ) -> None:
     """Exit the current lane for a unit."""
     workspace_root = workspace_root.resolve()
@@ -360,7 +616,7 @@ def lane_exit(
         repo_root = _lane_repo_root(workspace_root, owner_unit, lane_name, repo_name)
         if repo_root.exists():
             stash_if_dirty(repo_root, f"gr2 exit {owner_unit}/{lane_name}")
-    _run_lane_stage(workspace_root, owner_unit, lane_name, "on_exit")
+    _run_lane_stage(workspace_root, owner_unit, lane_name, "on_exit", manual_hooks=manual_hooks)
     ns = SimpleNamespace(
         workspace_root=workspace_root,
         owner_unit=owner_unit,
@@ -452,6 +708,65 @@ def review_requirements(
         json=json_output,
     )
     _exit(lane_proto.check_review_requirements(ns))
+
+
+@review_app.command("checkout-pr")
+def review_checkout_pr(
+    workspace_root: Path,
+    owner_unit: str,
+    repo: str,
+    pr_number: int,
+    lane_name: Optional[str] = typer.Option(None, "--lane", help="Override the review lane name"),
+    branch: Optional[str] = typer.Option(None, "--branch", help="Override the source branch/ref to fetch"),
+    enter: bool = typer.Option(False, "--enter", help="Enter the review lane after materialization"),
+    actor: Optional[str] = typer.Option(None, "--actor", help="Actor label to use when entering the lane"),
+    manual_hooks: bool = typer.Option(False, "--manual-hooks", help="Also run lifecycle hooks marked when=manual during materialization/enter"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Create and materialize a review lane for a PR."""
+    workspace_root = workspace_root.resolve()
+    resolved_branch = _prepare_review_branch(workspace_root, repo, pr_number, branch)
+    resolved_lane = _create_review_lane_metadata(
+        workspace_root,
+        owner_unit,
+        repo,
+        pr_number,
+        lane_name=lane_name,
+        branch=resolved_branch,
+    )
+    _materialize_lane_repos(workspace_root, owner_unit, resolved_lane, manual_hooks=manual_hooks)
+
+    entered = False
+    if enter:
+        if not actor:
+            raise typer.BadParameter("--actor is required when using --enter")
+        _run_lane_stage(workspace_root, owner_unit, resolved_lane, "on_enter", manual_hooks=manual_hooks)
+        ns = SimpleNamespace(
+            workspace_root=workspace_root,
+            owner_unit=owner_unit,
+            lane_name=resolved_lane,
+            actor=actor,
+            notify_channel=False,
+            recall=False,
+        )
+        with contextlib.redirect_stdout(io.StringIO()):
+            _exit(lane_proto.enter_lane(ns))
+        entered = True
+
+    payload = {
+        "workspace_root": str(workspace_root),
+        "owner_unit": owner_unit,
+        "repo": repo,
+        "pr_number": pr_number,
+        "lane_name": resolved_lane,
+        "branch": resolved_branch,
+        "entered": entered,
+        "lane_repo_root": str(_lane_repo_root(workspace_root, owner_unit, resolved_lane, repo)),
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(json.dumps(payload, indent=2))
 
 
 if __name__ == "__main__":

--- a/gr2/python_cli/execops.py
+++ b/gr2/python_cli/execops.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from gr2.prototypes import lane_workspace_prototype as lane_proto
+
+
+def _resolve_lane_name(workspace_root: Path, owner_unit: str, lane_name: str | None) -> str:
+    if lane_name:
+        return lane_name
+    current = lane_proto.load_current_lane_doc(workspace_root, owner_unit)
+    return str(current["current"]["lane_name"])
+
+
+def _selected_repos(lane_doc: dict[str, object], repos: str | None) -> list[str]:
+    selected = [str(repo) for repo in lane_doc.get("repos", [])]
+    if repos:
+        requested = set(lane_proto.parse_repo_list(repos))
+        selected = [repo for repo in selected if repo in requested]
+    return selected
+
+
+def _blocked_payload(
+    *,
+    reason: str,
+    lane_doc: dict[str, object],
+    owner_unit: str,
+    extra: dict[str, object] | None = None,
+) -> dict[str, object]:
+    payload = {
+        "status": "blocked",
+        "reason": reason,
+        "lane": str(lane_doc["lane_name"]),
+        "owner_unit": owner_unit,
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def exec_status_payload(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: str | None,
+    *,
+    repos: str | None = None,
+    actor: str = "agent:exec-status",
+) -> dict[str, object]:
+    owner_unit = str(owner_unit)
+    lane_name = _resolve_lane_name(workspace_root, owner_unit, lane_name)
+    lane_doc = lane_proto.load_lane_doc(workspace_root, owner_unit, lane_name)
+
+    rebind_doc = lane_proto.load_unit_rebind_doc(workspace_root, owner_unit)
+    if rebind_doc:
+        affected = {item["lane_name"]: item for item in rebind_doc.get("affected_lanes", [])}
+        if lane_name in affected:
+            return _blocked_payload(
+                reason="unit-rebound",
+                lane_doc=lane_doc,
+                owner_unit=owner_unit,
+                extra={
+                    "new_owner_unit": rebind_doc["new_owner_unit"],
+                    "hint": "create a continuation lane under the new unit before resuming work",
+                },
+            )
+
+    leases = lane_proto.load_lane_leases(workspace_root, owner_unit, lane_name)
+    active_conflicts, stale_conflicts = lane_proto.conflicting_leases(leases, actor, "exec")
+    if active_conflicts:
+        return _blocked_payload(
+            reason="conflicting-active-lease",
+            lane_doc=lane_doc,
+            owner_unit=owner_unit,
+            extra={"requested_mode": "exec", "conflicting_leases": active_conflicts},
+        )
+    if stale_conflicts:
+        return _blocked_payload(
+            reason="stale-conflicting-lease",
+            lane_doc=lane_doc,
+            owner_unit=owner_unit,
+            extra={
+                "requested_mode": "exec",
+                "conflicting_leases": stale_conflicts,
+                "hint": "break stale leases with gr2 lane lease acquire --force or clean them up first",
+            },
+        )
+
+    selected_repos = _selected_repos(lane_doc, repos)
+    rows: list[dict[str, object]] = []
+    for repo in selected_repos:
+        cwd = workspace_root / "agents" / owner_unit / "lanes" / lane_name / "repos" / repo
+        rows.append(
+            {
+                "lane": lane_name,
+                "owner_unit": owner_unit,
+                "repo": repo,
+                "branch": dict(lane_doc.get("branch_map", {})).get(repo),
+                "cwd": str(cwd),
+                "exists": cwd.exists(),
+                "shared_context_roots": lane_doc.get("context", {}).get("shared_roots", []),
+                "private_context_roots": lane_doc.get("context", {}).get("private_roots", []),
+                "parallelism": lane_doc["exec_defaults"].get("parallelism"),
+                "fail_fast": bool(lane_doc["exec_defaults"].get("fail_fast", True)),
+                "default_command_family": lane_doc["exec_defaults"].get("default_command_family", []),
+                "commands": lane_doc["exec_defaults"].get("commands", []),
+            }
+        )
+
+    return {
+        "status": "ready",
+        "lane": lane_name,
+        "owner_unit": owner_unit,
+        "lane_type": lane_doc["lane_type"],
+        "rows": rows,
+    }
+
+
+def render_exec_status(payload: dict[str, object]) -> str:
+    if payload["status"] != "ready":
+        lines = [
+            "ExecStatus",
+            f"status = {payload['status']}",
+            f"reason = {payload['reason']}",
+            f"owner_unit = {payload['owner_unit']}",
+            f"lane = {payload['lane']}",
+        ]
+        if "hint" in payload:
+            lines.append(f"hint = {payload['hint']}")
+        return "\n".join(lines)
+
+    lines = [
+        "ExecStatus",
+        f"status = {payload['status']}",
+        f"owner_unit = {payload['owner_unit']}",
+        f"lane = {payload['lane']}",
+        f"lane_type = {payload['lane_type']}",
+        "REPO\tBRANCH\tEXISTS\tCWD",
+    ]
+    for row in payload["rows"]:
+        lines.append(f"{row['repo']}\t{row['branch']}\t{row['exists']}\t{row['cwd']}")
+    return "\n".join(lines)
+
+
+def _emit_lease_event(
+    workspace_root: Path,
+    *,
+    owner_unit: str,
+    lane_name: str,
+    actor: str,
+    event_type: str,
+    ttl_seconds: int | None = None,
+) -> None:
+    lane_doc = lane_proto.load_lane_doc(workspace_root, owner_unit, lane_name)
+    unit_spec = lane_proto.find_unit_spec(workspace_root, owner_unit)
+    payload = {
+        "type": event_type,
+        "agent": actor,
+        "agent_id": unit_spec.get("agent_id"),
+        "owner_unit": owner_unit,
+        "lane": lane_name,
+        "lane_type": lane_doc["lane_type"],
+        "repos": lane_doc.get("repos", []),
+        "timestamp": lane_proto.now_utc(),
+    }
+    if ttl_seconds is not None:
+        payload["lease_mode"] = "exec"
+        payload["ttl_seconds"] = ttl_seconds
+    lane_proto.emit_lane_event(workspace_root, payload)
+
+
+def acquire_exec_lease(workspace_root: Path, owner_unit: str, lane_name: str, actor: str, ttl_seconds: int) -> None:
+    def mutator(leases: list[dict]) -> dict:
+        retained = [lease for lease in leases if lease["actor"] != actor]
+        active_conflicts, stale_conflicts = lane_proto.conflicting_leases(retained, actor, "exec")
+        if active_conflicts:
+            return {"status": "blocked", "payload": {"reason": "conflicting-active-lease", "conflicting_leases": active_conflicts}, "write": False}
+        if stale_conflicts:
+            return {"status": "blocked", "payload": {"reason": "stale-conflicting-lease", "conflicting_leases": stale_conflicts}, "write": False}
+        retained.append(lane_proto.build_lease(actor, "exec", ttl_seconds))
+        return {"status": "ok", "leases": retained, "write": True}
+
+    result = lane_proto.mutate_lane_leases(workspace_root, owner_unit, lane_name, mutator)
+    if result["status"] == "blocked":
+        raise SystemExit(json.dumps(result["payload"], indent=2))
+    _emit_lease_event(
+        workspace_root,
+        owner_unit=owner_unit,
+        lane_name=lane_name,
+        actor=actor,
+        event_type="lease_acquire",
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def release_exec_lease(workspace_root: Path, owner_unit: str, lane_name: str, actor: str) -> None:
+    lane_proto.mutate_lane_leases(
+        workspace_root,
+        owner_unit,
+        lane_name,
+        lambda leases: {
+            "status": "ok",
+            "leases": [lease for lease in leases if lease["actor"] != actor],
+            "write": True,
+        },
+    )
+    _emit_lease_event(
+        workspace_root,
+        owner_unit=owner_unit,
+        lane_name=lane_name,
+        actor=actor,
+        event_type="lease_release",
+    )
+
+
+def run_exec(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: str | None,
+    *,
+    actor: str,
+    command: list[str],
+    repos: str | None = None,
+    ttl_seconds: int = 900,
+) -> dict[str, object]:
+    status = exec_status_payload(workspace_root, owner_unit, lane_name, repos=repos, actor=actor)
+    if status["status"] != "ready":
+        return status
+
+    resolved_lane = str(status["lane"])
+    rows = list(status["rows"])
+    fail_fast = bool(rows[0]["fail_fast"]) if rows else True
+    acquire_exec_lease(workspace_root, owner_unit, resolved_lane, actor, ttl_seconds)
+    results: list[dict[str, object]] = []
+    overall = "success"
+
+    try:
+        for row in rows:
+            cwd = Path(str(row["cwd"]))
+            if not cwd.exists():
+                result = {
+                    "repo": row["repo"],
+                    "cwd": str(cwd),
+                    "status": "missing",
+                    "returncode": None,
+                    "stdout": "",
+                    "stderr": f"lane repo checkout missing: {cwd}",
+                }
+                results.append(result)
+                overall = "failed"
+                if fail_fast:
+                    break
+                continue
+
+            proc = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+            result = {
+                "repo": row["repo"],
+                "cwd": str(cwd),
+                "status": "ok" if proc.returncode == 0 else "failed",
+                "returncode": proc.returncode,
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+            }
+            results.append(result)
+            if proc.returncode != 0:
+                overall = "failed"
+                if fail_fast:
+                    break
+    finally:
+        release_exec_lease(workspace_root, owner_unit, resolved_lane, actor)
+
+    return {
+        "status": overall,
+        "owner_unit": owner_unit,
+        "lane": resolved_lane,
+        "command": command,
+        "results": results,
+    }
+
+
+def render_exec_run(payload: dict[str, object]) -> str:
+    if payload.get("status") == "blocked":
+        return render_exec_status(payload)
+    lines = [
+        "ExecRun",
+        f"status = {payload['status']}",
+        f"owner_unit = {payload['owner_unit']}",
+        f"lane = {payload['lane']}",
+        f"command = {' '.join(payload['command'])}",
+        "REPO\tSTATUS\tRETURNCODE\tCWD",
+    ]
+    for result in payload["results"]:
+        lines.append(
+            f"{result['repo']}\t{result['status']}\t{result['returncode']}\t{result['cwd']}"
+        )
+    return "\n".join(lines)

--- a/gr2/python_cli/gitops.py
+++ b/gr2/python_cli/gitops.py
@@ -32,19 +32,83 @@ def remote_origin_url(path: Path) -> str | None:
     return value or None
 
 
-def clone_repo(url: str, target_repo_root: Path) -> bool:
-    if target_repo_root.exists() and is_git_repo(target_repo_root):
+def ensure_repo_cache(url: str, cache_repo_root: Path) -> bool:
+    """Ensure a local bare mirror exists for a repo URL.
+
+    Returns True if a cache was created, False if it already existed and was refreshed.
+    """
+    if cache_repo_root.exists():
+        if not is_git_dir(cache_repo_root):
+            raise SystemExit(f"repo cache path exists but is not a git dir: {cache_repo_root}")
+        proc = subprocess.run(
+            ["git", "--git-dir", str(cache_repo_root), "remote", "update", "--prune"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise SystemExit(f"failed to refresh repo cache {cache_repo_root}:\n{proc.stderr or proc.stdout}")
         return False
-    target_repo_root.parent.mkdir(parents=True, exist_ok=True)
+
+    cache_repo_root.parent.mkdir(parents=True, exist_ok=True)
     proc = subprocess.run(
-        ["git", "clone", url, str(target_repo_root)],
+        ["git", "clone", "--mirror", url, str(cache_repo_root)],
         capture_output=True,
         text=True,
         check=False,
     )
     if proc.returncode != 0:
+        raise SystemExit(f"failed to seed repo cache {url} -> {cache_repo_root}:\n{proc.stderr or proc.stdout}")
+    return True
+
+
+def clone_repo(url: str, target_repo_root: Path, *, reference_repo_root: Path | None = None) -> bool:
+    if target_repo_root.exists() and is_git_repo(target_repo_root):
+        return False
+    target_repo_root.parent.mkdir(parents=True, exist_ok=True)
+    command = ["git", "clone"]
+    if reference_repo_root is not None:
+        command.extend(["--reference-if-able", str(reference_repo_root)])
+    command.extend([url, str(target_repo_root)])
+    proc = subprocess.run(command, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
         raise SystemExit(f"failed to clone {url} -> {target_repo_root}:\n{proc.stderr or proc.stdout}")
     return True
+
+
+def branch_exists(repo_root: Path, branch: str) -> bool:
+    return git(repo_root, "show-ref", "--verify", f"refs/heads/{branch}").returncode == 0
+
+
+def fetch_ref(repo_root: Path, remote: str, source_ref: str, local_branch: str) -> None:
+    proc = git(repo_root, "fetch", remote, f"{source_ref}:refs/heads/{local_branch}")
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"failed to fetch {source_ref} from {remote} into {local_branch} in {repo_root}:\n{proc.stderr or proc.stdout}"
+        )
+
+
+def refresh_existing_branch(repo_root: Path, remote: str, source_ref: str, local_branch: str) -> None:
+    proc = git(repo_root, "fetch", remote, source_ref)
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"failed to fetch {source_ref} from {remote} in {repo_root}:\n{proc.stderr or proc.stdout}"
+        )
+    proc = git(repo_root, "branch", "-f", local_branch, "FETCH_HEAD")
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"failed to refresh existing branch {local_branch} from {source_ref} in {repo_root}:\n{proc.stderr or proc.stdout}"
+        )
+
+
+def is_git_dir(path: Path) -> bool:
+    proc = subprocess.run(
+        ["git", "--git-dir", str(path), "rev-parse", "--is-bare-repository"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0 and proc.stdout.strip() == "true"
 
 
 def ensure_lane_checkout(

--- a/gr2/python_cli/hooks.py
+++ b/gr2/python_cli/hooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import sys
 import subprocess
 import tomllib
 from pathlib import Path
@@ -67,6 +68,28 @@ class HookContext:
     lane_owner: str
     lane_subject: str
     lane_name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class HookResult:
+    kind: str
+    name: str
+    status: str
+    detail: str
+    cwd: str | None = None
+    command: str | None = None
+    returncode: int | None = None
+    stdout: str | None = None
+    stderr: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+class HookRuntimeError(SystemExit):
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        super().__init__(json.dumps(payload, indent=2))
 
 
 def hook_file(repo_root: Path) -> Path:
@@ -149,7 +172,8 @@ def render_text(template: str, ctx: HookContext) -> str:
     )
 
 
-def apply_file_projections(hooks: RepoHooks, ctx: HookContext) -> None:
+def apply_file_projections(hooks: RepoHooks, ctx: HookContext) -> list[HookResult]:
+    results: list[HookResult] = []
     for item in [*hooks.file_links, *hooks.file_copies]:
         rendered_src = render_text(item.src, ctx)
         src = Path(rendered_src)
@@ -159,24 +183,81 @@ def apply_file_projections(hooks: RepoHooks, ctx: HookContext) -> None:
         dest.parent.mkdir(parents=True, exist_ok=True)
 
         if not src.exists():
-            raise SystemExit(f"projection source does not exist: {src} from {hooks.path}")
+            raise HookRuntimeError(
+                {
+                    "kind": "projection",
+                    "projection": item.kind,
+                    "status": "blocked",
+                    "detail": f"projection source does not exist: {src}",
+                    "repo_hooks_path": str(hooks.path),
+                    "src": str(src),
+                    "dest": str(dest),
+                }
+            )
 
         if dest.exists() or dest.is_symlink():
             if item.if_exists == "skip":
+                results.append(
+                    HookResult(
+                        kind="projection",
+                        name=f"{item.kind}:{dest.name}",
+                        status="skipped",
+                        detail=f"destination already exists and if_exists=skip: {dest}",
+                    )
+                )
                 continue
             if item.if_exists == "error":
-                raise SystemExit(f"projection conflict at {dest} from {hooks.path}")
+                raise HookRuntimeError(
+                    {
+                        "kind": "projection",
+                        "projection": item.kind,
+                        "status": "blocked",
+                        "detail": f"projection conflict at {dest}",
+                        "repo_hooks_path": str(hooks.path),
+                        "src": str(src),
+                        "dest": str(dest),
+                    }
+                )
             if item.if_exists == "merge":
-                raise SystemExit(f"merge projections not implemented yet for {dest}")
+                raise HookRuntimeError(
+                    {
+                        "kind": "projection",
+                        "projection": item.kind,
+                        "status": "blocked",
+                        "detail": f"merge projections not implemented yet for {dest}",
+                        "repo_hooks_path": str(hooks.path),
+                        "src": str(src),
+                        "dest": str(dest),
+                    }
+                )
             if item.if_exists == "overwrite":
                 if dest.is_dir() and not dest.is_symlink():
-                    raise SystemExit(f"refusing to overwrite directory projection target: {dest}")
+                    raise HookRuntimeError(
+                        {
+                            "kind": "projection",
+                            "projection": item.kind,
+                            "status": "blocked",
+                            "detail": f"refusing to overwrite directory projection target: {dest}",
+                            "repo_hooks_path": str(hooks.path),
+                            "src": str(src),
+                            "dest": str(dest),
+                        }
+                    )
                 dest.unlink(missing_ok=True)
 
         if item.kind == "link":
             dest.symlink_to(src)
         else:
             dest.write_bytes(src.read_bytes())
+        results.append(
+            HookResult(
+                kind="projection",
+                name=f"{item.kind}:{dest.name}",
+                status="applied",
+                detail=f"{item.kind} {src} -> {dest}",
+            )
+        )
+    return results
 
 
 def run_lifecycle_stage(
@@ -186,14 +267,29 @@ def run_lifecycle_stage(
     *,
     repo_dirty: bool,
     first_materialize: bool,
-) -> None:
+    allow_manual: bool = False,
+) -> list[HookResult]:
     hooks_for_stage = {
         "on_materialize": hooks.on_materialize,
         "on_enter": hooks.on_enter,
         "on_exit": hooks.on_exit,
     }[stage]
+    results: list[HookResult] = []
     for hook in hooks_for_stage:
-        if not _should_run(hook.when, repo_dirty=repo_dirty, first_materialize=first_materialize):
+        if not _should_run(
+            hook.when,
+            repo_dirty=repo_dirty,
+            first_materialize=first_materialize,
+            allow_manual=allow_manual,
+        ):
+            results.append(
+                HookResult(
+                    kind="lifecycle",
+                    name=hook.name,
+                    status="skipped",
+                    detail=f"hook when={hook.when} did not match current invocation",
+                )
+            )
             continue
         cwd = render_path(hook.cwd, ctx)
         command = render_text(hook.command, ctx)
@@ -205,26 +301,66 @@ def run_lifecycle_stage(
             text=True,
         )
         if proc.returncode == 0:
+            results.append(
+                HookResult(
+                    kind="lifecycle",
+                    name=hook.name,
+                    status="applied",
+                    detail=f"stage {stage} completed successfully",
+                    cwd=str(cwd),
+                    command=command,
+                    returncode=proc.returncode,
+                    stdout=proc.stdout,
+                    stderr=proc.stderr,
+                )
+            )
             continue
-        message = json.dumps(
-            {
-                "stage": stage,
-                "hook": hook.name,
-                "cwd": str(cwd),
-                "command": command,
-                "returncode": proc.returncode,
-                "stdout": proc.stdout,
-                "stderr": proc.stderr,
-            },
-            indent=2,
-        )
+        payload = {
+            "kind": "lifecycle",
+            "stage": stage,
+            "hook": hook.name,
+            "cwd": str(cwd),
+            "command": command,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "on_failure": hook.on_failure,
+        }
         if hook.on_failure == "block":
-            raise SystemExit(message)
+            raise HookRuntimeError(payload)
         if hook.on_failure == "warn":
-            print(message)
+            print(json.dumps(payload, indent=2), file=sys.stderr)
+            results.append(
+                HookResult(
+                    kind="lifecycle",
+                    name=hook.name,
+                    status="warned",
+                    detail=f"hook failed with on_failure=warn during {stage}",
+                    cwd=str(cwd),
+                    command=command,
+                    returncode=proc.returncode,
+                    stdout=proc.stdout,
+                    stderr=proc.stderr,
+                )
+            )
+            continue
+        results.append(
+            HookResult(
+                kind="lifecycle",
+                name=hook.name,
+                status="skipped",
+                detail=f"hook failed with on_failure=skip during {stage}",
+                cwd=str(cwd),
+                command=command,
+                returncode=proc.returncode,
+                stdout=proc.stdout,
+                stderr=proc.stderr,
+            )
+        )
+    return results
 
 
-def _should_run(when: str, *, repo_dirty: bool, first_materialize: bool) -> bool:
+def _should_run(when: str, *, repo_dirty: bool, first_materialize: bool, allow_manual: bool) -> bool:
     if when == "always":
         return True
     if when == "first_materialize":
@@ -232,5 +368,5 @@ def _should_run(when: str, *, repo_dirty: bool, first_materialize: bool) -> bool
     if when == "dirty":
         return repo_dirty
     if when == "manual":
-        return False
+        return allow_manual
     return False

--- a/gr2/python_cli/migration.py
+++ b/gr2/python_cli/migration.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import yaml
+
+
+def gr1_manifest_path(workspace_root: Path) -> Path:
+    return workspace_root / ".gitgrip" / "spaces" / "main" / "gripspace.yml"
+
+
+def gr1_agents_path(workspace_root: Path) -> Path:
+    return workspace_root / ".gitgrip" / "agents.toml"
+
+
+def gr1_state_paths(workspace_root: Path) -> dict[str, Path]:
+    gitgrip = workspace_root / ".gitgrip"
+    return {
+        "state_json": gitgrip / "state.json",
+        "sync_state_json": gitgrip / "sync-state.json",
+        "griptrees_json": gitgrip / "griptrees.json",
+        "manifest_yaml": gr1_manifest_path(workspace_root),
+    }
+
+
+def detect_gr1_workspace(workspace_root: Path) -> dict[str, object]:
+    manifest_path = gr1_manifest_path(workspace_root)
+    if not manifest_path.exists():
+        return {
+            "detected": False,
+            "workspace_root": str(workspace_root),
+            "reason": f"missing {manifest_path}",
+        }
+
+    manifest = yaml.safe_load(manifest_path.read_text()) or {}
+    repos = manifest.get("repos", {}) or {}
+    agents_doc = _load_agents_doc(workspace_root)
+    agent_names = sorted(((agents_doc.get("agents") or {}) or {}).keys())
+    reference_repos = sorted(name for name, repo in repos.items() if bool((repo or {}).get("reference", False)))
+    writable_repos = sorted(name for name in repos.keys() if name not in reference_repos)
+    state_paths = gr1_state_paths(workspace_root)
+
+    return {
+        "detected": True,
+        "workspace_root": str(workspace_root),
+        "manifest_path": str(manifest_path),
+        "repo_count": len(repos),
+        "reference_repo_count": len(reference_repos),
+        "agent_count": len(agent_names),
+        "repos": sorted(repos.keys()),
+        "reference_repos": reference_repos,
+        "writable_repos": writable_repos,
+        "agents": agent_names,
+        "state_files": {key: str(path) for key, path in state_paths.items() if path.exists()},
+    }
+
+
+def migrate_gr1_workspace(workspace_root: Path, *, force: bool = False) -> dict[str, object]:
+    detection = detect_gr1_workspace(workspace_root)
+    if not detection["detected"]:
+        raise SystemExit(detection["reason"])
+
+    grip_dir = workspace_root / ".grip"
+    spec_path = grip_dir / "workspace_spec.toml"
+    if spec_path.exists() and not force:
+        raise SystemExit(f"refusing to overwrite existing gr2 workspace spec: {spec_path}")
+
+    manifest = yaml.safe_load(Path(str(detection["manifest_path"])).read_text()) or {}
+    agents_doc = _load_agents_doc(workspace_root)
+    compiled = compile_gr1_to_workspace_spec(workspace_root, manifest, agents_doc)
+
+    grip_dir.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(render_workspace_spec(compiled))
+
+    migration_dir = grip_dir / "migrations" / "gr1"
+    migration_dir.mkdir(parents=True, exist_ok=True)
+    snapshots = preserve_gr1_state(workspace_root, migration_dir)
+    summary_path = migration_dir / "migration-summary.json"
+    summary = {
+        "source": "gr1",
+        "workspace_root": str(workspace_root),
+        "workspace_spec_path": str(spec_path),
+        "repo_count": len(compiled["repos"]),
+        "unit_count": len(compiled["units"]),
+        "snapshots": snapshots,
+    }
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+
+    return {
+        **summary,
+        "units": [unit["name"] for unit in compiled["units"]],
+        "repos": [repo["name"] for repo in compiled["repos"]],
+    }
+
+
+def compile_gr1_to_workspace_spec(
+    workspace_root: Path,
+    manifest: dict[str, object],
+    agents_doc: dict[str, object],
+) -> dict[str, object]:
+    repos_doc = manifest.get("repos", {}) or {}
+    repos: list[dict[str, object]] = []
+    writable_repo_names: list[str] = []
+
+    for repo_name, repo_doc in repos_doc.items():
+        repo_doc = repo_doc or {}
+        path = str(repo_doc.get("path", "")).strip()
+        normalized_path = path[2:] if path.startswith("./") else path
+        repo_item = {
+            "name": str(repo_name),
+            "path": normalized_path,
+            "url": str(repo_doc.get("url", "")).strip(),
+        }
+        if "revision" in repo_doc:
+            repo_item["default_branch"] = str(repo_doc.get("revision") or "").strip()
+        elif "default_branch" in repo_doc:
+            repo_item["default_branch"] = str(repo_doc.get("default_branch") or "").strip()
+        if repo_doc.get("reference", False):
+            repo_item["reference"] = True
+        repos.append(repo_item)
+        if not repo_doc.get("reference", False):
+            writable_repo_names.append(str(repo_name))
+
+    agents = (agents_doc.get("agents") or {}) or {}
+    unit_names = sorted(agents.keys()) if agents else ["default"]
+    units: list[dict[str, object]] = []
+    for unit_name in unit_names:
+        unit_doc = (agents.get(unit_name) or {}) if agents else {}
+        units.append(
+            {
+                "name": unit_name,
+                "path": f"agents/{unit_name}/home",
+                "repos": writable_repo_names,
+                "agent_id": f"gr1:{unit_name}",
+                "migration_source": {
+                    "worktree": unit_doc.get("worktree"),
+                    "channel": unit_doc.get("channel"),
+                },
+            }
+        )
+
+    return {
+        "workspace_name": workspace_root.name,
+        "repos": repos,
+        "units": units,
+        "workspace_constraints": {
+            "migration_source": "gr1",
+        },
+    }
+
+
+def preserve_gr1_state(workspace_root: Path, migration_dir: Path) -> dict[str, str]:
+    snapshots: dict[str, str] = {}
+    for name, src in gr1_state_paths(workspace_root).items():
+        if not src.exists():
+            continue
+        dest = migration_dir / src.name
+        shutil.copy2(src, dest)
+        snapshots[name] = str(dest)
+    return snapshots
+
+
+def render_workspace_spec(compiled: dict[str, object]) -> str:
+    lines = [
+        f'workspace_name = "{compiled["workspace_name"]}"',
+        "",
+    ]
+    constraints = compiled.get("workspace_constraints") or {}
+    if constraints:
+        lines.append("[workspace_constraints]")
+        for key, value in constraints.items():
+            lines.append(f'{key} = "{value}"')
+        lines.append("")
+
+    for repo in compiled["repos"]:
+        lines.extend(
+            [
+                "[[repos]]",
+                f'name = "{repo["name"]}"',
+                f'path = "{repo["path"]}"',
+                f'url = "{repo["url"]}"',
+            ]
+        )
+        default_branch = str(repo.get("default_branch", "")).strip()
+        if default_branch:
+            lines.append(f'default_branch = "{default_branch}"')
+        if repo.get("reference", False):
+            lines.append("reference = true")
+        lines.append("")
+
+    for unit in compiled["units"]:
+        lines.extend(
+            [
+                "[[units]]",
+                f'name = "{unit["name"]}"',
+                f'path = "{unit["path"]}"',
+                "repos = [" + ", ".join(f'"{repo}"' for repo in unit["repos"]) + "]",
+            ]
+        )
+        agent_id = str(unit.get("agent_id", "")).strip()
+        if agent_id:
+            lines.append(f'agent_id = "{agent_id}"')
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def render_detection(payload: dict[str, object]) -> str:
+    if not payload["detected"]:
+        return "\n".join(["Gr1Detection", "detected = false", f"reason = {payload['reason']}"])
+    lines = [
+        "Gr1Detection",
+        "detected = true",
+        f"workspace_root = {payload['workspace_root']}",
+        f"manifest_path = {payload['manifest_path']}",
+        f"repo_count = {payload['repo_count']}",
+        f"reference_repo_count = {payload['reference_repo_count']}",
+        f"agent_count = {payload['agent_count']}",
+        "REPOS",
+    ]
+    lines.extend(f"- {repo}" for repo in payload["repos"])
+    lines.append("AGENTS")
+    lines.extend(f"- {agent}" for agent in payload["agents"])
+    return "\n".join(lines)
+
+
+def render_migration(payload: dict[str, object]) -> str:
+    lines = [
+        "Gr1Migration",
+        f"workspace_root = {payload['workspace_root']}",
+        f"workspace_spec_path = {payload['workspace_spec_path']}",
+        f"repo_count = {payload['repo_count']}",
+        f"unit_count = {payload['unit_count']}",
+        "UNITS",
+    ]
+    lines.extend(f"- {unit}" for unit in payload["units"])
+    lines.append("SNAPSHOTS")
+    lines.extend(f"- {name}\t{path}" for name, path in payload["snapshots"].items())
+    return "\n".join(lines)
+
+
+def _load_agents_doc(workspace_root: Path) -> dict[str, object]:
+    path = gr1_agents_path(workspace_root)
+    if not path.exists():
+        return {}
+    import tomllib
+
+    with path.open("rb") as fh:
+        return tomllib.load(fh)

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .gitops import clone_repo, ensure_repo_cache, is_git_dir, is_git_repo, repo_dirty
+from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
+
+
+@dataclasses.dataclass(frozen=True)
+class ValidationIssue:
+    level: str
+    code: str
+    message: str
+    path: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class PlanOperation:
+    kind: str
+    subject: str
+    target_path: str
+    reason: str
+    details: dict[str, object]
+
+    def as_dict(self) -> dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+def workspace_spec_path(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "workspace_spec.toml"
+
+
+def workspace_cache_root(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "cache" / "repos"
+
+
+def repo_cache_path(workspace_root: Path, repo_name: str) -> Path:
+    return workspace_cache_root(workspace_root) / f"{repo_name}.git"
+
+
+def load_workspace_spec_doc(workspace_root: Path) -> dict[str, object]:
+    spec_path = workspace_spec_path(workspace_root)
+    if not spec_path.exists():
+        raise SystemExit(
+            f"workspace spec not found: {spec_path}\n"
+            "run `gr2 workspace init <path>` first or create .grip/workspace_spec.toml explicitly"
+        )
+    with spec_path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def show_spec(workspace_root: Path, *, json_output: bool) -> str:
+    spec_path = workspace_spec_path(workspace_root)
+    if json_output:
+        return json.dumps(load_workspace_spec_doc(workspace_root), indent=2)
+    return spec_path.read_text()
+
+
+def validate_spec(workspace_root: Path) -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    spec = load_workspace_spec_doc(workspace_root)
+
+    workspace_name = str(spec.get("workspace_name", "")).strip()
+    if not workspace_name:
+        issues.append(
+            ValidationIssue(
+                level="error",
+                code="missing_workspace_name",
+                message="workspace spec workspace_name must not be empty",
+                path="workspace_name",
+            )
+        )
+
+    repo_names: set[str] = set()
+    for idx, repo in enumerate(spec.get("repos", [])):
+        name = str(repo.get("name", "")).strip()
+        path = str(repo.get("path", "")).strip()
+        url = str(repo.get("url", "")).strip()
+        if not name:
+            issues.append(
+                ValidationIssue("error", "missing_repo_name", "repo name must not be empty", f"repos[{idx}].name")
+            )
+            continue
+        if name in repo_names:
+            issues.append(
+                ValidationIssue("error", "duplicate_repo_name", f"duplicate repo '{name}'", f"repos[{idx}].name")
+            )
+        repo_names.add(name)
+        if not path:
+            issues.append(
+                ValidationIssue("error", "missing_repo_path", f"repo '{name}' path must not be empty", f"repos[{idx}].path")
+            )
+        if not url:
+            issues.append(
+                ValidationIssue("error", "missing_repo_url", f"repo '{name}' url must not be empty", f"repos[{idx}].url")
+            )
+        repo_root = workspace_root / path
+        if repo_root.exists() and not is_git_repo(repo_root):
+            issues.append(
+                ValidationIssue(
+                    level="error",
+                    code="repo_path_conflict",
+                    message=f"repo path exists but is not a git repo: {repo_root}",
+                        path=f"repos[{idx}].path",
+                    )
+                )
+        cache_root = repo_cache_path(workspace_root, name)
+        if cache_root.exists() and not is_git_dir(cache_root):
+            issues.append(
+                ValidationIssue(
+                    level="error",
+                    code="repo_cache_conflict",
+                    message=f"repo cache path exists but is not a bare git dir: {cache_root}",
+                    path=f"repos[{idx}].name",
+                )
+            )
+        if repo_root.exists() and is_git_repo(repo_root):
+            try:
+                load_repo_hooks(repo_root)
+            except SystemExit as exc:
+                issues.append(
+                    ValidationIssue(
+                        level="error",
+                        code="invalid_repo_hooks",
+                        message=f"repo '{name}' has invalid .gr2/hooks.toml: {exc}",
+                        path=f"repos[{idx}]",
+                    )
+                )
+
+    unit_names: set[str] = set()
+    for idx, unit in enumerate(spec.get("units", [])):
+        name = str(unit.get("name", "")).strip()
+        path = str(unit.get("path", "")).strip()
+        repos = [str(item) for item in unit.get("repos", [])]
+        if not name:
+            issues.append(
+                ValidationIssue("error", "missing_unit_name", "unit name must not be empty", f"units[{idx}].name")
+            )
+            continue
+        if name in unit_names:
+            issues.append(
+                ValidationIssue("error", "duplicate_unit_name", f"duplicate unit '{name}'", f"units[{idx}].name")
+            )
+        unit_names.add(name)
+        if not path:
+            issues.append(
+                ValidationIssue("error", "missing_unit_path", f"unit '{name}' path must not be empty", f"units[{idx}].path")
+            )
+        unit_root = workspace_root / path
+        if unit_root.exists() and unit_root.is_file():
+            issues.append(
+                ValidationIssue(
+                    "error",
+                    "unit_path_conflict",
+                    f"unit path exists as a file: {unit_root}",
+                    f"units[{idx}].path",
+                )
+            )
+        missing = [repo for repo in repos if repo not in repo_names]
+        for repo_name in missing:
+            issues.append(
+                ValidationIssue(
+                    "error",
+                    "missing_unit_repo",
+                    f"unit '{name}' references missing repo '{repo_name}'",
+                    f"units[{idx}].repos",
+                )
+            )
+
+    return issues
+
+
+def render_validation(issues: list[ValidationIssue]) -> str:
+    if not issues:
+        return "WorkspaceSpec\n- valid\n"
+    lines = ["WorkspaceSpec", "LEVEL\tCODE\tPATH\tMESSAGE"]
+    for issue in issues:
+        lines.append(f"{issue.level}\t{issue.code}\t{issue.path or '-'}\t{issue.message}")
+    return "\n".join(lines)
+
+
+def build_plan(workspace_root: Path) -> tuple[dict[str, object], list[PlanOperation]]:
+    issues = validate_spec(workspace_root)
+    errors = [issue for issue in issues if issue.level == "error"]
+    if errors:
+        rendered = "\n".join(f"- {issue.message}" for issue in errors)
+        raise SystemExit(f"workspace spec validation failed:\n{rendered}")
+
+    spec = load_workspace_spec_doc(workspace_root)
+    operations: list[PlanOperation] = []
+
+    for repo in spec.get("repos", []):
+        repo_name = str(repo["name"])
+        repo_path = workspace_root / str(repo["path"])
+        cache_path = repo_cache_path(workspace_root, repo_name)
+        if not cache_path.exists():
+            operations.append(
+                PlanOperation(
+                    kind="seed_repo_cache",
+                    subject=repo_name,
+                    target_path=str(cache_path),
+                    reason="repo cache missing",
+                    details={"url": str(repo["url"])},
+                )
+            )
+        if not repo_path.exists():
+            operations.append(
+                PlanOperation(
+                    kind="clone_repo",
+                    subject=repo_name,
+                    target_path=str(repo_path),
+                    reason="repo path missing",
+                    details={"url": str(repo["url"]), "cache_path": str(cache_path)},
+                )
+            )
+
+    for unit in spec.get("units", []):
+        unit_name = str(unit["name"])
+        unit_root = workspace_root / str(unit["path"])
+        unit_toml = unit_root / "unit.toml"
+        if not unit_root.exists():
+            operations.append(
+                PlanOperation(
+                    kind="create_unit_root",
+                    subject=unit_name,
+                    target_path=str(unit_root),
+                    reason="unit path missing",
+                    details={"repos": [str(repo) for repo in unit.get("repos", [])]},
+                )
+            )
+        if not unit_toml.exists():
+            operations.append(
+                PlanOperation(
+                    kind="write_unit_metadata",
+                    subject=unit_name,
+                    target_path=str(unit_toml),
+                    reason="unit metadata missing",
+                    details={"repos": [str(repo) for repo in unit.get("repos", [])]},
+                )
+            )
+
+    return spec, operations
+
+
+def render_plan(operations: list[PlanOperation]) -> str:
+    if not operations:
+        return "ExecutionPlan\n- no changes required\n"
+    lines = ["ExecutionPlan", "KIND\tSUBJECT\tTARGET\tREASON"]
+    for op in operations:
+        lines.append(f"{op.kind}\t{op.subject}\t{op.target_path}\t{op.reason}")
+    return "\n".join(lines)
+
+
+def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -> dict[str, object]:
+    spec, operations = build_plan(workspace_root)
+    if len(operations) > 3 and not yes:
+        raise SystemExit("plan contains more than 3 operations; rerun with --yes to apply it")
+
+    applied: list[str] = []
+    for op in operations:
+        if op.kind == "clone_repo":
+            repo_spec = _find_repo(spec, op.subject)
+            repo_root = workspace_root / str(repo_spec["path"])
+            cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
+            first_materialize = clone_repo(str(repo_spec["url"]), repo_root, reference_repo_root=cache_path)
+            _run_materialize_hooks(
+                workspace_root,
+                repo_root,
+                str(repo_spec["name"]),
+                first_materialize,
+                manual_hooks=manual_hooks,
+            )
+            applied.append(f"cloned repo '{op.subject}' into {repo_root}")
+        elif op.kind == "seed_repo_cache":
+            repo_spec = _find_repo(spec, op.subject)
+            cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
+            created = ensure_repo_cache(str(repo_spec["url"]), cache_path)
+            if created:
+                applied.append(f"seeded repo cache for '{op.subject}' at {cache_path}")
+            else:
+                applied.append(f"refreshed repo cache for '{op.subject}' at {cache_path}")
+        elif op.kind == "create_unit_root":
+            unit_root = Path(op.target_path)
+            unit_root.mkdir(parents=True, exist_ok=True)
+            applied.append(f"created unit root for '{op.subject}' at {unit_root}")
+        elif op.kind == "write_unit_metadata":
+            unit_spec = _find_unit(spec, op.subject)
+            unit_root = workspace_root / str(unit_spec["path"])
+            unit_root.mkdir(parents=True, exist_ok=True)
+            unit_toml = unit_root / "unit.toml"
+            unit_toml.write_text(render_unit_toml(unit_spec))
+            applied.append(f"wrote unit metadata for '{op.subject}'")
+        else:
+            raise SystemExit(f"unknown plan operation kind: {op.kind}")
+
+    if applied:
+        _record_apply_state(workspace_root, applied)
+
+    return {
+        "workspace_root": str(workspace_root),
+        "applied": applied,
+        "operation_count": len(operations),
+    }
+
+
+def render_apply_result(payload: dict[str, object]) -> str:
+    applied = [str(item) for item in payload.get("applied", [])]
+    lines = ["ApplyResult", f"workspace_root = {payload['workspace_root']}", f"operation_count = {payload['operation_count']}"]
+    if not applied:
+        lines.append("- no changes applied")
+        return "\n".join(lines)
+    lines.append("ACTIONS")
+    lines.extend(f"- {item}" for item in applied)
+    return "\n".join(lines)
+
+
+def _find_repo(spec: dict[str, object], repo_name: str) -> dict[str, object]:
+    for repo in spec.get("repos", []):
+        if str(repo.get("name")) == repo_name:
+            return repo
+    raise SystemExit(f"repo not found in workspace spec: {repo_name}")
+
+
+def _find_unit(spec: dict[str, object], unit_name: str) -> dict[str, object]:
+    for unit in spec.get("units", []):
+        if str(unit.get("name")) == unit_name:
+            return unit
+    raise SystemExit(f"unit not found in workspace spec: {unit_name}")
+
+
+def _run_materialize_hooks(
+    workspace_root: Path,
+    repo_root: Path,
+    repo_name: str,
+    first_materialize: bool,
+    *,
+    manual_hooks: bool = False,
+) -> None:
+    hooks = load_repo_hooks(repo_root)
+    if not hooks:
+        return
+    ctx = HookContext(
+        workspace_root=workspace_root,
+        lane_root=repo_root,
+        repo_root=repo_root,
+        repo_name=repo_name,
+        lane_owner="workspace",
+        lane_subject=repo_name,
+        lane_name="workspace",
+    )
+    apply_file_projections(hooks, ctx)
+    run_lifecycle_stage(
+        hooks,
+        "on_materialize",
+        ctx,
+        repo_dirty=repo_dirty(repo_root),
+        first_materialize=first_materialize,
+        allow_manual=manual_hooks,
+    )
+
+
+def render_unit_toml(unit_spec: dict[str, object]) -> str:
+    repos = [str(repo) for repo in unit_spec.get("repos", [])]
+    repos_str = "[" + ", ".join(f'"{repo}"' for repo in repos) + "]"
+    lines = [
+        f'name = "{unit_spec["name"]}"',
+        'kind = "unit"',
+        f"repos = {repos_str}",
+    ]
+    agent_id = str(unit_spec.get("agent_id", "")).strip()
+    if agent_id:
+        lines.append(f'agent_id = "{agent_id}"')
+    return "\n".join(lines) + "\n"
+
+
+def _record_apply_state(workspace_root: Path, actions: list[str]) -> None:
+    state_dir = workspace_root / ".grip" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state_path = state_dir / "applied.toml"
+    timestamp = datetime.now(UTC).isoformat()
+    content = [
+        "[[applied]]",
+        f'timestamp = "{timestamp}"',
+        "actions = [" + ", ".join(json.dumps(action) for action in actions) + "]",
+        "",
+    ]
+    if state_path.exists():
+        existing = state_path.read_text().rstrip()
+        state_path.write_text(existing + "\n\n" + "\n".join(content))
+    else:
+        state_path.write_text("\n".join(content))


### PR DESCRIPTION
## Summary

This PR lands the Python-first `gr2` workspace orchestration surface in `grip` and makes Python `gr2` the active UX authority while Rust `gr2` remains out of the release path.

Included slices:
- Python `spec show`, `spec validate`, `plan`, and `apply`
- cache-backed workspace materialization with shared repo mirrors and `--reference-if-able`
- lane-aware `exec status` and `exec run`
- `gr1` detection and migration/coexistence commands
- hardened hook runtime semantics for `when`, `if_exists`, and `on_failure`
- review-lane `checkout-pr`
- workspace bootstrap commands and committed repo-local `.gr2/hooks.toml` examples
- integration seam docs/prototypes for identity binding, policy compilation, channel/recall events, and lane invariants

## Premium Boundary

This PR is OSS workspace orchestration in `grip`.

It does **not** move identity, org policy, or entitlement logic into OSS. The boundary remains:
- Premium owns persistent identity, org policy, entitlements, and compilation
- `gr2` consumes workspace-scoped constraints and enforces them locally
- recall/channel surfaces consume neutral lane events

## Rust gr2 Release Note

Earlier branch history temporarily included Rust `gr2` binary/release-file changes. Those were explicitly cleaned out before PR so this branch does not conflict with Apollo's `v0.19.0` release lane. `Cargo.toml`, `src/bin/gr2.rs`, and `tests/cli_tests.rs` were restored to `main` state in the final branch head.

## Verification

Self-review + playground verification completed:
- `python3 -m py_compile gr2/python_cli/*.py gr2/prototypes/python_*_playground.py`
- `python3 gr2/prototypes/python_spec_apply_playground.py --json`
- `python3 gr2/prototypes/python_exec_playground.py --json`
- `python3 gr2/prototypes/python_migration_playground.py --json`
- `python3 gr2/prototypes/python_hook_runtime_playground.py --json`
- `python3 gr2/prototypes/python_review_checkout_playground.py --json`

All harnesses returned `holds`.
