### PR TITLE
fix: config restore orphan deletion + JSON corruption quarantine

### DIFF
--- a/gr2/python_cli/config.py
+++ b/gr2/python_cli/config.py
@@ -27,6 +27,10 @@ class BaseStaleError(Exception):
     """Raised when overlay's _base_sha doesn't match current base content."""
 
 
+class OverlayCorruptError(Exception):
+    """Raised when an overlay JSON file contains invalid JSON."""
+
+
 class PolicyViolationError(Exception):
     """Raised when a write is blocked by the active policy."""
 
@@ -108,6 +112,19 @@ def _overlay_stem(base_path: Path) -> str:
     return base_path.stem
 
 
+def _safe_json_load(path: Path) -> dict:
+    """Load JSON from path. On corrupt JSON, quarantine the file and raise OverlayCorruptError."""
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, ValueError):
+        corrupt_path = path.with_suffix(path.suffix + ".corrupt")
+        path.rename(corrupt_path)
+        raise OverlayCorruptError(
+            f"Corrupt overlay JSON at {path.name}. "
+            f"Quarantined to {corrupt_path.name}."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -127,7 +144,7 @@ def config_apply(base_path: Path, overlay_dir: Path) -> dict:
     overlay_path = overlay_dir / f"{_overlay_stem(base_path)}.json"
 
     if overlay_path.exists():
-        existing = json.loads(overlay_path.read_text())
+        existing = _safe_json_load(overlay_path)
         existing.pop("_base_sha", None)
         merged = _deep_merge(base_data, existing)
     else:
@@ -158,7 +175,7 @@ def config_show(
     overlay_data: dict = {}
 
     if overlay_path.exists():
-        overlay_data = json.loads(overlay_path.read_text())
+        overlay_data = _safe_json_load(overlay_path)
         if strict:
             stored_sha = overlay_data.get("_base_sha", "")
             current_sha = _base_sha(base_content)
@@ -177,7 +194,7 @@ def config_show(
         prompts: dict[str, Any] = merged.get("prompts", {})
         for pf in sorted(prompts_dir.glob("*.json")):
             agent_name = pf.stem
-            agent_prompts = json.loads(pf.read_text())
+            agent_prompts = _safe_json_load(pf)
             if agent_name in prompts and isinstance(prompts[agent_name], dict):
                 prompts[agent_name] = _deep_merge(prompts[agent_name], agent_prompts)
             else:
@@ -239,34 +256,74 @@ def overlay_write(
 
 
 def config_restore(workspace: Path, ref: str, overlay_dir: Path) -> dict:
-    """Restore overlay files from a grip commit's config/ subtree."""
+    """Restore overlay files from a grip commit's config/ subtree.
+
+    This is an exact restore: files in the overlay directory that are not in
+    the snapshot are deleted (JSON files only; non-JSON files are preserved).
+    """
     from python_cli.grip import _grip_git
 
     proc = _grip_git(workspace, "ls-tree", f"{ref}:config")
-    if proc.returncode != 0:
-        return {}
+    has_config = proc.returncode == 0
 
     overlay_dir.mkdir(parents=True, exist_ok=True)
     restored: dict[str, str] = {}
+    snapshot_names: set[str] = set()
+    has_prompts_tree = False
 
+    if has_config:
+        for line in proc.stdout.strip().splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            if len(parts) < 2:
+                continue
+            meta, name = parts[0], parts[1]
+            obj_type = meta.split()[1]
+
+            if obj_type == "blob":
+                snapshot_names.add(name)
+                blob = _grip_git(workspace, "show", f"{ref}:config/{name}")
+                if blob.returncode == 0:
+                    (overlay_dir / name).write_text(blob.stdout)
+                    restored[name] = "restored"
+            elif obj_type == "tree" and name == "prompts":
+                has_prompts_tree = True
+                _restore_prompts(workspace, ref, overlay_dir)
+
+    for f in overlay_dir.glob("*.json"):
+        if f.name not in snapshot_names:
+            f.unlink()
+
+    prompts_dir = overlay_dir / "prompts"
+    if prompts_dir.is_dir():
+        if not has_prompts_tree:
+            for pf in prompts_dir.glob("*.json"):
+                pf.unlink()
+        else:
+            snapshot_prompts = _snapshot_prompt_names(workspace, ref)
+            for pf in prompts_dir.glob("*.json"):
+                if pf.name not in snapshot_prompts:
+                    pf.unlink()
+
+    return restored
+
+
+def _snapshot_prompt_names(workspace: Path, ref: str) -> set[str]:
+    """Get the set of prompt filenames in a grip commit's config/prompts/ subtree."""
+    from python_cli.grip import _grip_git
+
+    proc = _grip_git(workspace, "ls-tree", f"{ref}:config/prompts")
+    if proc.returncode != 0:
+        return set()
+    names: set[str] = set()
     for line in proc.stdout.strip().splitlines():
         if not line.strip():
             continue
         parts = line.split("\t")
-        if len(parts) < 2:
-            continue
-        meta, name = parts[0], parts[1]
-        obj_type = meta.split()[1]
-
-        if obj_type == "blob":
-            blob = _grip_git(workspace, "show", f"{ref}:config/{name}")
-            if blob.returncode == 0:
-                (overlay_dir / name).write_text(blob.stdout)
-                restored[name] = "restored"
-        elif obj_type == "tree" and name == "prompts":
-            _restore_prompts(workspace, ref, overlay_dir)
-
-    return restored
+        if len(parts) >= 2:
+            names.add(parts[1])
+    return names
 
 
 def _restore_prompts(workspace: Path, ref: str, overlay_dir: Path) -> None:

--- a/gr2/tests/test_config_corruption.py
+++ b/gr2/tests/test_config_corruption.py
@@ -1,0 +1,178 @@
+"""TDD tests for Story 8: JSON corruption repair/quarantine.
+
+Bug: when overlay JSON is corrupted, config_show and config_apply raise
+a raw json.JSONDecodeError with no recovery path.
+
+Expected behavior: detect corrupt JSON, quarantine the file (rename to
+.corrupt), and fall back to base-only config. Raise a structured
+OverlayCorruptError that callers can catch.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from python_cli.config import (
+    config_apply,
+    config_show,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_TOML = """\
+[spawn]
+session_name = "synapt"
+channel = "dev"
+
+[agents.opus]
+role = "CEO / product design"
+model = "claude-opus-4-6"
+"""
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    config_dir = ws / "config"
+    config_dir.mkdir()
+    (config_dir / "agents.toml").write_text(SAMPLE_TOML)
+    (config_dir / "overlay").mkdir()
+    return ws
+
+
+@pytest.fixture
+def applied_workspace(workspace: Path) -> Path:
+    config_apply(
+        base_path=workspace / "config" / "agents.toml",
+        overlay_dir=workspace / "config" / "overlay",
+    )
+    return workspace
+
+
+# ---------------------------------------------------------------------------
+# Tests: corrupt overlay quarantine
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptOverlayQuarantine:
+    def test_corrupt_overlay_raises_structured_error(self, applied_workspace: Path) -> None:
+        """Corrupt overlay should raise OverlayCorruptError, not raw JSONDecodeError."""
+        from python_cli.config import OverlayCorruptError
+
+        overlay_path = applied_workspace / "config" / "overlay" / "agents.json"
+        overlay_path.write_text("{corrupt json content!!!")
+
+        with pytest.raises(OverlayCorruptError):
+            config_show(
+                base_path=applied_workspace / "config" / "agents.toml",
+                overlay_dir=applied_workspace / "config" / "overlay",
+            )
+
+    def test_corrupt_overlay_quarantined(self, applied_workspace: Path) -> None:
+        """Corrupt overlay file should be renamed to .corrupt."""
+        from python_cli.config import OverlayCorruptError
+
+        overlay_path = applied_workspace / "config" / "overlay" / "agents.json"
+        overlay_path.write_text("{corrupt!!!")
+
+        with pytest.raises(OverlayCorruptError):
+            config_show(
+                base_path=applied_workspace / "config" / "agents.toml",
+                overlay_dir=applied_workspace / "config" / "overlay",
+            )
+
+        corrupt_path = applied_workspace / "config" / "overlay" / "agents.json.corrupt"
+        assert corrupt_path.exists(), "Corrupt file should be renamed to .corrupt"
+        assert not overlay_path.exists(), "Original corrupt file should be removed"
+
+    def test_config_show_falls_back_to_base_after_quarantine(
+        self, applied_workspace: Path
+    ) -> None:
+        """After quarantine, a second config_show should return base-only config."""
+        from python_cli.config import OverlayCorruptError
+
+        overlay_path = applied_workspace / "config" / "overlay" / "agents.json"
+        overlay_path.write_text("not json")
+
+        with pytest.raises(OverlayCorruptError):
+            config_show(
+                base_path=applied_workspace / "config" / "agents.toml",
+                overlay_dir=applied_workspace / "config" / "overlay",
+            )
+
+        # Second call should work (no overlay file, falls back to base)
+        result = config_show(
+            base_path=applied_workspace / "config" / "agents.toml",
+            overlay_dir=applied_workspace / "config" / "overlay",
+        )
+        assert result["agents"]["opus"]["role"] == "CEO / product design"
+
+    def test_config_apply_quarantines_corrupt_overlay(
+        self, applied_workspace: Path
+    ) -> None:
+        """config_apply with corrupt existing overlay should quarantine and reapply."""
+        from python_cli.config import OverlayCorruptError
+
+        overlay_path = applied_workspace / "config" / "overlay" / "agents.json"
+        overlay_path.write_text("{truncated...")
+
+        with pytest.raises(OverlayCorruptError):
+            config_apply(
+                base_path=applied_workspace / "config" / "agents.toml",
+                overlay_dir=applied_workspace / "config" / "overlay",
+            )
+
+        corrupt_path = applied_workspace / "config" / "overlay" / "agents.json.corrupt"
+        assert corrupt_path.exists()
+
+    def test_corrupt_prompt_overlay_quarantined(self, applied_workspace: Path) -> None:
+        """Corrupt prompt overlay should be quarantined during config_show."""
+        from python_cli.config import OverlayCorruptError
+
+        prompts_dir = applied_workspace / "config" / "overlay" / "prompts"
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+        corrupt_prompt = prompts_dir / "opus.json"
+        corrupt_prompt.write_text("{{bad json")
+
+        with pytest.raises(OverlayCorruptError):
+            config_show(
+                base_path=applied_workspace / "config" / "agents.toml",
+                overlay_dir=applied_workspace / "config" / "overlay",
+            )
+
+        assert (prompts_dir / "opus.json.corrupt").exists()
+        assert not corrupt_prompt.exists()
+
+    def test_error_message_includes_path(self, applied_workspace: Path) -> None:
+        """OverlayCorruptError message should include the file path."""
+        from python_cli.config import OverlayCorruptError
+
+        overlay_path = applied_workspace / "config" / "overlay" / "agents.json"
+        overlay_path.write_text("nope")
+
+        with pytest.raises(OverlayCorruptError, match="agents.json"):
+            config_show(
+                base_path=applied_workspace / "config" / "agents.toml",
+                overlay_dir=applied_workspace / "config" / "overlay",
+            )
+
+    def test_multiple_corrupt_files_quarantined(self, applied_workspace: Path) -> None:
+        """If overlay JSON and a prompt file are both corrupt, both get quarantined."""
+        from python_cli.config import OverlayCorruptError
+
+        overlay_path = applied_workspace / "config" / "overlay" / "agents.json"
+        overlay_path.write_text("bad")
+
+        with pytest.raises(OverlayCorruptError):
+            config_show(
+                base_path=applied_workspace / "config" / "agents.toml",
+                overlay_dir=applied_workspace / "config" / "overlay",
+            )
+
+        assert (applied_workspace / "config" / "overlay" / "agents.json.corrupt").exists()

--- a/gr2/tests/test_config_restore_orphans.py
+++ b/gr2/tests/test_config_restore_orphans.py
@@ -1,0 +1,187 @@
+"""TDD tests for Story 7: config_restore orphan overlay deletion.
+
+Bug: config_restore only writes files found in the grip commit's config/
+subtree. It never deletes files that exist locally but are absent from the
+snapshot. Example: if you add prompts/atlas.json after a snapshot and then
+restore to that snapshot, atlas.json survives the restore.
+
+Expected behavior: after config_restore, the overlay directory should be an
+exact mirror of the snapshot — no extra files.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from python_cli.config import config_apply, config_restore, overlay_write
+from python_cli.gitops import git
+from python_cli.grip import grip_init, grip_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_TOML = """\
+[spawn]
+session_name = "synapt"
+channel = "dev"
+
+[agents.opus]
+role = "CEO / product design"
+model = "claude-opus-4-6"
+"""
+
+
+@pytest.fixture
+def grip_workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    config_dir = ws / "config"
+    config_dir.mkdir()
+    (config_dir / "agents.toml").write_text(SAMPLE_TOML)
+    (config_dir / "overlay").mkdir()
+
+    repo = ws / "recall"
+    repo.mkdir()
+    git(repo, "init")
+    git(repo, "config", "user.email", "test@test.com")
+    git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("# recall\n")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "init")
+    git(repo, "remote", "add", "origin", "https://github.com/synapt-dev/recall")
+    grip_init(ws)
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# Tests: overlay file orphan deletion
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreDeletesOrphanOverlays:
+    def test_extra_overlay_file_deleted_on_restore(self, grip_workspace: Path) -> None:
+        """An overlay JSON file added after the snapshot should be deleted on restore."""
+        base_path = grip_workspace / "config" / "agents.toml"
+        overlay_dir = grip_workspace / "config" / "overlay"
+        config_apply(base_path, overlay_dir)
+
+        snap_sha = grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+            overlay_dir=overlay_dir,
+        )
+
+        # Add a new overlay file AFTER the snapshot
+        extra_file = overlay_dir / "extra_config.json"
+        extra_file.write_text(json.dumps({"rogue": True}))
+
+        config_restore(grip_workspace, snap_sha, overlay_dir)
+
+        assert not extra_file.exists(), (
+            "extra_config.json should be deleted by restore "
+            "(it wasn't in the snapshot)"
+        )
+
+    def test_extra_prompt_file_deleted_on_restore(self, grip_workspace: Path) -> None:
+        """A prompt overlay added after the snapshot should be deleted on restore."""
+        base_path = grip_workspace / "config" / "agents.toml"
+        overlay_dir = grip_workspace / "config" / "overlay"
+        config_apply(base_path, overlay_dir)
+
+        overlay_write(
+            overlay_dir, "prompts.opus", "hint", "original", prompt_overlay=True
+        )
+
+        snap_sha = grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+            overlay_dir=overlay_dir,
+        )
+
+        # Add a NEW agent's prompt after the snapshot
+        overlay_write(
+            overlay_dir, "prompts.atlas", "hint", "new agent", prompt_overlay=True
+        )
+        assert (overlay_dir / "prompts" / "atlas.json").exists()
+
+        config_restore(grip_workspace, snap_sha, overlay_dir)
+
+        assert not (overlay_dir / "prompts" / "atlas.json").exists(), (
+            "prompts/atlas.json should be deleted by restore "
+            "(it wasn't in the snapshot)"
+        )
+
+    def test_snapshot_prompt_files_survive_restore(self, grip_workspace: Path) -> None:
+        """Prompt files that WERE in the snapshot should still exist after restore."""
+        base_path = grip_workspace / "config" / "agents.toml"
+        overlay_dir = grip_workspace / "config" / "overlay"
+        config_apply(base_path, overlay_dir)
+
+        overlay_write(
+            overlay_dir, "prompts.opus", "hint", "keep me", prompt_overlay=True
+        )
+
+        snap_sha = grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+            overlay_dir=overlay_dir,
+        )
+
+        # Add orphan, then restore
+        overlay_write(
+            overlay_dir, "prompts.atlas", "hint", "delete me", prompt_overlay=True
+        )
+        config_restore(grip_workspace, snap_sha, overlay_dir)
+
+        assert (overlay_dir / "prompts" / "opus.json").exists()
+        prompt = json.loads((overlay_dir / "prompts" / "opus.json").read_text())
+        assert prompt["hint"] == "keep me"
+
+    def test_restore_to_snapshot_with_no_config_clears_overlay(
+        self, grip_workspace: Path
+    ) -> None:
+        """Restoring to a snapshot that has no config/ subtree should clear overlays."""
+        overlay_dir = grip_workspace / "config" / "overlay"
+
+        # Snapshot WITHOUT overlay_dir (no config subtree in grip commit)
+        snap_sha = grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+        )
+
+        # Now add overlay files
+        base_path = grip_workspace / "config" / "agents.toml"
+        config_apply(base_path, overlay_dir)
+        overlay_write(
+            overlay_dir, "prompts.opus", "hint", "should vanish", prompt_overlay=True
+        )
+
+        config_restore(grip_workspace, snap_sha, overlay_dir)
+
+        json_files = list(overlay_dir.glob("*.json"))
+        prompt_files = list((overlay_dir / "prompts").glob("*.json")) if (overlay_dir / "prompts").is_dir() else []
+        assert json_files == [], f"Expected no overlay JSONs, found {json_files}"
+        assert prompt_files == [], f"Expected no prompt JSONs, found {prompt_files}"
+
+    def test_non_json_files_in_overlay_untouched(self, grip_workspace: Path) -> None:
+        """Non-JSON files (e.g. .gitkeep) should not be deleted by restore."""
+        base_path = grip_workspace / "config" / "agents.toml"
+        overlay_dir = grip_workspace / "config" / "overlay"
+        config_apply(base_path, overlay_dir)
+
+        snap_sha = grip_snapshot(
+            grip_workspace,
+            repos={"recall": grip_workspace / "recall"},
+            overlay_dir=overlay_dir,
+        )
+
+        gitkeep = overlay_dir / ".gitkeep"
+        gitkeep.write_text("")
+
+        config_restore(grip_workspace, snap_sha, overlay_dir)
+
+        assert gitkeep.exists(), ".gitkeep should survive restore (not a JSON overlay)"


### PR DESCRIPTION
## Summary
- **Story 7**: `config_restore` now performs exact restore. Overlay JSON files absent from the snapshot are deleted. Prompt files follow the same rule. Non-JSON files (`.gitkeep`) are preserved.
- **Story 8**: Corrupt overlay JSON raises `OverlayCorruptError` (not raw `JSONDecodeError`). Corrupt file is quarantined (renamed to `.corrupt`). Subsequent calls fall back to base-only config.

## Changes
- `config.py`: Added `OverlayCorruptError` exception, `_safe_json_load` quarantine helper, `_snapshot_prompt_names` helper
- `config.py`: `config_restore` now deletes orphan JSON files and orphan prompt files after restoring snapshot content
- `config.py`: `config_show` and `config_apply` use `_safe_json_load` for all overlay JSON reads

## Test plan
- [x] 5 tests for orphan deletion (Story 7)
- [x] 7 tests for corruption quarantine (Story 8)
- [x] 124/124 full suite green, zero regressions

Premium boundary: OSS (config overlay primitives, no identity/org/policy)