### PR TITLE
feat: implement overlay refs push/pull transport (Story 3/12)

### DIFF
--- a/gr2/gr2_overlay/refs.py
+++ b/gr2/gr2_overlay/refs.py
@@ -1,0 +1,36 @@
+"""Overlay ref transport: push and fetch overlay refs between bare stores."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from gr2_overlay.types import OverlayRef
+
+
+def push_overlay_ref(
+    overlay_store: Path,
+    remote_store: Path,
+    overlay_ref: OverlayRef,
+) -> None:
+    refspec = f"{overlay_ref.ref_path}:{overlay_ref.ref_path}"
+    subprocess.run(
+        ["git", f"--git-dir={overlay_store}", "push", str(remote_store), refspec],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def fetch_overlay_ref(
+    overlay_store: Path,
+    remote_store: Path,
+    overlay_ref: OverlayRef,
+) -> None:
+    refspec = f"{overlay_ref.ref_path}:{overlay_ref.ref_path}"
+    subprocess.run(
+        ["git", f"--git-dir={overlay_store}", "fetch", str(remote_store), refspec],
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/gr2/pyproject.toml
+++ b/gr2/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
 include = ["gr2_overlay*"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "gr2_overlay/tests"]
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## Summary

- Implement `push_overlay_ref` and `fetch_overlay_ref` in `gr2_overlay/refs.py`
- Makes the S2 refs namespace spec tests from #630 pass (3/3 green)
- Uses `git push` and `git fetch` with identity-mapped refspecs (`refs/overlays/a/b:refs/overlays/a/b`) against bare repos
- M1 scope: filesystem-only transport (`Path` parameters); URL transport deferred
- Update `pyproject.toml` testpaths to discover tests in both `tests/` and `gr2_overlay/tests/`
- 17/17 total tests passing (12 CLI stubs + 2 encoding + 3 refs)

**Premium boundary:** core OSS (gr2 overlay refs transport, local git plumbing in grip). No identity, org, or policy semantics.

Closes Story 3 / S2 spec implementation.
Ref #623 (umbrella)

## Test plan

- [x] `pytest gr2_overlay/tests/test_overlay_refs_namespace.py` passes (3/3)
- [x] `pytest` full suite passes (17/17, no regression)
- [x] `ruff check gr2_overlay/` clean
- [x] `ruff format --check gr2_overlay/` clean
- [ ] Review: verify refspec is identity-mapped (no remotes/origin namespacing)
- [ ] Review: verify push/fetch use bare repo paths, not URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)