### PR TITLE
test: overlay trust model spec (S4)

### DIFF
--- a/gr2/tests/test_overlay_driver_registry.py
+++ b/gr2/tests/test_overlay_driver_registry.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from gr2_overlay.drivers import CURATED_DRIVERS, install_driver_registry, invoke_driver
+from gr2_overlay.types import OverlayRef
+
+
+def test_curated_driver_registry_is_exact_and_closed() -> None:
+    assert set(CURATED_DRIVERS) == {
+        "overlay-deep",
+        "overlay-prepend",
+        "overlay-union",
+    }
+
+
+def test_install_writes_driver_entries_to_home_gitconfig_not_calling_shell_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    shell_override = tmp_path / "shell-global.gitconfig"
+    shell_override.write_text("")
+
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(shell_override))
+
+    install_driver_registry()
+
+    home_gitconfig = fake_home / ".gitconfig"
+    assert home_gitconfig.exists()
+    config_text = home_gitconfig.read_text()
+
+    assert '[merge "overlay-deep"]' in config_text
+    assert '[merge "overlay-prepend"]' in config_text
+    assert '[merge "overlay-union"]' in config_text
+    assert "%O %A %B %P" in config_text
+
+    assert shell_override.read_text() == ""
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "current_text", "other_text", "expected_snippets"),
+    [
+        (
+            "settings.toml",
+            'theme = "base"\n[agent]\nname = "atlas"\n',
+            'theme = "overlay"\n[agent]\nrole = "reviewer"\n',
+            ['theme = "overlay"', 'name = "atlas"', 'role = "reviewer"'],
+        ),
+        (
+            "settings.yml",
+            "theme: base\nagent:\n  name: atlas\n",
+            "theme: overlay\nagent:\n  role: reviewer\n",
+            ["theme: overlay", "name: atlas", "role: reviewer"],
+        ),
+        (
+            "settings.json",
+            '{\n  "theme": "base",\n  "agent": {"name": "atlas"}\n}\n',
+            '{\n  "theme": "overlay",\n  "agent": {"role": "reviewer"}\n}\n',
+            ['"theme": "overlay"', '"name": "atlas"', '"role": "reviewer"'],
+        ),
+    ],
+)
+def test_overlay_deep_merges_tier_a_structured_files_with_overlay_wins(
+    tmp_path: Path,
+    relative_path: str,
+    current_text: str,
+    other_text: str,
+    expected_snippets: list[str],
+) -> None:
+    ancestor = tmp_path / "ancestor"
+    current = tmp_path / "current"
+    other = tmp_path / "other"
+    ancestor.write_text("")
+    current.write_text(current_text)
+    other.write_text(other_text)
+
+    invoke_driver(
+        "overlay-deep",
+        ancestor,
+        current,
+        other,
+        relative_path,
+        source_overlay=OverlayRef(author="atlas", name="theme-dark"),
+        trusted_overlay_sources={"refs/overlays/atlas/theme-dark"},
+    )
+
+    merged_text = current.read_text()
+    for snippet in expected_snippets:
+        assert snippet in merged_text
+
+
+def test_overlay_prepend_writes_overlay_before_base(tmp_path: Path) -> None:
+    ancestor = tmp_path / "ancestor"
+    current = tmp_path / "current"
+    other = tmp_path / "other"
+    ancestor.write_text("")
+    current.write_text("base line 1\nbase line 2\n")
+    other.write_text("overlay line 1\noverlay line 2\n")
+
+    invoke_driver(
+        "overlay-prepend",
+        ancestor,
+        current,
+        other,
+        "COMPOSE.md",
+        source_overlay=OverlayRef(author="atlas", name="compose-overlay"),
+        trusted_overlay_sources={"refs/overlays/atlas/compose-overlay"},
+    )
+
+    assert current.read_text() == "overlay line 1\noverlay line 2\nbase line 1\nbase line 2\n"
+
+
+def test_overlay_union_dedupes_duplicates_while_preserving_unique_lines(tmp_path: Path) -> None:
+    ancestor = tmp_path / "ancestor"
+    current = tmp_path / "current"
+    other = tmp_path / "other"
+    ancestor.write_text("")
+    current.write_text("line-a\nshared\nline-b\n")
+    other.write_text("shared\nline-c\nline-b\n")
+
+    invoke_driver(
+        "overlay-union",
+        ancestor,
+        current,
+        other,
+        "COMPOSE.md",
+        source_overlay=OverlayRef(author="atlas", name="compose-overlay"),
+        trusted_overlay_sources={"refs/overlays/atlas/compose-overlay"},
+    )
+
+    assert current.read_text() == "line-a\nshared\nline-b\nline-c\n"
+
+
+def test_driver_invocation_refuses_unallowlisted_overlay_source(tmp_path: Path) -> None:
+    ancestor = tmp_path / "ancestor"
+    current = tmp_path / "current"
+    other = tmp_path / "other"
+    ancestor.write_text("")
+    current.write_text("theme = \"base\"\n")
+    other.write_text("theme = \"overlay\"\n")
+
+    with pytest.raises(PermissionError):
+        invoke_driver(
+            "overlay-deep",
+            ancestor,
+            current,
+            other,
+            "settings.toml",
+            source_overlay=OverlayRef(author="mallory", name="malicious"),
+            trusted_overlay_sources={"refs/overlays/atlas/theme-dark"},
+        )
+
+    assert current.read_text() == 'theme = "base"\n'
+
+
+def test_driver_invocation_refuses_unknown_driver_even_if_requested(tmp_path: Path) -> None:
+    ancestor = tmp_path / "ancestor"
+    current = tmp_path / "current"
+    other = tmp_path / "other"
+    ancestor.write_text("")
+    current.write_text("safe\n")
+    other.write_text("unsafe\n")
+
+    with pytest.raises(ValueError):
+        invoke_driver(
+            "overlay-rce",
+            ancestor,
+            current,
+            other,
+            "settings.toml",
+            source_overlay=OverlayRef(author="atlas", name="theme-dark"),
+            trusted_overlay_sources={"refs/overlays/atlas/theme-dark"},
+        )
+
+    assert current.read_text() == "safe\n"

--- a/gr2/tests/test_overlay_trust_model.py
+++ b/gr2/tests/test_overlay_trust_model.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gr2_overlay.trust import (
+    OverlayTrustError,
+    TrustClass,
+    TrustSource,
+    authorize_overlay_driver,
+    can_diff_overlay,
+    can_inspect_overlay,
+    load_workspace_allowlist,
+    trust_config_path,
+)
+from gr2_overlay.types import OverlayRef
+
+
+def test_trust_config_lives_in_workspace_grip_directory(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    assert trust_config_path(workspace_root) == workspace_root / ".grip" / "trust.toml"
+
+
+def test_workspace_allowlist_loads_local_team_and_signed_sources(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    trust_path = workspace_root / ".grip" / "trust.toml"
+    trust_path.parent.mkdir(parents=True)
+    trust_path.write_text(
+        """
+[[source]]
+kind = "path"
+pattern = "vendor/*"
+trust_class = "local"
+
+[[source]]
+kind = "path"
+pattern = "team/*"
+trust_class = "team"
+
+[[source]]
+kind = "signed"
+signer = "minisign:atlas-team"
+trust_class = "team"
+"""
+    )
+
+    allowlist = load_workspace_allowlist(workspace_root)
+    assert allowlist == [
+        TrustSource(kind="path", pattern="vendor/*", signer=None, trust_class=TrustClass.LOCAL),
+        TrustSource(kind="path", pattern="team/*", signer=None, trust_class=TrustClass.TEAM),
+        TrustSource(
+            kind="signed",
+            pattern=None,
+            signer="minisign:atlas-team",
+            trust_class=TrustClass.TEAM,
+        ),
+    ]
+
+
+def test_allowlisted_source_allows_curated_driver_execution(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    trust_path = workspace_root / ".grip" / "trust.toml"
+    trust_path.parent.mkdir(parents=True)
+    trust_path.write_text(
+        """
+[[source]]
+kind = "path"
+pattern = "team/*"
+trust_class = "team"
+"""
+    )
+
+    allowlist = load_workspace_allowlist(workspace_root)
+    source_overlay = OverlayRef(author="team", name="shared-config")
+
+    trust_class = authorize_overlay_driver(
+        driver_name="overlay-union",
+        overlay_ref=source_overlay,
+        overlay_source_kind="path",
+        overlay_source_value="team/shared-config",
+        overlay_signer=None,
+        allowlist=allowlist,
+    )
+
+    assert trust_class == TrustClass.TEAM
+
+
+def test_unallowlisted_source_blocks_driver_with_overlay_untrusted(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    trust_path = workspace_root / ".grip" / "trust.toml"
+    trust_path.parent.mkdir(parents=True)
+    trust_path.write_text(
+        """
+[[source]]
+kind = "path"
+pattern = "team/*"
+trust_class = "team"
+"""
+    )
+
+    allowlist = load_workspace_allowlist(workspace_root)
+    source_overlay = OverlayRef(author="third-party", name="theme-pack")
+
+    with pytest.raises(OverlayTrustError) as exc:
+        authorize_overlay_driver(
+            driver_name="overlay-union",
+            overlay_ref=source_overlay,
+            overlay_source_kind="path",
+            overlay_source_value="vendor/theme-pack",
+            overlay_signer=None,
+            allowlist=allowlist,
+        )
+
+    assert exc.value.error_code == "overlay_untrusted"
+    assert "allowlist" in str(exc.value)
+
+
+def test_unallowlisted_source_still_allows_diff_and_inspect(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    trust_path = workspace_root / ".grip" / "trust.toml"
+    trust_path.parent.mkdir(parents=True)
+    trust_path.write_text("")
+
+    allowlist = load_workspace_allowlist(workspace_root)
+    source_overlay = OverlayRef(author="third-party", name="theme-pack")
+
+    assert can_inspect_overlay(
+        overlay_ref=source_overlay,
+        overlay_source_kind="path",
+        overlay_source_value="vendor/theme-pack",
+        overlay_signer=None,
+        allowlist=allowlist,
+    )
+    assert can_diff_overlay(
+        overlay_ref=source_overlay,
+        overlay_source_kind="path",
+        overlay_source_value="vendor/theme-pack",
+        overlay_signer=None,
+        allowlist=allowlist,
+    )
+
+
+def test_unknown_driver_is_refused_even_for_trusted_source(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    trust_path = workspace_root / ".grip" / "trust.toml"
+    trust_path.parent.mkdir(parents=True)
+    trust_path.write_text(
+        """
+[[source]]
+kind = "signed"
+signer = "minisign:atlas-team"
+trust_class = "team"
+"""
+    )
+
+    allowlist = load_workspace_allowlist(workspace_root)
+    source_overlay = OverlayRef(author="team", name="shared-config")
+
+    with pytest.raises(ValueError):
+        authorize_overlay_driver(
+            driver_name="overlay-rce",
+            overlay_ref=source_overlay,
+            overlay_source_kind="signed",
+            overlay_source_value=None,
+            overlay_signer="minisign:atlas-team",
+            allowlist=allowlist,
+        )
+
+
+def test_trust_model_treats_gitattributes_as_metadata_not_authority(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    trust_path = workspace_root / ".grip" / "trust.toml"
+    trust_path.parent.mkdir(parents=True)
+    trust_path.write_text("")
+
+    allowlist = load_workspace_allowlist(workspace_root)
+    source_overlay = OverlayRef(author="mallory", name="theme-pack")
+
+    with pytest.raises(OverlayTrustError) as exc:
+        authorize_overlay_driver(
+            driver_name="overlay-prepend",
+            overlay_ref=source_overlay,
+            overlay_source_kind="path",
+            overlay_source_value="vendor/mallory-pack",
+            overlay_signer=None,
+            allowlist=allowlist,
+            declared_driver="overlay-prepend",
+        )
+
+    assert exc.value.error_code == "overlay_untrusted"
+    assert "metadata" in str(exc.value)

--- a/gr2/tests/test_overlay_trust_model.py
+++ b/gr2/tests/test_overlay_trust_model.py
@@ -118,6 +118,35 @@ trust_class = "team"
     assert "allowlist" in str(exc.value)
 
 
+def test_path_pattern_allowlist_rejects_traversal_style_source_values(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    trust_path = workspace_root / ".grip" / "trust.toml"
+    trust_path.parent.mkdir(parents=True)
+    trust_path.write_text(
+        """
+[[source]]
+kind = "path"
+pattern = "team/*"
+trust_class = "team"
+"""
+    )
+
+    allowlist = load_workspace_allowlist(workspace_root)
+    source_overlay = OverlayRef(author="team", name="evil-pack")
+
+    with pytest.raises(OverlayTrustError) as exc:
+        authorize_overlay_driver(
+            driver_name="overlay-union",
+            overlay_ref=source_overlay,
+            overlay_source_kind="path",
+            overlay_source_value="team/../vendor/evil",
+            overlay_signer=None,
+            allowlist=allowlist,
+        )
+
+    assert exc.value.error_code == "overlay_untrusted"
+
+
 def test_unallowlisted_source_still_allows_diff_and_inspect(tmp_path: Path) -> None:
     workspace_root = tmp_path / "workspace"
     trust_path = workspace_root / ".grip" / "trust.toml"


### PR DESCRIPTION
Closes #634
Ref #623
Cross-ref: https://github.com/synapt-dev/gr2-playground/pull/12

Premium boundary: core OSS (gr2 overlay trust model contract tests in grip).

Adds failing Python Tier A tests for the M1 trust model:
- per-workspace allowlist config at `.grip/trust.toml`
- allowlisted source -> curated drivers may execute
- unallowlisted source -> activation blocked with `overlay_untrusted`
- diff/inspect remain allowed for untrusted overlays
- allowlist supports path patterns, signed sources, and trust classes (`local`, `team`)
- fetched `.gitattributes` is metadata, not authority
- unknown drivers are refused even for trusted sources

Current red state:
- `python3 -m pytest -q gr2/tests/test_overlay_trust_model.py`
- fails with `ModuleNotFoundError: No module named "gr2_overlay.trust"` because the trust module does not exist yet.