### PR TITLE
style: cargo fmt on gr2 dispatch

### DIFF
--- a/gr2/src/dispatch.rs
+++ b/gr2/src/dispatch.rs
@@ -3,9 +3,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
-use crate::args::{
-    Commands, ExecCommands, LaneCommands, RepoCommands, SpecCommands, UnitCommands,
-};
+use crate::args::{Commands, ExecCommands, LaneCommands, RepoCommands, SpecCommands, UnitCommands};
 use crate::exec::{ExecStatusFilter, ExecStatusReport};
 use crate::lane::{
     create_lane, list_lanes, remove_lane, render_lane_table, show_lane, validate_lane_name,


### PR DESCRIPTION
Pre-ceremony formatting fix. `cargo fmt` collapsed a multi-line import in `gr2/src/dispatch.rs`.

Premium boundary: OSS (grip repo, code style only).