### PR TITLE
release: gr1 1.0 — changelog, deprecation notice, README (grip#581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-17
+
+gr1 reaches stable. This release marks the feature-complete gr1 CLI before gr2 takes over as the primary workspace management system.
+
+### Summary
+
+gr1 ships as a production-ready multi-repo workspace tool with:
+
+- **Manifest-based configuration**: declarative YAML workspace definitions with composable gripspace inheritance, named remotes, and fork workflow support
+- **Synchronized operations**: branch, checkout, add, commit, push, pull, rebase, sync, and diff across all repos in parallel
+- **Linked PR workflow**: create, review, merge, and track pull requests that span multiple repos with all-or-nothing merge strategy and auto-merge support
+- **Griptrees**: worktree-based parallel workspaces for simultaneous multi-branch development with per-repo upstream tracking
+- **Multi-platform support**: GitHub, GitLab, Azure DevOps, and Bitbucket with platform-specific adapters and rate limiting
+- **Agent orchestration**: `gr spawn` for multi-agent session management with tmux, graceful shutdown, and configurable restart policies
+- **Developer tooling**: grep, prune, gc, cherry-pick, verify, release, benchmarks, shell completions, MCP server, and agent context generation
+- **Security hardening**: path traversal protection, credential sanitization, mutex poison recovery, thread panic propagation
+
+27 releases. 60+ commands. 4 hosting platforms. Production-tested across the synapt multi-agent team since January 2026.
+
+### Deprecation Notice
+
+**gr1 is now in maintenance mode.** gr2 (Python-first workspace orchestration) is the active development target. gr2 introduces declarative workspace specs, execution plans, lane-aware commands, and a migration path from gr1 gripspaces.
+
+See `gr2/docs/GR2-MVP.md` for the gr2 feature set and `gr2/docs/GR1-GR2-MIGRATION-PLAYBOOK.md` for migration instructions.
+
+New features will land in gr2. gr1 will receive only critical bug fixes.
+
 ## [0.20.0] - 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 ---
 
+> **gr1 has reached 1.0 and is now in maintenance mode.** [gr2](gr2/docs/GR2-MVP.md) is the active development target, bringing declarative workspace specs, lane-aware execution, and a migration path from gr1. See the [migration playbook](gr2/docs/GR1-GR2-MIGRATION-PLAYBOOK.md) for details. gr1 will receive critical bug fixes only.
+
 Manage multiple related repositories as a single workspace with synchronized branches, linked pull requests, and atomic merges.
 
 Inspired by Android's [repo tool](https://source.android.com/docs/setup/create/repo), gitgrip brings manifest-based multi-repo management to any project.


### PR DESCRIPTION
## Summary

gr1 reaches 1.0 stable. This PR adds the release framing before we tag:

- **CHANGELOG.md**: 1.0.0 entry summarizing the full gr1 capability set (27 releases, 60+ commands, 4 platforms)
- **README.md**: deprecation banner pointing to gr2 MVP doc and migration playbook

No code changes. No version bump yet (that happens at tag time).

Closes #581.

## Premium Boundary

Premium boundary: grip is OSS. Release documentation and deprecation notice are infrastructure housekeeping.

## Test Plan

- Doc-only change
- Verified links to gr2/docs/GR2-MVP.md and gr2/docs/GR1-GR2-MIGRATION-PLAYBOOK.md reference files that exist on sprint-23