### PR TITLE
feat: scaffold gr2 overlay substrate package (Story 1/12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,14 @@ typescript-legacy/dist/
 typescript-legacy/coverage/
 typescript-legacy/*.log
 typescript-legacy/npm-debug.log*
+
+# Python (gr2)
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+.venv/
+.pytest_cache/
+.ruff_cache/

--- a/gr2/README.md
+++ b/gr2/README.md
@@ -1,0 +1,22 @@
+# gr2 overlay substrate
+
+Config-overlay capture, composition, and materialization for gitgrip workspaces.
+
+## M1 scope
+
+- **Tier A only**: config files (`.toml`, `.yml`, `.json`)
+- **Eager materialization**: overlays write files into the workspace on activation
+- **Trust-gated**: overlays are classified as trusted or untrusted; untrusted overlays require explicit approval
+
+## Status
+
+Story 1/12: package skeleton and CLI stub scaffolding. All subcommands return "not implemented" and exit 1.
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+ruff check gr2_overlay/ tests/
+ruff format --check gr2_overlay/ tests/
+```

--- a/gr2/gr2_overlay/__init__.py
+++ b/gr2/gr2_overlay/__init__.py
@@ -1,0 +1,6 @@
+"""gr2 overlay substrate: config-overlay capture, composition, and materialization.
+
+M1 scope: Tier A only (config files), eager materialization, trust-gated.
+"""
+
+__version__ = "0.1.0"

--- a/gr2/gr2_overlay/cli.py
+++ b/gr2/gr2_overlay/cli.py
@@ -1,0 +1,110 @@
+"""CLI plumbing for `gr overlay` subcommands.
+
+All subcommands are stubs for M1 scaffolding. Implementation comes in Stories 2-12.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+overlay_app = typer.Typer(
+    help="Config overlay capture, composition, and materialization (Tier A).",
+)
+
+
+@overlay_app.command("activate")
+def overlay_activate(
+    workspace_root: Path,
+    ref: str = typer.Argument(..., help="Overlay ref: <author>/<name>"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Activate an overlay, eagerly materializing its files into the workspace."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)
+
+
+@overlay_app.command("deactivate")
+def overlay_deactivate(
+    workspace_root: Path,
+    ref: str = typer.Argument(..., help="Overlay ref: <author>/<name>"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Deactivate an overlay and remove its materialized files."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)
+
+
+@overlay_app.command("diff")
+def overlay_diff(
+    workspace_root: Path,
+    ref: str = typer.Argument(..., help="Overlay ref: <author>/<name>"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show the diff an overlay would produce if activated."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)
+
+
+@overlay_app.command("list")
+def overlay_list(
+    workspace_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """List all known overlays (local and remote refs)."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)
+
+
+@overlay_app.command("stack")
+def overlay_stack(
+    workspace_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show the current overlay activation stack with priority ordering."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)
+
+
+@overlay_app.command("status")
+def overlay_status(
+    workspace_root: Path,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show overlay materialization status: which overlays are active, stale, or conflicting."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)
+
+
+@overlay_app.command("trace")
+def overlay_trace(
+    workspace_root: Path,
+    file_path: str = typer.Argument(..., help="File path to trace overlay provenance for"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Trace which overlay(s) contributed to a specific file's current state."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)
+
+
+@overlay_app.command("why")
+def overlay_why(
+    workspace_root: Path,
+    key: str = typer.Argument(..., help="Config key (dotted path) to explain"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Explain why a config key has its current value (which overlay, base, or merge)."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)
+
+
+@overlay_app.command("impact")
+def overlay_impact(
+    workspace_root: Path,
+    ref: str = typer.Argument(..., help="Overlay ref: <author>/<name>"),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+) -> None:
+    """Show what files and keys would change if this overlay were activated or deactivated."""
+    typer.echo("not implemented", err=True)
+    raise typer.Exit(code=1)

--- a/gr2/gr2_overlay/types.py
+++ b/gr2/gr2_overlay/types.py
@@ -23,6 +23,13 @@ class OverlayRef:
     author: str
     name: str
 
+    @classmethod
+    def parse(cls, ref_str: str) -> OverlayRef:
+        parts = ref_str.strip().split("/")
+        if len(parts) != 2 or not all(parts):
+            raise ValueError(f"Invalid overlay ref '{ref_str}': expected '<author>/<name>'")
+        return cls(author=parts[0], name=parts[1])
+
     @property
     def ref_path(self) -> str:
         return f"refs/overlays/{self.author}/{self.name}"
@@ -35,6 +42,10 @@ class OverlayMeta:
     ref: OverlayRef
     tier: OverlayTier
     trust: TrustLevel
+    author: str = ""
+    signature: str = "unsigned"
+    timestamp: str = ""
+    parent_overlay_refs: list[str] = field(default_factory=list)
     files: list[str] = field(default_factory=list)
 
 

--- a/gr2/gr2_overlay/types.py
+++ b/gr2/gr2_overlay/types.py
@@ -1,0 +1,57 @@
+"""Data types for the overlay substrate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+
+class OverlayTier(StrEnum):
+    A = "config"
+
+
+class TrustLevel(StrEnum):
+    TRUSTED = "trusted"
+    UNTRUSTED = "untrusted"
+
+
+@dataclass(frozen=True)
+class OverlayRef:
+    """Reference to an overlay stored in refs/overlays/<author>/<name>."""
+
+    author: str
+    name: str
+
+    @property
+    def ref_path(self) -> str:
+        return f"refs/overlays/{self.author}/{self.name}"
+
+
+@dataclass
+class OverlayMeta:
+    """Metadata for a captured overlay."""
+
+    ref: OverlayRef
+    tier: OverlayTier
+    trust: TrustLevel
+    files: list[str] = field(default_factory=list)
+
+
+@dataclass
+class OverlayStackEntry:
+    """One entry in the activation stack."""
+
+    ref: OverlayRef
+    priority: int
+    active: bool
+
+
+@dataclass
+class MaterializeResult:
+    """Result of eagerly materializing an overlay."""
+
+    overlay: OverlayRef
+    files_written: list[Path]
+    conflicts: list[str]
+    idempotent: bool

--- a/gr2/pyproject.toml
+++ b/gr2/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gr2-overlay"
+version = "0.1.0"
+description = "gr2 overlay substrate: config-overlay capture, composition, and materialization"
+requires-python = ">=3.11"
+dependencies = [
+    "typer>=0.9",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.4",
+]
+
+[tool.setuptools.packages.find]
+include = ["gr2_overlay*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]

--- a/gr2/tests/test_overlay_cli.py
+++ b/gr2/tests/test_overlay_cli.py
@@ -1,0 +1,94 @@
+"""Scaffold tests for gr overlay CLI stubs.
+
+Verifies that every subcommand exists, accepts expected arguments,
+and exits with code 1 + 'not implemented' message (M1 stubs).
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from gr2_overlay.cli import overlay_app
+
+runner = CliRunner()
+
+
+def test_activate_stub():
+    result = runner.invoke(overlay_app, ["activate", "/tmp", "alice/theme-dark"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_deactivate_stub():
+    result = runner.invoke(overlay_app, ["deactivate", "/tmp", "alice/theme-dark"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_diff_stub():
+    result = runner.invoke(overlay_app, ["diff", "/tmp", "alice/theme-dark"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_list_stub():
+    result = runner.invoke(overlay_app, ["list", "/tmp"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_stack_stub():
+    result = runner.invoke(overlay_app, ["stack", "/tmp"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_status_stub():
+    result = runner.invoke(overlay_app, ["status", "/tmp"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_trace_stub():
+    result = runner.invoke(overlay_app, ["trace", "/tmp", "some/file.toml"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_why_stub():
+    result = runner.invoke(overlay_app, ["why", "/tmp", "agent.name"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_impact_stub():
+    result = runner.invoke(overlay_app, ["impact", "/tmp", "alice/theme-dark"])
+    assert result.exit_code == 1
+    assert "not implemented" in result.output
+
+
+def test_activate_json_flag():
+    result = runner.invoke(overlay_app, ["activate", "/tmp", "alice/theme-dark", "--json"])
+    assert result.exit_code == 1
+
+
+def test_list_json_flag():
+    result = runner.invoke(overlay_app, ["list", "/tmp", "--json"])
+    assert result.exit_code == 1
+
+
+def test_subcommand_count():
+    """Verify all 9 expected subcommands are registered."""
+    expected = {
+        "activate",
+        "deactivate",
+        "diff",
+        "list",
+        "stack",
+        "status",
+        "trace",
+        "why",
+        "impact",
+    }
+    registered = {cmd.name for cmd in overlay_app.registered_commands}
+    assert registered == expected


### PR DESCRIPTION
## Summary

- Bootstrap `gr2_overlay` Python package with CLI stubs for all 9 overlay subcommands: activate, deactivate, diff, list, stack, status, trace, why, impact
- Add types module with `OverlayRef`, `OverlayTier`, `TrustLevel`, `OverlayMeta`, `OverlayStackEntry`, `MaterializeResult`
- Configure pyproject.toml with pytest, ruff lint/format, and editable install support
- 12 passing tests verify every subcommand exists and returns the expected stub behavior
- Update .gitignore with Python artifact patterns

**Premium boundary:** grip is OSS (workspace orchestration). All overlay substrate code is local materialization, no identity or org semantics.

Closes #625
Parent umbrella: #623

## Test plan

- [x] `pip install -e ".[dev]"` succeeds
- [x] `pytest` passes (12/12)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [ ] Review: confirm no actual overlay logic leaked into stubs
- [ ] Review: confirm types match the architecture plan in `config/design/gr2-overlay-architecture-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)