### PR TITLE
chore: fix cargo fmt drift on main

### DIFF
--- a/src/cli/commands/spawn.rs
+++ b/src/cli/commands/spawn.rs
@@ -199,7 +199,10 @@ fn sorted_agent_names(agents: &HashMap<String, AgentConfig>) -> Vec<String> {
 }
 
 fn agent_window_tmux_options() -> [(&'static str, &'static str); 2] {
-    [("remain-on-exit", "on"), ("history-limit", AGENT_HISTORY_LIMIT)]
+    [
+        ("remain-on-exit", "on"),
+        ("history-limit", AGENT_HISTORY_LIMIT),
+    ]
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_grip_object_model_phase0.rs
+++ b/tests/test_grip_object_model_phase0.rs
@@ -32,7 +32,11 @@ fn test_grip_snapshot_bootstraps_dedicated_repo_and_commits_repo_state() {
     );
 
     assert!(
-        playground.workspace_root.join(".grip").join(".git").exists(),
+        playground
+            .workspace_root
+            .join(".grip")
+            .join(".git")
+            .exists(),
         "gr grip should bootstrap a dedicated .grip git repo"
     );
 }
@@ -132,7 +136,10 @@ fn test_grip_checkout_restores_prior_snapshot_repo_heads() {
         "Add later change",
     );
     let after_sha = git_helpers::get_head_sha(&playground.repo_path("recall"));
-    assert_ne!(before_sha, after_sha, "test setup requires a changed repo head");
+    assert_ne!(
+        before_sha, after_sha,
+        "test setup requires a changed repo head"
+    );
 
     let output = playground.run_in_workspace_output(["checkout", "HEAD~1"]);
     assert!(


### PR DESCRIPTION
## Summary

Fix three `cargo fmt` violations on `main` that cause the Format CI check to fail on the ceremony PR #653. Pure whitespace changes, no logic.

## Premium Boundary

Premium boundary: grip is OSS (workspace orchestrator tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)