### PR TITLE
fix: consolidate spawn env vars (1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-04-20
+
+### Fixed
+
+- `gr spawn up` no longer sends duplicate env vars. Hardcoded defaults, `spawn.env`, and `agent.env` are now consolidated into a single `export` command. Agent env wins over spawn env wins over hardcoded defaults.
+
 ## [1.0.0] - 2026-04-17
 
 gr1 reaches stable. This release marks the feature-complete gr1 CLI before gr2 takes over as the primary workspace management system.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"

--- a/src/cli/commands/spawn.rs
+++ b/src/cli/commands/spawn.rs
@@ -6,7 +6,7 @@
 use crate::cli::output::Output;
 use colored::Colorize;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -287,31 +287,29 @@ pub fn run_spawn_up(
             }
         };
 
-        // Send environment variables — GRIPSPACE_ROOT + SYNAPT_AGENT_ID first (#418, #510)
+        // Consolidate env vars into one export. Priority: agent.env > spawn.env > hardcoded.
         let grip_root = workspace_root.display();
-        let env_cmd = format!(
-            "export GRIPSPACE_ROOT=\"{}\" SYNAPT_AGENT_ID=\"{}\" AGENT_NAME={} AGENT_ROLE=\"{}\" SYNAPT_CHANNELS={} SYNAPT_LOOP_INTERVAL={}",
-            grip_root, agent_id, name, agent.role, channel, agent.loop_interval
-        );
+        let mut env_vars: BTreeMap<String, String> = BTreeMap::new();
+        env_vars.insert("GRIPSPACE_ROOT".into(), grip_root.to_string());
+        env_vars.insert("SYNAPT_AGENT_ID".into(), agent_id.clone());
+        env_vars.insert("AGENT_NAME".into(), name.to_string());
+        env_vars.insert("AGENT_ROLE".into(), agent.role.clone());
+        env_vars.insert("SYNAPT_CHANNELS".into(), channel.to_string());
+        env_vars.insert("SYNAPT_LOOP_INTERVAL".into(), agent.loop_interval.clone());
+        for (key, val) in &config.spawn.env {
+            env_vars.insert(key.clone(), val.clone());
+        }
+        for (key, val) in &agent.env {
+            env_vars.insert(key.clone(), val.clone());
+        }
+        let pairs: Vec<String> = env_vars
+            .iter()
+            .map(|(k, v)| format!("{}=\"{}\"", k, v))
+            .collect();
+        let env_cmd = format!("export {}", pairs.join(" "));
         let _ = Command::new("tmux")
             .args(["send-keys", "-t", &target, &env_cmd, "Enter"])
             .status();
-
-        // Send global spawn env vars from [spawn] config
-        for (key, val) in &config.spawn.env {
-            let global_env = format!("export {}=\"{}\"", key, val);
-            let _ = Command::new("tmux")
-                .args(["send-keys", "-t", &target, &global_env, "Enter"])
-                .status();
-        }
-
-        // Send per-agent custom env vars
-        for (key, val) in &agent.env {
-            let custom_env = format!("export {}=\"{}\"", key, val);
-            let _ = Command::new("tmux")
-                .args(["send-keys", "-t", &target, &custom_env, "Enter"])
-                .status();
-        }
 
         // Build and send launch command
         let launch_cmd = if mock_mode {


### PR DESCRIPTION
## Summary

- `gr spawn up` was sending each env var as a separate tmux `send-keys` call, with hardcoded vars (AGENT_NAME, SYNAPT_AGENT_ID, AGENT_ROLE, SYNAPT_CHANNELS, SYNAPT_LOOP_INTERVAL) duplicated by `agent.env` in agents.toml
- Consolidated into a single `export` command using a BTreeMap with clear priority: `agent.env` > `spawn.env` > hardcoded defaults
- Reduces ~9 tmux send-keys calls to 2 (one export, one launch command)
- Bumps version to 1.0.1

**Premium boundary**: core OSS (spawn orchestration infrastructure).

## Test plan

- [x] `cargo build` compiles clean
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] All 9 spawn tests pass
- [ ] Manual: `gr spawn up --agent opus` sends one consolidated export line

🤖 Generated with [Claude Code](https://claude.com/claude-code)