### PR TITLE
fix: grip object model hardening (adversarial edge cases)

### DIFF
--- a/gr2/python_cli/grip.py
+++ b/gr2/python_cli/grip.py
@@ -13,6 +13,19 @@ from python_cli.gitops import git
 
 
 # ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class GripInitError(Exception):
+    """Raised when .grip/ repo is missing or not properly initialized."""
+
+
+class GripCorruptError(Exception):
+    """Raised when .grip/ repo state is corrupt (bad HEAD, missing objects)."""
+
+
+# ---------------------------------------------------------------------------
 # Data types
 # ---------------------------------------------------------------------------
 
@@ -39,6 +52,25 @@ class GripDiff:
 
 def _grip_git(workspace: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return git(workspace / ".grip", *args)
+
+
+def _validate_grip_repo(workspace: Path) -> None:
+    """Verify .grip/ is a valid git repo. Raises GripInitError if not."""
+    grip_dir = workspace / ".grip"
+    if not grip_dir.exists():
+        raise GripInitError(
+            f"No .grip/ directory at {workspace}. Run grip_init first."
+        )
+    git_dir = grip_dir / ".git"
+    if not git_dir.exists():
+        raise GripInitError(
+            f".grip/ exists but has no .git/ at {workspace}. Run grip_init to repair."
+        )
+    if git_dir.is_file():
+        raise GripInitError(
+            f".grip/.git is a file, not a directory (corrupt). "
+            f"Remove {git_dir} and run grip_init to repair."
+        )
 
 
 def _hash_blob(workspace: Path, content: str) -> str:
@@ -101,15 +133,35 @@ def _git_env() -> dict[str, str]:
     return env
 
 
-def _current_head(workspace: Path) -> str | None:
+def _current_head(workspace: Path, *, strict: bool = False) -> str | None:
+    """Get current HEAD of .grip/ repo.
+
+    Returns None if no commits yet. Raises GripCorruptError if HEAD exists
+    but points to invalid state (when strict=True or when HEAD file is missing/corrupt).
+    """
+    head_path = workspace / ".grip" / ".git" / "HEAD"
+    if not head_path.exists():
+        raise GripCorruptError(
+            f".grip/.git/HEAD is missing at {workspace}. "
+            "The grip repo may be corrupt."
+        )
+
     proc = _grip_git(workspace, "rev-parse", "HEAD")
     if proc.returncode != 0:
-        return None
+        head_content = head_path.read_text().strip()
+        if head_content.startswith("ref: "):
+            return None
+        raise GripCorruptError(
+            f".grip/HEAD points to invalid ref: {head_content!r}. "
+            "The grip repo may be corrupt."
+        )
     return proc.stdout.strip() or None
 
 
 def _repo_tree_entries(workspace: Path, name: str, repo_path: Path) -> str:
     """Build a tree for one repo and return an mktree entry line."""
+    from python_cli.gitops import repo_dirty
+
     blobs: list[str] = []
 
     head = git(repo_path, "rev-parse", "HEAD")
@@ -126,6 +178,10 @@ def _repo_tree_entries(workspace: Path, name: str, repo_path: Path) -> str:
     if remote.returncode == 0 and remote.stdout.strip():
         sha = _hash_blob(workspace, remote.stdout.strip())
         blobs.append(f"100644 blob {sha}\tremote")
+
+    is_dirty = repo_dirty(repo_path)
+    dirty_sha = _hash_blob(workspace, "true" if is_dirty else "false")
+    blobs.append(f"100644 blob {dirty_sha}\tdirty")
 
     tree_sha = _mktree(workspace, blobs)
     return f"040000 tree {tree_sha}\t{name}"
@@ -189,6 +245,11 @@ def grip_init(workspace: Path) -> Path:
     if not grip_dir.exists():
         grip_dir.mkdir(parents=True)
     git_dir = grip_dir / ".git"
+    if git_dir.is_file():
+        raise GripInitError(
+            f".grip/.git is a file, not a directory (corrupt). "
+            f"Remove {git_dir} and run grip_init again."
+        )
     if not git_dir.exists():
         git(grip_dir, "init")
         git(grip_dir, "config", "user.email", "grip@synapt.dev")
@@ -206,6 +267,7 @@ def grip_snapshot(
     overlay_dir: Path | None = None,
 ) -> str:
     """Create a grip commit from current repo states. Returns commit SHA."""
+    _validate_grip_repo(workspace)
     repo_entries: list[str] = []
     for name in sorted(repos):
         entry = _repo_tree_entries(workspace, name, repos[name])
@@ -236,6 +298,7 @@ def grip_snapshot(
 
 def grip_log(workspace: Path, *, max_count: int = 10) -> list[GripCommitInfo]:
     """List grip commit history, most recent first."""
+    _validate_grip_repo(workspace)
     head = _current_head(workspace)
     if not head:
         return []
@@ -282,6 +345,7 @@ def _read_repo_names(workspace: Path, commit_sha: str) -> list[str]:
 
 def grip_diff(workspace: Path, ref_a: str, ref_b: str) -> GripDiff:
     """Compare two grip commits and return changed/added/removed repos."""
+    _validate_grip_repo(workspace)
     repos_a = _read_repo_state(workspace, ref_a)
     repos_b = _read_repo_state(workspace, ref_b)
 
@@ -336,6 +400,15 @@ def grip_checkout(workspace: Path, ref: str) -> dict[str, str]:
 
     Returns dict mapping repo name to commit SHA.
     """
+    _validate_grip_repo(workspace)
+
+    # Verify the ref resolves to a valid object
+    verify = _grip_git(workspace, "cat-file", "-t", ref)
+    if verify.returncode != 0:
+        raise GripCorruptError(
+            f"Ref '{ref}' does not resolve to a valid object in .grip/ repo."
+        )
+
     repo_states = _read_repo_state(workspace, ref)
     result: dict[str, str] = {}
 

--- a/gr2/tests/test_grip_hardening.py
+++ b/gr2/tests/test_grip_hardening.py
@@ -1,0 +1,270 @@
+"""Hardening tests for grip object model edge cases.
+
+Covers adversarial scenarios found during Phase 0 testing:
+  1. Missing/corrupt .grip/.git recovery
+  2. Corrupt .grip HEAD detection and repair
+  3. Dirty repo marker in grip commit tree
+  4. Empty repo handling
+  5. Partial state detection on corrupt blob reads
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from python_cli.gitops import git
+from python_cli.grip import (
+    GripCorruptError,
+    GripInitError,
+    GripCommitInfo,
+    grip_checkout,
+    grip_diff,
+    grip_init,
+    grip_log,
+    grip_snapshot,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(path: Path, *, name: str = "test", empty: bool = False) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    git(path, "init")
+    git(path, "config", "user.email", "test@test.com")
+    git(path, "config", "user.name", "Test")
+    if not empty:
+        (path / "README.md").write_text(f"# {name}\n")
+        git(path, "add", ".")
+        git(path, "commit", "-m", f"init {name}")
+    return path
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _init_repo(ws / "recall", name="recall")
+    git(ws / "recall", "remote", "add", "origin", "https://github.com/synapt-dev/recall")
+    _init_repo(ws / "config", name="config")
+    git(ws / "config", "remote", "add", "origin", "https://github.com/synapt-dev/config")
+    return ws
+
+
+@pytest.fixture
+def grip_repo(workspace: Path) -> Path:
+    grip_init(workspace)
+    return workspace
+
+
+# ---------------------------------------------------------------------------
+# 1. Missing/corrupt .grip/.git init recovery
+# ---------------------------------------------------------------------------
+
+
+class TestGripInitRecovery:
+    def test_init_when_dot_grip_exists_but_no_git(self, workspace: Path) -> None:
+        (workspace / ".grip").mkdir()
+        grip_init(workspace)
+        assert (workspace / ".grip" / ".git").exists()
+
+    def test_init_when_dot_grip_git_is_file_not_dir(self, workspace: Path) -> None:
+        grip_dir = workspace / ".grip"
+        grip_dir.mkdir()
+        (grip_dir / ".git").write_text("corrupted")
+        with pytest.raises(GripInitError, match="corrupt"):
+            grip_init(workspace)
+
+    def test_init_creates_fresh_after_rmtree(self, workspace: Path) -> None:
+        grip_init(workspace)
+        shutil.rmtree(workspace / ".grip")
+        grip_init(workspace)
+        assert (workspace / ".grip" / ".git").is_dir()
+
+    def test_snapshot_without_init_raises(self, workspace: Path) -> None:
+        with pytest.raises(GripInitError):
+            grip_snapshot(workspace, repos={"recall": workspace / "recall"})
+
+    def test_log_without_init_raises(self, workspace: Path) -> None:
+        with pytest.raises(GripInitError):
+            grip_log(workspace)
+
+    def test_diff_without_init_raises(self, workspace: Path) -> None:
+        with pytest.raises(GripInitError):
+            grip_diff(workspace, "HEAD", "HEAD~1")
+
+    def test_checkout_without_init_raises(self, workspace: Path) -> None:
+        with pytest.raises(GripInitError):
+            grip_checkout(workspace, "HEAD")
+
+
+# ---------------------------------------------------------------------------
+# 2. Corrupt .grip HEAD detection and repair
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptHead:
+    def test_corrupt_head_ref_detected(self, grip_repo: Path) -> None:
+        grip_snapshot(grip_repo, repos={"recall": grip_repo / "recall"})
+        head_path = grip_repo / ".grip" / ".git" / "HEAD"
+        head_path.write_text("corrupt-not-a-sha\n")
+        with pytest.raises(GripCorruptError, match="HEAD"):
+            grip_log(grip_repo)
+
+    def test_missing_head_file_detected(self, grip_repo: Path) -> None:
+        grip_snapshot(grip_repo, repos={"recall": grip_repo / "recall"})
+        head_path = grip_repo / ".grip" / ".git" / "HEAD"
+        head_path.unlink()
+        with pytest.raises(GripCorruptError, match="HEAD"):
+            grip_log(grip_repo)
+
+    def test_empty_head_returns_empty_log(self, grip_repo: Path) -> None:
+        entries = grip_log(grip_repo)
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Dirty repo marker in grip commit tree
+# ---------------------------------------------------------------------------
+
+
+class TestDirtyRepoMarker:
+    def test_clean_repo_has_dirty_false(self, grip_repo: Path) -> None:
+        sha = grip_snapshot(
+            grip_repo, repos={"recall": grip_repo / "recall"}
+        )
+        blob = git(grip_repo / ".grip", "show", f"{sha}:repos/recall/dirty").stdout.strip()
+        assert blob == "false"
+
+    def test_dirty_repo_has_dirty_true(self, grip_repo: Path) -> None:
+        (grip_repo / "recall" / "uncommitted.txt").write_text("wip")
+        sha = grip_snapshot(
+            grip_repo, repos={"recall": grip_repo / "recall"}
+        )
+        blob = git(grip_repo / ".grip", "show", f"{sha}:repos/recall/dirty").stdout.strip()
+        assert blob == "true"
+
+    def test_staged_changes_count_as_dirty(self, grip_repo: Path) -> None:
+        (grip_repo / "recall" / "staged.txt").write_text("staged")
+        git(grip_repo / "recall", "add", "staged.txt")
+        sha = grip_snapshot(
+            grip_repo, repos={"recall": grip_repo / "recall"}
+        )
+        blob = git(grip_repo / ".grip", "show", f"{sha}:repos/recall/dirty").stdout.strip()
+        assert blob == "true"
+
+    def test_dirty_flag_in_diff(self, grip_repo: Path) -> None:
+        sha1 = grip_snapshot(
+            grip_repo, repos={"recall": grip_repo / "recall"}
+        )
+        (grip_repo / "recall" / "wip.txt").write_text("wip")
+        sha2 = grip_snapshot(
+            grip_repo, repos={"recall": grip_repo / "recall"}
+        )
+        diff = grip_diff(grip_repo, sha1, sha2)
+        assert "recall" not in diff.changed
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty repo handling
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyRepo:
+    def test_empty_repo_snapshot_succeeds(self, grip_repo: Path) -> None:
+        _init_repo(grip_repo / "empty", name="empty", empty=True)
+        sha = grip_snapshot(
+            grip_repo, repos={"empty": grip_repo / "empty"}
+        )
+        assert len(sha) >= 40
+
+    def test_empty_repo_has_no_commit_blob(self, grip_repo: Path) -> None:
+        _init_repo(grip_repo / "empty", name="empty", empty=True)
+        sha = grip_snapshot(
+            grip_repo, repos={"empty": grip_repo / "empty"}
+        )
+        proc = git(grip_repo / ".grip", "ls-tree", f"{sha}:repos/empty")
+        entry_names = [e.split("\t")[-1] for e in proc.stdout.strip().splitlines() if e.strip()]
+        assert "commit" not in entry_names
+
+    def test_empty_repo_has_branch_blob(self, grip_repo: Path) -> None:
+        _init_repo(grip_repo / "empty", name="empty", empty=True)
+        sha = grip_snapshot(
+            grip_repo, repos={"empty": grip_repo / "empty"}
+        )
+        proc = git(grip_repo / ".grip", "ls-tree", f"{sha}:repos/empty")
+        entry_names = [e.split("\t")[-1] for e in proc.stdout.strip().splitlines() if e.strip()]
+        # Empty repos still have a branch (main/master) even without commits
+        # This may or may not exist depending on git version; just verify no crash
+        assert isinstance(entry_names, list)
+
+    def test_checkout_skips_empty_repo(self, grip_repo: Path) -> None:
+        _init_repo(grip_repo / "empty", name="empty", empty=True)
+        grip_snapshot(
+            grip_repo,
+            repos={
+                "recall": grip_repo / "recall",
+                "empty": grip_repo / "empty",
+            },
+        )
+        result = grip_checkout(grip_repo, "HEAD")
+        assert "recall" in result
+        assert "empty" not in result
+
+
+# ---------------------------------------------------------------------------
+# 5. Partial state / corrupt blob detection
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptBlobs:
+    def test_corrupt_blob_in_repo_state_raises(self, grip_repo: Path) -> None:
+        sha = grip_snapshot(
+            grip_repo, repos={"recall": grip_repo / "recall"}
+        )
+        # Corrupt the object store by replacing a pack/loose object
+        # We simulate by asking for a nonexistent tree path
+        with pytest.raises(GripCorruptError):
+            grip_checkout(grip_repo, "0000000000000000000000000000000000000000")
+
+    def test_missing_repos_subtree_raises(self, grip_repo: Path) -> None:
+        # Create a bare commit with no repos/ subtree
+        proc = git(
+            grip_repo / ".grip",
+            "hash-object", "-w", "--stdin",
+        )
+        # We need to create a commit that has a tree without repos/
+        empty_tree = git(grip_repo / ".grip", "mktree")
+        if empty_tree.returncode != 0:
+            pytest.skip("Cannot create empty tree")
+        # mktree with empty stdin gives the empty tree
+        import subprocess
+        result = subprocess.run(
+            ["git", "mktree"],
+            cwd=grip_repo / ".grip",
+            input="",
+            capture_output=True,
+            text=True,
+        )
+        empty_tree_sha = result.stdout.strip()
+        result2 = subprocess.run(
+            ["git", "commit-tree", empty_tree_sha, "-m", "empty"],
+            cwd=grip_repo / ".grip",
+            capture_output=True,
+            text=True,
+            env={"GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t",
+                 "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t",
+                 "PATH": __import__("os").environ["PATH"]},
+        )
+        bad_commit = result2.stdout.strip()
+        result = grip_checkout(grip_repo, bad_commit)
+        assert result == {}
+
+    def test_validate_grip_repo_detects_no_git(self, workspace: Path) -> None:
+        (workspace / ".grip").mkdir(exist_ok=True)
+        with pytest.raises(GripInitError):
+            grip_snapshot(workspace, repos={"recall": workspace / "recall"})


### PR DESCRIPTION
## Summary

Addresses 5 edge cases found during Phase 0 adversarial testing:

- **Init recovery**: `GripInitError` raised when `.grip/` missing, `.git/` absent, or `.git` is a file. All public functions validate before operating.
- **Corrupt HEAD**: `GripCorruptError` raised when `.grip/.git/HEAD` is missing or points to invalid ref. Distinguishes empty state from corrupt state.
- **Dirty repo marker**: every repo subtree includes a `dirty` blob (true/false) recording uncommitted changes at snapshot time. `grip_diff` ignores it (compares commit SHA only).
- **Empty repo handling**: repos with no commits produce a tree without a commit blob. `grip_checkout` skips them.
- **Corrupt blob detection**: `grip_checkout` validates ref resolves to a valid object. Missing `repos/` subtree returns empty dict.

## Premium boundary

Premium boundary: OSS (error handling for local data primitives, no identity or policy logic)

## Test plan

- [x] 21 new hardening tests pass
- [x] 35 Phase 0 tests pass (no regressions from dirty marker addition)
- [x] 33 Phase 1 config overlay tests pass (no regressions)
- [x] 89 total tests, all green

Ref: #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)