### PR TITLE
chore: release v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "0.20.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "0.20.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
## Summary

Bump version from 0.20.0 to 1.0.0. CHANGELOG entry was added in grip#591 (Sprint 23 ceremony).

gr1 reaches stable: 27 releases, 60+ commands, 4 hosting platforms. Now in maintenance mode; gr2 is the active development target.

Premium boundary: OSS (grip repo, version bump only).

## Test plan

- [x] `cargo build --release` — compiles cleanly
- [x] All tests passed in ceremony PR