### PR TITLE
feat: M2.2 config overlay for zep reference repo

### DIFF
--- a/config/overlays/zep/COMPOSE.md
+++ b/config/overlays/zep/COMPOSE.md
@@ -1,0 +1,31 @@
+# zep Reference Overlay
+
+Config overlay for analyzing the zep reference repository (getzep/zep).
+
+## Purpose
+
+This overlay configures a synapt agent workspace for structured analysis
+of the zep codebase. zep is a memory platform for AI assistants that
+scores J=65.99 on the LOCOMO benchmark.
+
+## Architecture Context
+
+zep is a cloud-first memory platform with a thin Python SDK wrapping
+a hosted GraphQL API. Key differences from local-first systems:
+
+- `integrations/python/` -- Python SDK for the hosted Zep Cloud service
+- `ontology/` -- Default ontology for knowledge graph extraction
+- `zep-eval-harness/` -- Evaluation scripts for LOCOMO and LongMemEval
+- `benchmarks/` -- Benchmark dataset configs (LOCOMO, LongMemEval)
+- `legacy/` -- Self-hosted CE edition (Docker Compose, deprecated)
+
+Key patterns to analyze:
+- Cloud-first: memory storage and retrieval are API calls, not local operations
+- Knowledge graph: entities and relationships extracted via ontology
+- Dual benchmark: evaluates on both LOCOMO and LongMemEval
+- SDK-thin pattern: most logic lives server-side, SDK is a transport layer
+
+## Evaluation Baseline
+
+LOCOMO J-score: 65.99 (cloud API, graph-enhanced retrieval).
+LongMemEval: evaluated but scores vary by category.

--- a/config/overlays/zep/analysis.yml
+++ b/config/overlays/zep/analysis.yml
@@ -1,0 +1,44 @@
+modules:
+  - path: integrations/python/
+    role: python-sdk
+    patterns:
+      - cloud-api-transport
+      - session-and-user-management
+      - memory-search-api
+
+  - path: ontology/default_ontology.py
+    role: knowledge-graph-schema
+    patterns:
+      - entity-type-definitions
+      - relationship-extraction-rules
+
+  - path: zep-eval-harness/zep_evaluate.py
+    role: eval-runner
+    patterns:
+      - locomo-conversation-ingestion
+      - question-answer-scoring
+
+  - path: benchmarks/locomo/
+    role: locomo-benchmark-config
+    patterns:
+      - conversation-dataset-loading
+      - score-aggregation
+
+evaluation:
+  locomo:
+    conversations: 10
+    questions_per_conv: 154
+    categories:
+      - single-hop
+      - multi-hop
+      - temporal
+      - open-domain
+      - adversarial
+    gate_conversation: 3
+  longmemeval:
+    enabled: true
+    categories:
+      - information-extraction
+      - temporal-reasoning
+      - knowledge-update
+      - abstention

--- a/config/overlays/zep/settings.toml
+++ b/config/overlays/zep/settings.toml
@@ -1,0 +1,27 @@
+[overlay]
+name = "zep"
+author = "synapt"
+version = "0.1.0"
+repo = "getzep/zep"
+
+[analysis]
+focus = ["cloud-api-pattern", "knowledge-graph-ontology", "eval-harness"]
+entry_points = ["integrations/python/", "ontology/default_ontology.py"]
+eval_root = "zep-eval-harness/"
+benchmark_root = "benchmarks/"
+
+[analysis.benchmark]
+dataset = "LOCOMO"
+baseline_score = 65.99
+judge_model = "gpt-4o-mini"
+secondary_dataset = "LongMemEval"
+
+[workspace]
+python_version = ">=3.12"
+package_manager = "uv"
+install_command = "uv sync"
+test_command = "pytest"
+
+[comparison]
+competitors = ["mem0", "langmem", "hindsight", "memobase"]
+primary_metric = "locomo_j_score"

--- a/gr2/tests/test_m2_overlay_zep.py
+++ b/gr2/tests/test_m2_overlay_zep.py
@@ -1,0 +1,195 @@
+"""M2.2 validation: zep reference overlay end-to-end.
+
+Exercises the M1 substrate against real overlay content from
+config/overlays/zep/. Proves capture -> activate -> verify
+for the second reference repo overlay.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from gr2_overlay.activate import (
+    activate_overlay,
+    deactivate_overlay,
+    read_active_overlay_stack,
+)
+from gr2_overlay.objects import capture_overlay_object
+from gr2_overlay.refs import fetch_overlay_ref, push_overlay_ref
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
+
+OVERLAY_SOURCE = Path(__file__).resolve().parent.parent.parent / "config" / "overlays" / "zep"
+
+EXPECTED_FILES = {
+    "COMPOSE.md",
+    "settings.toml",
+    "analysis.yml",
+}
+
+
+def test_zep_overlay_source_exists_and_has_expected_files() -> None:
+    assert OVERLAY_SOURCE.is_dir(), f"Overlay source missing: {OVERLAY_SOURCE}"
+    actual = {p.name for p in OVERLAY_SOURCE.iterdir() if p.is_file()}
+    assert EXPECTED_FILES == actual, f"Expected {EXPECTED_FILES}, got {actual}"
+
+
+def test_zep_overlay_capture_and_activate_roundtrip(tmp_path: Path) -> None:
+    local_store = _init_bare_git_repo(tmp_path / "local.git")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    overlay_ref = OverlayRef(author="synapt", name="zep")
+
+    capture_overlay_object(
+        local_store,
+        OVERLAY_SOURCE,
+        _overlay_meta(overlay_ref),
+    )
+
+    result = activate_overlay(
+        workspace_root=workspace,
+        overlay_store=local_store,
+        overlay_ref=overlay_ref,
+        overlay_source_kind="path",
+        overlay_source_value="synapt/zep",
+        overlay_signer=None,
+    )
+
+    assert result.status == "ok"
+    assert result.completed == ["overlay.activated"]
+
+    for filename in EXPECTED_FILES:
+        target = workspace / filename
+        source = OVERLAY_SOURCE / filename
+        assert target.exists(), f"File not materialized: {filename}"
+        assert target.read_text() == source.read_text(), f"Content mismatch: {filename}"
+
+
+def test_zep_overlay_content_fidelity_across_push_fetch(tmp_path: Path) -> None:
+    local_store = _init_bare_git_repo(tmp_path / "local.git")
+    remote_store = _init_bare_git_repo(tmp_path / "remote.git")
+    peer_store = _init_bare_git_repo(tmp_path / "peer.git")
+    peer_workspace = tmp_path / "peer-workspace"
+    peer_workspace.mkdir()
+
+    overlay_ref = OverlayRef(author="synapt", name="zep")
+
+    capture_overlay_object(
+        local_store,
+        OVERLAY_SOURCE,
+        _overlay_meta(overlay_ref),
+    )
+    push_overlay_ref(local_store, remote_store, overlay_ref)
+    fetch_overlay_ref(peer_store, remote_store, overlay_ref)
+
+    result = activate_overlay(
+        workspace_root=peer_workspace,
+        overlay_store=peer_store,
+        overlay_ref=overlay_ref,
+        overlay_source_kind="path",
+        overlay_source_value="synapt/zep",
+        overlay_signer=None,
+    )
+
+    assert result.status == "ok"
+
+    for filename in EXPECTED_FILES:
+        target = peer_workspace / filename
+        source = OVERLAY_SOURCE / filename
+        assert target.read_text() == source.read_text(), (
+            f"Content mismatch after push/fetch: {filename}"
+        )
+
+
+def test_zep_overlay_deactivate_restores_clean_workspace(tmp_path: Path) -> None:
+    store = _init_bare_git_repo(tmp_path / "store.git")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    _write_file(workspace / "local-notes.txt", "user notes\n")
+
+    overlay_ref = OverlayRef(author="synapt", name="zep")
+    capture_overlay_object(store, OVERLAY_SOURCE, _overlay_meta(overlay_ref))
+
+    activate_overlay(
+        workspace_root=workspace,
+        overlay_store=store,
+        overlay_ref=overlay_ref,
+        overlay_source_kind="path",
+        overlay_source_value="synapt/zep",
+        overlay_signer=None,
+    )
+
+    assert (workspace / "settings.toml").exists()
+    assert (workspace / "local-notes.txt").read_text() == "user notes\n"
+
+    deactivate_overlay(workspace_root=workspace, overlay_ref=overlay_ref)
+
+    assert not (workspace / "settings.toml").exists()
+    assert not (workspace / "analysis.yml").exists()
+    assert not (workspace / "COMPOSE.md").exists()
+    assert (workspace / "local-notes.txt").read_text() == "user notes\n"
+    assert read_active_overlay_stack(workspace) == []
+
+
+def test_zep_overlay_settings_toml_has_required_fields(tmp_path: Path) -> None:
+    import tomllib
+
+    settings = OVERLAY_SOURCE / "settings.toml"
+    with open(settings, "rb") as f:
+        data = tomllib.load(f)
+
+    assert data["overlay"]["name"] == "zep"
+    assert data["overlay"]["repo"] == "getzep/zep"
+    assert data["analysis"]["benchmark"]["dataset"] == "LOCOMO"
+    assert data["analysis"]["benchmark"]["baseline_score"] == 65.99
+    assert data["analysis"]["benchmark"]["secondary_dataset"] == "LongMemEval"
+    assert "mem0" in data["comparison"]["competitors"]
+    assert "hindsight" in data["comparison"]["competitors"]
+
+
+def test_zep_overlay_analysis_yml_has_module_entries_and_dual_eval() -> None:
+    import yaml
+
+    analysis = OVERLAY_SOURCE / "analysis.yml"
+    with open(analysis) as f:
+        data = yaml.safe_load(f)
+
+    modules = data["modules"]
+    assert len(modules) >= 3
+    paths = [m["path"] for m in modules]
+    assert "integrations/python/" in paths
+    assert "ontology/default_ontology.py" in paths
+
+    eval_cfg = data["evaluation"]
+    assert eval_cfg["locomo"]["conversations"] == 10
+    assert eval_cfg["locomo"]["gate_conversation"] == 3
+    assert eval_cfg["longmemeval"]["enabled"] is True
+
+
+def _overlay_meta(overlay_ref: OverlayRef) -> OverlayMeta:
+    return OverlayMeta(
+        ref=overlay_ref,
+        tier=OverlayTier.A,
+        trust=TrustLevel.TRUSTED,
+        author=overlay_ref.author,
+        signature="unsigned",
+        timestamp="2026-04-30T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    subprocess.run(
+        ["git", "init", "--bare", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return path
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)


### PR DESCRIPTION
## Summary

- Create `config/overlays/zep/` with three Tier A files: COMPOSE.md (cloud-first architecture context, SDK-thin pattern, dual benchmark baseline), settings.toml (analysis config with LongMemEval secondary dataset), analysis.yml (module map with 4 entries including ontology and eval harness, dual eval config)
- Six validation tests proving M1 substrate works against zep overlay content

## Test Results

```
tests/test_m2_overlay_zep.py::test_zep_overlay_source_exists_and_has_expected_files PASSED
tests/test_m2_overlay_zep.py::test_zep_overlay_capture_and_activate_roundtrip PASSED
tests/test_m2_overlay_zep.py::test_zep_overlay_content_fidelity_across_push_fetch PASSED
tests/test_m2_overlay_zep.py::test_zep_overlay_deactivate_restores_clean_workspace PASSED
tests/test_m2_overlay_zep.py::test_zep_overlay_settings_toml_has_required_fields PASSED
tests/test_m2_overlay_zep.py::test_zep_overlay_analysis_yml_has_module_entries_and_dual_eval PASSED
```

6 passed in 0.86s.

## Premium Boundary

Premium boundary: grip is OSS (workspace orchestrator tooling). Config overlay content is reference material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)