### PR TITLE
feat: start sprint 21 sync engine and platform adapter lane

### DIFF
--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -13,6 +13,7 @@ import typer
 from . import execops
 from . import failures
 from . import migration
+from . import pr as pr_ops
 from . import syncops
 from .gitops import (
     branch_exists,
@@ -208,24 +209,8 @@ def _resolve_lane_name(workspace_root: Path, owner_unit: str, lane_name: Optiona
     return str(current_doc["current"]["lane_name"])
 
 
-def _pr_groups_root(workspace_root: Path) -> Path:
-    return workspace_root / ".grip" / "pr_groups"
-
-
-def _pr_group_path(workspace_root: Path, pr_group_id: str) -> Path:
-    return _pr_groups_root(workspace_root) / f"{pr_group_id}.json"
-
-
-def _write_pr_group(workspace_root: Path, payload: dict[str, object]) -> Path:
-    pr_group_id = str(payload["pr_group_id"])
-    path = _pr_group_path(workspace_root, pr_group_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2) + "\n")
-    return path
-
-
 def _find_pr_group(workspace_root: Path, owner_unit: str, lane_name: str) -> tuple[Path, dict[str, object]]:
-    root = _pr_groups_root(workspace_root)
+    root = workspace_root / ".grip" / "pr_groups"
     if not root.exists():
         raise SystemExit(f"pr group not found for {owner_unit}/{lane_name}: {root}")
     for path in sorted(root.glob("*.json")):
@@ -1007,31 +992,24 @@ def pr_create(
     lane_doc = lane_proto.load_lane_doc(workspace_root, owner_unit, resolved_lane)
     spec = lane_proto.load_workspace_spec(workspace_root)
     adapter = get_platform_adapter(platform)
-    pr_group_id = f"pg_{os.urandom(4).hex()}"
-    refs: list[dict[str, object]] = []
     branch_map = dict(lane_doc.get("branch_map", {}))
+    repos: list[str] = []
     for repo_name in lane_doc.get("repos", []):
         repo_spec = next(repo for repo in spec.get("repos", []) if repo.get("name") == repo_name)
-        request = CreatePRRequest(
-            repo=_repo_slug_from_url(str(repo_spec.get("url", "")), repo_name),
-            title=resolved_lane,
-            body=f"gr2 PR group {pr_group_id} for {owner_unit}/{resolved_lane}",
-            head_branch=str(branch_map.get(repo_name, resolved_lane)),
-            base_branch=base_branch,
-            draft=draft,
-        )
-        ref = adapter.create_pr(request)
-        refs.append(ref.as_dict())
-    payload = {
-        "pr_group_id": pr_group_id,
-        "owner_unit": owner_unit,
-        "lane_name": resolved_lane,
-        "platform": platform,
-        "refs": refs,
-        "group_state": "open",
-    }
-    path = _write_pr_group(workspace_root, payload)
-    payload["state_path"] = str(path)
+        repos.append(_repo_slug_from_url(str(repo_spec.get("url", "")), repo_name))
+    payload = pr_ops.create_pr_group(
+        workspace_root=workspace_root,
+        owner_unit=owner_unit,
+        lane_name=resolved_lane,
+        title=resolved_lane,
+        base_branch=base_branch,
+        head_branch=str(branch_map.get(next(iter(lane_doc.get("repos", [])), resolved_lane), resolved_lane)),
+        repos=repos,
+        adapter=adapter,
+        actor=f"agent:{owner_unit}",
+        body=f"gr2 PR group for {owner_unit}/{resolved_lane}",
+        draft=draft,
+    )
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:
@@ -1050,18 +1028,22 @@ def pr_status(
     resolved_lane = _resolve_lane_name(workspace_root, owner_unit, lane_name)
     group_path, group = _find_pr_group(workspace_root, owner_unit, resolved_lane)
     adapter = get_platform_adapter(str(group.get("platform", "github")))
+    group = pr_ops.check_pr_group_status(
+        workspace_root=workspace_root,
+        pr_group_id=str(group["pr_group_id"]),
+        adapter=adapter,
+        actor=f"agent:{owner_unit}",
+    )
     statuses = []
-    for ref_doc in group.get("refs", []):
-        ref = PRRef(**ref_doc)
-        statuses.append(adapter.pr_status(ref.repo, int(ref.number)).as_dict())
-    group["statuses"] = statuses
-    group["group_state"] = _group_state_from_statuses(statuses)
-    _write_pr_group(workspace_root, group)
+    for pr_info in group.get("prs", []):
+        repo = str(pr_info["repo"])
+        number = int(pr_info["pr_number"])
+        statuses.append(adapter.pr_status(repo, number).as_dict())
     payload = {
         "pr_group_id": group["pr_group_id"],
         "owner_unit": owner_unit,
         "lane_name": resolved_lane,
-        "group_state": group["group_state"],
+        "group_state": _group_state_from_statuses(statuses),
         "statuses": statuses,
         "state_path": str(group_path),
     }
@@ -1084,8 +1066,8 @@ def pr_checks(
     group_path, group = _find_pr_group(workspace_root, owner_unit, resolved_lane)
     adapter = get_platform_adapter(str(group.get("platform", "github")))
     rows = []
-    for ref_doc in group.get("refs", []):
-        ref = PRRef(**ref_doc)
+    for pr_info in group.get("prs", []):
+        ref = PRRef(repo=str(pr_info["repo"]), number=int(pr_info["pr_number"]), url=pr_info.get("url"))
         rows.append(
             {
                 "repo": ref.repo,
@@ -1120,18 +1102,10 @@ def pr_merge(
     adapter = get_platform_adapter(str(group.get("platform", "github")))
     merged: list[str] = []
     failed: list[dict[str, object]] = []
-    for ref_doc in group.get("refs", []):
-        ref = PRRef(**ref_doc)
-        try:
-            adapter.merge_pr(ref.repo, int(ref.number))
-            merged.append(ref.repo)
-        except Exception as exc:
-            failed.append({"repo": ref.repo, "number": ref.number, "reason": str(exc)})
-            break
     if failed:
         group["group_state"] = "partially_merged" if merged else "merge_failed"
         group["merged"] = merged
-        _write_pr_group(workspace_root, group)
+        group_path.write_text(json.dumps(group, indent=2) + "\n")
         payload = {
             "status": "partial_failure" if merged else "failed",
             "pr_group_id": group["pr_group_id"],
@@ -1146,13 +1120,40 @@ def pr_merge(
         else:
             typer.echo(json.dumps(payload, indent=2))
         raise typer.Exit(code=1)
-    payload = {
-        "pr_group_id": group["pr_group_id"],
-        "owner_unit": owner_unit,
-        "lane_name": resolved_lane,
-        "merged": merged,
-        "state_path": str(group_path),
-    }
+    try:
+        pr_ops.merge_pr_group(
+            workspace_root=workspace_root,
+            pr_group_id=str(group["pr_group_id"]),
+            adapter=adapter,
+            actor=f"agent:{owner_unit}",
+        )
+        merged = [str(pr_info["repo"]) for pr_info in group.get("prs", [])]
+        payload = {
+            "pr_group_id": group["pr_group_id"],
+            "owner_unit": owner_unit,
+            "lane_name": resolved_lane,
+            "merged": merged,
+            "state_path": str(group_path),
+        }
+    except pr_ops.PRMergeError as exc:
+        merged = [str(pr_info["repo"]) for pr_info in group.get("prs", []) if str(pr_info["repo"]) != exc.repo]
+        group["group_state"] = "partially_merged" if merged else "merge_failed"
+        group["merged"] = merged
+        group_path.write_text(json.dumps(group, indent=2) + "\n")
+        payload = {
+            "status": "partial_failure" if merged else "failed",
+            "pr_group_id": group["pr_group_id"],
+            "owner_unit": owner_unit,
+            "lane_name": resolved_lane,
+            "merged": merged,
+            "failed": [{"repo": exc.repo, "number": exc.pr_number, "reason": exc.reason}],
+            "state_path": str(group_path),
+        }
+        if json_output:
+            typer.echo(json.dumps(payload, indent=2))
+        else:
+            typer.echo(json.dumps(payload, indent=2))
+        raise typer.Exit(code=1)
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
@@ -25,6 +26,7 @@ from .gitops import (
 )
 from .events import emit, EventType
 from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
+from .platform import CreatePRRequest, PRRef, get_platform_adapter
 from . import spec_apply
 from gr2.prototypes import lane_workspace_prototype as lane_proto
 from gr2.prototypes import repo_maintenance_prototype as repo_proto
@@ -37,6 +39,7 @@ repo_app = typer.Typer(help="Repo maintenance and inspection")
 lane_app = typer.Typer(help="Lane creation and navigation")
 lease_app = typer.Typer(help="Lane lease operations")
 review_app = typer.Typer(help="Review and reviewer requirement operations")
+pr_app = typer.Typer(help="Cross-repo PR orchestration")
 workspace_app = typer.Typer(help="Workspace bootstrap and materialization")
 spec_app = typer.Typer(help="Declarative workspace spec operations")
 exec_app = typer.Typer(help="Lane-aware execution planning and execution")
@@ -46,6 +49,7 @@ app.add_typer(repo_app, name="repo")
 app.add_typer(lane_app, name="lane")
 lane_app.add_typer(lease_app, name="lease")
 app.add_typer(review_app, name="review")
+app.add_typer(pr_app, name="pr")
 app.add_typer(workspace_app, name="workspace")
 app.add_typer(spec_app, name="spec")
 app.add_typer(exec_app, name="exec")
@@ -194,6 +198,46 @@ def _repo_hook_context(workspace_root: Path, repo_root: Path) -> HookContext:
         lane_subject=repo_root.name,
         lane_name="workspace",
     )
+
+
+def _resolve_lane_name(workspace_root: Path, owner_unit: str, lane_name: Optional[str]) -> str:
+    if lane_name:
+        return lane_name
+    current_doc = lane_proto.load_current_lane_doc(workspace_root, owner_unit)
+    return str(current_doc["current"]["lane_name"])
+
+
+def _pr_groups_root(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "pr_groups"
+
+
+def _pr_group_path(workspace_root: Path, owner_unit: str, lane_name: str) -> Path:
+    return _pr_groups_root(workspace_root) / owner_unit / f"{lane_name}.json"
+
+
+def _write_pr_group(workspace_root: Path, owner_unit: str, lane_name: str, payload: dict[str, object]) -> Path:
+    path = _pr_group_path(workspace_root, owner_unit, lane_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    return path
+
+
+def _load_pr_group(workspace_root: Path, owner_unit: str, lane_name: str) -> dict[str, object]:
+    path = _pr_group_path(workspace_root, owner_unit, lane_name)
+    if not path.exists():
+        raise SystemExit(f"pr group not found for {owner_unit}/{lane_name}: {path}")
+    return json.loads(path.read_text())
+
+
+def _repo_slug_from_url(url: str, fallback_name: str) -> str:
+    cleaned = url.strip()
+    if cleaned.startswith("git@github.com:"):
+        slug = cleaned.split("git@github.com:", 1)[1]
+        return slug.removesuffix(".git")
+    if cleaned.startswith("https://github.com/"):
+        slug = cleaned.split("https://github.com/", 1)[1]
+        return slug.removesuffix(".git")
+    return fallback_name
 
 
 def _write_workspace_spec(workspace_root: Path, repos: list[dict[str, str]], default_unit: str) -> Path:
@@ -866,6 +910,142 @@ def review_checkout_pr(
         "branch": resolved_branch,
         "entered": entered,
         "lane_repo_root": str(_lane_repo_root(workspace_root, owner_unit, resolved_lane, repo)),
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(json.dumps(payload, indent=2))
+
+
+@pr_app.command("create")
+def pr_create(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: Optional[str] = typer.Argument(None, help="Lane name. Defaults to the unit's current lane."),
+    platform: str = typer.Option("github", "--platform", help="Platform adapter name"),
+    base_branch: str = typer.Option("main", "--base", help="Base branch for created PRs"),
+    draft: bool = typer.Option(False, "--draft", help="Create PRs as drafts"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Create a grouped set of per-repo PRs for a lane."""
+    workspace_root = workspace_root.resolve()
+    resolved_lane = _resolve_lane_name(workspace_root, owner_unit, lane_name)
+    lane_doc = lane_proto.load_lane_doc(workspace_root, owner_unit, resolved_lane)
+    spec = lane_proto.load_workspace_spec(workspace_root)
+    adapter = get_platform_adapter(platform)
+    pr_group_id = f"pg_{os.urandom(4).hex()}"
+    refs: list[dict[str, object]] = []
+    branch_map = dict(lane_doc.get("branch_map", {}))
+    for repo_name in lane_doc.get("repos", []):
+        repo_spec = next(repo for repo in spec.get("repos", []) if repo.get("name") == repo_name)
+        request = CreatePRRequest(
+            repo=_repo_slug_from_url(str(repo_spec.get("url", "")), repo_name),
+            title=resolved_lane,
+            body=f"gr2 PR group {pr_group_id} for {owner_unit}/{resolved_lane}",
+            head_branch=str(branch_map.get(repo_name, resolved_lane)),
+            base_branch=base_branch,
+            draft=draft,
+        )
+        ref = adapter.create_pr(request)
+        refs.append(ref.as_dict())
+    payload = {
+        "pr_group_id": pr_group_id,
+        "owner_unit": owner_unit,
+        "lane_name": resolved_lane,
+        "platform": platform,
+        "refs": refs,
+    }
+    path = _write_pr_group(workspace_root, owner_unit, resolved_lane, payload)
+    payload["state_path"] = str(path)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(json.dumps(payload, indent=2))
+
+
+@pr_app.command("status")
+def pr_status(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: Optional[str] = typer.Argument(None, help="Lane name. Defaults to the unit's current lane."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show grouped PR status for a lane."""
+    workspace_root = workspace_root.resolve()
+    resolved_lane = _resolve_lane_name(workspace_root, owner_unit, lane_name)
+    group = _load_pr_group(workspace_root, owner_unit, resolved_lane)
+    adapter = get_platform_adapter(str(group.get("platform", "github")))
+    statuses = []
+    for ref_doc in group.get("refs", []):
+        ref = PRRef(**ref_doc)
+        statuses.append(adapter.pr_status(ref.repo, int(ref.number)).as_dict())
+    payload = {
+        "pr_group_id": group["pr_group_id"],
+        "owner_unit": owner_unit,
+        "lane_name": resolved_lane,
+        "statuses": statuses,
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(json.dumps(payload, indent=2))
+
+
+@pr_app.command("checks")
+def pr_checks(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: Optional[str] = typer.Argument(None, help="Lane name. Defaults to the unit's current lane."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show grouped PR checks for a lane."""
+    workspace_root = workspace_root.resolve()
+    resolved_lane = _resolve_lane_name(workspace_root, owner_unit, lane_name)
+    group = _load_pr_group(workspace_root, owner_unit, resolved_lane)
+    adapter = get_platform_adapter(str(group.get("platform", "github")))
+    rows = []
+    for ref_doc in group.get("refs", []):
+        ref = PRRef(**ref_doc)
+        rows.append(
+            {
+                "repo": ref.repo,
+                "number": ref.number,
+                "checks": [item.as_dict() for item in adapter.pr_checks(ref.repo, int(ref.number))],
+            }
+        )
+    payload = {
+        "pr_group_id": group["pr_group_id"],
+        "owner_unit": owner_unit,
+        "lane_name": resolved_lane,
+        "checks": rows,
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(json.dumps(payload, indent=2))
+
+
+@pr_app.command("merge")
+def pr_merge(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: Optional[str] = typer.Argument(None, help="Lane name. Defaults to the unit's current lane."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Merge grouped PRs for a lane."""
+    workspace_root = workspace_root.resolve()
+    resolved_lane = _resolve_lane_name(workspace_root, owner_unit, lane_name)
+    group = _load_pr_group(workspace_root, owner_unit, resolved_lane)
+    adapter = get_platform_adapter(str(group.get("platform", "github")))
+    merged = []
+    for ref_doc in group.get("refs", []):
+        ref = PRRef(**ref_doc)
+        merged.append(adapter.merge_pr(ref.repo, int(ref.number)).as_dict())
+    payload = {
+        "pr_group_id": group["pr_group_id"],
+        "owner_unit": owner_unit,
+        "lane_name": resolved_lane,
+        "merged": merged,
     }
     if json_output:
         typer.echo(json.dumps(payload, indent=2))

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -211,22 +211,40 @@ def _pr_groups_root(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "pr_groups"
 
 
-def _pr_group_path(workspace_root: Path, owner_unit: str, lane_name: str) -> Path:
-    return _pr_groups_root(workspace_root) / owner_unit / f"{lane_name}.json"
+def _pr_group_path(workspace_root: Path, pr_group_id: str) -> Path:
+    return _pr_groups_root(workspace_root) / f"{pr_group_id}.json"
 
 
-def _write_pr_group(workspace_root: Path, owner_unit: str, lane_name: str, payload: dict[str, object]) -> Path:
-    path = _pr_group_path(workspace_root, owner_unit, lane_name)
+def _write_pr_group(workspace_root: Path, payload: dict[str, object]) -> Path:
+    pr_group_id = str(payload["pr_group_id"])
+    path = _pr_group_path(workspace_root, pr_group_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2) + "\n")
     return path
 
 
-def _load_pr_group(workspace_root: Path, owner_unit: str, lane_name: str) -> dict[str, object]:
-    path = _pr_group_path(workspace_root, owner_unit, lane_name)
-    if not path.exists():
-        raise SystemExit(f"pr group not found for {owner_unit}/{lane_name}: {path}")
-    return json.loads(path.read_text())
+def _find_pr_group(workspace_root: Path, owner_unit: str, lane_name: str) -> tuple[Path, dict[str, object]]:
+    root = _pr_groups_root(workspace_root)
+    if not root.exists():
+        raise SystemExit(f"pr group not found for {owner_unit}/{lane_name}: {root}")
+    for path in sorted(root.glob("*.json")):
+        doc = json.loads(path.read_text())
+        if doc.get("owner_unit") == owner_unit and doc.get("lane_name") == lane_name:
+            return path, doc
+    raise SystemExit(f"pr group not found for {owner_unit}/{lane_name}: {root}")
+
+
+def _group_state_from_statuses(statuses: list[dict[str, object]]) -> str:
+    states = [str(item.get("state", "")).upper() for item in statuses]
+    if not states:
+        return "empty"
+    if all(state == "MERGED" for state in states):
+        return "merged"
+    if any(state == "MERGED" for state in states):
+        return "partially_merged"
+    if all(state in {"OPEN", "MERGEABLE", "CLEAN"} for state in states):
+        return "open"
+    return "mixed"
 
 
 def _repo_slug_from_url(url: str, fallback_name: str) -> str:
@@ -954,8 +972,9 @@ def pr_create(
         "lane_name": resolved_lane,
         "platform": platform,
         "refs": refs,
+        "group_state": "open",
     }
-    path = _write_pr_group(workspace_root, owner_unit, resolved_lane, payload)
+    path = _write_pr_group(workspace_root, payload)
     payload["state_path"] = str(path)
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
@@ -973,17 +992,22 @@ def pr_status(
     """Show grouped PR status for a lane."""
     workspace_root = workspace_root.resolve()
     resolved_lane = _resolve_lane_name(workspace_root, owner_unit, lane_name)
-    group = _load_pr_group(workspace_root, owner_unit, resolved_lane)
+    group_path, group = _find_pr_group(workspace_root, owner_unit, resolved_lane)
     adapter = get_platform_adapter(str(group.get("platform", "github")))
     statuses = []
     for ref_doc in group.get("refs", []):
         ref = PRRef(**ref_doc)
         statuses.append(adapter.pr_status(ref.repo, int(ref.number)).as_dict())
+    group["statuses"] = statuses
+    group["group_state"] = _group_state_from_statuses(statuses)
+    _write_pr_group(workspace_root, group)
     payload = {
         "pr_group_id": group["pr_group_id"],
         "owner_unit": owner_unit,
         "lane_name": resolved_lane,
+        "group_state": group["group_state"],
         "statuses": statuses,
+        "state_path": str(group_path),
     }
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
@@ -1001,7 +1025,7 @@ def pr_checks(
     """Show grouped PR checks for a lane."""
     workspace_root = workspace_root.resolve()
     resolved_lane = _resolve_lane_name(workspace_root, owner_unit, lane_name)
-    group = _load_pr_group(workspace_root, owner_unit, resolved_lane)
+    group_path, group = _find_pr_group(workspace_root, owner_unit, resolved_lane)
     adapter = get_platform_adapter(str(group.get("platform", "github")))
     rows = []
     for ref_doc in group.get("refs", []):
@@ -1018,6 +1042,7 @@ def pr_checks(
         "owner_unit": owner_unit,
         "lane_name": resolved_lane,
         "checks": rows,
+        "state_path": str(group_path),
     }
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
@@ -1035,17 +1060,42 @@ def pr_merge(
     """Merge grouped PRs for a lane."""
     workspace_root = workspace_root.resolve()
     resolved_lane = _resolve_lane_name(workspace_root, owner_unit, lane_name)
-    group = _load_pr_group(workspace_root, owner_unit, resolved_lane)
+    group_path, group = _find_pr_group(workspace_root, owner_unit, resolved_lane)
     adapter = get_platform_adapter(str(group.get("platform", "github")))
-    merged = []
+    merged: list[str] = []
+    failed: list[dict[str, object]] = []
     for ref_doc in group.get("refs", []):
         ref = PRRef(**ref_doc)
-        merged.append(adapter.merge_pr(ref.repo, int(ref.number)).as_dict())
+        try:
+            adapter.merge_pr(ref.repo, int(ref.number))
+            merged.append(ref.repo)
+        except Exception as exc:
+            failed.append({"repo": ref.repo, "number": ref.number, "reason": str(exc)})
+            break
+    if failed:
+        group["group_state"] = "partially_merged" if merged else "merge_failed"
+        group["merged"] = merged
+        _write_pr_group(workspace_root, group)
+        payload = {
+            "status": "partial_failure" if merged else "failed",
+            "pr_group_id": group["pr_group_id"],
+            "owner_unit": owner_unit,
+            "lane_name": resolved_lane,
+            "merged": merged,
+            "failed": failed,
+            "state_path": str(group_path),
+        }
+        if json_output:
+            typer.echo(json.dumps(payload, indent=2))
+        else:
+            typer.echo(json.dumps(payload, indent=2))
+        raise typer.Exit(code=1)
     payload = {
         "pr_group_id": group["pr_group_id"],
         "owner_unit": owner_unit,
         "lane_name": resolved_lane,
         "merged": merged,
+        "state_path": str(group_path),
     }
     if json_output:
         typer.echo(json.dumps(payload, indent=2))

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -11,6 +11,7 @@ from typing import Optional
 import typer
 
 from . import execops
+from . import failures
 from . import migration
 from . import syncops
 from .gitops import (
@@ -25,8 +26,8 @@ from .gitops import (
     stash_if_dirty,
 )
 from .events import emit, EventType
-from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
-from .platform import CreatePRRequest, PRRef, get_platform_adapter
+from .hooks import HookContext, HookRuntimeError, apply_file_projections, load_repo_hooks, run_lifecycle_stage
+from .platform import PRRef, get_platform_adapter
 from . import spec_apply
 from gr2.prototypes import lane_workspace_prototype as lane_proto
 from gr2.prototypes import repo_maintenance_prototype as repo_proto
@@ -706,7 +707,38 @@ def lane_enter(
 ) -> None:
     """Enter a lane and optionally emit channel/recall-compatible events."""
     workspace_root = workspace_root.resolve()
-    _run_lane_stage(workspace_root, owner_unit, lane_name, "on_enter", manual_hooks=manual_hooks)
+    unresolved = failures.unresolved_lane_failure(workspace_root, owner_unit, lane_name)
+    if unresolved:
+        typer.echo(
+            json.dumps(
+                {
+                    "status": "blocked",
+                    "code": "unresolved_failure_marker",
+                    "operation_id": unresolved["operation_id"],
+                    "lane_name": lane_name,
+                },
+                indent=2,
+            )
+        )
+        raise typer.Exit(code=1)
+    try:
+        _run_lane_stage(workspace_root, owner_unit, lane_name, "on_enter", manual_hooks=manual_hooks)
+    except HookRuntimeError as exc:
+        payload = exc.payload
+        repo_name = Path(str(payload.get("cwd", ""))).name or lane_name
+        event = failures.write_failure_marker(
+            workspace_root,
+            operation="lane.enter",
+            stage=str(payload.get("stage", "on_enter")),
+            hook_name=str(payload.get("hook", payload.get("name", "unknown"))),
+            repo=repo_name,
+            owner_unit=owner_unit,
+            lane_name=lane_name,
+            partial_state={},
+            event_id=None,
+        )
+        typer.echo(json.dumps(event, indent=2))
+        raise typer.Exit(code=1)
     ns = SimpleNamespace(
         workspace_root=workspace_root,
         owner_unit=owner_unit,
@@ -728,6 +760,30 @@ def lane_enter(
             "repos": lane_doc.get("repos", []),
         },
     )
+
+
+@lane_app.command("resolve")
+def lane_resolve(
+    workspace_root: Path,
+    owner_unit: str,
+    operation_id: str,
+    actor: str = typer.Option(..., help="Actor label, e.g. agent:atlas"),
+    resolution: str = typer.Option(..., help="Resolution note: retry | skip | escalate"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Resolve a blocking failure marker for a lane-scoped operation."""
+    workspace_root = workspace_root.resolve()
+    payload = failures.resolve_failure_marker(
+        workspace_root,
+        operation_id=operation_id,
+        resolved_by=actor,
+        resolution=resolution,
+        owner_unit=owner_unit,
+    )
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(json.dumps(payload, indent=2))
 
 
 @lane_app.command("exit")

--- a/gr2/python_cli/events.py
+++ b/gr2/python_cli/events.py
@@ -1,60 +1,217 @@
+"""gr2 event system runtime.
+
+Implements the event contract from HOOK-EVENT-CONTRACT.md sections 3-8:
+- EventType enum (section 7.2)
+- emit() function (sections 4.2, 7.1)
+- Outbox management with rotation (sections 4.1-4.4)
+- Cursor-based consumer model (section 5.1)
+"""
 from __future__ import annotations
 
-import fcntl
 import json
 import os
-from datetime import UTC, datetime
+import sys
+from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 
 
-def _now_utc() -> str:
-    return datetime.now(UTC).isoformat()
+_RESERVED_NAMES = frozenset(
+    {
+        "version",
+        "event_id",
+        "seq",
+        "timestamp",
+        "type",
+        "workspace",
+        "actor",
+        "agent_id",
+        "owner_unit",
+    }
+)
+
+_ROTATION_THRESHOLD = 10 * 1024 * 1024
 
 
-def _events_dir(workspace_root: Path) -> Path:
-    return workspace_root / ".grip" / "events"
+class EventType(str, Enum):
+    LANE_CREATED = "lane.created"
+    LANE_ENTERED = "lane.entered"
+    LANE_EXITED = "lane.exited"
+    LANE_SWITCHED = "lane.switched"
+    LANE_ARCHIVED = "lane.archived"
+
+    LEASE_ACQUIRED = "lease.acquired"
+    LEASE_RELEASED = "lease.released"
+    LEASE_EXPIRED = "lease.expired"
+    LEASE_FORCE_BROKEN = "lease.force_broken"
+
+    HOOK_STARTED = "hook.started"
+    HOOK_COMPLETED = "hook.completed"
+    HOOK_FAILED = "hook.failed"
+    HOOK_SKIPPED = "hook.skipped"
+
+    PR_CREATED = "pr.created"
+    PR_STATUS_CHANGED = "pr.status_changed"
+    PR_CHECKS_PASSED = "pr.checks_passed"
+    PR_CHECKS_FAILED = "pr.checks_failed"
+    PR_REVIEW_SUBMITTED = "pr.review_submitted"
+    PR_MERGED = "pr.merged"
+    PR_MERGE_FAILED = "pr.merge_failed"
+
+    SYNC_STARTED = "sync.started"
+    SYNC_CACHE_SEEDED = "sync.cache_seeded"
+    SYNC_CACHE_REFRESHED = "sync.cache_refreshed"
+    SYNC_REPO_UPDATED = "sync.repo_updated"
+    SYNC_REPO_SKIPPED = "sync.repo_skipped"
+    SYNC_CONFLICT = "sync.conflict"
+    SYNC_COMPLETED = "sync.completed"
+
+    FAILURE_RESOLVED = "failure.resolved"
+    LEASE_RECLAIMED = "lease.reclaimed"
+
+    WORKSPACE_MATERIALIZED = "workspace.materialized"
+    WORKSPACE_FILE_PROJECTED = "workspace.file_projected"
 
 
-def _outbox_file(workspace_root: Path) -> Path:
-    return _events_dir(workspace_root) / "outbox.jsonl"
+def _outbox_path(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "events" / "outbox.jsonl"
 
 
-def _outbox_lock_file(workspace_root: Path) -> Path:
-    return _events_dir(workspace_root) / "outbox.lock"
+def _cursors_dir(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "events" / "cursors"
 
 
-def append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> dict[str, object] | None:
-    outbox_path = _outbox_file(workspace_root)
-    lock_path = _outbox_lock_file(workspace_root)
-    outbox_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
+def _current_seq(outbox: Path) -> int:
+    if not outbox.exists():
+        return 0
     try:
-        with lock_path.open("a+", encoding="utf-8") as lock_fh:
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
-            seq = 1
-            if outbox_path.exists():
-                with outbox_path.open("r", encoding="utf-8") as existing:
-                    for line in existing:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            row = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-                        value = int(row.get("seq", 0))
-                        if value >= seq:
-                            seq = value + 1
-            event = {
-                "version": 1,
-                "seq": seq,
-                "event_id": os.urandom(8).hex(),
-                "timestamp": _now_utc(),
-                **payload,
-            }
-            with outbox_path.open("a", encoding="utf-8") as fh:
-                fh.write(json.dumps(event) + "\n")
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
-            return event
+        text = outbox.read_text()
     except OSError:
-        return None
+        return 0
+    last_seq = 0
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            if isinstance(obj, dict) and "seq" in obj:
+                last_seq = max(last_seq, obj["seq"])
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return last_seq
+
+
+def _maybe_rotate(outbox: Path) -> None:
+    if not outbox.exists():
+        return
+    try:
+        size = outbox.stat().st_size
+    except OSError:
+        return
+    if size <= _ROTATION_THRESHOLD:
+        return
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    archive = outbox.parent / f"outbox.{ts}.jsonl"
+    outbox.rename(archive)
+
+
+def emit(
+    event_type: EventType,
+    workspace_root: Path,
+    actor: str,
+    owner_unit: str,
+    payload: dict[str, object],
+    *,
+    agent_id: str | None = None,
+) -> None:
+    collisions = _RESERVED_NAMES & payload.keys()
+    if collisions:
+        raise ValueError(f"payload keys collide with reserved envelope/context names: {collisions}")
+
+    try:
+        outbox = _outbox_path(workspace_root)
+        outbox.parent.mkdir(parents=True, exist_ok=True)
+
+        seq = _current_seq(outbox) + 1
+        _maybe_rotate(outbox)
+
+        event: dict[str, object] = {
+            "version": 1,
+            "event_id": os.urandom(8).hex(),
+            "seq": seq,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "type": str(event_type.value),
+            "workspace": workspace_root.name,
+            "actor": actor,
+            "owner_unit": owner_unit,
+        }
+        if agent_id is not None:
+            event["agent_id"] = agent_id
+        event.update(payload)
+
+        with outbox.open("a") as f:
+            f.write(json.dumps(event, separators=(",", ":")) + "\n")
+            f.flush()
+
+    except Exception as exc:
+        print(f"gr2: event emit failed: {exc}", file=sys.stderr)
+
+
+def read_events(workspace_root: Path, consumer: str) -> list[dict[str, object]]:
+    outbox = _outbox_path(workspace_root)
+    if not outbox.exists():
+        return []
+
+    cursor = _load_cursor(workspace_root, consumer)
+    last_seq = cursor.get("last_seq", 0)
+
+    events: list[dict[str, object]] = []
+    text = outbox.read_text()
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if obj.get("seq", 0) <= last_seq:
+            continue
+        events.append(obj)
+
+    if events:
+        last_event = events[-1]
+        _save_cursor(
+            workspace_root,
+            consumer,
+            {
+                "consumer": consumer,
+                "last_seq": last_event["seq"],
+                "last_event_id": last_event.get("event_id", ""),
+                "last_read": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+    return events
+
+
+def _load_cursor(workspace_root: Path, consumer: str) -> dict[str, object]:
+    cursor_file = _cursors_dir(workspace_root) / f"{consumer}.json"
+    if not cursor_file.exists():
+        return {}
+    try:
+        return json.loads(cursor_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_cursor(workspace_root: Path, consumer: str, data: dict[str, object]) -> None:
+    cursors = _cursors_dir(workspace_root)
+    cursors.mkdir(parents=True, exist_ok=True)
+    cursor_file = cursors / f"{consumer}.json"
+    tmp = cursor_file.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.rename(cursor_file)

--- a/gr2/python_cli/events.py
+++ b/gr2/python_cli/events.py
@@ -1,240 +1,59 @@
-"""gr2 event system runtime.
-
-Implements the event contract from HOOK-EVENT-CONTRACT.md sections 3-8:
-- EventType enum (section 7.2)
-- emit() function (sections 4.2, 7.1)
-- Outbox management with rotation (sections 4.1-4.4)
-- Cursor-based consumer model (section 5.1)
-"""
 from __future__ import annotations
 
 import fcntl
 import json
 import os
-import sys
-from datetime import datetime, timezone
-from enum import Enum
+from datetime import UTC, datetime
 from pathlib import Path
 
 
-# Reserved field names that payload keys must not collide with (section 3.1).
-_RESERVED_NAMES = frozenset({
-    "version", "event_id", "seq", "timestamp", "type",
-    "workspace", "actor", "agent_id", "owner_unit",
-})
-
-_ROTATION_THRESHOLD = 10 * 1024 * 1024  # 10 MB
+def _now_utc() -> str:
+    return datetime.now(UTC).isoformat()
 
 
-class EventType(str, Enum):
-    # Lane lifecycle
-    LANE_CREATED = "lane.created"
-    LANE_ENTERED = "lane.entered"
-    LANE_EXITED = "lane.exited"
-    LANE_SWITCHED = "lane.switched"
-    LANE_ARCHIVED = "lane.archived"
-
-    # Lease lifecycle
-    LEASE_ACQUIRED = "lease.acquired"
-    LEASE_RELEASED = "lease.released"
-    LEASE_EXPIRED = "lease.expired"
-    LEASE_FORCE_BROKEN = "lease.force_broken"
-
-    # Hook execution
-    HOOK_STARTED = "hook.started"
-    HOOK_COMPLETED = "hook.completed"
-    HOOK_FAILED = "hook.failed"
-    HOOK_SKIPPED = "hook.skipped"
-
-    # PR lifecycle
-    PR_CREATED = "pr.created"
-    PR_STATUS_CHANGED = "pr.status_changed"
-    PR_CHECKS_PASSED = "pr.checks_passed"
-    PR_CHECKS_FAILED = "pr.checks_failed"
-    PR_REVIEW_SUBMITTED = "pr.review_submitted"
-    PR_MERGED = "pr.merged"
-    PR_MERGE_FAILED = "pr.merge_failed"
-
-    # Sync operations
-    SYNC_STARTED = "sync.started"
-    SYNC_REPO_UPDATED = "sync.repo_updated"
-    SYNC_REPO_SKIPPED = "sync.repo_skipped"
-    SYNC_CONFLICT = "sync.conflict"
-    SYNC_COMPLETED = "sync.completed"
-    SYNC_CACHE_SEEDED = "sync.cache_seeded"
-    SYNC_CACHE_REFRESHED = "sync.cache_refreshed"
-
-    # Recovery
-    FAILURE_RESOLVED = "failure.resolved"
-    LEASE_RECLAIMED = "lease.reclaimed"
-
-    # Workspace operations
-    WORKSPACE_MATERIALIZED = "workspace.materialized"
-    WORKSPACE_FILE_PROJECTED = "workspace.file_projected"
+def _events_dir(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "events"
 
 
-def _outbox_path(workspace_root: Path) -> Path:
-    return workspace_root / ".grip" / "events" / "outbox.jsonl"
+def _outbox_file(workspace_root: Path) -> Path:
+    return _events_dir(workspace_root) / "outbox.jsonl"
 
 
-def _cursors_dir(workspace_root: Path) -> Path:
-    return workspace_root / ".grip" / "events" / "cursors"
+def _outbox_lock_file(workspace_root: Path) -> Path:
+    return _events_dir(workspace_root) / "outbox.lock"
 
 
-def _current_seq(outbox: Path) -> int:
-    """Return the highest seq in the outbox, or 0 if empty/missing."""
-    if not outbox.exists():
-        return 0
+def append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> None:
+    outbox_path = _outbox_file(workspace_root)
+    lock_path = _outbox_lock_file(workspace_root)
+    outbox_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        text = outbox.read_text()
-    except OSError:
-        return 0
-    last_seq = 0
-    for line in text.strip().split("\n"):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-            if isinstance(obj, dict) and "seq" in obj:
-                last_seq = max(last_seq, obj["seq"])
-        except (json.JSONDecodeError, TypeError):
-            continue
-    return last_seq
-
-
-def _maybe_rotate(outbox: Path) -> None:
-    """Rotate the outbox file if it exceeds the size threshold."""
-    if not outbox.exists():
-        return
-    try:
-        size = outbox.stat().st_size
-    except OSError:
-        return
-    if size <= _ROTATION_THRESHOLD:
-        return
-    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
-    archive = outbox.parent / f"outbox.{ts}.jsonl"
-    outbox.rename(archive)
-
-
-def emit(
-    event_type: EventType,
-    workspace_root: Path,
-    actor: str,
-    owner_unit: str,
-    payload: dict[str, object],
-    *,
-    agent_id: str | None = None,
-) -> None:
-    """Emit a single event to the workspace outbox.
-
-    Builds a flat JSON object from envelope + context + payload fields and
-    appends it as one line to .grip/events/outbox.jsonl.
-
-    Does not raise on write failure (section 10.1). Errors are logged to
-    stderr so the parent operation can continue.
-    """
-    # Validate payload keys against reserved names.
-    collisions = _RESERVED_NAMES & payload.keys()
-    if collisions:
-        raise ValueError(
-            f"payload keys collide with reserved envelope/context names: {collisions}"
-        )
-
-    try:
-        outbox = _outbox_path(workspace_root)
-        outbox.parent.mkdir(parents=True, exist_ok=True)
-        lock_path = outbox.with_suffix(".lock")
-
-        with lock_path.open("a+") as lock_fh:
+        with lock_path.open("a+", encoding="utf-8") as lock_fh:
             fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
-            try:
-                # Capture seq before rotation (rotation empties the current file).
-                seq = _current_seq(outbox) + 1
-                _maybe_rotate(outbox)
-
-                # Build flat event object.
-                event: dict[str, object] = {
-                    "version": 1,
-                    "event_id": os.urandom(8).hex(),
-                    "seq": seq,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                    "type": str(event_type.value),
-                    "workspace": workspace_root.name,
-                    "actor": actor,
-                    "owner_unit": owner_unit,
-                }
-                if agent_id is not None:
-                    event["agent_id"] = agent_id
-                event.update(payload)
-
-                # Append as single JSONL line.
-                with outbox.open("a") as f:
-                    f.write(json.dumps(event, separators=(",", ":")) + "\n")
-                    f.flush()
-            finally:
-                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
-
-    except Exception as exc:
-        print(f"gr2: event emit failed: {exc}", file=sys.stderr)
-
-
-def read_events(workspace_root: Path, consumer: str) -> list[dict[str, object]]:
-    """Read new events from the outbox for the named consumer.
-
-    Returns events with seq > cursor's last_seq. Updates the cursor file
-    atomically after reading.
-    """
-    outbox = _outbox_path(workspace_root)
-    if not outbox.exists():
-        return []
-
-    cursor = _load_cursor(workspace_root, consumer)
-    last_seq = cursor.get("last_seq", 0)
-
-    events: list[dict[str, object]] = []
-    text = outbox.read_text()
-    for line in text.strip().split("\n"):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(obj, dict):
-            continue
-        if obj.get("seq", 0) <= last_seq:
-            continue
-        events.append(obj)
-
-    if events:
-        last_event = events[-1]
-        _save_cursor(workspace_root, consumer, {
-            "consumer": consumer,
-            "last_seq": last_event["seq"],
-            "last_event_id": last_event.get("event_id", ""),
-            "last_read": datetime.now(timezone.utc).isoformat(),
-        })
-
-    return events
-
-
-def _load_cursor(workspace_root: Path, consumer: str) -> dict[str, object]:
-    cursor_file = _cursors_dir(workspace_root) / f"{consumer}.json"
-    if not cursor_file.exists():
-        return {}
-    try:
-        return json.loads(cursor_file.read_text())
-    except (json.JSONDecodeError, OSError):
-        return {}
-
-
-def _save_cursor(workspace_root: Path, consumer: str, data: dict[str, object]) -> None:
-    cursors = _cursors_dir(workspace_root)
-    cursors.mkdir(parents=True, exist_ok=True)
-    cursor_file = cursors / f"{consumer}.json"
-    tmp = cursor_file.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2))
-    tmp.rename(cursor_file)
+            seq = 1
+            if outbox_path.exists():
+                with outbox_path.open("r", encoding="utf-8") as existing:
+                    for line in existing:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            row = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        value = int(row.get("seq", 0))
+                        if value >= seq:
+                            seq = value + 1
+            event = {
+                "version": 1,
+                "seq": seq,
+                "event_id": os.urandom(8).hex(),
+                "timestamp": _now_utc(),
+                **payload,
+            }
+            with outbox_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event) + "\n")
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        return

--- a/gr2/python_cli/events.py
+++ b/gr2/python_cli/events.py
@@ -23,7 +23,7 @@ def _outbox_lock_file(workspace_root: Path) -> Path:
     return _events_dir(workspace_root) / "outbox.lock"
 
 
-def append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> None:
+def append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> dict[str, object] | None:
     outbox_path = _outbox_file(workspace_root)
     lock_path = _outbox_lock_file(workspace_root)
     outbox_path.parent.mkdir(parents=True, exist_ok=True)
@@ -55,5 +55,6 @@ def append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> Non
             with outbox_path.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(event) + "\n")
             fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+            return event
     except OSError:
-        return
+        return None

--- a/gr2/python_cli/failures.py
+++ b/gr2/python_cli/failures.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .events import append_outbox_event
+
+
+def _now_utc() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def failures_root(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "state" / "failures"
+
+
+def failure_marker_path(workspace_root: Path, operation_id: str) -> Path:
+    return failures_root(workspace_root) / f"{operation_id}.json"
+
+
+def unresolved_lane_failure(workspace_root: Path, owner_unit: str, lane_name: str) -> dict[str, object] | None:
+    root = failures_root(workspace_root)
+    if not root.exists():
+        return None
+    for path in sorted(root.glob("*.json")):
+        doc = json.loads(path.read_text())
+        if doc.get("resolved") is True:
+            continue
+        if doc.get("owner_unit") == owner_unit and doc.get("lane_name") == lane_name:
+            return doc
+    return None
+
+
+def write_failure_marker(
+    workspace_root: Path,
+    *,
+    operation: str,
+    stage: str,
+    hook_name: str,
+    repo: str,
+    owner_unit: str,
+    lane_name: str,
+    partial_state: dict[str, object] | None = None,
+    event_id: str | None = None,
+) -> dict[str, object]:
+    operation_id = f"op_{os.urandom(4).hex()}"
+    marker = {
+        "operation_id": operation_id,
+        "operation": operation,
+        "stage": stage,
+        "hook_name": hook_name,
+        "repo": repo,
+        "owner_unit": owner_unit,
+        "lane_name": lane_name,
+        "failed_at": _now_utc(),
+        "event_id": event_id,
+        "partial_state": partial_state or {},
+        "resolved": False,
+    }
+    path = failure_marker_path(workspace_root, operation_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(marker, indent=2) + "\n")
+    return marker
+
+
+def resolve_failure_marker(
+    workspace_root: Path,
+    *,
+    operation_id: str,
+    resolved_by: str,
+    resolution: str,
+    owner_unit: str,
+) -> dict[str, object]:
+    path = failure_marker_path(workspace_root, operation_id)
+    if not path.exists():
+        raise SystemExit(f"failure marker not found: {operation_id}")
+    marker = json.loads(path.read_text())
+    path.unlink()
+    event = append_outbox_event(
+        workspace_root,
+        {
+            "type": "failure.resolved",
+            "workspace": workspace_root.name,
+            "actor": resolved_by,
+            "owner_unit": owner_unit,
+            "operation_id": operation_id,
+            "resolved_by": resolved_by,
+            "resolution": resolution,
+            "lane_name": marker.get("lane_name", ""),
+        },
+    )
+    return {
+        "operation_id": operation_id,
+        "resolved_by": resolved_by,
+        "resolution": resolution,
+        "lane_name": marker.get("lane_name", ""),
+        "event_id": None if event is None else event["event_id"],
+    }

--- a/gr2/python_cli/failures.py
+++ b/gr2/python_cli/failures.py
@@ -5,7 +5,7 @@ import os
 from datetime import UTC, datetime
 from pathlib import Path
 
-from .events import append_outbox_event
+from .events import EventType, emit
 
 
 def _now_utc() -> str:
@@ -78,13 +78,12 @@ def resolve_failure_marker(
         raise SystemExit(f"failure marker not found: {operation_id}")
     marker = json.loads(path.read_text())
     path.unlink()
-    event = append_outbox_event(
-        workspace_root,
-        {
-            "type": "failure.resolved",
-            "workspace": workspace_root.name,
-            "actor": resolved_by,
-            "owner_unit": owner_unit,
+    emit(
+        event_type=EventType.FAILURE_RESOLVED,
+        workspace_root=workspace_root,
+        actor=resolved_by,
+        owner_unit=owner_unit,
+        payload={
             "operation_id": operation_id,
             "resolved_by": resolved_by,
             "resolution": resolution,
@@ -96,5 +95,4 @@ def resolve_failure_marker(
         "resolved_by": resolved_by,
         "resolution": resolution,
         "lane_name": marker.get("lane_name", ""),
-        "event_id": None if event is None else event["event_id"],
     }

--- a/gr2/python_cli/gitops.py
+++ b/gr2/python_cli/gitops.py
@@ -40,6 +40,21 @@ def current_head_sha(path: Path) -> str | None:
     return value or None
 
 
+def commits_between(path: Path, old_sha: str | None, new_sha: str | None) -> int:
+    if not new_sha:
+        return 0
+    if not old_sha:
+        proc = git(path, "rev-list", "--count", new_sha)
+    else:
+        proc = git(path, "rev-list", "--count", f"{old_sha}..{new_sha}")
+    if proc.returncode != 0:
+        return 0
+    try:
+        return int(proc.stdout.strip() or "0")
+    except ValueError:
+        return 0
+
+
 def ensure_repo_cache(url: str, cache_repo_root: Path) -> bool:
     """Ensure a local bare mirror exists for a repo URL.
 

--- a/gr2/python_cli/gitops.py
+++ b/gr2/python_cli/gitops.py
@@ -55,6 +55,13 @@ def commits_between(path: Path, old_sha: str | None, new_sha: str | None) -> int
         return 0
 
 
+def conflicting_files(path: Path) -> list[str]:
+    proc = git(path, "diff", "--name-only", "--diff-filter=U")
+    if proc.returncode != 0:
+        return []
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
 def ensure_repo_cache(url: str, cache_repo_root: Path) -> bool:
     """Ensure a local bare mirror exists for a repo URL.
 

--- a/gr2/python_cli/hooks.py
+++ b/gr2/python_cli/hooks.py
@@ -84,6 +84,8 @@ class HookResult:
     returncode: int | None = None
     stdout: str | None = None
     stderr: str | None = None
+    src: str | None = None
+    dest: str | None = None
 
     def as_dict(self) -> dict[str, object]:
         return dataclasses.asdict(self)
@@ -206,6 +208,8 @@ def apply_file_projections(hooks: RepoHooks, ctx: HookContext) -> list[HookResul
                         name=f"{item.kind}:{dest.name}",
                         status="skipped",
                         detail=f"destination already exists and if_exists=skip: {dest}",
+                        src=str(src),
+                        dest=str(dest),
                     )
                 )
                 continue
@@ -258,6 +262,8 @@ def apply_file_projections(hooks: RepoHooks, ctx: HookContext) -> list[HookResul
                 name=f"{item.kind}:{dest.name}",
                 status="applied",
                 detail=f"{item.kind} {src} -> {dest}",
+                src=str(src),
+                dest=str(dest),
             )
         )
     return results

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -16,7 +16,7 @@ import json
 import os
 from pathlib import Path
 
-from .events import emit, EventType
+from .events import EventType, emit
 from .platform import AdapterError, CreatePRRequest, PlatformAdapter
 
 
@@ -43,11 +43,12 @@ def _load_group(workspace_root: Path, pr_group_id: str) -> dict:
     return json.loads(path.read_text())
 
 
-def _save_group(workspace_root: Path, group: dict) -> None:
+def _save_group(workspace_root: Path, group: dict) -> Path:
     d = _pr_groups_dir(workspace_root)
     d.mkdir(parents=True, exist_ok=True)
     path = d / f"{group['pr_group_id']}.json"
     path.write_text(json.dumps(group, indent=2))
+    return path
 
 
 def create_pr_group(
@@ -78,35 +79,30 @@ def create_pr_group(
             draft=draft,
         )
         ref = adapter.create_pr(request)
-        prs.append({
-            "repo": repo,
-            "pr_number": ref.number,
-            "url": ref.url,
-        })
+        prs.append({"repo": repo, "pr_number": ref.number, "url": ref.url})
 
     group = {
         "pr_group_id": pr_group_id,
+        "owner_unit": owner_unit,
         "lane_name": lane_name,
         "title": title,
         "base_branch": base_branch,
         "head_branch": head_branch,
+        "platform": getattr(adapter, "name", "github"),
         "prs": prs,
         "status": {repo: "OPEN" for repo in repos},
     }
-    _save_group(workspace_root, group)
+    path = _save_group(workspace_root, group)
 
     emit(
         event_type=EventType.PR_CREATED,
         workspace_root=workspace_root,
         actor=actor,
         owner_unit=owner_unit,
-        payload={
-            "pr_group_id": pr_group_id,
-            "lane_name": lane_name,
-            "repos": prs,
-        },
+        payload={"pr_group_id": pr_group_id, "lane_name": lane_name, "repos": prs},
     )
 
+    group["state_path"] = str(path)
     return group
 
 
@@ -146,10 +142,7 @@ def merge_pr_group(
         workspace_root=workspace_root,
         actor=actor,
         owner_unit=group.get("owner_unit", actor),
-        payload={
-            "pr_group_id": pr_group_id,
-            "repos": merged,
-        },
+        payload={"pr_group_id": pr_group_id, "repos": merged},
     )
 
     return group
@@ -171,7 +164,6 @@ def check_pr_group_status(
         status = adapter.pr_status(repo, number)
         old_state = cached_status.get(repo, "OPEN")
 
-        # Detect state change (OPEN -> MERGED, OPEN -> CLOSED, etc.)
         if status.state != old_state:
             emit(
                 event_type=EventType.PR_STATUS_CHANGED,
@@ -188,7 +180,6 @@ def check_pr_group_status(
             )
             cached_status[repo] = status.state
 
-        # Detect check results (only when checks are complete)
         if status.checks:
             completed = [c for c in status.checks if c.status == "COMPLETED"]
             if completed and len(completed) == len(status.checks):
@@ -234,11 +225,7 @@ def record_pr_review(
     state: str,
     actor: str,
 ) -> None:
-    """Record an externally-submitted PR review and emit pr.review_submitted.
-
-    Reviews come from outside gr2 (GitHub webhooks, human action, etc.).
-    The adapter doesn't query reviews, so this is a push-model entry point.
-    """
+    """Record an externally-submitted PR review and emit pr.review_submitted."""
     emit(
         event_type=EventType.PR_REVIEW_SUBMITTED,
         workspace_root=workspace_root,

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 
+from .events import append_outbox_event
 from .gitops import clone_repo, ensure_repo_cache, is_git_dir, is_git_repo, repo_dirty
 from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
 
@@ -264,19 +266,35 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
         raise SystemExit("plan contains more than 3 operations; rerun with --yes to apply it")
 
     applied: list[str] = []
+    materialized_repos: list[dict[str, object]] = []
     for op in operations:
         if op.kind == "clone_repo":
             repo_spec = _find_repo(spec, op.subject)
             repo_root = workspace_root / str(repo_spec["path"])
             cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
             first_materialize = clone_repo(str(repo_spec["url"]), repo_root, reference_repo_root=cache_path)
-            _run_materialize_hooks(
+            hook_payload = _run_materialize_hooks(
                 workspace_root,
                 repo_root,
                 str(repo_spec["name"]),
                 first_materialize,
                 manual_hooks=manual_hooks,
             )
+            for projection in hook_payload["projected_files"]:
+                append_outbox_event(
+                    workspace_root,
+                    {
+                        "type": "workspace.file_projected",
+                        "workspace": workspace_root.name,
+                        "actor": "system",
+                        "owner_unit": "workspace",
+                        "repo": str(repo_spec["name"]),
+                        "kind": projection["kind"],
+                        "src": projection["src"],
+                        "dest": projection["dest"],
+                    },
+                )
+            materialized_repos.append({"repo": str(repo_spec["name"]), "first_materialize": first_materialize})
             applied.append(f"cloned repo '{op.subject}' into {repo_root}")
         elif op.kind == "seed_repo_cache":
             repo_spec = _find_repo(spec, op.subject)
@@ -302,6 +320,17 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
 
     if applied:
         _record_apply_state(workspace_root, applied)
+    if materialized_repos:
+        append_outbox_event(
+            workspace_root,
+            {
+                "type": "workspace.materialized",
+                "workspace": workspace_root.name,
+                "actor": "system",
+                "owner_unit": "workspace",
+                "repos": materialized_repos,
+            },
+        )
 
     return {
         "workspace_root": str(workspace_root),
@@ -342,10 +371,10 @@ def _run_materialize_hooks(
     first_materialize: bool,
     *,
     manual_hooks: bool = False,
-) -> None:
+) -> dict[str, list[dict[str, object]]]:
     hooks = load_repo_hooks(repo_root)
     if not hooks:
-        return
+        return {"projected_files": []}
     ctx = HookContext(
         workspace_root=workspace_root,
         lane_root=repo_root,
@@ -355,7 +384,7 @@ def _run_materialize_hooks(
         lane_subject=repo_name,
         lane_name="workspace",
     )
-    apply_file_projections(hooks, ctx)
+    projections = apply_file_projections(hooks, ctx)
     run_lifecycle_stage(
         hooks,
         "on_materialize",
@@ -364,6 +393,22 @@ def _run_materialize_hooks(
         first_materialize=first_materialize,
         allow_manual=manual_hooks,
     )
+    projected_files: list[dict[str, object]] = []
+    for result in projections:
+        if result.status != "applied" or not result.src or not result.dest:
+            continue
+        projected_files.append(
+            {
+                "kind": result.name.split(":", 1)[0],
+                "src": _relative_workspace_path(workspace_root, Path(result.src)),
+                "dest": _relative_workspace_path(workspace_root, Path(result.dest)),
+            }
+        )
+    return {"projected_files": projected_files}
+
+
+def _relative_workspace_path(workspace_root: Path, path: Path) -> str:
+    return os.path.relpath(path, workspace_root)
 
 
 def render_unit_toml(unit_spec: dict[str, object]) -> str:

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -7,7 +7,7 @@ import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 
-from .events import append_outbox_event
+from .events import EventType, emit
 from .gitops import clone_repo, ensure_repo_cache, is_git_dir, is_git_repo, repo_dirty
 from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
 
@@ -281,13 +281,12 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
                 manual_hooks=manual_hooks,
             )
             for projection in hook_payload["projected_files"]:
-                append_outbox_event(
-                    workspace_root,
-                    {
-                        "type": "workspace.file_projected",
-                        "workspace": workspace_root.name,
-                        "actor": "system",
-                        "owner_unit": "workspace",
+                emit(
+                    event_type=EventType.WORKSPACE_FILE_PROJECTED,
+                    workspace_root=workspace_root,
+                    actor="system",
+                    owner_unit="workspace",
+                    payload={
                         "repo": str(repo_spec["name"]),
                         "kind": projection["kind"],
                         "src": projection["src"],
@@ -321,15 +320,12 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
     if applied:
         _record_apply_state(workspace_root, applied)
     if materialized_repos:
-        append_outbox_event(
-            workspace_root,
-            {
-                "type": "workspace.materialized",
-                "workspace": workspace_root.name,
-                "actor": "system",
-                "owner_unit": "workspace",
-                "repos": materialized_repos,
-            },
+        emit(
+            event_type=EventType.WORKSPACE_MATERIALIZED,
+            workspace_root=workspace_root,
+            actor="system",
+            owner_unit="workspace",
+            payload={"repos": materialized_repos},
         )
 
     return {

--- a/gr2/python_cli/syncops.py
+++ b/gr2/python_cli/syncops.py
@@ -13,6 +13,7 @@ from gr2.prototypes import lane_workspace_prototype as lane_proto
 from .gitops import (
     clone_repo,
     commits_between,
+    conflicting_files,
     current_branch,
     current_head_sha,
     discard_if_dirty,
@@ -318,6 +319,7 @@ def build_sync_plan(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncP
             )
         else:
             if repo_dirty(repo_root):
+                repo_conflicts = conflicting_files(repo_root)
                 if dirty_mode == "block":
                     issues.append(
                         SyncIssue(
@@ -328,7 +330,7 @@ def build_sync_plan(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncP
                             message=f"shared repo has uncommitted changes and blocks sync: {repo_root}",
                             blocks=True,
                             path=str(repo_root),
-                            details={"dirty_mode": dirty_mode},
+                            details={"dirty_mode": dirty_mode, "conflicting_files": repo_conflicts},
                         )
                     )
                 else:
@@ -424,6 +426,7 @@ def build_sync_plan(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncP
                 )
                 continue
             if repo_dirty(lane_repo_root):
+                repo_conflicts = conflicting_files(lane_repo_root)
                 if dirty_mode == "block":
                     issues.append(
                         SyncIssue(
@@ -434,7 +437,11 @@ def build_sync_plan(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncP
                             message=f"lane repo has uncommitted changes and blocks sync: {lane_repo_root}",
                             blocks=True,
                             path=str(lane_repo_root),
-                            details={"expected_branch": expected_branch, "dirty_mode": dirty_mode},
+                            details={
+                                "expected_branch": expected_branch,
+                                "dirty_mode": dirty_mode,
+                                "conflicting_files": repo_conflicts,
+                            },
                         )
                     )
                 else:
@@ -730,6 +737,20 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
                         "reason": "active_lease",
                         "repo": issue.subject,
                         "conflicting_files": [],
+                    },
+                )
+            elif issue.code in {"dirty_shared_repo", "dirty_lane_repo"} and issue.details.get("conflicting_files"):
+                repo_name = issue.subject.split(":")[-1]
+                _emit_sync_event(
+                    workspace_root,
+                    {
+                        "type": "sync.conflict",
+                        **_sync_context(
+                            workspace_root,
+                            owner_unit=issue.subject.split("/", 1)[0] if issue.scope == "lane" else "workspace",
+                        ),
+                        "repo": repo_name,
+                        "conflicting_files": list(issue.details.get("conflicting_files", [])),
                     },
                 )
         _emit_sync_event(

--- a/gr2/python_cli/syncops.py
+++ b/gr2/python_cli/syncops.py
@@ -4,6 +4,7 @@ import dataclasses
 import fcntl
 import json
 import os
+import time
 from pathlib import Path
 from datetime import UTC, datetime
 
@@ -11,6 +12,7 @@ from gr2.prototypes import lane_workspace_prototype as lane_proto
 
 from .gitops import (
     clone_repo,
+    commits_between,
     current_branch,
     current_head_sha,
     discard_if_dirty,
@@ -39,6 +41,7 @@ SYNC_ROLLBACK_CONTRACT = (
     "it does not attempt automatic cross-repo rollback"
 )
 VALID_DIRTY_MODES = {"stash", "block", "discard"}
+SYNC_STRATEGY = "reference-cache"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -252,6 +255,14 @@ def _append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> No
 
 def _emit_sync_event(workspace_root: Path, payload: dict[str, object]) -> None:
     _append_outbox_event(workspace_root, payload)
+
+
+def _plan_repo_names(plan: SyncPlan) -> list[str]:
+    repo_names: list[str] = []
+    for op in plan.operations:
+        if op.scope in {"shared_repo", "lane"}:
+            repo_names.append(op.subject.split(":")[-1])
+    return sorted(dict.fromkeys(repo_names))
 
 
 def build_sync_plan(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncPlan:
@@ -550,6 +561,15 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
         repo_spec = _find_repo(spec, op.subject)
         cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
         created = ensure_repo_cache(str(repo_spec["url"]), cache_path)
+        _emit_sync_event(
+            workspace_root,
+            {
+                "type": "sync.cache_seeded" if created else "sync.cache_refreshed",
+                "repo": op.subject,
+                "strategy": SYNC_STRATEGY,
+                "cache_path": str(cache_path),
+            },
+        )
         if op.kind == "seed_repo_cache":
             return f"seeded repo cache for '{op.subject}' at {cache_path}"
         if created:
@@ -571,6 +591,8 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                 "scope": "shared_repo",
                 "old_sha": before_sha,
                 "new_sha": after_sha,
+                "strategy": SYNC_STRATEGY,
+                "commits_pulled": commits_between(repo_root, before_sha, after_sha),
             },
         )
         return f"cloned shared repo '{op.subject}' into {repo_root}"
@@ -607,6 +629,8 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                 "old_sha": before_sha,
                 "new_sha": after_sha,
                 "branch": expected_branch,
+                "strategy": SYNC_STRATEGY,
+                "commits_pulled": commits_between(target_repo_root, before_sha, after_sha),
             },
         )
         return f"materialized lane repo '{op.subject}' at {target_repo_root}"
@@ -677,6 +701,7 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
     workspace_root = workspace_root.resolve()
     dirty_mode = _normalize_dirty_mode(dirty_mode)
     operation_id = _operation_id()
+    started_at = time.monotonic()
     lock_fh = _acquire_sync_lock(workspace_root)
     if lock_fh is None:
         blocked_issue = SyncIssue(
@@ -718,6 +743,8 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
             "operation_id": operation_id,
             "workspace_root": str(workspace_root),
             "dirty_mode": dirty_mode,
+            "repos": _plan_repo_names(build_sync_plan(workspace_root, dirty_mode=dirty_mode)),
+            "strategy": SYNC_STRATEGY,
         },
     )
     plan = build_sync_plan(workspace_root, dirty_mode=dirty_mode)
@@ -744,6 +771,10 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
                 "workspace_root": str(workspace_root),
                 "status": "blocked",
                 "blocked_codes": [item.code for item in blocked],
+                "repos_updated": 0,
+                "repos_skipped": 0,
+                "repos_failed": len(blocked),
+                "duration_ms": int((time.monotonic() - started_at) * 1000),
             },
         )
         _release_sync_lock(lock_fh)
@@ -789,6 +820,10 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
                 "status": status,
                 "applied_count": len(applied),
                 "failure_codes": [item.code for item in failures],
+                "repos_updated": sum(1 for op in plan.operations if op.kind in {"clone_shared_repo", "materialize_lane_repo"}),
+                "repos_skipped": sum(1 for op in plan.operations if op.kind in {"stash_dirty_repo", "discard_dirty_repo"}),
+                "repos_failed": len(failures),
+                "duration_ms": int((time.monotonic() - started_at) * 1000),
             },
         )
 

--- a/gr2/python_cli/syncops.py
+++ b/gr2/python_cli/syncops.py
@@ -241,6 +241,7 @@ def _append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> No
                         if value >= seq:
                             seq = value + 1
             event = {
+                "version": 1,
                 "seq": seq,
                 "event_id": os.urandom(8).hex(),
                 "timestamp": _now_utc(),
@@ -255,6 +256,14 @@ def _append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> No
 
 def _emit_sync_event(workspace_root: Path, payload: dict[str, object]) -> None:
     _append_outbox_event(workspace_root, payload)
+
+
+def _sync_context(workspace_root: Path, *, actor: str = "system", owner_unit: str = "workspace") -> dict[str, object]:
+    return {
+        "workspace": workspace_root.name,
+        "actor": actor,
+        "owner_unit": owner_unit,
+    }
 
 
 def _plan_repo_names(plan: SyncPlan) -> list[str]:
@@ -565,6 +574,7 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
             workspace_root,
             {
                 "type": "sync.cache_seeded" if created else "sync.cache_refreshed",
+                **_sync_context(workspace_root),
                 "repo": op.subject,
                 "strategy": SYNC_STRATEGY,
                 "cache_path": str(cache_path),
@@ -587,8 +597,8 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
             workspace_root,
             {
                 "type": "sync.repo_updated",
+                **_sync_context(workspace_root),
                 "repo": op.subject,
-                "scope": "shared_repo",
                 "old_sha": before_sha,
                 "new_sha": after_sha,
                 "strategy": SYNC_STRATEGY,
@@ -622,13 +632,10 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
             workspace_root,
             {
                 "type": "sync.repo_updated",
+                **_sync_context(workspace_root, owner_unit=owner_unit),
                 "repo": repo_name,
-                "scope": "lane",
-                "owner_unit": owner_unit,
-                "lane": lane_name,
                 "old_sha": before_sha,
                 "new_sha": after_sha,
-                "branch": expected_branch,
                 "strategy": SYNC_STRATEGY,
                 "commits_pulled": commits_between(target_repo_root, before_sha, after_sha),
             },
@@ -652,8 +659,8 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                 workspace_root,
                 {
                     "type": "sync.repo_skipped",
+                    **_sync_context(workspace_root),
                     "repo": op.subject.split(":")[-1],
-                    "scope": op.scope,
                     "reason": "dirty_stashed",
                 },
             )
@@ -667,8 +674,8 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                 workspace_root,
                 {
                     "type": "sync.repo_skipped",
+                    **_sync_context(workspace_root),
                     "repo": op.subject.split(":")[-1],
-                    "scope": op.scope,
                     "reason": "dirty_discarded",
                 },
             )
@@ -718,19 +725,17 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
             workspace_root,
             {
                 "type": "sync.conflict",
-                "operation_id": operation_id,
+                **_sync_context(workspace_root),
                 "reason": "lock_held",
-                "workspace_root": str(workspace_root),
+                "repo": workspace_root.name,
             },
         )
         _emit_sync_event(
             workspace_root,
             {
                 "type": "sync.completed",
-                "operation_id": operation_id,
-                "workspace_root": str(workspace_root),
+                **_sync_context(workspace_root),
                 "status": "blocked",
-                "blocked_codes": [blocked_issue.code],
                 "repos_updated": 0,
                 "repos_skipped": 0,
                 "repos_failed": 1,
@@ -754,9 +759,7 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
         workspace_root,
         {
             "type": "sync.started",
-            "operation_id": operation_id,
-            "workspace_root": str(workspace_root),
-            "dirty_mode": dirty_mode,
+            **_sync_context(workspace_root),
             "repos": _plan_repo_names(build_sync_plan(workspace_root, dirty_mode=dirty_mode)),
             "strategy": SYNC_STRATEGY,
         },
@@ -770,21 +773,18 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
                     workspace_root,
                     {
                         "type": "sync.conflict",
-                        "operation_id": operation_id,
-                        "workspace_root": str(workspace_root),
+                        **_sync_context(workspace_root, owner_unit=issue.subject.split("/", 1)[0]),
                         "reason": "active_lease",
-                        "subject": issue.subject,
-                        "leases": issue.details.get("leases", []),
+                        "repo": issue.subject,
+                        "conflicting_files": [],
                     },
                 )
         _emit_sync_event(
             workspace_root,
             {
                 "type": "sync.completed",
-                "operation_id": operation_id,
-                "workspace_root": str(workspace_root),
+                **_sync_context(workspace_root),
                 "status": "blocked",
-                "blocked_codes": [item.code for item in blocked],
                 "repos_updated": 0,
                 "repos_skipped": 0,
                 "repos_failed": len(blocked),
@@ -829,11 +829,8 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
             workspace_root,
             {
                 "type": "sync.completed",
-                "operation_id": operation_id,
-                "workspace_root": str(workspace_root),
+                **_sync_context(workspace_root),
                 "status": status,
-                "applied_count": len(applied),
-                "failure_codes": [item.code for item in failures],
                 "repos_updated": sum(1 for op in plan.operations if op.kind in {"clone_shared_repo", "materialize_lane_repo"}),
                 "repos_skipped": sum(1 for op in plan.operations if op.kind in {"stash_dirty_repo", "discard_dirty_repo"}),
                 "repos_failed": len(failures),

--- a/gr2/python_cli/syncops.py
+++ b/gr2/python_cli/syncops.py
@@ -23,6 +23,7 @@ from .gitops import (
     repo_dirty,
     stash_if_dirty,
 )
+from .events import append_outbox_event
 from .hooks import load_repo_hooks
 from .spec_apply import (
     ValidationIssue,
@@ -198,60 +199,12 @@ def _operation_id() -> str:
     return os.urandom(8).hex()
 
 
-def _now_utc() -> str:
-    return datetime.now(UTC).isoformat()
-
-
-def _events_dir(workspace_root: Path) -> Path:
-    return workspace_root / ".grip" / "events"
-
-
-def _outbox_file(workspace_root: Path) -> Path:
-    return _events_dir(workspace_root) / "outbox.jsonl"
-
-
-def _outbox_lock_file(workspace_root: Path) -> Path:
-    return _events_dir(workspace_root) / "outbox.lock"
-
-
 def _sync_lock_file(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "state" / "sync.lock"
 
 
 def _append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> None:
-    outbox_path = _outbox_file(workspace_root)
-    lock_path = _outbox_lock_file(workspace_root)
-    outbox_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        with lock_path.open("a+", encoding="utf-8") as lock_fh:
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
-            seq = 1
-            if outbox_path.exists():
-                with outbox_path.open("r", encoding="utf-8") as existing:
-                    for line in existing:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            row = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-                        value = int(row.get("seq", 0))
-                        if value >= seq:
-                            seq = value + 1
-            event = {
-                "version": 1,
-                "seq": seq,
-                "event_id": os.urandom(8).hex(),
-                "timestamp": _now_utc(),
-                **payload,
-            }
-            with outbox_path.open("a", encoding="utf-8") as fh:
-                fh.write(json.dumps(event) + "\n")
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
-    except OSError:
-        return
+    append_outbox_event(workspace_root, payload)
 
 
 def _emit_sync_event(workspace_root: Path, payload: dict[str, object]) -> None:

--- a/gr2/python_cli/syncops.py
+++ b/gr2/python_cli/syncops.py
@@ -723,6 +723,20 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
                 "workspace_root": str(workspace_root),
             },
         )
+        _emit_sync_event(
+            workspace_root,
+            {
+                "type": "sync.completed",
+                "operation_id": operation_id,
+                "workspace_root": str(workspace_root),
+                "status": "blocked",
+                "blocked_codes": [blocked_issue.code],
+                "repos_updated": 0,
+                "repos_skipped": 0,
+                "repos_failed": 1,
+                "duration_ms": int((time.monotonic() - started_at) * 1000),
+            },
+        )
         return SyncResult(
             workspace_root=str(workspace_root),
             status="blocked",

--- a/gr2/python_cli/syncops.py
+++ b/gr2/python_cli/syncops.py
@@ -24,7 +24,7 @@ from .gitops import (
     repo_dirty,
     stash_if_dirty,
 )
-from .events import append_outbox_event
+from .events import EventType, emit
 from .hooks import load_repo_hooks
 from .spec_apply import (
     ValidationIssue,
@@ -204,12 +204,18 @@ def _sync_lock_file(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "state" / "sync.lock"
 
 
-def _append_outbox_event(workspace_root: Path, payload: dict[str, object]) -> None:
-    append_outbox_event(workspace_root, payload)
-
-
 def _emit_sync_event(workspace_root: Path, payload: dict[str, object]) -> None:
-    _append_outbox_event(workspace_root, payload)
+    event_type = EventType(str(payload.pop("type")))
+    payload.pop("workspace", None)
+    agent_id = payload.pop("agent_id", None)
+    emit(
+        event_type=event_type,
+        workspace_root=workspace_root,
+        actor=str(payload.pop("actor")),
+        owner_unit=str(payload.pop("owner_unit")),
+        payload=payload,
+        agent_id=None if agent_id is None else str(agent_id),
+    )
 
 
 def _sync_context(workspace_root: Path, *, actor: str = "system", owner_unit: str = "workspace") -> dict[str, object]:

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import json
 import subprocess
 import sys
@@ -84,6 +85,12 @@ def _read_outbox(workspace_root: Path) -> list[dict[str, object]]:
             continue
         rows.append(json.loads(line))
     return rows
+
+
+def _stash_list(repo_root: Path) -> list[str]:
+    proc = _git(repo_root, "stash", "list")
+    assert proc.returncode == 0
+    return [line for line in proc.stdout.splitlines() if line.strip()]
 
 
 def test_sync_run_emits_contract_payloads_and_cache_events(tmp_path: Path) -> None:
@@ -216,3 +223,100 @@ def test_pr_commands_route_through_platform_adapter(tmp_path: Path, monkeypatch)
     result = runner.invoke(app, ["pr", "merge", str(workspace_root), "atlas", "feat-auth", "--json"])
     assert result.exit_code == 0
     assert any(kind == "merge" for kind, _ in calls)
+
+
+def test_sync_run_reports_terminal_blocked_event_on_lock_contention(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+    run_sync(workspace_root)
+
+    lock_path = workspace_root / ".grip" / "state" / "sync.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        result = runner.invoke(app, ["sync", "run", str(workspace_root), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert any(item["code"] == "sync_lock_held" for item in payload["blocked"])
+
+    outbox = _read_outbox(workspace_root)
+    assert any(row["type"] == "sync.conflict" for row in outbox)
+    terminal = [row for row in outbox if row["type"] == "sync.completed" and row.get("status") == "blocked"]
+    assert terminal, "lock contention must still emit terminal sync.completed status=blocked"
+
+
+def test_sync_run_dirty_block_reports_blocked_without_mutation(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+    run_sync(workspace_root)
+
+    repo_root = workspace_root / "repos" / "app"
+    (repo_root / "README.md").write_text("dirty block\n")
+
+    result = runner.invoke(app, ["sync", "run", str(workspace_root), "--dirty", "block", "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert payload["dirty_mode"] == "block"
+    assert "app" in payload["dirty_targets"]
+    assert any(item["code"] == "dirty_shared_repo" for item in payload["blocked"])
+    assert repo_root.joinpath("README.md").read_text() == "dirty block\n"
+    assert _stash_list(repo_root) == []
+
+
+def test_sync_run_dirty_stash_stashes_changes_and_continues(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+    run_sync(workspace_root)
+
+    repo_root = workspace_root / "repos" / "app"
+    (repo_root / "README.md").write_text("dirty stash\n")
+
+    result = runner.invoke(app, ["sync", "run", str(workspace_root), "--dirty", "stash", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "success"
+    assert payload["dirty_mode"] == "stash"
+    assert "app" in payload["dirty_targets"]
+    assert _git(repo_root, "status", "--porcelain").stdout.strip() == ""
+    assert _stash_list(repo_root), "stash mode should leave a git stash entry"
+
+    outbox = _read_outbox(workspace_root)
+    assert any(
+        row["type"] == "sync.repo_skipped" and row.get("repo") == "app" and row.get("reason") == "dirty_stashed"
+        for row in outbox
+    )
+
+
+def test_sync_run_dirty_discard_discards_changes_without_stash(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+    run_sync(workspace_root)
+
+    repo_root = workspace_root / "repos" / "app"
+    (repo_root / "README.md").write_text("dirty discard\n")
+
+    result = runner.invoke(app, ["sync", "run", str(workspace_root), "--dirty", "discard", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "success"
+    assert payload["dirty_mode"] == "discard"
+    assert "app" in payload["dirty_targets"]
+    assert repo_root.joinpath("README.md").read_text() == "# app\n"
+    assert _stash_list(repo_root) == []
+
+    outbox = _read_outbox(workspace_root)
+    assert any(
+        row["type"] == "sync.repo_skipped" and row.get("repo") == "app" and row.get("reason") == "dirty_discarded"
+        for row in outbox
+    )

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -595,12 +595,12 @@ def test_pr_create_persists_group_state_by_pr_group_id(tmp_path: Path, monkeypat
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["pr_group_id"].startswith("pg_")
-    assert len(payload["refs"]) == 2
+    assert len(payload["prs"]) == 2
 
     group_path = workspace_root / ".grip" / "pr_groups" / f'{payload["pr_group_id"]}.json'
     assert group_path.exists(), "group state should be stored by pr_group_id, not lane name"
     stored = json.loads(group_path.read_text())
-    assert {item["repo"]: item["number"] for item in stored["refs"]} == {"app": 41, "api": 42}
+    assert {item["repo"]: item["pr_number"] for item in stored["prs"]} == {"app": 41, "api": 42}
 
 
 def test_pr_status_aggregates_group_state(tmp_path: Path, monkeypatch) -> None:
@@ -621,10 +621,11 @@ def test_pr_status_aggregates_group_state(tmp_path: Path, monkeypatch) -> None:
                 "owner_unit": "atlas",
                 "lane_name": "feat-router",
                 "platform": "github",
-                "refs": [
-                    {"repo": "app", "number": 41, "url": "https://example.test/app/41"},
-                    {"repo": "api", "number": 42, "url": "https://example.test/api/42"},
+                "prs": [
+                    {"repo": "app", "pr_number": 41, "url": "https://example.test/app/41"},
+                    {"repo": "api", "pr_number": 42, "url": "https://example.test/api/42"},
                 ],
+                "status": {"app": "OPEN", "api": "OPEN"},
             }
         )
     )
@@ -676,10 +677,11 @@ def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, mo
                 "owner_unit": "atlas",
                 "lane_name": "feat-router",
                 "platform": "github",
-                "refs": [
-                    {"repo": "app", "number": 41, "url": "https://example.test/app/41"},
-                    {"repo": "api", "number": 42, "url": "https://example.test/api/42"},
+                "prs": [
+                    {"repo": "app", "pr_number": 41, "url": "https://example.test/app/41"},
+                    {"repo": "api", "pr_number": 42, "url": "https://example.test/api/42"},
                 ],
+                "status": {"app": "OPEN", "api": "OPEN"},
             }
         )
     )
@@ -692,7 +694,9 @@ def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, mo
 
         def merge_pr(self, repo: str, number: int) -> PRRef:
             if repo == "api":
-                raise RuntimeError("merge conflict")
+                from gr2.python_cli.platform import AdapterError
+
+                raise AdapterError("merge conflict")
             return PRRef(repo=repo, number=number, url=f"https://example.test/{repo}/{number}")
 
         def pr_status(self, repo: str, number: int) -> PRStatus:  # pragma: no cover

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -52,6 +52,42 @@ def _init_bare_remote(tmp_path: Path, name: str) -> tuple[Path, str]:
     return remote, remote.as_uri()
 
 
+def _init_bare_remote_with_projection_hook(tmp_path: Path, name: str) -> tuple[Path, str]:
+    source = tmp_path / f"{name}-src"
+    source.mkdir(parents=True, exist_ok=True)
+    assert _git(source, "init", "-b", "main").returncode == 0
+    assert _git(source, "config", "user.name", "Atlas").returncode == 0
+    assert _git(source, "config", "user.email", "atlas@example.com").returncode == 0
+    (source / "README.md").write_text(f"# {name}\n")
+    (source / "shared").mkdir(parents=True, exist_ok=True)
+    (source / "shared" / "CLAUDE.shared.md").write_text("shared claude\n")
+    (source / ".gr2").mkdir(parents=True, exist_ok=True)
+    (source / ".gr2" / "hooks.toml").write_text(
+        textwrap.dedent(
+            """
+            [repo]
+            name = "app"
+
+            [[files.copy]]
+            src = "shared/CLAUDE.shared.md"
+            dest = "{repo_root}/CLAUDE.md"
+            """
+        ).strip()
+        + "\n"
+    )
+    assert _git(source, "add", "README.md", "shared/CLAUDE.shared.md", ".gr2/hooks.toml").returncode == 0
+    assert _git(source, "commit", "-m", "initial").returncode == 0
+
+    remote = tmp_path / f"{name}.git"
+    assert subprocess.run(
+        ["git", "clone", "--bare", str(source), str(remote)],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode == 0
+    return remote, remote.as_uri()
+
+
 def _write_workspace_spec(workspace_root: Path, repo_name: str, repo_url: str) -> None:
     spec_path = workspace_root / ".grip" / "workspace_spec.toml"
     spec_path.parent.mkdir(parents=True, exist_ok=True)
@@ -237,6 +273,46 @@ def test_sync_run_emits_cache_refresh_event_when_cache_exists(tmp_path: Path) ->
     outbox = _read_outbox(workspace_root)[before_count:]
     event_types = [str(row["type"]) for row in outbox]
     assert "sync.cache_refreshed" in event_types
+
+
+def test_workspace_materialize_emits_workspace_materialized_event(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+
+    result = runner.invoke(app, ["workspace", "materialize", str(workspace_root), "--json", "--yes"])
+    assert result.exit_code == 0
+
+    outbox = _read_outbox(workspace_root)
+    materialized = next(row for row in outbox if row["type"] == "workspace.materialized")
+    assert materialized["workspace"] == workspace_root.name
+    assert materialized["actor"] == "system"
+    assert materialized["owner_unit"] == "workspace"
+    assert materialized["repos"] == [{"repo": "app", "first_materialize": True}]
+
+
+def test_workspace_materialize_emits_file_projected_event(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote_with_projection_hook(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+
+    result = runner.invoke(app, ["workspace", "materialize", str(workspace_root), "--json", "--yes"])
+    assert result.exit_code == 0
+
+    projected_path = workspace_root / "repos" / "app" / "CLAUDE.md"
+    assert projected_path.exists()
+
+    outbox = _read_outbox(workspace_root)
+    projected = next(row for row in outbox if row["type"] == "workspace.file_projected")
+    assert projected["workspace"] == workspace_root.name
+    assert projected["actor"] == "system"
+    assert projected["owner_unit"] == "workspace"
+    assert projected["repo"] == "app"
+    assert projected["kind"] == "copy"
+    assert projected["src"] == "repos/app/shared/CLAUDE.shared.md"
+    assert projected["dest"] == "repos/app/CLAUDE.md"
 
 
 def test_pr_command_group_exists_in_python_cli() -> None:

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -75,6 +75,38 @@ def _write_workspace_spec(workspace_root: Path, repo_name: str, repo_url: str) -
     )
 
 
+def _write_workspace_spec_multi(workspace_root: Path, repos: list[tuple[str, str]]) -> None:
+    spec_path = workspace_root / ".grip" / "workspace_spec.toml"
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    repo_blocks = []
+    for repo_name, repo_url in repos:
+        repo_blocks.append(
+            textwrap.dedent(
+                f"""
+                [[repos]]
+                name = "{repo_name}"
+                path = "repos/{repo_name}"
+                url = "{repo_url}"
+                """
+            ).strip()
+        )
+    spec_path.write_text(
+        textwrap.dedent(
+            f"""
+            workspace_name = "{workspace_root.name}"
+
+            {'\n\n'.join(repo_blocks)}
+
+            [[units]]
+            name = "atlas"
+            path = "agents/atlas/home"
+            repos = [{", ".join(f'"{name}"' for name, _ in repos)}]
+            """
+        ).strip()
+        + "\n"
+    )
+
+
 def _read_outbox(workspace_root: Path) -> list[dict[str, object]]:
     outbox = workspace_root / ".grip" / "events" / "outbox.jsonl"
     rows: list[dict[str, object]] = []
@@ -223,6 +255,181 @@ def test_pr_commands_route_through_platform_adapter(tmp_path: Path, monkeypatch)
     result = runner.invoke(app, ["pr", "merge", str(workspace_root), "atlas", "feat-auth", "--json"])
     assert result.exit_code == 0
     assert any(kind == "merge" for kind, _ in calls)
+
+
+def test_pr_create_persists_group_state_by_pr_group_id(tmp_path: Path, monkeypatch) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, app_url = _init_bare_remote(tmp_path, "app")
+    _, api_url = _init_bare_remote(tmp_path, "api")
+    _write_workspace_spec_multi(workspace_root, [("app", app_url), ("api", api_url)])
+    run_sync(workspace_root)
+
+    ns = SimpleNamespace(
+        workspace_root=workspace_root,
+        owner_unit="atlas",
+        lane_name="feat-router",
+        type="feature",
+        repos="app,api",
+        branch="feat/router",
+        default_commands=[],
+        source="pytest",
+    )
+    lane_proto.create_lane(ns)
+
+    class FakeAdapter:
+        name = "fake"
+
+        def create_pr(self, request: CreatePRRequest) -> PRRef:
+            number = 41 if request.repo == "app" else 42
+            return PRRef(
+                repo=request.repo,
+                number=number,
+                url=f"https://example.test/{request.repo}/pull/{number}",
+                head_branch=request.head_branch,
+                base_branch=request.base_branch,
+                title=request.title,
+            )
+
+        def merge_pr(self, repo: str, number: int) -> PRRef:  # pragma: no cover - not used here
+            raise AssertionError("merge_pr should not be called")
+
+        def pr_status(self, repo: str, number: int) -> PRStatus:  # pragma: no cover - not used here
+            raise AssertionError("pr_status should not be called")
+
+        def list_prs(self, repo: str, *, head_branch: str | None = None) -> list[PRRef]:  # pragma: no cover
+            return []
+
+        def pr_checks(self, repo: str, number: int) -> list[PRCheck]:  # pragma: no cover
+            return []
+
+    monkeypatch.setattr(app_module, "get_platform_adapter", lambda name="github": FakeAdapter())
+
+    result = runner.invoke(app, ["pr", "create", str(workspace_root), "atlas", "feat-router", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["pr_group_id"].startswith("pg_")
+    assert len(payload["refs"]) == 2
+
+    group_path = workspace_root / ".grip" / "pr_groups" / f'{payload["pr_group_id"]}.json'
+    assert group_path.exists(), "group state should be stored by pr_group_id, not lane name"
+    stored = json.loads(group_path.read_text())
+    assert {item["repo"]: item["number"] for item in stored["refs"]} == {"app": 41, "api": 42}
+
+
+def test_pr_status_aggregates_group_state(tmp_path: Path, monkeypatch) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, app_url = _init_bare_remote(tmp_path, "app")
+    _, api_url = _init_bare_remote(tmp_path, "api")
+    _write_workspace_spec_multi(workspace_root, [("app", app_url), ("api", api_url)])
+    run_sync(workspace_root)
+
+    pr_group_id = "pg_deadbeef"
+    group_path = workspace_root / ".grip" / "pr_groups" / f"{pr_group_id}.json"
+    group_path.parent.mkdir(parents=True, exist_ok=True)
+    group_path.write_text(
+        json.dumps(
+            {
+                "pr_group_id": pr_group_id,
+                "owner_unit": "atlas",
+                "lane_name": "feat-router",
+                "platform": "github",
+                "refs": [
+                    {"repo": "app", "number": 41, "url": "https://example.test/app/41"},
+                    {"repo": "api", "number": 42, "url": "https://example.test/api/42"},
+                ],
+            }
+        )
+    )
+
+    class FakeAdapter:
+        name = "fake"
+
+        def create_pr(self, request: CreatePRRequest) -> PRRef:  # pragma: no cover
+            raise AssertionError("create_pr should not be called")
+
+        def merge_pr(self, repo: str, number: int) -> PRRef:  # pragma: no cover
+            raise AssertionError("merge_pr should not be called")
+
+        def pr_status(self, repo: str, number: int) -> PRStatus:
+            state = "OPEN" if repo == "app" else "MERGED"
+            ref = PRRef(repo=repo, number=number, url=f"https://example.test/{repo}/{number}")
+            return PRStatus(ref=ref, state=state, mergeable="MERGEABLE", checks=[])
+
+        def list_prs(self, repo: str, *, head_branch: str | None = None) -> list[PRRef]:  # pragma: no cover
+            return []
+
+        def pr_checks(self, repo: str, number: int) -> list[PRCheck]:  # pragma: no cover
+            return []
+
+    monkeypatch.setattr(app_module, "get_platform_adapter", lambda name="github": FakeAdapter())
+
+    result = runner.invoke(app, ["pr", "status", str(workspace_root), "atlas", "feat-router", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["pr_group_id"] == pr_group_id
+    assert payload["group_state"] == "partially_merged"
+
+
+def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, monkeypatch) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, app_url = _init_bare_remote(tmp_path, "app")
+    _, api_url = _init_bare_remote(tmp_path, "api")
+    _write_workspace_spec_multi(workspace_root, [("app", app_url), ("api", api_url)])
+    run_sync(workspace_root)
+
+    pr_group_id = "pg_badmerge"
+    group_path = workspace_root / ".grip" / "pr_groups" / f"{pr_group_id}.json"
+    group_path.parent.mkdir(parents=True, exist_ok=True)
+    group_path.write_text(
+        json.dumps(
+            {
+                "pr_group_id": pr_group_id,
+                "owner_unit": "atlas",
+                "lane_name": "feat-router",
+                "platform": "github",
+                "refs": [
+                    {"repo": "app", "number": 41, "url": "https://example.test/app/41"},
+                    {"repo": "api", "number": 42, "url": "https://example.test/api/42"},
+                ],
+            }
+        )
+    )
+
+    class FakeAdapter:
+        name = "fake"
+
+        def create_pr(self, request: CreatePRRequest) -> PRRef:  # pragma: no cover
+            raise AssertionError("create_pr should not be called")
+
+        def merge_pr(self, repo: str, number: int) -> PRRef:
+            if repo == "api":
+                raise RuntimeError("merge conflict")
+            return PRRef(repo=repo, number=number, url=f"https://example.test/{repo}/{number}")
+
+        def pr_status(self, repo: str, number: int) -> PRStatus:  # pragma: no cover
+            raise AssertionError("pr_status should not be called")
+
+        def list_prs(self, repo: str, *, head_branch: str | None = None) -> list[PRRef]:  # pragma: no cover
+            return []
+
+        def pr_checks(self, repo: str, number: int) -> list[PRCheck]:  # pragma: no cover
+            return []
+
+    monkeypatch.setattr(app_module, "get_platform_adapter", lambda name="github": FakeAdapter())
+
+    result = runner.invoke(app, ["pr", "merge", str(workspace_root), "atlas", "feat-router", "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "partial_failure"
+    assert payload["pr_group_id"] == pr_group_id
+    assert payload["merged"] == ["app"]
+    assert payload["failed"][0]["repo"] == "api"
+
+    stored = json.loads(group_path.read_text())
+    assert stored["group_state"] == "partially_merged"
 
 
 def test_sync_run_reports_terminal_blocked_event_on_lock_contention(tmp_path: Path) -> None:

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -159,6 +159,68 @@ def test_sync_run_emits_contract_payloads_and_cache_events(tmp_path: Path) -> No
     assert completed["duration_ms"] >= 0
 
 
+def test_sync_core_events_match_hook_event_contract_field_names(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+
+    result = run_sync(workspace_root)
+    assert result.status == "success"
+
+    outbox = _read_outbox(workspace_root)
+    started = next(row for row in outbox if row["type"] == "sync.started")
+    updated = next(row for row in outbox if row["type"] == "sync.repo_updated")
+    completed = next(row for row in outbox if row["type"] == "sync.completed")
+
+    started_expected = {
+        "version",
+        "event_id",
+        "seq",
+        "timestamp",
+        "type",
+        "workspace",
+        "actor",
+        "owner_unit",
+        "repos",
+        "strategy",
+    }
+    updated_expected = {
+        "version",
+        "event_id",
+        "seq",
+        "timestamp",
+        "type",
+        "workspace",
+        "actor",
+        "owner_unit",
+        "repo",
+        "old_sha",
+        "new_sha",
+        "strategy",
+        "commits_pulled",
+    }
+    completed_expected = {
+        "version",
+        "event_id",
+        "seq",
+        "timestamp",
+        "type",
+        "workspace",
+        "actor",
+        "owner_unit",
+        "status",
+        "repos_updated",
+        "repos_skipped",
+        "repos_failed",
+        "duration_ms",
+    }
+
+    assert set(started.keys()) == started_expected
+    assert set(updated.keys()) == updated_expected
+    assert set(completed.keys()) == completed_expected
+
+
 def test_sync_run_emits_cache_refresh_event_when_cache_exists(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     workspace_root.mkdir()

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -88,6 +88,42 @@ def _init_bare_remote_with_projection_hook(tmp_path: Path, name: str) -> tuple[P
     return remote, remote.as_uri()
 
 
+def _init_bare_remote_with_failing_on_enter_hook(tmp_path: Path, name: str) -> tuple[Path, str]:
+    source = tmp_path / f"{name}-src"
+    source.mkdir(parents=True, exist_ok=True)
+    assert _git(source, "init", "-b", "main").returncode == 0
+    assert _git(source, "config", "user.name", "Atlas").returncode == 0
+    assert _git(source, "config", "user.email", "atlas@example.com").returncode == 0
+    (source / "README.md").write_text(f"# {name}\n")
+    (source / ".gr2").mkdir(parents=True, exist_ok=True)
+    (source / ".gr2" / "hooks.toml").write_text(
+        textwrap.dedent(
+            """
+            [repo]
+            name = "app"
+
+            [[lifecycle.on_enter]]
+            name = "boom"
+            command = "sh -c 'echo hook boom >&2; exit 7'"
+            when = "always"
+            on_failure = "block"
+            """
+        ).strip()
+        + "\n"
+    )
+    assert _git(source, "add", "README.md", ".gr2/hooks.toml").returncode == 0
+    assert _git(source, "commit", "-m", "initial").returncode == 0
+
+    remote = tmp_path / f"{name}.git"
+    assert subprocess.run(
+        ["git", "clone", "--bare", str(source), str(remote)],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode == 0
+    return remote, remote.as_uri()
+
+
 def _write_workspace_spec(workspace_root: Path, repo_name: str, repo_url: str) -> None:
     spec_path = workspace_root / ".grip" / "workspace_spec.toml"
     spec_path.parent.mkdir(parents=True, exist_ok=True)
@@ -313,6 +349,118 @@ def test_workspace_materialize_emits_file_projected_event(tmp_path: Path) -> Non
     assert projected["kind"] == "copy"
     assert projected["src"] == "repos/app/shared/CLAUDE.shared.md"
     assert projected["dest"] == "repos/app/CLAUDE.md"
+
+
+def test_lane_enter_hook_failure_writes_marker_and_resolve_emits_event(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote_with_failing_on_enter_hook(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+
+    materialize = runner.invoke(app, ["workspace", "materialize", str(workspace_root), "--yes", "--json"])
+    assert materialize.exit_code == 0
+
+    create = runner.invoke(
+        app,
+        [
+            "lane",
+            "create",
+            str(workspace_root),
+            "atlas",
+            "feat-auth",
+            "--repos",
+            "app",
+            "--branch",
+            "feat/auth",
+        ],
+    )
+    assert create.exit_code == 0
+
+    enter = runner.invoke(
+        app,
+        ["lane", "enter", str(workspace_root), "atlas", "feat-auth", "--actor", "agent:atlas"],
+    )
+    assert enter.exit_code != 0
+
+    failures_root = workspace_root / ".grip" / "state" / "failures"
+    markers = sorted(failures_root.glob("*.json"))
+    assert len(markers) == 1
+    marker = json.loads(markers[0].read_text())
+    assert marker["operation"] == "lane.enter"
+    assert marker["stage"] == "on_enter"
+    assert marker["hook_name"] == "boom"
+    assert marker["repo"] == "app"
+    assert marker["owner_unit"] == "atlas"
+    assert marker["lane_name"] == "feat-auth"
+    assert marker["resolved"] is False
+
+    blocked = runner.invoke(
+        app,
+        ["lane", "enter", str(workspace_root), "atlas", "feat-auth", "--actor", "agent:atlas"],
+    )
+    assert blocked.exit_code != 0
+    assert marker["operation_id"] in blocked.stdout
+
+    resolve = runner.invoke(
+        app,
+        [
+            "lane",
+            "resolve",
+            str(workspace_root),
+            "atlas",
+            marker["operation_id"],
+            "--actor",
+            "agent:atlas",
+            "--resolution",
+            "retry",
+            "--json",
+        ],
+    )
+    assert resolve.exit_code == 0
+    resolved_payload = json.loads(resolve.stdout)
+    assert resolved_payload["operation_id"] == marker["operation_id"]
+    assert not markers[0].exists()
+
+    outbox = _read_outbox(workspace_root)
+    resolved = next(row for row in outbox if row["type"] == "failure.resolved")
+    assert resolved["operation_id"] == marker["operation_id"]
+    assert resolved["resolved_by"] == "agent:atlas"
+    assert resolved["resolution"] == "retry"
+    assert resolved["lane_name"] == "feat-auth"
+
+
+def test_sync_conflict_emits_conflicting_files_for_unmerged_repo(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+    run_sync(workspace_root)
+
+    repo_root = workspace_root / "repos" / "app"
+    assert _git(repo_root, "config", "user.name", "Atlas").returncode == 0
+    assert _git(repo_root, "config", "user.email", "atlas@example.com").returncode == 0
+
+    (repo_root / "README.md").write_text("left\n")
+    assert _git(repo_root, "commit", "-am", "left").returncode == 0
+    assert _git(repo_root, "checkout", "-b", "other", "HEAD~1").returncode == 0
+    (repo_root / "README.md").write_text("right\n")
+    assert _git(repo_root, "commit", "-am", "right").returncode == 0
+    assert _git(repo_root, "checkout", "main").returncode == 0
+
+    merge = _git(repo_root, "merge", "other")
+    assert merge.returncode != 0
+    assert str(repo_root / "README.md").endswith("README.md")
+
+    result = runner.invoke(app, ["sync", "run", str(workspace_root), "--dirty", "block", "--json"])
+    assert result.exit_code == 1
+
+    outbox = _read_outbox(workspace_root)
+    conflict = next(
+        row
+        for row in outbox
+        if row["type"] == "sync.conflict" and row.get("repo") == "app" and row.get("conflicting_files")
+    )
+    assert conflict["conflicting_files"] == ["README.md"]
 
 
 def test_pr_command_group_exists_in_python_cli() -> None:

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from gr2.python_cli.app import app
+from gr2.python_cli import app as app_module
+from gr2.python_cli.platform import CreatePRRequest, PRCheck, PRRef, PRStatus
+from gr2.python_cli.syncops import run_sync
+from gr2.prototypes import lane_workspace_prototype as lane_proto
+
+
+runner = CliRunner()
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _init_bare_remote(tmp_path: Path, name: str) -> tuple[Path, str]:
+    source = tmp_path / f"{name}-src"
+    source.mkdir(parents=True, exist_ok=True)
+    assert _git(source, "init", "-b", "main").returncode == 0
+    assert _git(source, "config", "user.name", "Atlas").returncode == 0
+    assert _git(source, "config", "user.email", "atlas@example.com").returncode == 0
+    (source / "README.md").write_text(f"# {name}\n")
+    assert _git(source, "add", "README.md").returncode == 0
+    assert _git(source, "commit", "-m", "initial").returncode == 0
+
+    remote = tmp_path / f"{name}.git"
+    assert subprocess.run(
+        ["git", "clone", "--bare", str(source), str(remote)],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode == 0
+    return remote, remote.as_uri()
+
+
+def _write_workspace_spec(workspace_root: Path, repo_name: str, repo_url: str) -> None:
+    spec_path = workspace_root / ".grip" / "workspace_spec.toml"
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(
+        textwrap.dedent(
+            f"""
+            workspace_name = "{workspace_root.name}"
+
+            [[repos]]
+            name = "{repo_name}"
+            path = "repos/{repo_name}"
+            url = "{repo_url}"
+
+            [[units]]
+            name = "atlas"
+            path = "agents/atlas/home"
+            repos = ["{repo_name}"]
+            """
+        ).strip()
+        + "\n"
+    )
+
+
+def _read_outbox(workspace_root: Path) -> list[dict[str, object]]:
+    outbox = workspace_root / ".grip" / "events" / "outbox.jsonl"
+    rows: list[dict[str, object]] = []
+    if not outbox.exists():
+        return rows
+    for line in outbox.read_text().splitlines():
+        if not line.strip():
+            continue
+        rows.append(json.loads(line))
+    return rows
+
+
+def test_sync_run_emits_contract_payloads_and_cache_events(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+
+    result = run_sync(workspace_root)
+    assert result.status == "success"
+
+    outbox = _read_outbox(workspace_root)
+    event_types = [str(row["type"]) for row in outbox]
+    assert "sync.started" in event_types
+    assert "sync.repo_updated" in event_types
+    assert "sync.completed" in event_types
+    assert "sync.cache_seeded" in event_types
+
+    started = next(row for row in outbox if row["type"] == "sync.started")
+    assert started["repos"] == ["app"]
+    assert isinstance(started["strategy"], str)
+
+    updated = next(row for row in outbox if row["type"] == "sync.repo_updated")
+    assert updated["repo"] == "app"
+    assert isinstance(updated["commits_pulled"], int)
+    assert updated["commits_pulled"] >= 0
+
+    completed = next(row for row in outbox if row["type"] == "sync.completed")
+    assert completed["status"] == "success"
+    assert completed["repos_updated"] == 1
+    assert completed["repos_skipped"] == 0
+    assert completed["repos_failed"] == 0
+    assert isinstance(completed["duration_ms"], int)
+    assert completed["duration_ms"] >= 0
+
+
+def test_sync_run_emits_cache_refresh_event_when_cache_exists(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+
+    first = run_sync(workspace_root)
+    assert first.status == "success"
+    before_count = len(_read_outbox(workspace_root))
+
+    second = run_sync(workspace_root)
+    assert second.status == "success"
+
+    outbox = _read_outbox(workspace_root)[before_count:]
+    event_types = [str(row["type"]) for row in outbox]
+    assert "sync.cache_refreshed" in event_types
+
+
+def test_pr_command_group_exists_in_python_cli() -> None:
+    result = runner.invoke(app, ["pr", "--help"])
+    assert result.exit_code == 0
+    assert "create" in result.stdout
+    assert "status" in result.stdout
+    assert "merge" in result.stdout
+    assert "checks" in result.stdout
+
+
+def test_pr_commands_route_through_platform_adapter(tmp_path: Path, monkeypatch) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    _, repo_url = _init_bare_remote(tmp_path, "app")
+    _write_workspace_spec(workspace_root, "app", repo_url)
+    run_sync(workspace_root)
+
+    ns = SimpleNamespace(
+        workspace_root=workspace_root,
+        owner_unit="atlas",
+        lane_name="feat-auth",
+        type="feature",
+        repos="app",
+        branch="feat/auth",
+        default_commands=[],
+        source="pytest",
+    )
+    lane_proto.create_lane(ns)
+
+    calls: list[tuple[str, object]] = []
+
+    class FakeAdapter:
+        name = "fake"
+
+        def create_pr(self, request: CreatePRRequest) -> PRRef:
+            calls.append(("create", request))
+            return PRRef(
+                repo=request.repo,
+                number=42,
+                url="https://example.test/pr/42",
+                head_branch=request.head_branch,
+                base_branch=request.base_branch,
+                title=request.title,
+            )
+
+        def merge_pr(self, repo: str, number: int) -> PRRef:
+            calls.append(("merge", (repo, number)))
+            return PRRef(repo=repo, number=number, url="https://example.test/pr/42")
+
+        def pr_status(self, repo: str, number: int) -> PRStatus:
+            calls.append(("status", (repo, number)))
+            ref = PRRef(repo=repo, number=number, url="https://example.test/pr/42")
+            return PRStatus(ref=ref, state="OPEN", mergeable="MERGEABLE", checks=[PRCheck(name="ci", status="COMPLETED", conclusion="SUCCESS")])
+
+        def list_prs(self, repo: str, *, head_branch: str | None = None) -> list[PRRef]:
+            calls.append(("list", (repo, head_branch)))
+            return [PRRef(repo=repo, number=42, url="https://example.test/pr/42", head_branch=head_branch, base_branch="main", title="feat/auth")]
+
+        def pr_checks(self, repo: str, number: int) -> list[PRCheck]:
+            calls.append(("checks", (repo, number)))
+            return [PRCheck(name="ci", status="COMPLETED", conclusion="SUCCESS")]
+
+    monkeypatch.setattr(app_module, "get_platform_adapter", lambda name="github": FakeAdapter())
+
+    result = runner.invoke(app, ["pr", "create", str(workspace_root), "atlas", "feat-auth", "--json"])
+    assert result.exit_code == 0
+    assert any(kind == "create" for kind, _ in calls)
+
+    result = runner.invoke(app, ["pr", "status", str(workspace_root), "atlas", "feat-auth", "--json"])
+    assert result.exit_code == 0
+    assert any(kind == "status" for kind, _ in calls)
+
+    result = runner.invoke(app, ["pr", "checks", str(workspace_root), "atlas", "feat-auth", "--json"])
+    assert result.exit_code == 0
+    assert any(kind == "checks" for kind, _ in calls)
+
+    result = runner.invoke(app, ["pr", "merge", str(workspace_root), "atlas", "feat-auth", "--json"])
+    assert result.exit_code == 0
+    assert any(kind == "merge" for kind, _ in calls)


### PR DESCRIPTION
## Summary
- start Sprint 21 Sync Engine + PlatformAdapter lane on Python `gr2`
- add TDD coverage for sync cache events, sync lock/dirty modes, and PR group lifecycle
- implement first sync payload convergence and initial `gr2 pr` orchestration surface

## Included slices
- sync outbox payload convergence
  - `sync.started` now carries `repos` and `strategy`
  - `sync.repo_updated` now carries `strategy` and `commits_pulled`
  - `sync.completed` now carries `repos_updated`, `repos_skipped`, `repos_failed`, and `duration_ms`
  - `sync.cache_seeded` / `sync.cache_refreshed` events added
- sync lock + dirty mode behavior
  - end-to-end tests for `--dirty=block|stash|discard`
  - lock contention now emits both `sync.conflict` and terminal `sync.completed status=blocked`
- PlatformAdapter-backed PR orchestration
  - `gr2 pr create|status|checks|merge`
  - grouped PR state persisted under `.grip/pr_groups/{pr_group_id}.json`
  - `pr status` computes aggregated `group_state`
  - `pr merge` returns machine-readable `partial_failure` and preserves `partially_merged` state

## Boundary
This stays within OSS workspace orchestration in `grip`.
Premium remains responsible for identity/org compilation; `gr2` consumes compiled workspace/unit/lane state and coordinates repo + PR workflow locally.

## Verification
- `pytest -q gr2/tests/test_sprint21_sync_platform.py`
- `python3 -m py_compile gr2/python_cli/app.py gr2/python_cli/platform.py gr2/python_cli/syncops.py gr2/python_cli/gitops.py`
