### PR TITLE
chore: fix gr2 test lint drift before ceremony

### DIFF
--- a/gr2/tests/test_overlay_object_encoding.py
+++ b/gr2/tests/test_overlay_object_encoding.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-import pytest
-
 from gr2_overlay.objects import apply_overlay_object, capture_overlay_object
+
 from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
 
 


### PR DESCRIPTION
Ref #623

Premium boundary: core OSS (test/lint cleanup in grip).

Small ceremony-prep PR to clear remaining `ruff` drift in `gr2/tests/` on `sprint-33`.

What changed:
- removed one unused `pytest` import
- normalized import block ordering in `gr2/tests/test_overlay_object_encoding.py`

Validation:
- `ruff check gr2/tests/`
- `ruff format --check gr2/tests/`
- both pass in the repo venv (`.venv`)

No behavior changes.