### PR TITLE
feat: config base+overlay model Phase 1

### DIFF
--- a/gr2/python_cli/config.py
+++ b/gr2/python_cli/config.py
@@ -1,0 +1,291 @@
+"""Config base + overlay model: Docker OverlayFS analogy for workspace config.
+
+Base layer: TOML files (cold, human-authored, git-reviewed)
+Overlay layer: JSON files (hot, agent-writable)
+Reads: overlay first, base fallback
+Writes: overlay only
+_base_sha: overlay tracks which base version it extends
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import toml
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class BaseStaleError(Exception):
+    """Raised when overlay's _base_sha doesn't match current base content."""
+
+
+class PolicyViolationError(Exception):
+    """Raised when a write is blocked by the active policy."""
+
+
+# ---------------------------------------------------------------------------
+# Policies
+# ---------------------------------------------------------------------------
+
+
+class WritePolicy(ABC):
+    @abstractmethod
+    def can_write(self, agent: str, section: str, key: str) -> bool: ...
+
+
+class FreeWritePolicy(WritePolicy):
+    def can_write(self, agent: str, section: str, key: str) -> bool:
+        return True
+
+
+class OwnWriteOnlyPolicy(WritePolicy):
+    """Agents can only write to their own section (agents.<name>, prompts.<name>).
+
+    Shared sections (spawn, tools, etc.) are writable by anyone.
+    """
+
+    _SCOPED_PREFIXES = ("agents.", "prompts.")
+
+    def can_write(self, agent: str, section: str, key: str) -> bool:
+        for prefix in self._SCOPED_PREFIXES:
+            if section.startswith(prefix):
+                section_owner = section[len(prefix) :].split(".")[0]
+                return section_owner == agent
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_sha(content: str) -> str:
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def _deep_merge(base: dict, overlay: dict) -> dict:
+    """Recursively merge overlay into base. Overlay wins on conflict."""
+    result = deepcopy(base)
+    for key, val in overlay.items():
+        if key == "_base_sha":
+            continue
+        if key in result and isinstance(result[key], dict) and isinstance(val, dict):
+            result[key] = _deep_merge(result[key], val)
+        else:
+            result[key] = deepcopy(val)
+    return result
+
+
+def _resolve_dotted_key(data: dict, key: str) -> Any:
+    parts = key.split(".")
+    current: Any = data
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _set_nested(data: dict, dotted_section: str, key: str, value: Any) -> None:
+    parts = dotted_section.split(".")
+    current = data
+    for part in parts:
+        if part not in current or not isinstance(current[part], dict):
+            current[part] = {}
+        current = current[part]
+    current[key] = value
+
+
+def _overlay_stem(base_path: Path) -> str:
+    return base_path.stem
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def config_apply(base_path: Path, overlay_dir: Path) -> dict:
+    """Materialize TOML base into JSON overlay with _base_sha.
+
+    If overlay already exists, merges new base keys into it while
+    preserving existing overlay modifications.
+    """
+    base_content = base_path.read_text()
+    base_data = toml.loads(base_content)
+    sha = _base_sha(base_content)
+
+    overlay_dir.mkdir(parents=True, exist_ok=True)
+    overlay_path = overlay_dir / f"{_overlay_stem(base_path)}.json"
+
+    if overlay_path.exists():
+        existing = json.loads(overlay_path.read_text())
+        existing.pop("_base_sha", None)
+        merged = _deep_merge(base_data, existing)
+    else:
+        merged = deepcopy(base_data)
+
+    merged["_base_sha"] = sha
+    overlay_path.write_text(json.dumps(merged, indent=2) + "\n")
+    return {k: v for k, v in merged.items() if k != "_base_sha"}
+
+
+def config_show(
+    base_path: Path,
+    overlay_dir: Path,
+    key: str | None = None,
+    *,
+    strict: bool = False,
+) -> Any:
+    """Read config with overlay-first, base-fallback resolution.
+
+    If key is None, returns the full merged dict.
+    If key is a dotted path (e.g. "agents.opus.model"), resolves to that value.
+    Returns None for missing keys.
+    """
+    base_content = base_path.read_text()
+    base_data = toml.loads(base_content)
+
+    overlay_path = overlay_dir / f"{_overlay_stem(base_path)}.json"
+    overlay_data: dict = {}
+
+    if overlay_path.exists():
+        overlay_data = json.loads(overlay_path.read_text())
+        if strict:
+            stored_sha = overlay_data.get("_base_sha", "")
+            current_sha = _base_sha(base_content)
+            if stored_sha != current_sha:
+                raise BaseStaleError(
+                    f"Overlay _base_sha ({stored_sha[:12]}...) does not match "
+                    f"current base ({current_sha[:12]}...)"
+                )
+
+    clean_overlay = {k: v for k, v in overlay_data.items() if k != "_base_sha"}
+    merged = _deep_merge(base_data, clean_overlay)
+
+    # Include prompt overlays in the merged view
+    prompts_dir = overlay_dir / "prompts"
+    if prompts_dir.is_dir():
+        prompts: dict[str, Any] = merged.get("prompts", {})
+        for pf in sorted(prompts_dir.glob("*.json")):
+            agent_name = pf.stem
+            agent_prompts = json.loads(pf.read_text())
+            if agent_name in prompts and isinstance(prompts[agent_name], dict):
+                prompts[agent_name] = _deep_merge(prompts[agent_name], agent_prompts)
+            else:
+                prompts[agent_name] = agent_prompts
+        if prompts:
+            merged["prompts"] = prompts
+
+    if key is None:
+        return merged
+    return _resolve_dotted_key(merged, key)
+
+
+def overlay_write(
+    overlay_dir: Path,
+    section: str,
+    key: str,
+    value: Any,
+    *,
+    agent: str = "",
+    policy: WritePolicy | None = None,
+    prompt_overlay: bool = False,
+) -> None:
+    """Write a value to the overlay. Respects policy enforcement.
+
+    If prompt_overlay is True, writes to prompts/{agent_name}.json instead
+    of the main overlay file.
+    """
+    if policy is not None and agent:
+        if not policy.can_write(agent=agent, section=section, key=key):
+            raise PolicyViolationError(
+                f"Agent '{agent}' cannot write to section '{section}' "
+                f"under {policy.__class__.__name__}"
+            )
+
+    if prompt_overlay:
+        parts = section.split(".")
+        if len(parts) >= 2 and parts[0] == "prompts":
+            agent_name = parts[1]
+            prompts_dir = overlay_dir / "prompts"
+            prompts_dir.mkdir(parents=True, exist_ok=True)
+            prompt_path = prompts_dir / f"{agent_name}.json"
+
+            data: dict = {}
+            if prompt_path.exists():
+                data = json.loads(prompt_path.read_text())
+            data[key] = value
+            prompt_path.write_text(json.dumps(data, indent=2) + "\n")
+            return
+
+    overlay_path = overlay_dir / "agents.json"
+    if not overlay_path.exists():
+        raise FileNotFoundError(
+            f"Overlay file not found: {overlay_path}. Run config_apply first."
+        )
+
+    data = json.loads(overlay_path.read_text())
+    _set_nested(data, section, key, value)
+    overlay_path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def config_restore(workspace: Path, ref: str, overlay_dir: Path) -> dict:
+    """Restore overlay files from a grip commit's config/ subtree."""
+    from python_cli.grip import _grip_git
+
+    proc = _grip_git(workspace, "ls-tree", f"{ref}:config")
+    if proc.returncode != 0:
+        return {}
+
+    overlay_dir.mkdir(parents=True, exist_ok=True)
+    restored: dict[str, str] = {}
+
+    for line in proc.stdout.strip().splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        meta, name = parts[0], parts[1]
+        obj_type = meta.split()[1]
+
+        if obj_type == "blob":
+            blob = _grip_git(workspace, "show", f"{ref}:config/{name}")
+            if blob.returncode == 0:
+                (overlay_dir / name).write_text(blob.stdout)
+                restored[name] = "restored"
+        elif obj_type == "tree" and name == "prompts":
+            _restore_prompts(workspace, ref, overlay_dir)
+
+    return restored
+
+
+def _restore_prompts(workspace: Path, ref: str, overlay_dir: Path) -> None:
+    from python_cli.grip import _grip_git
+
+    prompts_dir = overlay_dir / "prompts"
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+
+    proc = _grip_git(workspace, "ls-tree", f"{ref}:config/prompts")
+    if proc.returncode != 0:
+        return
+
+    for line in proc.stdout.strip().splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        name = parts[1]
+        blob = _grip_git(workspace, "show", f"{ref}:config/prompts/{name}")
+        if blob.returncode == 0:
+            (prompts_dir / name).write_text(blob.stdout)

--- a/gr2/python_cli/grip.py
+++ b/gr2/python_cli/grip.py
@@ -153,6 +153,31 @@ def _changeset_tree(
     return _mktree(workspace, blobs)
 
 
+def _config_overlay_tree(workspace: Path, overlay_dir: Path) -> str | None:
+    """Build a config/ tree from overlay JSON files for inclusion in grip commit."""
+    entries: list[str] = []
+
+    for f in sorted(overlay_dir.glob("*.json")):
+        content = f.read_text()
+        sha = _hash_blob(workspace, content)
+        entries.append(f"100644 blob {sha}\t{f.name}")
+
+    prompts_dir = overlay_dir / "prompts"
+    if prompts_dir.is_dir():
+        prompt_entries: list[str] = []
+        for pf in sorted(prompts_dir.glob("*.json")):
+            content = pf.read_text()
+            sha = _hash_blob(workspace, content)
+            prompt_entries.append(f"100644 blob {sha}\t{pf.name}")
+        if prompt_entries:
+            prompts_tree = _mktree(workspace, prompt_entries)
+            entries.append(f"040000 tree {prompts_tree}\tprompts")
+
+    if not entries:
+        return None
+    return _mktree(workspace, entries)
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -178,6 +203,7 @@ def grip_snapshot(
     changeset_type: str = "",
     sprint: str = "",
     message: str = "",
+    overlay_dir: Path | None = None,
 ) -> str:
     """Create a grip commit from current repo states. Returns commit SHA."""
     repo_entries: list[str] = []
@@ -191,6 +217,11 @@ def grip_snapshot(
     cs_tree = _changeset_tree(workspace, changeset_type=changeset_type, sprint=sprint)
     if cs_tree:
         root_entries.append(f"040000 tree {cs_tree}\t.grip")
+
+    if overlay_dir and overlay_dir.is_dir():
+        config_tree = _config_overlay_tree(workspace, overlay_dir)
+        if config_tree:
+            root_entries.append(f"040000 tree {config_tree}\tconfig")
 
     root_tree = _mktree(workspace, root_entries)
 

--- a/gr2/tests/test_config_overlay.py
+++ b/gr2/tests/test_config_overlay.py
@@ -1,0 +1,508 @@
+"""TDD tests for Phase 1: base + overlay configuration model.
+
+Tests define the interface contract for:
+  - config_apply: materialize TOML base into JSON overlay with _base_sha
+  - config_show: overlay-first read resolution with base fallback
+  - config_restore: roll back overlay to grip commit snapshot
+  - overlay_write: write to overlay with policy enforcement
+  - Per-agent prompt overlays
+  - _base_sha referential integrity
+  - Policy stubs: FreeWritePolicy, OwnWriteOnlyPolicy
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from python_cli.config import (
+    BaseStaleError,
+    FreeWritePolicy,
+    OwnWriteOnlyPolicy,
+    PolicyViolationError,
+    config_apply,
+    config_restore,
+    config_show,
+    overlay_write,
+)
+from python_cli.gitops import git
+from python_cli.grip import grip_init, grip_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_TOML = """\
+[spawn]
+session_name = "synapt"
+channel = "dev"
+
+[agents.opus]
+role = "CEO / product design"
+model = "claude-opus-4-6"
+worktree = "main"
+loop_interval = "1m"
+
+[agents.apollo]
+role = "Rust implementation / gitgrip"
+model = "claude-opus-4-6"
+worktree = "synapt-dev"
+loop_interval = "5m"
+"""
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Workspace with a TOML base config and overlay directory."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    config_dir = ws / "config"
+    config_dir.mkdir()
+    (config_dir / "agents.toml").write_text(SAMPLE_TOML)
+    (config_dir / "overlay").mkdir()
+    return ws
+
+
+@pytest.fixture
+def applied_workspace(workspace: Path) -> Path:
+    """Workspace with config_apply already run."""
+    config_apply(
+        base_path=workspace / "config" / "agents.toml",
+        overlay_dir=workspace / "config" / "overlay",
+    )
+    return workspace
+
+
+@pytest.fixture
+def grip_workspace(workspace: Path) -> Path:
+    """Workspace with .grip/ repo and a sample git repo for snapshotting."""
+    repo = workspace / "recall"
+    repo.mkdir()
+    git(repo, "init")
+    git(repo, "config", "user.email", "test@test.com")
+    git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("# recall\n")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "init")
+    git(repo, "remote", "add", "origin", "https://github.com/synapt-dev/recall")
+    grip_init(workspace)
+    return workspace
+
+
+# ---------------------------------------------------------------------------
+# config_apply
+# ---------------------------------------------------------------------------
+
+
+class TestConfigApply:
+    def test_creates_overlay_json(self, workspace: Path) -> None:
+        config_apply(
+            base_path=workspace / "config" / "agents.toml",
+            overlay_dir=workspace / "config" / "overlay",
+        )
+        overlay = workspace / "config" / "overlay" / "agents.json"
+        assert overlay.exists()
+
+    def test_overlay_contains_base_data(self, workspace: Path) -> None:
+        config_apply(
+            base_path=workspace / "config" / "agents.toml",
+            overlay_dir=workspace / "config" / "overlay",
+        )
+        overlay = json.loads(
+            (workspace / "config" / "overlay" / "agents.json").read_text()
+        )
+        assert overlay["spawn"]["session_name"] == "synapt"
+        assert overlay["agents"]["opus"]["role"] == "CEO / product design"
+
+    def test_overlay_has_base_sha(self, workspace: Path) -> None:
+        config_apply(
+            base_path=workspace / "config" / "agents.toml",
+            overlay_dir=workspace / "config" / "overlay",
+        )
+        overlay = json.loads(
+            (workspace / "config" / "overlay" / "agents.json").read_text()
+        )
+        assert "_base_sha" in overlay
+        expected = hashlib.sha256(SAMPLE_TOML.encode()).hexdigest()
+        assert overlay["_base_sha"] == expected
+
+    def test_returns_applied_config(self, workspace: Path) -> None:
+        result = config_apply(
+            base_path=workspace / "config" / "agents.toml",
+            overlay_dir=workspace / "config" / "overlay",
+        )
+        assert isinstance(result, dict)
+        assert "agents" in result
+        assert "spawn" in result
+
+    def test_idempotent(self, workspace: Path) -> None:
+        overlay_dir = workspace / "config" / "overlay"
+        r1 = config_apply(
+            base_path=workspace / "config" / "agents.toml",
+            overlay_dir=overlay_dir,
+        )
+        r2 = config_apply(
+            base_path=workspace / "config" / "agents.toml",
+            overlay_dir=overlay_dir,
+        )
+        assert r1 == r2
+
+
+# ---------------------------------------------------------------------------
+# config_show
+# ---------------------------------------------------------------------------
+
+
+class TestConfigShow:
+    def test_returns_full_merged_config(self, applied_workspace: Path) -> None:
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=applied_workspace / "config" / "overlay",
+        )
+        assert "spawn" in result
+        assert "agents" in result
+
+    def test_base_values_present(self, applied_workspace: Path) -> None:
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=applied_workspace / "config" / "overlay",
+        )
+        assert result["agents"]["opus"]["model"] == "claude-opus-4-6"
+
+    def test_overlay_overrides_base(self, applied_workspace: Path) -> None:
+        overlay_path = applied_workspace / "config" / "overlay" / "agents.json"
+        overlay = json.loads(overlay_path.read_text())
+        overlay["agents"]["opus"]["model"] = "claude-opus-4-7"
+        overlay_path.write_text(json.dumps(overlay))
+
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=applied_workspace / "config" / "overlay",
+        )
+        assert result["agents"]["opus"]["model"] == "claude-opus-4-7"
+
+    def test_base_fallback_for_missing_overlay_key(self, applied_workspace: Path) -> None:
+        overlay_path = applied_workspace / "config" / "overlay" / "agents.json"
+        overlay = json.loads(overlay_path.read_text())
+        del overlay["agents"]["opus"]["worktree"]
+        overlay_path.write_text(json.dumps(overlay))
+
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=applied_workspace / "config" / "overlay",
+        )
+        assert result["agents"]["opus"]["worktree"] == "main"
+
+    def test_dotted_key_access(self, applied_workspace: Path) -> None:
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=applied_workspace / "config" / "overlay",
+            key="agents.opus.role",
+        )
+        assert result == "CEO / product design"
+
+    def test_dotted_key_returns_subtree(self, applied_workspace: Path) -> None:
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=applied_workspace / "config" / "overlay",
+            key="agents.opus",
+        )
+        assert isinstance(result, dict)
+        assert "role" in result
+        assert "model" in result
+
+    def test_missing_key_returns_none(self, applied_workspace: Path) -> None:
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=applied_workspace / "config" / "overlay",
+            key="agents.nonexistent.field",
+        )
+        assert result is None
+
+    def test_no_overlay_file_falls_back_to_base(self, workspace: Path) -> None:
+        result = config_show(
+            base_path=workspace / "config" / "agents.toml",
+            overlay_dir=workspace / "config" / "overlay",
+        )
+        assert result["spawn"]["session_name"] == "synapt"
+
+
+# ---------------------------------------------------------------------------
+# overlay_write
+# ---------------------------------------------------------------------------
+
+
+class TestOverlayWrite:
+    def test_writes_value_to_overlay(self, applied_workspace: Path) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        overlay_write(overlay_dir, "agents.opus", "model", "claude-opus-4-7")
+
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        assert overlay["agents"]["opus"]["model"] == "claude-opus-4-7"
+
+    def test_preserves_existing_overlay_values(self, applied_workspace: Path) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        overlay_write(overlay_dir, "agents.opus", "model", "claude-opus-4-7")
+
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        assert overlay["agents"]["opus"]["role"] == "CEO / product design"
+        assert overlay["spawn"]["session_name"] == "synapt"
+
+    def test_creates_new_section(self, applied_workspace: Path) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        overlay_write(overlay_dir, "agents.sentinel", "model", "gpt-5.4")
+
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        assert overlay["agents"]["sentinel"]["model"] == "gpt-5.4"
+
+    def test_preserves_base_sha(self, applied_workspace: Path) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        original = json.loads((overlay_dir / "agents.json").read_text())
+        original_sha = original["_base_sha"]
+
+        overlay_write(overlay_dir, "agents.opus", "model", "claude-opus-4-7")
+
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        assert overlay["_base_sha"] == original_sha
+
+
+# ---------------------------------------------------------------------------
+# Per-agent prompt overlays
+# ---------------------------------------------------------------------------
+
+
+class TestPromptOverlays:
+    def test_write_agent_prompt(self, applied_workspace: Path) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        overlay_write(
+            overlay_dir,
+            "prompts.opus",
+            "system_prompt",
+            "You are the CEO.",
+            prompt_overlay=True,
+        )
+        prompt_file = overlay_dir / "prompts" / "opus.json"
+        assert prompt_file.exists()
+
+    def test_read_agent_prompt(self, applied_workspace: Path) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        overlay_write(
+            overlay_dir,
+            "prompts.opus",
+            "system_prompt",
+            "You are the CEO.",
+            prompt_overlay=True,
+        )
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=overlay_dir,
+            key="prompts.opus.system_prompt",
+        )
+        assert result == "You are the CEO."
+
+    def test_separate_files_per_agent(self, applied_workspace: Path) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        overlay_write(
+            overlay_dir, "prompts.opus", "hint", "product focus", prompt_overlay=True
+        )
+        overlay_write(
+            overlay_dir, "prompts.apollo", "hint", "rust focus", prompt_overlay=True
+        )
+        assert (overlay_dir / "prompts" / "opus.json").exists()
+        assert (overlay_dir / "prompts" / "apollo.json").exists()
+
+        opus_data = json.loads((overlay_dir / "prompts" / "opus.json").read_text())
+        apollo_data = json.loads((overlay_dir / "prompts" / "apollo.json").read_text())
+        assert opus_data["hint"] == "product focus"
+        assert apollo_data["hint"] == "rust focus"
+
+
+# ---------------------------------------------------------------------------
+# _base_sha referential integrity
+# ---------------------------------------------------------------------------
+
+
+class TestBaseShaIntegrity:
+    def test_stale_overlay_detected(self, applied_workspace: Path) -> None:
+        base_path = applied_workspace / "config" / "agents.toml"
+        overlay_dir = applied_workspace / "config" / "overlay"
+
+        base_path.write_text(SAMPLE_TOML + '\n[agents.sentinel]\nrole = "QA"\n')
+
+        with pytest.raises(BaseStaleError):
+            config_show(base_path, overlay_dir, strict=True)
+
+    def test_stale_overlay_allowed_in_non_strict_mode(
+        self, applied_workspace: Path
+    ) -> None:
+        base_path = applied_workspace / "config" / "agents.toml"
+        overlay_dir = applied_workspace / "config" / "overlay"
+
+        base_path.write_text(SAMPLE_TOML + '\n[agents.sentinel]\nrole = "QA"\n')
+
+        result = config_show(base_path, overlay_dir)
+        assert "agents" in result
+
+    def test_reapply_updates_base_sha(self, applied_workspace: Path) -> None:
+        base_path = applied_workspace / "config" / "agents.toml"
+        overlay_dir = applied_workspace / "config" / "overlay"
+
+        new_toml = SAMPLE_TOML + '\n[agents.sentinel]\nrole = "QA"\n'
+        base_path.write_text(new_toml)
+        config_apply(base_path, overlay_dir)
+
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        expected = hashlib.sha256(new_toml.encode()).hexdigest()
+        assert overlay["_base_sha"] == expected
+
+    def test_reapply_preserves_overlay_modifications(
+        self, applied_workspace: Path
+    ) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        overlay_write(overlay_dir, "agents.opus", "model", "claude-opus-4-7")
+
+        base_path = applied_workspace / "config" / "agents.toml"
+        new_toml = SAMPLE_TOML + '\n[agents.sentinel]\nrole = "QA"\n'
+        base_path.write_text(new_toml)
+        config_apply(base_path, overlay_dir)
+
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        assert overlay["agents"]["opus"]["model"] == "claude-opus-4-7"
+        assert overlay["agents"]["sentinel"]["role"] == "QA"
+
+
+# ---------------------------------------------------------------------------
+# config_restore
+# ---------------------------------------------------------------------------
+
+
+class TestConfigRestore:
+    def test_restores_overlay_from_grip_commit(self, grip_workspace: Path) -> None:
+        base_path = grip_workspace / "config" / "agents.toml"
+        overlay_dir = grip_workspace / "config" / "overlay"
+        config_apply(base_path, overlay_dir)
+
+        snap_sha = grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+            overlay_dir=overlay_dir,
+        )
+
+        overlay_write(overlay_dir, "agents.opus", "model", "claude-opus-4-7")
+
+        config_restore(grip_workspace, snap_sha, overlay_dir)
+
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        assert overlay["agents"]["opus"]["model"] == "claude-opus-4-6"
+
+    def test_restores_prompt_overlays(self, grip_workspace: Path) -> None:
+        base_path = grip_workspace / "config" / "agents.toml"
+        overlay_dir = grip_workspace / "config" / "overlay"
+        config_apply(base_path, overlay_dir)
+        overlay_write(
+            overlay_dir, "prompts.opus", "hint", "original hint", prompt_overlay=True
+        )
+
+        snap_sha = grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+            overlay_dir=overlay_dir,
+        )
+
+        overlay_write(
+            overlay_dir, "prompts.opus", "hint", "changed hint", prompt_overlay=True
+        )
+
+        config_restore(grip_workspace, snap_sha, overlay_dir)
+
+        prompt = json.loads((overlay_dir / "prompts" / "opus.json").read_text())
+        assert prompt["hint"] == "original hint"
+
+    def test_restore_to_older_snapshot(self, grip_workspace: Path) -> None:
+        base_path = grip_workspace / "config" / "agents.toml"
+        overlay_dir = grip_workspace / "config" / "overlay"
+        config_apply(base_path, overlay_dir)
+
+        sha1 = grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+            overlay_dir=overlay_dir,
+        )
+
+        overlay_write(overlay_dir, "agents.opus", "model", "claude-opus-4-7")
+        (grip_workspace / "recall" / "new.txt").write_text("change")
+        git(grip_workspace / "recall", "add", ".")
+        git(grip_workspace / "recall", "commit", "-m", "second")
+
+        grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+            overlay_dir=overlay_dir,
+        )
+
+        config_restore(grip_workspace, sha1, overlay_dir)
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        assert overlay["agents"]["opus"]["model"] == "claude-opus-4-6"
+
+
+# ---------------------------------------------------------------------------
+# Policy stubs
+# ---------------------------------------------------------------------------
+
+
+class TestPolicies:
+    def test_free_write_allows_any_write(self) -> None:
+        policy = FreeWritePolicy()
+        assert policy.can_write(agent="opus", section="agents.apollo", key="model")
+        assert policy.can_write(agent="apollo", section="spawn", key="channel")
+
+    def test_own_write_only_allows_own_section(self) -> None:
+        policy = OwnWriteOnlyPolicy()
+        assert policy.can_write(agent="opus", section="agents.opus", key="model")
+        assert policy.can_write(agent="apollo", section="agents.apollo", key="model")
+        assert policy.can_write(agent="opus", section="prompts.opus", key="hint")
+
+    def test_own_write_only_blocks_other_section(self) -> None:
+        policy = OwnWriteOnlyPolicy()
+        assert not policy.can_write(agent="opus", section="agents.apollo", key="model")
+        assert not policy.can_write(agent="apollo", section="agents.opus", key="role")
+        assert not policy.can_write(agent="opus", section="prompts.apollo", key="hint")
+
+    def test_own_write_only_allows_shared_sections(self) -> None:
+        policy = OwnWriteOnlyPolicy()
+        assert policy.can_write(agent="opus", section="spawn", key="channel")
+
+    def test_overlay_write_with_policy_enforcement(
+        self, applied_workspace: Path
+    ) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        policy = OwnWriteOnlyPolicy()
+
+        overlay_write(
+            overlay_dir,
+            "agents.opus",
+            "model",
+            "claude-opus-4-7",
+            agent="opus",
+            policy=policy,
+        )
+        overlay = json.loads((overlay_dir / "agents.json").read_text())
+        assert overlay["agents"]["opus"]["model"] == "claude-opus-4-7"
+
+    def test_overlay_write_blocked_by_policy(self, applied_workspace: Path) -> None:
+        overlay_dir = applied_workspace / "config" / "overlay"
+        policy = OwnWriteOnlyPolicy()
+
+        with pytest.raises(PolicyViolationError):
+            overlay_write(
+                overlay_dir,
+                "agents.apollo",
+                "model",
+                "gpt-5.4",
+                agent="opus",
+                policy=policy,
+            )


### PR DESCRIPTION
## Summary

- Implements `python_cli/config.py`: config_apply, config_show, overlay_write, config_restore
- Docker OverlayFS analogy: TOML base (cold, reviewed) + JSON overlay (hot, agent-writable)
- `_base_sha` referential integrity: overlay tracks which base version it extends, strict mode detects stale overlay
- Per-agent prompt overlays at `config/overlay/prompts/{agent}.json`
- Policy protocol with two stubs: `FreeWritePolicy` (any write allowed), `OwnWriteOnlyPolicy` (agents restricted to own section)
- Extends `grip_snapshot` with `overlay_dir` parameter to include config state in grip commits
- All 33 Phase 1 tests pass, all 35 Phase 0 tests still pass (68 total)

## Premium boundary

Premium boundary: OSS (local config materialization). Policy stubs receive agent name as parameter; they don't derive identity from filesystem or org context. The `WritePolicy` ABC is a neutral seam for premium policy implementations.

## Test plan

- [x] 33/33 config overlay tests pass
- [x] 35/35 Phase 0 grip snapshot tests pass (no regressions)
- [x] config_apply materializes TOML to JSON with correct _base_sha
- [x] config_show merges overlay over base, supports dotted key access
- [x] overlay_write respects policy enforcement
- [x] config_restore rolls back overlay from grip commit
- [x] Per-agent prompt overlays stored in separate files
- [x] Stale overlay detection in strict mode

Ref: #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)