### PR TITLE
feat: gr2 CLI polish for grip commands (Story 10)

### DIFF
--- a/gr2/python_cli/config.py
+++ b/gr2/python_cli/config.py
@@ -27,6 +27,10 @@ class BaseStaleError(Exception):
     """Raised when overlay's _base_sha doesn't match current base content."""
 
 
+class OverlayCorruptError(Exception):
+    """Raised when an overlay JSON file contains invalid JSON."""
+
+
 class PolicyViolationError(Exception):
     """Raised when a write is blocked by the active policy."""
 
@@ -108,6 +112,19 @@ def _overlay_stem(base_path: Path) -> str:
     return base_path.stem
 
 
+def _safe_json_load(path: Path) -> dict:
+    """Load JSON from path. On corrupt JSON, quarantine the file and raise."""
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, ValueError):
+        corrupt_path = path.with_suffix(path.suffix + ".corrupt")
+        path.rename(corrupt_path)
+        raise OverlayCorruptError(
+            f"Corrupt overlay JSON at {path.name}. "
+            f"Quarantined to {corrupt_path.name}."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -127,7 +144,7 @@ def config_apply(base_path: Path, overlay_dir: Path) -> dict:
     overlay_path = overlay_dir / f"{_overlay_stem(base_path)}.json"
 
     if overlay_path.exists():
-        existing = json.loads(overlay_path.read_text())
+        existing = _safe_json_load(overlay_path)
         existing.pop("_base_sha", None)
         merged = _deep_merge(base_data, existing)
     else:
@@ -158,7 +175,7 @@ def config_show(
     overlay_data: dict = {}
 
     if overlay_path.exists():
-        overlay_data = json.loads(overlay_path.read_text())
+        overlay_data = _safe_json_load(overlay_path)
         if strict:
             stored_sha = overlay_data.get("_base_sha", "")
             current_sha = _base_sha(base_content)
@@ -171,13 +188,12 @@ def config_show(
     clean_overlay = {k: v for k, v in overlay_data.items() if k != "_base_sha"}
     merged = _deep_merge(base_data, clean_overlay)
 
-    # Include prompt overlays in the merged view
     prompts_dir = overlay_dir / "prompts"
     if prompts_dir.is_dir():
         prompts: dict[str, Any] = merged.get("prompts", {})
         for pf in sorted(prompts_dir.glob("*.json")):
             agent_name = pf.stem
-            agent_prompts = json.loads(pf.read_text())
+            agent_prompts = _safe_json_load(pf)
             if agent_name in prompts and isinstance(prompts[agent_name], dict):
                 prompts[agent_name] = _deep_merge(prompts[agent_name], agent_prompts)
             else:

--- a/gr2/python_cli/grip.py
+++ b/gr2/python_cli/grip.py
@@ -343,9 +343,20 @@ def _read_repo_names(workspace: Path, commit_sha: str) -> list[str]:
     ]
 
 
+def _validate_ref(workspace: Path, ref: str) -> None:
+    """Verify a ref resolves to a valid object in .grip/."""
+    verify = _grip_git(workspace, "cat-file", "-t", ref)
+    if verify.returncode != 0:
+        raise GripCorruptError(
+            f"Ref '{ref}' does not resolve to a valid object in .grip/ repo."
+        )
+
+
 def grip_diff(workspace: Path, ref_a: str, ref_b: str) -> GripDiff:
     """Compare two grip commits and return changed/added/removed repos."""
     _validate_grip_repo(workspace)
+    _validate_ref(workspace, ref_a)
+    _validate_ref(workspace, ref_b)
     repos_a = _read_repo_state(workspace, ref_a)
     repos_b = _read_repo_state(workspace, ref_b)
 
@@ -401,13 +412,7 @@ def grip_checkout(workspace: Path, ref: str) -> dict[str, str]:
     Returns dict mapping repo name to commit SHA.
     """
     _validate_grip_repo(workspace)
-
-    # Verify the ref resolves to a valid object
-    verify = _grip_git(workspace, "cat-file", "-t", ref)
-    if verify.returncode != 0:
-        raise GripCorruptError(
-            f"Ref '{ref}' does not resolve to a valid object in .grip/ repo."
-        )
+    _validate_ref(workspace, ref)
 
     repo_states = _read_repo_state(workspace, ref)
     result: dict[str, str] = {}

--- a/gr2/python_cli/grip_cli.py
+++ b/gr2/python_cli/grip_cli.py
@@ -13,8 +13,24 @@ import typer
 from . import config as config_mod
 from . import grip as grip_mod
 
-grip_app = typer.Typer(help="Grip object model: workspace snapshots and history")
-config_cli_app = typer.Typer(help="Config base+overlay management")
+grip_app = typer.Typer(
+    help="Workspace snapshots and history. "
+    "Stores multi-repo state as content-addressable objects in .grip/.",
+)
+config_cli_app = typer.Typer(
+    help="Config base+overlay management. "
+    "TOML base (cold, reviewed) + JSON overlay (hot, agent-writable).",
+)
+
+verbose_option = typer.Option(
+    False, "--verbose", "-v",
+    help="Print debug details (paths, SHAs, timings) to stderr.",
+)
+
+
+def _debug(verbose: bool, msg: str) -> None:
+    if verbose:
+        typer.echo(f"[debug] {msg}", err=True)
 
 
 def _resolve_repos(workspace: Path, repos_csv: str) -> dict[str, Path]:
@@ -36,14 +52,17 @@ def _resolve_repos(workspace: Path, repos_csv: str) -> dict[str, Path]:
 def grip_init_cmd(
     workspace_root: Path,
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    verbose: bool = verbose_option,
 ) -> None:
-    """Initialize the .grip/ git repo at workspace root."""
+    """Initialize the .grip/ snapshot repo at a workspace root. Idempotent."""
     workspace_root = workspace_root.resolve()
+    _debug(verbose, f"workspace_root={workspace_root}")
     try:
         grip_mod.grip_init(workspace_root)
     except grip_mod.GripInitError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
+    _debug(verbose, f"grip_dir={workspace_root / '.grip'}")
     if json_output:
         typer.echo(json.dumps({"status": "initialized", "path": str(workspace_root / ".grip")}))
     else:
@@ -53,17 +72,22 @@ def grip_init_cmd(
 @grip_app.command("snapshot")
 def grip_snapshot_cmd(
     workspace_root: Path,
-    repos: str = typer.Option(..., "--repos", help="Comma-separated repo names"),
-    message: str = typer.Option("", "--message", "-m", help="Snapshot message"),
-    changeset_type: str = typer.Option("", "--type", help="Changeset type (e.g. ceremony, feature)"),
-    sprint: str = typer.Option("", "--sprint", help="Sprint number"),
+    repos: str = typer.Option(..., "--repos", help="Comma-separated repo names to include"),
+    message: str = typer.Option("", "--message", "-m", help="Snapshot message (shown in 'grip log')"),
+    changeset_type: str = typer.Option("", "--type", help="Changeset type tag (e.g. ceremony, feature)"),
+    sprint: str = typer.Option("", "--sprint", help="Sprint number tag"),
     overlay_dir: str = typer.Option("", "--overlay-dir", help="Config overlay directory to include in snapshot"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    verbose: bool = verbose_option,
 ) -> None:
-    """Snapshot current workspace into a grip commit."""
+    """Record current repo HEADs and config overlay as a grip commit."""
     workspace_root = workspace_root.resolve()
     repo_map = _resolve_repos(workspace_root, repos)
     overlay = Path(overlay_dir).resolve() if overlay_dir else None
+    _debug(verbose, f"workspace_root={workspace_root}")
+    _debug(verbose, f"repos={sorted(repo_map.keys())}")
+    if overlay:
+        _debug(verbose, f"overlay_dir={overlay}")
     try:
         sha = grip_mod.grip_snapshot(
             workspace_root,
@@ -76,6 +100,7 @@ def grip_snapshot_cmd(
     except grip_mod.GripInitError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
+    _debug(verbose, f"commit_sha={sha}")
     if json_output:
         typer.echo(json.dumps({"sha": sha, "repos": sorted(repo_map.keys())}))
     else:
@@ -85,16 +110,23 @@ def grip_snapshot_cmd(
 @grip_app.command("log")
 def grip_log_cmd(
     workspace_root: Path,
-    max_count: int = typer.Option(10, "--max-count", "-n", help="Max entries to show"),
+    max_count: int = typer.Option(10, "--max-count", "-n", help="Maximum number of entries to display"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    verbose: bool = verbose_option,
 ) -> None:
-    """Show grip commit history."""
+    """List grip snapshot history, most recent first.
+
+    Each entry shows the short SHA, message, and repos captured.
+    Use the full SHA from --json output as a ref for 'grip diff' or 'grip checkout'.
+    """
     workspace_root = workspace_root.resolve()
+    _debug(verbose, f"workspace_root={workspace_root}")
     try:
         entries = grip_mod.grip_log(workspace_root, max_count=max_count)
     except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
+    _debug(verbose, f"entries_found={len(entries)}")
     if json_output:
         typer.echo(json.dumps({
             "entries": [
@@ -104,7 +136,7 @@ def grip_log_cmd(
         }))
     else:
         if not entries:
-            typer.echo("No grip commits yet.")
+            typer.echo("No grip commits yet. Run 'grip snapshot' to create one.")
             return
         for e in entries:
             typer.echo(f"{e.sha[:12]}  {e.message}  [{', '.join(e.repos)}]")
@@ -113,16 +145,24 @@ def grip_log_cmd(
 @grip_app.command("diff")
 def grip_diff_cmd(
     workspace_root: Path,
-    ref_a: str = typer.Argument(..., help="First grip commit ref"),
-    ref_b: str = typer.Argument(..., help="Second grip commit ref"),
+    ref_a: str = typer.Argument(..., help="First grip commit SHA (from 'grip log')"),
+    ref_b: str = typer.Argument(..., help="Second grip commit SHA (from 'grip log')"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    verbose: bool = verbose_option,
 ) -> None:
-    """Show changes between two grip commits."""
+    """Compare two grip snapshots and show which repos changed.
+
+    Pass full or abbreviated SHAs from 'grip log --json'.
+    """
     workspace_root = workspace_root.resolve()
+    _debug(verbose, f"ref_a={ref_a} ref_b={ref_b}")
     try:
         result = grip_mod.grip_diff(workspace_root, ref_a, ref_b)
-    except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
+    except grip_mod.GripInitError as exc:
         typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1)
+    except grip_mod.GripCorruptError as exc:
+        _emit_ref_not_found_hint(str(exc))
         raise typer.Exit(code=1)
     if json_output:
         typer.echo(json.dumps({
@@ -132,7 +172,7 @@ def grip_diff_cmd(
         }))
     else:
         if not result.changed and not result.added and not result.removed:
-            typer.echo("No changes.")
+            typer.echo("No changes between the two snapshots.")
             return
         for name, info in result.changed.items():
             typer.echo(f"  ~ {name}: {info['old_commit'][:12]} -> {info['new_commit'][:12]}")
@@ -145,21 +185,39 @@ def grip_diff_cmd(
 @grip_app.command("checkout")
 def grip_checkout_cmd(
     workspace_root: Path,
-    ref: str = typer.Argument(..., help="Grip commit ref to restore"),
+    ref: str = typer.Argument(..., help="Grip commit SHA to restore (from 'grip log')"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    verbose: bool = verbose_option,
 ) -> None:
-    """Restore workspace repo HEADs from a grip commit."""
+    """Restore workspace repo HEADs to the state recorded in a grip snapshot.
+
+    Each repo is checked out to the exact commit captured at snapshot time.
+    Repos already at the correct commit are left untouched.
+    """
     workspace_root = workspace_root.resolve()
+    _debug(verbose, f"ref={ref}")
     try:
         result = grip_mod.grip_checkout(workspace_root, ref)
-    except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
+    except grip_mod.GripInitError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
+    except grip_mod.GripCorruptError as exc:
+        _emit_ref_not_found_hint(str(exc))
+        raise typer.Exit(code=1)
+    _debug(verbose, f"restored_repos={list(result.keys())}")
     if json_output:
         typer.echo(json.dumps({"repos": result}))
     else:
         for name, sha in result.items():
             typer.echo(f"  {name} -> {sha[:12]}")
+
+
+def _emit_ref_not_found_hint(error_msg: str) -> None:
+    typer.echo(error_msg, err=True)
+    typer.echo(
+        "Hint: run 'grip log' to list valid grip commit SHAs.",
+        err=True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -172,11 +230,23 @@ def config_apply_cmd(
     base_path: Path = typer.Argument(..., help="Path to base TOML config file"),
     overlay_dir: str = typer.Option("", "--overlay-dir", help="Overlay directory (default: sibling overlay/)"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    verbose: bool = verbose_option,
 ) -> None:
-    """Materialize TOML base into JSON runtime overlay."""
+    """Materialize a TOML base into a JSON runtime overlay.
+
+    Creates the overlay directory if it does not exist. If an overlay
+    already exists, new base keys are merged while preserving overlay edits.
+    """
     base_path = base_path.resolve()
     overlay = Path(overlay_dir).resolve() if overlay_dir else base_path.parent / "overlay"
-    result = config_mod.config_apply(base_path, overlay)
+    _debug(verbose, f"base_path={base_path}")
+    _debug(verbose, f"overlay_dir={overlay}")
+    try:
+        result = config_mod.config_apply(base_path, overlay)
+    except config_mod.OverlayCorruptError as exc:
+        _emit_corrupt_overlay_hint(str(exc))
+        raise typer.Exit(code=1)
+    _debug(verbose, f"keys={sorted(result.keys())}")
     if json_output:
         typer.echo(json.dumps(result))
     else:
@@ -188,12 +258,21 @@ def config_show_cmd(
     base_path: Path = typer.Argument(..., help="Path to base TOML config file"),
     overlay_dir: str = typer.Option("", "--overlay-dir", help="Overlay directory"),
     key: str = typer.Option("", "--key", "-k", help="Dotted key path (e.g. agents.opus.model)"),
-    strict: bool = typer.Option(False, "--strict", help="Fail if overlay is stale"),
+    strict: bool = typer.Option(False, "--strict", help="Fail if overlay _base_sha is stale"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    verbose: bool = verbose_option,
 ) -> None:
-    """Show merged config (overlay-first, base-fallback)."""
+    """Show merged config: overlay values win, base fills gaps.
+
+    Without --key, prints the full merged document. With --key, resolves
+    a dotted path (e.g. agents.opus.model) and prints that value only.
+    """
     base_path = base_path.resolve()
     overlay = Path(overlay_dir).resolve() if overlay_dir else base_path.parent / "overlay"
+    _debug(verbose, f"base_path={base_path}")
+    _debug(verbose, f"overlay_dir={overlay}")
+    if key:
+        _debug(verbose, f"key={key}")
     try:
         result = config_mod.config_show(
             base_path, overlay,
@@ -202,6 +281,13 @@ def config_show_cmd(
         )
     except config_mod.BaseStaleError as exc:
         typer.echo(str(exc), err=True)
+        typer.echo(
+            "Hint: run 'config apply' to re-materialize the overlay from the current base.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    except config_mod.OverlayCorruptError as exc:
+        _emit_corrupt_overlay_hint(str(exc))
         raise typer.Exit(code=1)
     if json_output:
         if key:
@@ -215,15 +301,36 @@ def config_show_cmd(
 @config_cli_app.command("restore")
 def config_restore_cmd(
     workspace_root: Path,
-    ref: str = typer.Argument(..., help="Grip commit ref to restore config from"),
+    ref: str = typer.Argument(..., help="Grip commit SHA to restore config from (from 'grip log')"),
     overlay_dir: str = typer.Option("", "--overlay-dir", help="Overlay directory to restore into"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    verbose: bool = verbose_option,
 ) -> None:
-    """Restore config overlay from a grip commit snapshot."""
+    """Restore config overlay files from a prior grip snapshot.
+
+    This is an exact restore: overlay JSON files not present in the target
+    snapshot are deleted. Non-JSON files in the overlay directory are preserved.
+    """
     workspace_root = workspace_root.resolve()
     overlay = Path(overlay_dir).resolve() if overlay_dir else workspace_root / "config" / "overlay"
-    result = config_mod.config_restore(workspace_root, ref, overlay)
+    _debug(verbose, f"ref={ref}")
+    _debug(verbose, f"overlay_dir={overlay}")
+    try:
+        result = config_mod.config_restore(workspace_root, ref, overlay)
+    except config_mod.OverlayCorruptError as exc:
+        _emit_corrupt_overlay_hint(str(exc))
+        raise typer.Exit(code=1)
+    _debug(verbose, f"restored_files={sorted(result.keys())}")
     if json_output:
         typer.echo(json.dumps({"restored": result}))
     else:
         typer.echo(f"Restored {len(result)} file(s) from {ref[:12]}")
+
+
+def _emit_corrupt_overlay_hint(error_msg: str) -> None:
+    typer.echo(error_msg, err=True)
+    typer.echo(
+        "The corrupt file has been quarantined with a .corrupt extension. "
+        "Run 'config apply' to rebuild the overlay from the TOML base.",
+        err=True,
+    )

--- a/gr2/tests/test_grip_cli.py
+++ b/gr2/tests/test_grip_cli.py
@@ -22,6 +22,7 @@ app.add_typer(grip_app, name="grip")
 app.add_typer(config_cli_app, name="config")
 
 runner = CliRunner()
+runner_stderr = CliRunner(mix_stderr=False)
 
 SAMPLE_TOML = """\
 [spawn]
@@ -370,3 +371,115 @@ class TestConfigRestoreCLI:
             "--overlay-dir", str(workspace / "config_files" / "overlay"),
         ])
         assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# --verbose flag
+# ---------------------------------------------------------------------------
+
+
+class TestVerboseFlag:
+    def test_snapshot_verbose_prints_debug(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner_stderr.invoke(app, [
+            "grip", "snapshot", str(workspace),
+            "--repos", "recall", "--verbose",
+        ])
+        assert result.exit_code == 0
+        assert "[debug]" in result.stderr
+
+    def test_log_verbose_prints_debug(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner_stderr.invoke(app, [
+            "grip", "log", str(workspace), "--verbose",
+        ])
+        assert result.exit_code == 0
+        assert "[debug]" in result.stderr
+
+    def test_config_show_verbose_prints_debug(self, workspace: Path) -> None:
+        runner.invoke(app, [
+            "config", "apply",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+        ])
+        result = runner_stderr.invoke(app, [
+            "config", "show",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+            "--verbose",
+        ])
+        assert result.exit_code == 0
+        assert "[debug]" in result.stderr
+
+    def test_no_debug_without_verbose(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        result = runner_stderr.invoke(app, [
+            "grip", "snapshot", str(workspace), "--repos", "recall",
+        ])
+        assert result.exit_code == 0
+        assert "[debug]" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Improved error messages
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHints:
+    def test_checkout_bad_ref_suggests_grip_log(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        runner.invoke(app, [
+            "grip", "snapshot", str(workspace), "--repos", "recall",
+        ])
+        result = runner_stderr.invoke(app, [
+            "grip", "checkout", str(workspace), "deadbeef1234deadbeef1234deadbeef1234dead",
+        ])
+        assert result.exit_code != 0
+        assert "grip log" in result.stderr
+
+    def test_diff_bad_ref_suggests_grip_log(self, workspace: Path) -> None:
+        runner.invoke(app, ["grip", "init", str(workspace)])
+        runner.invoke(app, [
+            "grip", "snapshot", str(workspace), "--repos", "recall",
+        ])
+        result = runner_stderr.invoke(app, [
+            "grip", "diff", str(workspace),
+            "deadbeef1234deadbeef1234deadbeef1234dead",
+            "deadbeef1234deadbeef1234deadbeef1234dead",
+        ])
+        assert result.exit_code != 0
+        assert "grip log" in result.stderr
+
+    def test_config_show_corrupt_overlay_suggests_apply(self, workspace: Path) -> None:
+        runner.invoke(app, [
+            "config", "apply",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+        ])
+        overlay_file = workspace / "config_files" / "overlay" / "agents.json"
+        overlay_file.write_text("{{{corrupt json")
+        result = runner_stderr.invoke(app, [
+            "config", "show",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+        ])
+        assert result.exit_code != 0
+        assert "quarantined" in result.stderr.lower()
+        assert "config apply" in result.stderr
+
+    def test_config_show_stale_suggests_apply(self, workspace: Path) -> None:
+        runner.invoke(app, [
+            "config", "apply",
+            str(workspace / "config_files" / "agents.toml"),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+        ])
+        base = workspace / "config_files" / "agents.toml"
+        base.write_text(SAMPLE_TOML + '\n[agents.new]\nrole = "new"\n')
+        result = runner_stderr.invoke(app, [
+            "config", "show",
+            str(base),
+            "--overlay-dir", str(workspace / "config_files" / "overlay"),
+            "--strict",
+        ])
+        assert result.exit_code != 0
+        assert "config apply" in result.stderr


### PR DESCRIPTION
## Summary

- Polished help text for all grip/config CLI commands: descriptive docstrings explaining what each command does, clearer option/argument descriptions, actionable empty-state messages (e.g. "No grip commits yet. Run 'grip snapshot' to create one.")
- Added `--verbose` / `-v` flag to all grip/config commands. Prints debug details (workspace paths, commit SHAs, resolved overlay dirs, file counts) to stderr without cluttering stdout or JSON output.
- Improved error messages with actionable hints:
  - Bad grip commit ref now suggests `grip log` to list valid SHAs
  - Corrupt overlay JSON is quarantined to `.corrupt` extension and hints at `config apply` to rebuild from base
  - Stale base/overlay mismatch hints at `config apply` to re-materialize
- Added `OverlayCorruptError` + `_safe_json_load` quarantine to `config.py` (replaces raw `json.loads` in all read paths)
- Extracted `_validate_ref` helper in `grip.py`; `grip_diff` now validates both refs before comparing (previously silently returned empty diff for invalid refs)

## Premium boundary

Premium boundary: OSS (CLI primitives and workspace orchestration).

## Test plan

- [x] 31 grip CLI tests pass (23 existing + 8 new)
- [x] 4 new tests for `--verbose` flag: debug output appears with flag, absent without
- [x] 4 new tests for error hints: bad ref -> suggests `grip log`, corrupt overlay -> quarantine + suggests `config apply`, stale base -> suggests `config apply`
- [x] 89 other gr2 tests pass (12 pre-existing failures in `test_grip_object_model.py` unrelated to this PR)
- [x] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)