### PR TITLE
chore: fix remaining 14 ruff lint issues in gr2 spec tests

### DIFF
--- a/gr2/tests/test_overlay_activate.py
+++ b/gr2/tests/test_overlay_activate.py
@@ -25,7 +25,10 @@ def test_activate_materializes_overlay_eagerly_into_working_tree(tmp_path: Path)
     _write_file(source_root / "settings.toml", 'theme = "owl"\n')
 
     capture_overlay_object(overlay_store, source_root, metadata)
-    write_workspace_allowlist(workspace_root, [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}])
+    write_workspace_allowlist(
+        workspace_root,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}],
+    )
 
     result = activate_overlay(
         workspace_root=workspace_root,
@@ -51,7 +54,10 @@ def test_activate_twice_is_idempotent_and_reversible_via_deactivate(tmp_path: Pa
     _write_file(source_root / "settings.toml", 'theme = "owl"\n')
 
     capture_overlay_object(overlay_store, source_root, _overlay_meta(overlay_ref))
-    write_workspace_allowlist(workspace_root, [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}])
+    write_workspace_allowlist(
+        workspace_root,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}],
+    )
 
     first = activate_overlay(
         workspace_root=workspace_root,
@@ -104,7 +110,10 @@ def test_activate_and_deactivate_mutate_workspace_overlay_stack(tmp_path: Path) 
     _write_file(source_root / "COMPOSE.md", "overlay compose\n")
 
     capture_overlay_object(overlay_store, source_root, _overlay_meta(overlay_ref))
-    write_workspace_allowlist(workspace_root, [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}])
+    write_workspace_allowlist(
+        workspace_root,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}],
+    )
 
     assert read_active_overlay_stack(workspace_root) == []
 
@@ -154,8 +163,11 @@ def test_activate_fails_when_base_has_advanced_since_capture(tmp_path: Path) -> 
     _write_file(source_root / "settings.toml", 'theme = "owl"\n')
 
     capture_overlay_object(overlay_store, source_root, _overlay_meta(overlay_ref))
-    write_workspace_allowlist(workspace_root, [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}])
-    _write_file(workspace_root / ".grip" / "overlay-base-state.toml", 'advanced = true\n')
+    write_workspace_allowlist(
+        workspace_root,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}],
+    )
+    _write_file(workspace_root / ".grip" / "overlay-base-state.toml", "advanced = true\n")
 
     with pytest.raises(OverlayActivationError) as exc:
         activate_overlay(
@@ -178,10 +190,13 @@ def test_activate_reports_composition_conflict_when_curated_merge_cannot_resolve
     _write_file(source_root / "settings.toml", 'theme = "overlay"\n')
     _write_file(workspace_root / "settings.toml", 'theme = "base"\n')
     _write_file(workspace_root / ".gitattributes", "*.toml merge=overlay-deep\n")
-    _write_file(workspace_root / ".grip" / "force-conflict.toml", 'enabled = true\n')
+    _write_file(workspace_root / ".grip" / "force-conflict.toml", "enabled = true\n")
 
     capture_overlay_object(overlay_store, source_root, _overlay_meta(overlay_ref))
-    write_workspace_allowlist(workspace_root, [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}])
+    write_workspace_allowlist(
+        workspace_root,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}],
+    )
 
     with pytest.raises(OverlayActivationError) as exc:
         activate_overlay(
@@ -217,7 +232,10 @@ def test_roundtrip_activate_on_peer_workspace_after_push_and_pull(tmp_path: Path
     capture_overlay_object(local_store, source_root, _overlay_meta(overlay_ref))
     push_overlay_ref(local_store, remote_store, overlay_ref)
     fetch_overlay_ref(peer_store, remote_store, overlay_ref)
-    write_workspace_allowlist(peer_workspace, [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}])
+    write_workspace_allowlist(
+        peer_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "local"}],
+    )
 
     result = activate_overlay(
         workspace_root=peer_workspace,

--- a/gr2/tests/test_overlay_driver_registry.py
+++ b/gr2/tests/test_overlay_driver_registry.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -141,8 +140,8 @@ def test_driver_invocation_refuses_unallowlisted_overlay_source(tmp_path: Path) 
     current = tmp_path / "current"
     other = tmp_path / "other"
     ancestor.write_text("")
-    current.write_text("theme = \"base\"\n")
-    other.write_text("theme = \"overlay\"\n")
+    current.write_text('theme = "base"\n')
+    other.write_text('theme = "overlay"\n')
 
     with pytest.raises(PermissionError):
         invoke_driver(

--- a/gr2/tests/test_overlay_introspection.py
+++ b/gr2/tests/test_overlay_introspection.py
@@ -27,11 +27,20 @@ def test_overlay_stack_reports_active_stack_with_metadata_in_human_and_json(tmp_
     _capture_compose_overlay(overlay_store, source_root, available_ref)
     _write_file(
         workspace_root / ".grip" / "overlay-stack.toml",
-        'active = ["refs/overlays/atlas/theme-dark"]\navailable = ["refs/overlays/team/shared-base"]\n',
+        'active = ["refs/overlays/atlas/theme-dark"]\n'
+        'available = ["refs/overlays/team/shared-base"]\n',
     )
 
-    human = overlay_stack(workspace_root=workspace_root, overlay_store=overlay_store, json_output=False)
-    machine = overlay_stack(workspace_root=workspace_root, overlay_store=overlay_store, json_output=True)
+    human = overlay_stack(
+        workspace_root=workspace_root,
+        overlay_store=overlay_store,
+        json_output=False,
+    )
+    machine = overlay_stack(
+        workspace_root=workspace_root,
+        overlay_store=overlay_store,
+        json_output=True,
+    )
 
     assert "atlas/theme-dark" in human
     assert "active" in human.lower()
@@ -53,7 +62,8 @@ def test_overlay_trace_attributes_lines_to_overlay_regions(tmp_path: Path) -> No
     _write_file(workspace_root / "settings.toml", 'theme = "owl"\naccent = "teal"\n')
     _write_file(
         workspace_root / ".grip" / "overlay-attribution.toml",
-        '[files."settings.toml"]\nlines = [{start = 1, end = 2, ref = "refs/overlays/atlas/theme-dark"}]\n',
+        '[files."settings.toml"]\n'
+        'lines = [{start = 1, end = 2, ref = "refs/overlays/atlas/theme-dark"}]\n',
     )
 
     human = overlay_trace(
@@ -90,7 +100,10 @@ def test_overlay_why_reports_winning_merge_rule_and_reason(tmp_path: Path) -> No
     _capture_compose_overlay(overlay_store, source_root, overlay_ref)
     _write_file(
         workspace_root / ".grip" / "overlay-why.toml",
-        '[files."settings.toml"]\nrule = "overlay-deep"\nreason = "matched *.toml via curated driver registry"\nref = "refs/overlays/atlas/theme-dark"\n',
+        '[files."settings.toml"]\n'
+        'rule = "overlay-deep"\n'
+        'reason = "matched *.toml via curated driver registry"\n'
+        'ref = "refs/overlays/atlas/theme-dark"\n',
     )
 
     human = overlay_why(
@@ -150,7 +163,9 @@ def test_overlay_status_reports_active_available_and_applied_sets(tmp_path: Path
 
     _write_file(
         workspace_root / ".grip" / "overlay-status.toml",
-        'active = ["refs/overlays/atlas/theme-dark"]\navailable = ["refs/overlays/team/shared-base"]\napplied = ["refs/overlays/atlas/already-applied"]\n',
+        'active = ["refs/overlays/atlas/theme-dark"]\n'
+        'available = ["refs/overlays/team/shared-base"]\n'
+        'applied = ["refs/overlays/atlas/already-applied"]\n',
     )
 
     human = overlay_status(
@@ -172,7 +187,9 @@ def test_overlay_status_reports_active_available_and_applied_sets(tmp_path: Path
     assert machine["applied"] == ["refs/overlays/atlas/already-applied"]
 
 
-def _capture_compose_overlay(overlay_store: Path, source_root: Path, overlay_ref: OverlayRef) -> None:
+def _capture_compose_overlay(
+    overlay_store: Path, source_root: Path, overlay_ref: OverlayRef
+) -> None:
     _write_file(source_root / "COMPOSE.md", "compose\n")
     capture_overlay_object(overlay_store, source_root, _overlay_meta(overlay_ref))
 

--- a/gr2/tests/test_overlay_object_encoding.py
+++ b/gr2/tests/test_overlay_object_encoding.py
@@ -4,7 +4,6 @@ import subprocess
 from pathlib import Path
 
 from gr2_overlay.objects import apply_overlay_object, capture_overlay_object
-
 from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
 
 

--- a/gr2/tests/test_overlay_perf_gates.py
+++ b/gr2/tests/test_overlay_perf_gates.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import pytest
 
 from gr2_overlay.perf import (


### PR DESCRIPTION
## Summary

Completes the ceremony lint cleanup started by #651 (which fixed 2/16 issues). This PR fixes the remaining 14:

- **F401** (unused imports): removed `import os` from `test_overlay_driver_registry.py`, `from dataclasses import dataclass` from `test_overlay_perf_gates.py`
- **E501** (line too long): broke 6 long `write_workspace_allowlist()` calls in `test_overlay_activate.py` and 6 long inline TOML strings + function signatures in `test_overlay_introspection.py`
- **I001** (import sort): fixed import block in `test_overlay_object_encoding.py` (introduced by #651)

`ruff check tests/ gr2_overlay/` and `ruff format --check tests/ gr2_overlay/` now pass clean. 68/68 tests pass.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] 68/68 tests pass

Premium boundary: core OSS (test lint cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)