### PR TITLE
feat: implement overlay introspection queries (Story 8/12)

### DIFF
--- a/gr2/gr2_overlay/introspection.py
+++ b/gr2/gr2_overlay/introspection.py
@@ -1,0 +1,155 @@
+"""Overlay introspection: stack, trace, why, impact, status queries."""
+
+from __future__ import annotations
+
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from gr2_overlay.types import OverlayRef
+
+GRIP_DIR = ".grip"
+
+
+def overlay_stack(
+    workspace_root: Path,
+    overlay_store: Path,
+    json_output: bool,
+) -> str | dict[str, Any]:
+    stack_file = workspace_root / GRIP_DIR / "overlay-stack.toml"
+    data = _load_toml(stack_file)
+
+    active_refs = data.get("active", [])
+    available_refs = data.get("available", [])
+
+    active_entries = [_ref_entry(r) for r in active_refs]
+    available_entries = [_ref_entry(r) for r in available_refs]
+
+    if json_output:
+        return {"active": active_entries, "available": available_entries}
+
+    lines = ["Active overlays:"]
+    for entry in active_entries:
+        lines.append(f"  {entry['author']}/{entry['name']} ({entry['ref']})")
+    lines.append("Available overlays:")
+    for entry in available_entries:
+        lines.append(f"  {entry['author']}/{entry['name']} ({entry['ref']})")
+    return "\n".join(lines)
+
+
+def overlay_trace(
+    workspace_root: Path,
+    overlay_store: Path,
+    file_path: str,
+    json_output: bool,
+) -> str | dict[str, Any]:
+    attr_file = workspace_root / GRIP_DIR / "overlay-attribution.toml"
+    data = _load_toml(attr_file)
+
+    file_data = data.get("files", {}).get(file_path, {})
+    regions = file_data.get("lines", [])
+
+    if json_output:
+        return {"file": file_path, "regions": regions}
+
+    lines = [f"Trace for {file_path}:"]
+    for region in regions:
+        lines.append(f"  lines {region['start']}-{region['end']}: {region['ref']}")
+    return "\n".join(lines)
+
+
+def overlay_why(
+    workspace_root: Path,
+    overlay_store: Path,
+    file_path: str,
+    json_output: bool,
+) -> str | dict[str, Any]:
+    why_file = workspace_root / GRIP_DIR / "overlay-why.toml"
+    data = _load_toml(why_file)
+
+    file_data = data.get("files", {}).get(file_path, {})
+    rule = file_data.get("rule", "")
+    reason = file_data.get("reason", "")
+    ref = file_data.get("ref", "")
+
+    if json_output:
+        return {"rule": rule, "reason": reason, "ref": ref}
+
+    return f"{file_path}: rule={rule}, reason={reason} (ref={ref})"
+
+
+def overlay_impact(
+    overlay_store: Path,
+    overlay_ref: OverlayRef,
+    json_output: bool,
+) -> str | dict[str, Any]:
+    files = _read_overlay_file_list(overlay_store, overlay_ref)
+
+    if json_output:
+        return {"files": files}
+
+    lines = [f"Files touched by {overlay_ref.author}/{overlay_ref.name}:"]
+    for f in files:
+        lines.append(f"  {f}")
+    return "\n".join(lines)
+
+
+def overlay_status(
+    workspace_root: Path,
+    overlay_store: Path,
+    json_output: bool,
+) -> str | dict[str, Any]:
+    status_file = workspace_root / GRIP_DIR / "overlay-status.toml"
+    data = _load_toml(status_file)
+
+    active = data.get("active", [])
+    available = data.get("available", [])
+    applied = data.get("applied", [])
+
+    if json_output:
+        return {"active": active, "available": available, "applied": applied}
+
+    lines = [
+        "Active: " + ", ".join(active) if active else "Active: (none)",
+        "Available: " + ", ".join(available) if available else "Available: (none)",
+        "Applied: " + ", ".join(applied) if applied else "Applied: (none)",
+    ]
+    return "\n".join(lines)
+
+
+def _ref_entry(ref_path: str) -> dict[str, str]:
+    parts = ref_path.replace("refs/overlays/", "").split("/", 1)
+    author = parts[0] if parts else ""
+    name = parts[1] if len(parts) > 1 else ""
+    return {"ref": ref_path, "author": author, "name": name}
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    text = path.read_text()
+    if not text.strip():
+        return {}
+    return tomllib.loads(text)
+
+
+def _read_overlay_file_list(overlay_store: Path, overlay_ref: OverlayRef) -> list[str]:
+    tag_oid = _git_output(overlay_store, "rev-parse", overlay_ref.ref_path)
+    structured_tree_oid = _git_output(overlay_store, "rev-parse", f"{tag_oid}^{{tree}}")
+    wt_line = _git_output(overlay_store, "ls-tree", structured_tree_oid, "working_tree_tree")
+    working_tree_oid = wt_line.split()[2]
+    ls_output = _git_output(overlay_store, "ls-tree", "-r", "--name-only", working_tree_oid)
+    if not ls_output:
+        return []
+    return sorted(ls_output.splitlines())
+
+
+def _git_output(git_dir: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", f"--git-dir={git_dir}", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()


### PR DESCRIPTION
## Summary

- Implements `gr2_overlay/introspection.py`: five query functions with dual human/JSON output
- `overlay_stack`: active + available overlays from `.grip/overlay-stack.toml`
- `overlay_trace`: per-file line-region attribution from `.grip/overlay-attribution.toml`
- `overlay_why`: winning merge rule + reason from `.grip/overlay-why.toml`
- `overlay_impact`: file list from git object store directly (ls-tree)
- `overlay_status`: active/available/applied sets from `.grip/overlay-status.toml`

**Scope: query primitives only.** These functions correctly parse their TOML contracts as defined by the S6 spec fixtures, but the current activate implementation (Story 7) writes JSON state files with different names and structure. The integration convergence (making activate emit the TOML files introspection reads, or vice versa) will land in Story 11 (acceptance harness), which is designed for end-to-end roundtrip validation.

## Test plan

- [x] All 5 S6 spec tests GREEN (`test_overlay_introspection.py`)
- [x] Full suite pass, zero regressions
- [x] `ruff check` and `ruff format --check` clean

Premium boundary: core OSS (introspection query substrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)