### PR TITLE
feat: wire grip + config into gr2 CLI (stretch goal)

### DIFF
--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -30,6 +30,7 @@ from .events import emit, EventType
 from .hooks import HookContext, HookRuntimeError, apply_file_projections, load_repo_hooks, run_lifecycle_stage
 from .platform import PRRef, get_platform_adapter
 from . import spec_apply
+from .grip_cli import config_cli_app, grip_app
 from gr2.prototypes import lane_workspace_prototype as lane_proto
 from gr2.prototypes import repo_maintenance_prototype as repo_proto
 
@@ -56,6 +57,8 @@ app.add_typer(workspace_app, name="workspace")
 app.add_typer(spec_app, name="spec")
 app.add_typer(exec_app, name="exec")
 app.add_typer(sync_app, name="sync")
+app.add_typer(grip_app, name="grip")
+app.add_typer(config_cli_app, name="config")
 
 
 def _workspace_repo_spec(workspace_root: Path, repo_name: str) -> dict[str, object]:

--- a/gr2/python_cli/grip_cli.py
+++ b/gr2/python_cli/grip_cli.py
@@ -1,0 +1,229 @@
+"""CLI commands for grip object model and config overlay.
+
+Separate module so tests can import without pulling in all of app.py's
+dependencies (gr2.prototypes, lane_workspace_prototype, etc.).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+from . import config as config_mod
+from . import grip as grip_mod
+
+grip_app = typer.Typer(help="Grip object model: workspace snapshots and history")
+config_cli_app = typer.Typer(help="Config base+overlay management")
+
+
+def _resolve_repos(workspace: Path, repos_csv: str) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for name in repos_csv.split(","):
+        name = name.strip()
+        if not name:
+            continue
+        result[name] = workspace / name
+    return result
+
+
+# ---------------------------------------------------------------------------
+# gr grip
+# ---------------------------------------------------------------------------
+
+
+@grip_app.command("init")
+def grip_init_cmd(
+    workspace_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Initialize the .grip/ git repo at workspace root."""
+    workspace_root = workspace_root.resolve()
+    try:
+        grip_mod.grip_init(workspace_root)
+    except grip_mod.GripInitError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+    if json_output:
+        typer.echo(json.dumps({"status": "initialized", "path": str(workspace_root / ".grip")}))
+    else:
+        typer.echo(f"Initialized .grip/ at {workspace_root}")
+
+
+@grip_app.command("snapshot")
+def grip_snapshot_cmd(
+    workspace_root: Path,
+    repos: str = typer.Option(..., "--repos", help="Comma-separated repo names"),
+    message: str = typer.Option("", "--message", "-m", help="Snapshot message"),
+    changeset_type: str = typer.Option("", "--type", help="Changeset type (e.g. ceremony, feature)"),
+    sprint: str = typer.Option("", "--sprint", help="Sprint number"),
+    overlay_dir: str = typer.Option("", "--overlay-dir", help="Config overlay directory to include in snapshot"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Snapshot current workspace into a grip commit."""
+    workspace_root = workspace_root.resolve()
+    repo_map = _resolve_repos(workspace_root, repos)
+    overlay = Path(overlay_dir).resolve() if overlay_dir else None
+    try:
+        sha = grip_mod.grip_snapshot(
+            workspace_root,
+            repo_map,
+            changeset_type=changeset_type,
+            sprint=sprint,
+            message=message,
+            overlay_dir=overlay,
+        )
+    except grip_mod.GripInitError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+    if json_output:
+        typer.echo(json.dumps({"sha": sha, "repos": sorted(repo_map.keys())}))
+    else:
+        typer.echo(f"grip snapshot {sha[:12]} ({len(repo_map)} repos)")
+
+
+@grip_app.command("log")
+def grip_log_cmd(
+    workspace_root: Path,
+    max_count: int = typer.Option(10, "--max-count", "-n", help="Max entries to show"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show grip commit history."""
+    workspace_root = workspace_root.resolve()
+    try:
+        entries = grip_mod.grip_log(workspace_root, max_count=max_count)
+    except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+    if json_output:
+        typer.echo(json.dumps({
+            "entries": [
+                {"sha": e.sha, "message": e.message, "repos": e.repos, "timestamp": e.timestamp}
+                for e in entries
+            ]
+        }))
+    else:
+        if not entries:
+            typer.echo("No grip commits yet.")
+            return
+        for e in entries:
+            typer.echo(f"{e.sha[:12]}  {e.message}  [{', '.join(e.repos)}]")
+
+
+@grip_app.command("diff")
+def grip_diff_cmd(
+    workspace_root: Path,
+    ref_a: str = typer.Argument(..., help="First grip commit ref"),
+    ref_b: str = typer.Argument(..., help="Second grip commit ref"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show changes between two grip commits."""
+    workspace_root = workspace_root.resolve()
+    try:
+        result = grip_mod.grip_diff(workspace_root, ref_a, ref_b)
+    except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+    if json_output:
+        typer.echo(json.dumps({
+            "changed": result.changed,
+            "added": result.added,
+            "removed": result.removed,
+        }))
+    else:
+        if not result.changed and not result.added and not result.removed:
+            typer.echo("No changes.")
+            return
+        for name, info in result.changed.items():
+            typer.echo(f"  ~ {name}: {info['old_commit'][:12]} -> {info['new_commit'][:12]}")
+        for name in result.added:
+            typer.echo(f"  + {name}")
+        for name in result.removed:
+            typer.echo(f"  - {name}")
+
+
+@grip_app.command("checkout")
+def grip_checkout_cmd(
+    workspace_root: Path,
+    ref: str = typer.Argument(..., help="Grip commit ref to restore"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Restore workspace repo HEADs from a grip commit."""
+    workspace_root = workspace_root.resolve()
+    try:
+        result = grip_mod.grip_checkout(workspace_root, ref)
+    except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+    if json_output:
+        typer.echo(json.dumps({"repos": result}))
+    else:
+        for name, sha in result.items():
+            typer.echo(f"  {name} -> {sha[:12]}")
+
+
+# ---------------------------------------------------------------------------
+# gr config
+# ---------------------------------------------------------------------------
+
+
+@config_cli_app.command("apply")
+def config_apply_cmd(
+    base_path: Path = typer.Argument(..., help="Path to base TOML config file"),
+    overlay_dir: str = typer.Option("", "--overlay-dir", help="Overlay directory (default: sibling overlay/)"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Materialize TOML base into JSON runtime overlay."""
+    base_path = base_path.resolve()
+    overlay = Path(overlay_dir).resolve() if overlay_dir else base_path.parent / "overlay"
+    result = config_mod.config_apply(base_path, overlay)
+    if json_output:
+        typer.echo(json.dumps(result))
+    else:
+        typer.echo(f"Applied {base_path.name} -> {overlay / (base_path.stem + '.json')}")
+
+
+@config_cli_app.command("show")
+def config_show_cmd(
+    base_path: Path = typer.Argument(..., help="Path to base TOML config file"),
+    overlay_dir: str = typer.Option("", "--overlay-dir", help="Overlay directory"),
+    key: str = typer.Option("", "--key", "-k", help="Dotted key path (e.g. agents.opus.model)"),
+    strict: bool = typer.Option(False, "--strict", help="Fail if overlay is stale"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show merged config (overlay-first, base-fallback)."""
+    base_path = base_path.resolve()
+    overlay = Path(overlay_dir).resolve() if overlay_dir else base_path.parent / "overlay"
+    try:
+        result = config_mod.config_show(
+            base_path, overlay,
+            key=key or None,
+            strict=strict,
+        )
+    except config_mod.BaseStaleError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+    if json_output:
+        if key:
+            typer.echo(json.dumps({"key": key, "value": result}))
+        else:
+            typer.echo(json.dumps(result))
+    else:
+        typer.echo(json.dumps(result, indent=2))
+
+
+@config_cli_app.command("restore")
+def config_restore_cmd(
+    workspace_root: Path,
+    ref: str = typer.Argument(..., help="Grip commit ref to restore config from"),
+    overlay_dir: str = typer.Option("", "--overlay-dir", help="Overlay directory to restore into"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Restore config overlay from a grip commit snapshot."""
+    workspace_root = workspace_root.resolve()
+    overlay = Path(overlay_dir).resolve() if overlay_dir else workspace_root / "config" / "overlay"
+    result = config_mod.config_restore(workspace_root, ref, overlay)
+    if json_output:
+        typer.echo(json.dumps({"restored": result}))
+    else:
+        typer.echo(f"Restored {len(result)} file(s) from {ref[:12]}")

--- a/gr2/tests/test_grip_cli.py
+++ b/gr2/tests/test_grip_cli.py
@@ -1,0 +1,372 @@
+"""TDD tests for grip + config CLI wiring.
+
+Tests the typer CLI layer, not the library functions (those are tested
+in test_grip_snapshot.py, test_config_overlay.py, test_grip_hardening.py).
+
+Focus: argument parsing, exit codes, JSON output format, error messages.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from python_cli.gitops import git
+from python_cli.grip_cli import config_cli_app, grip_app
+
+app = typer.Typer()
+app.add_typer(grip_app, name="grip")
+app.add_typer(config_cli_app, name="config")
+
+runner = CliRunner()
+
+SAMPLE_TOML = """\
+[spawn]
+session_name = "synapt"
+channel = "dev"
+
+[agents.opus]
+role = "CEO / product design"
+model = "claude-opus-4-6"
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(path: Path, *, name: str = "test") -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    git(path, "init")
+    git(path, "config", "user.email", "test@test.com")
+    git(path, "config", "user.name", "Test")
+    (path / "README.md").write_text(f"# {name}\n")
+    git(path, "add", ".")
+    git(path, "commit", "-m", f"init {name}")
+    return path
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _init_repo(ws / "recall", name="recall")
+    git(ws / "recall", "remote", "add", "origin", "https://github.com/synapt-dev/recall")
+    config_dir = ws / "config_files"
+    config_dir.mkdir()
+    (config_dir / "agents.toml").write_text(SAMPLE_TOML)
+    (config_dir / "overlay").mkdir()
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# gr grip init
+# ---------------------------------------------------------------------------
+
+
+class TestGripInitCLI:
+    def test_init_succeeds(self, workspace: Path) -> None:
+        result = runner.invoke(app, ["grip", "init", str(workspace)])
+        assert result.exit_code == 0
+
+    def test_init_json_output(self, workspace: Path) -> None:
+        result = runner.invoke(app, ["grip", "init", str(workspace), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "initialized"
+
+    def test_init_idempotent(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner.invoke(app, ["grip", "init", str(workspace)])
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# gr grip snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestGripSnapshotCLI:
+    def test_snapshot_succeeds(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner.invoke(app, [
+            "grip", "snapshot", str(workspace),
+            "--repos", "recall",
+        ])
+        assert result.exit_code == 0
+
+    def test_snapshot_json_output(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner.invoke(app, [
+            "grip", "snapshot", str(workspace),
+            "--repos", "recall",
+            "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "sha" in data
+        assert len(data["sha"]) >= 40
+
+    def test_snapshot_with_message(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner.invoke(app, [
+            "grip", "snapshot", str(workspace),
+            "--repos", "recall",
+            "--message", "Sprint 27 ceremony",
+            "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "sha" in data
+
+    def test_snapshot_with_type_and_sprint(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner.invoke(app, [
+            "grip", "snapshot", str(workspace),
+            "--repos", "recall",
+            "--type", "ceremony",
+            "--sprint", "27",
+            "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "sha" in data
+
+    def test_snapshot_without_init_fails(self, workspace: Path) -> None:
+        result = runner.invoke(app, [
+            "grip", "snapshot", str(workspace),
+            "--repos", "recall",
+        ])
+        assert result.exit_code != 0
+
+    def test_snapshot_multiple_repos(self, workspace: Path) -> None:
+        _init_repo(workspace / "premium", name="premium")
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner.invoke(app, [
+            "grip", "snapshot", str(workspace),
+            "--repos", "recall,premium",
+            "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "recall" in data["repos"]
+        assert "premium" in data["repos"]
+
+
+# ---------------------------------------------------------------------------
+# gr grip log
+# ---------------------------------------------------------------------------
+
+
+class TestGripLogCLI:
+    def test_log_empty(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner.invoke(app, ["grip", "log", str(workspace), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["entries"] == []
+
+    def test_log_after_snapshot(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        runner.invoke(app, [
+            "grip", "snapshot", str(workspace), "--repos", "recall",
+            "--message", "test snap",
+        ])
+        result = runner.invoke(app, ["grip", "log", str(workspace), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data["entries"]) == 1
+        assert "test snap" in data["entries"][0]["message"]
+
+    def test_log_max_count(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        for i in range(3):
+            (workspace / "recall" / f"f{i}.txt").write_text(str(i))
+            git(workspace / "recall", "add", ".")
+            git(workspace / "recall", "commit", "-m", f"c{i}")
+            runner.invoke(app, [
+                "grip", "snapshot", str(workspace), "--repos", "recall",
+            ])
+        result = runner.invoke(app, [
+            "grip", "log", str(workspace), "--max-count", "2", "--json",
+        ])
+        data = json.loads(result.stdout)
+        assert len(data["entries"]) == 2
+
+    def test_log_without_init_fails(self, workspace: Path) -> None:
+        result = runner.invoke(app, ["grip", "log", str(workspace)])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# gr grip diff
+# ---------------------------------------------------------------------------
+
+
+class TestGripDiffCLI:
+    def test_diff_json(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        r1 = runner.invoke(app, [
+            "grip", "snapshot", str(workspace), "--repos", "recall", "--json",
+        ])
+        sha1 = json.loads(r1.stdout)["sha"]
+
+        (workspace / "recall" / "new.txt").write_text("x")
+        git(workspace / "recall", "add", ".")
+        git(workspace / "recall", "commit", "-m", "change")
+
+        r2 = runner.invoke(app, [
+            "grip", "snapshot", str(workspace), "--repos", "recall", "--json",
+        ])
+        sha2 = json.loads(r2.stdout)["sha"]
+
+        result = runner.invoke(app, [
+            "grip", "diff", str(workspace), sha1, sha2, "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "recall" in data["changed"]
+
+    def test_diff_without_init_fails(self, workspace: Path) -> None:
+        result = runner.invoke(app, [
+            "grip", "diff", str(workspace), "abc", "def",
+        ])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# gr grip checkout
+# ---------------------------------------------------------------------------
+
+
+class TestGripCheckoutCLI:
+    def test_checkout_json(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        r1 = runner.invoke(app, [
+            "grip", "snapshot", str(workspace), "--repos", "recall", "--json",
+        ])
+        sha = json.loads(r1.stdout)["sha"]
+
+        result = runner.invoke(app, [
+            "grip", "checkout", str(workspace), sha, "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "recall" in data["repos"]
+
+    def test_checkout_without_init_fails(self, workspace: Path) -> None:
+        result = runner.invoke(app, [
+            "grip", "checkout", str(workspace), "HEAD",
+        ])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# gr config apply
+# ---------------------------------------------------------------------------
+
+
+class TestConfigApplyCLI:
+    def test_apply_succeeds(self, workspace: Path) -> None:
+        result = runner.invoke(app, [
+            "config", "apply",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+        ])
+        assert result.exit_code == 0
+
+    def test_apply_json_output(self, workspace: Path) -> None:
+        result = runner.invoke(app, [
+            "config", "apply",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+            "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "agents" in data
+        assert "spawn" in data
+
+
+# ---------------------------------------------------------------------------
+# gr config show
+# ---------------------------------------------------------------------------
+
+
+class TestConfigShowCLI:
+    def _apply_first(self, workspace: Path) -> None:
+        runner.invoke(app, [
+            "config", "apply",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+        ])
+
+    def test_show_full(self, workspace: Path) -> None:
+        self._apply_first(workspace)
+        result = runner.invoke(app, [
+            "config", "show",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+            "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "agents" in data
+
+    def test_show_with_key(self, workspace: Path) -> None:
+        self._apply_first(workspace)
+        result = runner.invoke(app, [
+            "config", "show",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+            "--key", "agents.opus.role",
+            "--json",
+        ])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert data["value"] == "CEO / product design"
+
+    def test_show_strict_stale(self, workspace: Path) -> None:
+        self._apply_first(workspace)
+        base = workspace / "config_files" / "agents.toml"
+        base.write_text(SAMPLE_TOML + '\n[agents.new]\nrole = "new"\n')
+        result = runner.invoke(app, [
+            "config", "show",
+            str(base),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+            "--strict",
+        ])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# gr config restore
+# ---------------------------------------------------------------------------
+
+
+class TestConfigRestoreCLI:
+    def test_restore_from_grip_commit(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        runner.invoke(app, [
+            "config", "apply",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+        ])
+        snap = runner.invoke(app, [
+            "grip", "snapshot", str(workspace),
+            "--repos", "recall",
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+            "--json",
+        ])
+        sha = json.loads(snap.stdout)["sha"]
+
+        result = runner.invoke(app, [
+            "config", "restore",
+            str(workspace), sha,
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+        ])
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary

Wires the grip object model and config overlay library functions into callable gr2 CLI commands:

**Grip commands:**
- `gr grip init WORKSPACE` -- initialize .grip/ repo
- `gr grip snapshot WORKSPACE --repos recall,premium [--message MSG] [--type ceremony] [--sprint 27]`
- `gr grip log WORKSPACE [--max-count N]`
- `gr grip diff WORKSPACE REF_A REF_B`
- `gr grip checkout WORKSPACE REF`

**Config commands:**
- `gr config apply BASE_PATH [--overlay-dir DIR]`
- `gr config show BASE_PATH [--key agents.opus.model] [--strict]`
- `gr config restore WORKSPACE REF [--overlay-dir DIR]`

All commands support `--json` for machine-readable output and return proper exit codes.

CLI module (`grip_cli.py`) is standalone -- no dependency on `gr2.prototypes`, so tests run without the full workspace materialization stack.

## Premium boundary

Premium boundary: OSS (CLI wiring for local workspace primitives, no identity or policy logic)

## Test plan

- [x] 23 CLI tests pass (argument parsing, JSON output, exit codes, error handling)
- [x] 89 existing library tests pass (no regressions)
- [x] 112 total tests, all green

Ref: #606, #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)