### PR TITLE
feat: exec lane-aware with parallel mode and events (grip#544)

### DIFF
--- a/gr2/python_cli/events.py
+++ b/gr2/python_cli/events.py
@@ -66,6 +66,11 @@ class EventType(str, Enum):
     SYNC_CONFLICT = "sync.conflict"
     SYNC_COMPLETED = "sync.completed"
 
+    # Execution
+    EXEC_STARTED = "exec.started"
+    EXEC_COMPLETED = "exec.completed"
+    EXEC_FAILED = "exec.failed"
+
     FAILURE_RESOLVED = "failure.resolved"
     LEASE_RECLAIMED = "lease.reclaimed"
 

--- a/gr2/python_cli/execops.py
+++ b/gr2/python_cli/execops.py
@@ -2,9 +2,72 @@ from __future__ import annotations
 
 import json
 import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from pathlib import Path
 
 from gr2.prototypes import lane_workspace_prototype as lane_proto
+from gr2.python_cli.events import emit, EventType
+
+
+@dataclass
+class ExecResult:
+    repo: str
+    cwd: str
+    status: str
+    returncode: int | None
+    stdout: str
+    stderr: str
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status == "ok"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "repo": self.repo,
+            "cwd": self.cwd,
+            "status": self.status,
+            "returncode": self.returncode,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+        }
+
+
+def _exec_one(command: list[str], repo: str, cwd: str) -> ExecResult:
+    cwd_path = Path(cwd)
+    if not cwd_path.exists():
+        return ExecResult(
+            repo=repo, cwd=cwd, status="missing",
+            returncode=None, stdout="",
+            stderr=f"lane repo checkout missing: {cwd}",
+        )
+    proc = subprocess.run(command, cwd=cwd_path, capture_output=True, text=True, check=False)
+    return ExecResult(
+        repo=repo, cwd=cwd,
+        status="ok" if proc.returncode == 0 else "failed",
+        returncode=proc.returncode,
+        stdout=proc.stdout, stderr=proc.stderr,
+    )
+
+
+def run_exec_parallel(
+    command: list[str],
+    repo_rows: list[dict[str, str]],
+    max_workers: int = 4,
+) -> list[ExecResult]:
+    futures_map: dict[int, object] = {}
+    results: list[ExecResult | None] = [None] * len(repo_rows)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        for idx, row in enumerate(repo_rows):
+            future = pool.submit(_exec_one, command, row["repo"], row["cwd"])
+            futures_map[id(future)] = (idx, future)
+
+        for _, (idx, future) in futures_map.items():
+            results[idx] = future.result()
+
+    return [r for r in results if r is not None]
 
 
 def _resolve_lane_name(workspace_root: Path, owner_unit: str, lane_name: str | None) -> str:
@@ -231,51 +294,79 @@ def run_exec(
     resolved_lane = str(status["lane"])
     rows = list(status["rows"])
     fail_fast = bool(rows[0]["fail_fast"]) if rows else True
+    parallelism = str(rows[0]["parallelism"]) if rows else "sequential"
     acquire_exec_lease(workspace_root, owner_unit, resolved_lane, actor, ttl_seconds)
-    results: list[dict[str, object]] = []
+
+    emit(
+        event_type=EventType.EXEC_STARTED,
+        workspace_root=workspace_root,
+        actor=actor,
+        owner_unit=owner_unit,
+        payload={
+            "lane": resolved_lane,
+            "command": command,
+            "repos": [r["repo"] for r in rows],
+            "parallelism": parallelism,
+        },
+    )
+
+    exec_results: list[ExecResult] = []
     overall = "success"
 
     try:
-        for row in rows:
-            cwd = Path(str(row["cwd"]))
-            if not cwd.exists():
-                result = {
-                    "repo": row["repo"],
-                    "cwd": str(cwd),
-                    "status": "missing",
-                    "returncode": None,
-                    "stdout": "",
-                    "stderr": f"lane repo checkout missing: {cwd}",
-                }
-                results.append(result)
+        if parallelism == "parallel":
+            repo_rows = [{"repo": r["repo"], "cwd": str(r["cwd"])} for r in rows]
+            exec_results = run_exec_parallel(command, repo_rows)
+            if any(not r.succeeded for r in exec_results):
                 overall = "failed"
-                if fail_fast:
-                    break
-                continue
-
-            proc = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
-            result = {
-                "repo": row["repo"],
-                "cwd": str(cwd),
-                "status": "ok" if proc.returncode == 0 else "failed",
-                "returncode": proc.returncode,
-                "stdout": proc.stdout,
-                "stderr": proc.stderr,
-            }
-            results.append(result)
-            if proc.returncode != 0:
-                overall = "failed"
-                if fail_fast:
-                    break
+        else:
+            for row in rows:
+                r = _exec_one(command, str(row["repo"]), str(row["cwd"]))
+                exec_results.append(r)
+                if not r.succeeded:
+                    overall = "failed"
+                    if fail_fast:
+                        break
     finally:
         release_exec_lease(workspace_root, owner_unit, resolved_lane, actor)
+
+    result_dicts = [r.to_dict() for r in exec_results]
+    failed_repos = [r.repo for r in exec_results if not r.succeeded]
+
+    if overall == "success":
+        emit(
+            event_type=EventType.EXEC_COMPLETED,
+            workspace_root=workspace_root,
+            actor=actor,
+            owner_unit=owner_unit,
+            payload={
+                "lane": resolved_lane,
+                "command": command,
+                "overall_status": "success",
+                "repo_count": len(exec_results),
+            },
+        )
+    else:
+        emit(
+            event_type=EventType.EXEC_FAILED,
+            workspace_root=workspace_root,
+            actor=actor,
+            owner_unit=owner_unit,
+            payload={
+                "lane": resolved_lane,
+                "command": command,
+                "overall_status": "failed",
+                "failed_repos": failed_repos,
+                "repo_count": len(exec_results),
+            },
+        )
 
     return {
         "status": overall,
         "owner_unit": owner_unit,
         "lane": resolved_lane,
         "command": command,
-        "results": results,
+        "results": result_dicts,
     }
 
 

--- a/gr2/tests/test_events.py
+++ b/gr2/tests/test_events.py
@@ -78,8 +78,8 @@ class TestEventTypeEnum:
 
     def test_total_count(self):
         from gr2.python_cli.events import EventType
-        # 5 lane + 4 lease + 4 hook + 7 PR + 7 sync + 2 recovery + 2 workspace = 31
-        assert len(EventType) == 31
+        # 5 lane + 4 lease + 4 hook + 7 PR + 7 sync + 3 exec + 2 recovery + 2 workspace = 34
+        assert len(EventType) == 34
 
 
 # ---------------------------------------------------------------------------

--- a/gr2/tests/test_execops.py
+++ b/gr2/tests/test_execops.py
@@ -1,0 +1,292 @@
+"""Tests for gr2 exec lane-aware execution (grip#544).
+
+Tests the execution surface defined in GR2-MVP.md Gap 1:
+- Lane-scoped execution with repo filtering
+- Parallel vs sequential execution policy
+- Fail-fast vs collect-all behavior
+- Structured result reporting
+- Event emission (exec.started, exec.completed, exec.failed)
+"""
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from gr2.python_cli.events import EventType, _outbox_path
+from gr2.python_cli.execops import run_exec, ExecResult, run_exec_parallel
+
+
+class ExecTestBase(unittest.TestCase):
+    """Base class that sets up a minimal workspace with lane metadata."""
+
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.mkdtemp()
+        self.workspace = Path(self.tmp)
+        self.owner_unit = "test-unit"
+        self.lane_name = "test-lane"
+        self.actor = "agent:test"
+
+        lane_base = self.workspace / "agents" / self.owner_unit / "lanes" / self.lane_name
+        self.repos = ["repo-a", "repo-b", "repo-c"]
+        for repo in self.repos:
+            repo_dir = lane_base / "repos" / repo
+            repo_dir.mkdir(parents=True, exist_ok=True)
+
+        self.lane_doc = {
+            "lane_name": self.lane_name,
+            "owner_unit": self.owner_unit,
+            "lane_type": "feature",
+            "repos": self.repos,
+            "branch_map": {"repo-a": "feat/x", "repo-b": "feat/x", "repo-c": "feat/x"},
+            "exec_defaults": {
+                "parallelism": "sequential",
+                "fail_fast": True,
+                "commands": [],
+            },
+            "context": {"shared_roots": [], "private_roots": []},
+        }
+
+        events_dir = self.workspace / ".grip" / "events"
+        events_dir.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _read_events(self) -> list[dict]:
+        outbox = _outbox_path(self.workspace)
+        if not outbox.exists():
+            return []
+        events = []
+        for line in outbox.read_text().strip().split("\n"):
+            if line.strip():
+                events.append(json.loads(line))
+        return events
+
+    def _mock_lane_proto(self):
+        mock = MagicMock()
+        mock.load_current_lane_doc.return_value = {
+            "current": {"lane_name": self.lane_name}
+        }
+        mock.load_lane_doc.return_value = self.lane_doc
+        mock.load_unit_rebind_doc.return_value = None
+        mock.load_lane_leases.return_value = []
+        mock.conflicting_leases.return_value = ([], [])
+        mock.parse_repo_list.side_effect = lambda x: x.split(",")
+        mock.build_lease.return_value = {
+            "actor": self.actor, "mode": "exec", "ttl_seconds": 900
+        }
+        mock.mutate_lane_leases.return_value = {"status": "ok"}
+        mock.find_unit_spec.return_value = {}
+        mock.now_utc.return_value = "2026-04-17T00:00:00Z"
+        mock.emit_lane_event.return_value = None
+        return mock
+
+
+class TestExecRunSequential(ExecTestBase):
+    """Test sequential execution across lane repos."""
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_runs_command_in_each_repo(self, mock_proto):
+        mock_proto.__dict__.update(self._mock_lane_proto().__dict__)
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+
+        result = run_exec(
+            self.workspace, self.owner_unit, self.lane_name,
+            actor=self.actor, command=["echo", "hello"],
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(result["results"]), 3)
+        for r in result["results"]:
+            self.assertEqual(r["status"], "ok")
+            self.assertEqual(r["returncode"], 0)
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_fail_fast_stops_on_first_failure(self, mock_proto):
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+
+        result = run_exec(
+            self.workspace, self.owner_unit, self.lane_name,
+            actor=self.actor, command=["false"],
+        )
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(len(result["results"]), 1)
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_collect_all_continues_after_failure(self, mock_proto):
+        self.lane_doc["exec_defaults"]["fail_fast"] = False
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+
+        result = run_exec(
+            self.workspace, self.owner_unit, self.lane_name,
+            actor=self.actor, command=["false"],
+        )
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(len(result["results"]), 3)
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_repo_filtering(self, mock_proto):
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+
+        result = run_exec(
+            self.workspace, self.owner_unit, self.lane_name,
+            actor=self.actor, command=["echo", "hello"],
+            repos="repo-a,repo-c",
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(result["results"]), 2)
+        repo_names = [r["repo"] for r in result["results"]]
+        self.assertEqual(repo_names, ["repo-a", "repo-c"])
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_structured_results(self, mock_proto):
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+
+        result = run_exec(
+            self.workspace, self.owner_unit, self.lane_name,
+            actor=self.actor, command=["echo", "hello"],
+        )
+        r = result["results"][0]
+        self.assertIn("repo", r)
+        self.assertIn("cwd", r)
+        self.assertIn("status", r)
+        self.assertIn("returncode", r)
+        self.assertIn("stdout", r)
+        self.assertIn("stderr", r)
+
+
+class TestExecRunParallel(ExecTestBase):
+    """Test parallel execution mode."""
+
+    def test_parallel_runs_all_repos(self):
+        results = run_exec_parallel(
+            command=["echo", "hello"],
+            repo_rows=[
+                {"repo": "repo-a", "cwd": str(self.workspace / "agents" / self.owner_unit / "lanes" / self.lane_name / "repos" / "repo-a")},
+                {"repo": "repo-b", "cwd": str(self.workspace / "agents" / self.owner_unit / "lanes" / self.lane_name / "repos" / "repo-b")},
+            ],
+            max_workers=2,
+        )
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertEqual(r.status, "ok")
+            self.assertEqual(r.returncode, 0)
+
+    def test_parallel_preserves_repo_order_in_results(self):
+        results = run_exec_parallel(
+            command=["echo", "hello"],
+            repo_rows=[
+                {"repo": "repo-c", "cwd": str(self.workspace / "agents" / self.owner_unit / "lanes" / self.lane_name / "repos" / "repo-c")},
+                {"repo": "repo-a", "cwd": str(self.workspace / "agents" / self.owner_unit / "lanes" / self.lane_name / "repos" / "repo-a")},
+            ],
+            max_workers=2,
+        )
+        self.assertEqual(results[0].repo, "repo-c")
+        self.assertEqual(results[1].repo, "repo-a")
+
+    def test_parallel_handles_missing_dir(self):
+        results = run_exec_parallel(
+            command=["echo", "hello"],
+            repo_rows=[
+                {"repo": "repo-a", "cwd": str(self.workspace / "nonexistent")},
+            ],
+            max_workers=1,
+        )
+        self.assertEqual(results[0].status, "missing")
+
+
+class TestExecEvents(ExecTestBase):
+    """Test that exec emits proper events."""
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_emits_exec_started_event(self, mock_proto):
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+
+        run_exec(
+            self.workspace, self.owner_unit, self.lane_name,
+            actor=self.actor, command=["echo", "hello"],
+        )
+        events = self._read_events()
+        started = [e for e in events if e["type"] == "exec.started"]
+        self.assertEqual(len(started), 1)
+        self.assertEqual(started[0]["lane"], self.lane_name)
+        self.assertIn("command", started[0])
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_emits_exec_completed_on_success(self, mock_proto):
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+
+        run_exec(
+            self.workspace, self.owner_unit, self.lane_name,
+            actor=self.actor, command=["echo", "hello"],
+        )
+        events = self._read_events()
+        completed = [e for e in events if e["type"] == "exec.completed"]
+        self.assertEqual(len(completed), 1)
+        self.assertEqual(completed[0]["overall_status"], "success")
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_emits_exec_failed_on_failure(self, mock_proto):
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+
+        run_exec(
+            self.workspace, self.owner_unit, self.lane_name,
+            actor=self.actor, command=["false"],
+        )
+        events = self._read_events()
+        failed = [e for e in events if e["type"] == "exec.failed"]
+        self.assertEqual(len(failed), 1)
+        self.assertIn("failed_repos", failed[0])
+
+
+class TestExecResult(unittest.TestCase):
+    """Test ExecResult dataclass."""
+
+    def test_from_completed_process(self):
+        r = ExecResult(
+            repo="test-repo", cwd="/tmp/test", status="ok",
+            returncode=0, stdout="output\n", stderr="",
+        )
+        self.assertEqual(r.repo, "test-repo")
+        self.assertTrue(r.succeeded)
+
+    def test_failed_result(self):
+        r = ExecResult(
+            repo="test-repo", cwd="/tmp/test", status="failed",
+            returncode=1, stdout="", stderr="error\n",
+        )
+        self.assertFalse(r.succeeded)
+
+    def test_to_dict(self):
+        r = ExecResult(
+            repo="test-repo", cwd="/tmp/test", status="ok",
+            returncode=0, stdout="out", stderr="",
+        )
+        d = r.to_dict()
+        self.assertEqual(d["repo"], "test-repo")
+        self.assertEqual(d["returncode"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the exec lane-aware surface defined in GR2-MVP.md Gap 1. This is M1 work for Sprint 23.

**What changed:**
- `ExecResult` dataclass with `succeeded` property and `to_dict()` for structured results
- `_exec_one()` shared helper for single-repo execution (handles missing dirs)
- `run_exec_parallel()` using `ThreadPoolExecutor` with order-preserving results
- `run_exec()` now reads `parallelism` from lane defaults and dispatches to parallel or sequential mode
- Event emission: `exec.started` (before execution), `exec.completed` (on success), `exec.failed` (on failure with failed_repos list)
- 3 new `EventType` members: `EXEC_STARTED`, `EXEC_COMPLETED`, `EXEC_FAILED`
- 14 new tests across 4 test classes (sequential, parallel, events, ExecResult)

**Acceptance criteria (from grip#544):**
- [x] Commands run against the selected lane, not the whole workspace by default
- [x] Supports repo filtering (`repos` parameter)
- [x] Records enough metadata to report what ran and where (ExecResult with per-repo returncode, stdout, stderr)
- [x] Integrates with lane metadata rather than shell convention only
- [x] Parallel vs sequential execution policy (reads `parallelism` from lane `exec_defaults`)
- [x] Fail-fast vs collect-all behavior

Closes #544.

## Premium Boundary

**Premium boundary**: grip is OSS. The exec surface is neutral workspace infrastructure. It runs commands in lane-scoped repo directories. No identity resolution, no org routing, no agent identity logic.

## Test Plan

- 128 tests pass (14 new + 114 existing)
- Sequential: runs in each repo, fail-fast stops on first failure, collect-all continues
- Parallel: runs all repos concurrently, preserves result order, handles missing dirs
- Events: exec.started emitted before execution, exec.completed on success, exec.failed on failure
- Repo filtering: only selected repos are executed