### PR TITLE
ci: enforce OSS boundary checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 Brief description of changes.
 
+## Premium Boundary
+
+Premium boundary: grip is OSS because <reason>.
+
 ## Changes
 
 - Change 1
@@ -11,9 +15,16 @@ Brief description of changes.
 
 How were these changes tested?
 
-## Checklist
+## Boundary Checklist
 
-- [ ] Code compiles (`pnpm build`)
-- [ ] Linting passes (`pnpm lint`)
-- [ ] Tests pass (`pnpm test`)
+- [ ] Premium boundary declaration present
+- [ ] Identity test passed (no "who is this agent?" code in OSS)
+- [ ] Plugin seam built before premium extension
+- [ ] No workspace metadata parsing, identity derivation, or premium prefixes
+
+## General Checklist
+
+- [ ] Code compiles
+- [ ] Linting passes
+- [ ] Tests pass
 - [ ] Documentation updated (if applicable)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,53 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  boundary-lint:
+    name: Boundary Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Block premium identity markers in OSS surfaces
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SEARCH_PATHS=(
+            src
+            tests
+            .github
+            benches
+          )
+
+          PATTERNS=(
+            'workspace\.toml'
+            'agent\.toml'
+            'repo\.toml'
+            'g2_'
+          )
+
+          failed=0
+          for pattern in "${PATTERNS[@]}"; do
+            if rg -n --hidden \
+              --glob '!*.md' \
+              --glob '!*.json' \
+              --glob '!CHANGELOG*' \
+              --glob '!.github/workflows/ci.yml' \
+              "$pattern" "${SEARCH_PATHS[@]}"; then
+              echo
+              echo "Boundary lint violation: found forbidden premium marker pattern '$pattern' in OSS surfaces."
+              failed=1
+            fi
+          done
+
+          if [[ "$failed" -ne 0 ]]; then
+            echo
+            echo "Premium boundary violation detected. Move identity or workspace-resolution behavior out of OSS."
+            exit 1
+          fi
+
+          echo "Boundary lint passed."
+
   check:
     name: Check
     runs-on: ubuntu-latest
@@ -153,12 +200,13 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
-    needs: [check, fmt, clippy, test, build, bench, integration]
+    needs: [boundary-lint, check, fmt, clippy, test, build, bench, integration]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          if [[ "${{ needs.check.result }}" != "success" ]] || \
+          if [[ "${{ needs.boundary-lint.result }}" != "success" ]] || \
+             [[ "${{ needs.check.result }}" != "success" ]] || \
              [[ "${{ needs.fmt.result }}" != "success" ]] || \
              [[ "${{ needs.clippy.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \


### PR DESCRIPTION
## Summary
- add merge-blocking OSS boundary linting to grip CI
- add a PR template boundary checklist so premium-boundary review starts at author time

## Why
- closes grip#583
- closes grip#584
- enforces the Sprint 21 retro rules before Track 1 work begins

## Changes
- add `boundary-lint` to `.github/workflows/ci.yml`
- block premium markers in executable OSS surfaces: `workspace.toml`, `agent.toml`, `repo.toml`, `g2_`
- require `boundary-lint` in the summary `CI` job
- add a PR template section for:
  - premium boundary declaration
  - identity test
  - plugin seam check
  - no workspace metadata parsing / identity derivation / premium prefixes

## Testing
- local dry run of the boundary grep logic against `src`, `tests`, `.github`, and `benches`
- verified the workflow excludes its own `ci.yml` so the forbidden-pattern list does not self-trigger

Premium boundary: grip is OSS because this PR only adds process enforcement and CI guards to keep premium identity logic out of the public workspace orchestrator.
