### PR TITLE
feat: M2.3 config overlay for hindsight reference repo

### DIFF
--- a/config/overlays/hindsight/COMPOSE.md
+++ b/config/overlays/hindsight/COMPOSE.md
@@ -1,0 +1,34 @@
+# hindsight Reference Overlay
+
+Config overlay for analyzing the hindsight reference repository (vectorize-io/hindsight).
+
+## Purpose
+
+This overlay configures a synapt agent workspace for structured analysis
+of the hindsight codebase. Hindsight is an agent memory system that
+achieves state-of-the-art performance on both LOCOMO (J=72.0) and
+LongMemEval benchmarks.
+
+## Architecture Context
+
+Hindsight is a monorepo with Python API, TypeScript control plane, and
+embedding service. Key differences from vector-only memory systems:
+
+- `hindsight-api-slim/hindsight_api/engine/` -- Core memory engine with reflect, consolidation, and query analysis
+- `hindsight-api-slim/hindsight_api/engine/reflect/` -- Reflect pipeline: extracts structured knowledge from conversations
+- `hindsight-api-slim/hindsight_api/engine/consolidation/` -- Memory consolidation and deduplication
+- `hindsight-embed/` -- Embedding service (local MLX reranker + provider abstraction)
+- `hindsight-control-plane/` -- TypeScript admin UI and management
+- `hindsight-clients/python/` -- Python SDK
+
+Key patterns to analyze:
+- Reflect pipeline: conversations are processed through LLM-based extraction to produce structured "reflections" (facts, preferences, relationships)
+- Memory consolidation: periodic deduplication and merging of overlapping memories
+- Cross-encoder reranking: two-stage retrieval with embedding search followed by cross-encoder reranking
+- Docker-first: PostgreSQL-backed, runs as a containerized service
+- Dual benchmark leader: SOTA on both LOCOMO and LongMemEval
+
+## Evaluation Baseline
+
+LOCOMO J-score: 72.0 (SOTA as of 2026-01, independently reproduced by Virginia Tech).
+LongMemEval: SOTA across all categories (information-extraction, temporal-reasoning, knowledge-update, abstention).

--- a/config/overlays/hindsight/analysis.yml
+++ b/config/overlays/hindsight/analysis.yml
@@ -1,0 +1,47 @@
+modules:
+  - path: hindsight-api-slim/hindsight_api/engine/memory_engine.py
+    role: core-memory-engine
+    patterns:
+      - retain-and-recall-lifecycle
+      - memory-bank-management
+      - query-routing
+
+  - path: hindsight-api-slim/hindsight_api/engine/reflect/
+    role: reflect-pipeline
+    patterns:
+      - conversation-to-reflection-extraction
+      - structured-knowledge-output
+      - llm-driven-fact-extraction
+
+  - path: hindsight-api-slim/hindsight_api/engine/consolidation/
+    role: memory-consolidation
+    patterns:
+      - deduplication-and-merging
+      - temporal-decay
+      - contradiction-resolution
+
+  - path: hindsight-embed/hindsight_embed/
+    role: embedding-service
+    patterns:
+      - provider-abstraction
+      - local-mlx-reranker
+      - cross-encoder-scoring
+
+evaluation:
+  locomo:
+    conversations: 10
+    questions_per_conv: 154
+    categories:
+      - single-hop
+      - multi-hop
+      - temporal
+      - open-domain
+      - adversarial
+    gate_conversation: 3
+  longmemeval:
+    enabled: true
+    categories:
+      - information-extraction
+      - temporal-reasoning
+      - knowledge-update
+      - abstention

--- a/config/overlays/hindsight/settings.toml
+++ b/config/overlays/hindsight/settings.toml
@@ -1,0 +1,28 @@
+[overlay]
+name = "hindsight"
+author = "synapt"
+version = "0.1.0"
+repo = "vectorize-io/hindsight"
+
+[analysis]
+focus = ["reflect-pipeline", "memory-consolidation", "cross-encoder-reranking", "eval-harness"]
+entry_points = ["hindsight-api-slim/hindsight_api/engine/memory_engine.py", "hindsight-api-slim/hindsight_api/engine/reflect/"]
+config_root = "hindsight-api-slim/hindsight_api/"
+test_root = "hindsight-api-slim/tests/"
+eval_root = "hindsight-integration-tests/"
+
+[analysis.benchmark]
+dataset = "LOCOMO"
+baseline_score = 72.0
+judge_model = "gpt-4o-mini"
+secondary_dataset = "LongMemEval"
+
+[workspace]
+python_version = ">=3.11"
+package_manager = "uv"
+install_command = "uv sync"
+test_command = "pytest"
+
+[comparison]
+competitors = ["mem0", "zep", "langmem", "memobase"]
+primary_metric = "locomo_j_score"

--- a/gr2/tests/test_m2_overlay_hindsight.py
+++ b/gr2/tests/test_m2_overlay_hindsight.py
@@ -1,0 +1,196 @@
+"""M2.3 validation: hindsight reference overlay end-to-end.
+
+Exercises the M1 substrate against real overlay content from
+config/overlays/hindsight/. Proves capture -> activate -> verify
+for the third reference repo overlay (SOTA on LOCOMO + LongMemEval).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from gr2_overlay.activate import (
+    activate_overlay,
+    deactivate_overlay,
+    read_active_overlay_stack,
+)
+from gr2_overlay.objects import capture_overlay_object
+from gr2_overlay.refs import fetch_overlay_ref, push_overlay_ref
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
+
+OVERLAY_SOURCE = Path(__file__).resolve().parent.parent.parent / "config" / "overlays" / "hindsight"
+
+EXPECTED_FILES = {
+    "COMPOSE.md",
+    "settings.toml",
+    "analysis.yml",
+}
+
+
+def test_hindsight_overlay_source_exists_and_has_expected_files() -> None:
+    assert OVERLAY_SOURCE.is_dir(), f"Overlay source missing: {OVERLAY_SOURCE}"
+    actual = {p.name for p in OVERLAY_SOURCE.iterdir() if p.is_file()}
+    assert EXPECTED_FILES == actual, f"Expected {EXPECTED_FILES}, got {actual}"
+
+
+def test_hindsight_overlay_capture_and_activate_roundtrip(tmp_path: Path) -> None:
+    local_store = _init_bare_git_repo(tmp_path / "local.git")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    overlay_ref = OverlayRef(author="synapt", name="hindsight")
+
+    capture_overlay_object(
+        local_store,
+        OVERLAY_SOURCE,
+        _overlay_meta(overlay_ref),
+    )
+
+    result = activate_overlay(
+        workspace_root=workspace,
+        overlay_store=local_store,
+        overlay_ref=overlay_ref,
+        overlay_source_kind="path",
+        overlay_source_value="synapt/hindsight",
+        overlay_signer=None,
+    )
+
+    assert result.status == "ok"
+    assert result.completed == ["overlay.activated"]
+
+    for filename in EXPECTED_FILES:
+        target = workspace / filename
+        source = OVERLAY_SOURCE / filename
+        assert target.exists(), f"File not materialized: {filename}"
+        assert target.read_text() == source.read_text(), f"Content mismatch: {filename}"
+
+
+def test_hindsight_overlay_content_fidelity_across_push_fetch(tmp_path: Path) -> None:
+    local_store = _init_bare_git_repo(tmp_path / "local.git")
+    remote_store = _init_bare_git_repo(tmp_path / "remote.git")
+    peer_store = _init_bare_git_repo(tmp_path / "peer.git")
+    peer_workspace = tmp_path / "peer-workspace"
+    peer_workspace.mkdir()
+
+    overlay_ref = OverlayRef(author="synapt", name="hindsight")
+
+    capture_overlay_object(
+        local_store,
+        OVERLAY_SOURCE,
+        _overlay_meta(overlay_ref),
+    )
+    push_overlay_ref(local_store, remote_store, overlay_ref)
+    fetch_overlay_ref(peer_store, remote_store, overlay_ref)
+
+    result = activate_overlay(
+        workspace_root=peer_workspace,
+        overlay_store=peer_store,
+        overlay_ref=overlay_ref,
+        overlay_source_kind="path",
+        overlay_source_value="synapt/hindsight",
+        overlay_signer=None,
+    )
+
+    assert result.status == "ok"
+
+    for filename in EXPECTED_FILES:
+        target = peer_workspace / filename
+        source = OVERLAY_SOURCE / filename
+        assert target.read_text() == source.read_text(), (
+            f"Content mismatch after push/fetch: {filename}"
+        )
+
+
+def test_hindsight_overlay_deactivate_restores_clean_workspace(tmp_path: Path) -> None:
+    store = _init_bare_git_repo(tmp_path / "store.git")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    _write_file(workspace / "local-notes.txt", "user notes\n")
+
+    overlay_ref = OverlayRef(author="synapt", name="hindsight")
+    capture_overlay_object(store, OVERLAY_SOURCE, _overlay_meta(overlay_ref))
+
+    activate_overlay(
+        workspace_root=workspace,
+        overlay_store=store,
+        overlay_ref=overlay_ref,
+        overlay_source_kind="path",
+        overlay_source_value="synapt/hindsight",
+        overlay_signer=None,
+    )
+
+    assert (workspace / "settings.toml").exists()
+    assert (workspace / "local-notes.txt").read_text() == "user notes\n"
+
+    deactivate_overlay(workspace_root=workspace, overlay_ref=overlay_ref)
+
+    assert not (workspace / "settings.toml").exists()
+    assert not (workspace / "analysis.yml").exists()
+    assert not (workspace / "COMPOSE.md").exists()
+    assert (workspace / "local-notes.txt").read_text() == "user notes\n"
+    assert read_active_overlay_stack(workspace) == []
+
+
+def test_hindsight_overlay_settings_toml_has_required_fields(tmp_path: Path) -> None:
+    import tomllib
+
+    settings = OVERLAY_SOURCE / "settings.toml"
+    with open(settings, "rb") as f:
+        data = tomllib.load(f)
+
+    assert data["overlay"]["name"] == "hindsight"
+    assert data["overlay"]["repo"] == "vectorize-io/hindsight"
+    assert data["analysis"]["benchmark"]["dataset"] == "LOCOMO"
+    assert data["analysis"]["benchmark"]["baseline_score"] == 72.0
+    assert data["analysis"]["benchmark"]["secondary_dataset"] == "LongMemEval"
+    assert "mem0" in data["comparison"]["competitors"]
+    assert "zep" in data["comparison"]["competitors"]
+
+
+def test_hindsight_overlay_analysis_yml_has_module_entries_and_dual_eval() -> None:
+    import yaml
+
+    analysis = OVERLAY_SOURCE / "analysis.yml"
+    with open(analysis) as f:
+        data = yaml.safe_load(f)
+
+    modules = data["modules"]
+    assert len(modules) >= 4
+    paths = [m["path"] for m in modules]
+    assert "hindsight-api-slim/hindsight_api/engine/memory_engine.py" in paths
+    assert "hindsight-api-slim/hindsight_api/engine/reflect/" in paths
+    assert "hindsight-api-slim/hindsight_api/engine/consolidation/" in paths
+
+    eval_cfg = data["evaluation"]
+    assert eval_cfg["locomo"]["conversations"] == 10
+    assert eval_cfg["locomo"]["gate_conversation"] == 3
+    assert eval_cfg["longmemeval"]["enabled"] is True
+
+
+def _overlay_meta(overlay_ref: OverlayRef) -> OverlayMeta:
+    return OverlayMeta(
+        ref=overlay_ref,
+        tier=OverlayTier.A,
+        trust=TrustLevel.TRUSTED,
+        author=overlay_ref.author,
+        signature="unsigned",
+        timestamp="2026-04-30T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    subprocess.run(
+        ["git", "init", "--bare", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return path
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)


### PR DESCRIPTION
## Summary

- Third reference repo overlay: `config/overlays/hindsight/` with COMPOSE.md, settings.toml, and analysis.yml
- Hindsight is SOTA on both LOCOMO (J=72.0) and LongMemEval
- Architecture context covers reflect pipeline, memory consolidation, cross-encoder reranking, and the monorepo structure (Python API + TypeScript control plane + embedding service)
- Dual benchmark config matches zep overlay pattern: LOCOMO primary + LongMemEval secondary
- 6 validation tests prove M1 substrate works against hindsight overlay content

With M2.1 (mem0), M2.2 (zep), and M2.3 (hindsight) shipped, the three primary competitor overlays are complete.

Premium boundary: OSS (overlay content + substrate validation).

## Test plan

- [x] `pytest tests/test_m2_overlay_hindsight.py` (6/6 green)
- [x] Source existence and expected files
- [x] Capture + activate roundtrip
- [x] Push/fetch content fidelity
- [x] Deactivate restores clean workspace
- [x] settings.toml schema validation (baseline_score=72.0, dual benchmark)
- [x] analysis.yml module entries (4 modules, dual eval config)
- [x] ruff lint + format clean