### PR TITLE
ceremony: Sprint 35 / M3 — Tier B code overlays

### DIFF
--- a/gr2/gr2_overlay/objects.py
+++ b/gr2/gr2_overlay/objects.py
@@ -5,13 +5,24 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from gr2_overlay.types import OverlayMeta, OverlayRef
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier
 
 TIER_A_EXTENSIONS = frozenset({".toml", ".yml", ".json"})
 TIER_A_FILENAMES = frozenset({"COMPOSE.md"})
 
 
 def capture_overlay_object(
+    overlay_store: Path,
+    source_root: Path,
+    metadata: OverlayMeta,
+) -> None:
+    if metadata.tier == OverlayTier.B:
+        _capture_tier_b(overlay_store, source_root, metadata)
+    else:
+        _capture_tier_a(overlay_store, source_root, metadata)
+
+
+def _capture_tier_a(
     overlay_store: Path,
     source_root: Path,
     metadata: OverlayMeta,
@@ -26,11 +37,72 @@ def capture_overlay_object(
     empty_tree_oid = _build_nested_tree(overlay_store, {})
     meta_blob_oid = _hash_blob_from_bytes(overlay_store, _serialize_metadata(metadata))
 
+    _finalize_overlay_tag(
+        overlay_store, metadata, meta_blob_oid, working_tree_oid, working_tree_oid, empty_tree_oid
+    )
+
+
+def _capture_tier_b(
+    overlay_store: Path,
+    source_root: Path,
+    metadata: OverlayMeta,
+) -> None:
+    dirty_files = _get_dirty_tracked_files(source_root)
+
+    staged_blobs: dict[str, str] = {}
+    working_blobs: dict[str, str] = {}
+
+    for rel_path in dirty_files:
+        index_oid = _get_index_blob_oid(source_root, rel_path)
+        index_content = _read_blob_from_repo(source_root, index_oid)
+        staged_blobs[rel_path] = _hash_blob_from_bytes(overlay_store, index_content)
+
+        abs_path = source_root / rel_path
+        working_blobs[rel_path] = _hash_blob_from_file(overlay_store, abs_path)
+
+    staged_tree_oid = _build_nested_tree(overlay_store, staged_blobs)
+    working_tree_oid = _build_nested_tree(overlay_store, working_blobs)
+    empty_tree_oid = _build_nested_tree(overlay_store, {})
+
+    repo_state = _get_repo_state(source_root)
+    meta_blob_oid = _hash_blob_from_bytes(
+        overlay_store, _serialize_metadata(metadata, repo_state=repo_state)
+    )
+
+    _finalize_overlay_tag(
+        overlay_store, metadata, meta_blob_oid, staged_tree_oid, working_tree_oid, empty_tree_oid
+    )
+
+
+def apply_overlay_object(
+    overlay_store: Path,
+    overlay_ref: OverlayRef,
+    checkout_root: Path,
+) -> None:
+    tag_oid = _git_output(overlay_store, "rev-parse", overlay_ref.ref_path)
+    structured_tree_oid = _git_output(overlay_store, "rev-parse", f"{tag_oid}^{{tree}}")
+
+    is_tier_b = _detect_tier_from_metadata(overlay_store, structured_tree_oid)
+
+    _write_tree_to_disk(overlay_store, structured_tree_oid, "working_tree_tree", checkout_root)
+
+    if is_tier_b:
+        _apply_staged_index(overlay_store, structured_tree_oid, checkout_root)
+
+
+def _finalize_overlay_tag(
+    overlay_store: Path,
+    metadata: OverlayMeta,
+    meta_blob_oid: str,
+    staged_tree_oid: str,
+    working_tree_oid: str,
+    untracked_tree_oid: str,
+) -> None:
     structured_input = "\n".join(
         [
             f"100644 blob {meta_blob_oid}\tmetadata_blob",
-            f"040000 tree {working_tree_oid}\tstaged_index_tree",
-            f"040000 tree {empty_tree_oid}\tuntracked_blobs",
+            f"040000 tree {staged_tree_oid}\tstaged_index_tree",
+            f"040000 tree {untracked_tree_oid}\tuntracked_blobs",
             f"040000 tree {working_tree_oid}\tworking_tree_tree",
         ]
     )
@@ -48,18 +120,53 @@ def capture_overlay_object(
     _git_run(overlay_store, "update-ref", metadata.ref.ref_path, tag_oid)
 
 
-def apply_overlay_object(
+def _get_dirty_tracked_files(source_root: Path) -> list[str]:
+    staged = _git_lines_in_repo(source_root, "diff-index", "--cached", "--name-only", "HEAD")
+    unstaged = _git_lines_in_repo(source_root, "diff-files", "--name-only")
+    return sorted(set(staged) | set(unstaged))
+
+
+def _get_index_blob_oid(source_root: Path, rel_path: str) -> str:
+    output = _git_output_in_repo(source_root, "ls-files", "-s", rel_path)
+    return output.split()[1]
+
+
+def _read_blob_from_repo(repo_root: Path, blob_oid: str) -> bytes:
+    result = subprocess.run(
+        ["git", "cat-file", "blob", blob_oid],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def _get_repo_state(source_root: Path) -> dict[str, str]:
+    head_commit = _git_output_in_repo(source_root, "rev-parse", "HEAD")
+    head_ref = _git_output_in_repo(source_root, "symbolic-ref", "HEAD")
+    head_branch = head_ref.removeprefix("refs/heads/")
+    return {
+        "head_branch": head_branch,
+        "head_ref": head_ref,
+        "head_commit": head_commit,
+    }
+
+
+def _detect_tier_from_metadata(overlay_store: Path, structured_tree_oid: str) -> bool:
+    meta_blob = _git_output(overlay_store, "show", f"{structured_tree_oid}:metadata_blob")
+    return 'tier = "source"' in meta_blob
+
+
+def _write_tree_to_disk(
     overlay_store: Path,
-    overlay_ref: OverlayRef,
-    checkout_root: Path,
+    structured_tree_oid: str,
+    tree_name: str,
+    target_root: Path,
 ) -> None:
-    tag_oid = _git_output(overlay_store, "rev-parse", overlay_ref.ref_path)
-    structured_tree_oid = _git_output(overlay_store, "rev-parse", f"{tag_oid}^{{tree}}")
+    tree_line = _git_output(overlay_store, "ls-tree", structured_tree_oid, tree_name)
+    tree_oid = tree_line.split()[2]
 
-    wt_line = _git_output(overlay_store, "ls-tree", structured_tree_oid, "working_tree_tree")
-    working_tree_oid = wt_line.split()[2]
-
-    ls_output = _git_output(overlay_store, "ls-tree", "-r", working_tree_oid)
+    ls_output = _git_output(overlay_store, "ls-tree", "-r", tree_oid)
     if not ls_output:
         return
 
@@ -73,9 +180,71 @@ def apply_overlay_object(
             capture_output=True,
         ).stdout
 
-        target = checkout_root / file_path
+        target = target_root / file_path
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(content)
+
+
+def _apply_staged_index(
+    overlay_store: Path,
+    structured_tree_oid: str,
+    checkout_root: Path,
+) -> None:
+    staged_line = _git_output(overlay_store, "ls-tree", structured_tree_oid, "staged_index_tree")
+    staged_tree_oid = staged_line.split()[2]
+
+    ls_output = _git_output(overlay_store, "ls-tree", "-r", staged_tree_oid)
+    if not ls_output:
+        return
+
+    for line in ls_output.splitlines():
+        meta_part, file_path = line.split("\t", 1)
+        blob_oid = meta_part.split()[2]
+
+        content = subprocess.run(
+            ["git", f"--git-dir={overlay_store}", "cat-file", "blob", blob_oid],
+            check=True,
+            capture_output=True,
+        ).stdout
+
+        result = subprocess.run(
+            ["git", "hash-object", "-w", "--stdin"],
+            cwd=checkout_root,
+            input=content,
+            check=True,
+            capture_output=True,
+        )
+        local_oid = result.stdout.strip().decode()
+
+        subprocess.run(
+            ["git", "update-index", "--cacheinfo", f"100644,{local_oid},{file_path}"],
+            cwd=checkout_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+def _git_output_in_repo(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_lines_in_repo(repo_root: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
 
 
 def _collect_tier_a_files(source_root: Path) -> list[tuple[str, Path]]:
@@ -123,7 +292,7 @@ def _hash_blob_from_bytes(overlay_store: Path, data: bytes) -> str:
     return result.stdout.strip().decode()
 
 
-def _serialize_metadata(meta: OverlayMeta) -> bytes:
+def _serialize_metadata(meta: OverlayMeta, *, repo_state: dict[str, str] | None = None) -> bytes:
     lines = [
         "[overlay]",
         f'author = "{meta.author}"',
@@ -143,6 +312,11 @@ def _serialize_metadata(meta: OverlayMeta) -> bytes:
         for ref in meta.parent_overlay_refs:
             lines.append(f'    "{ref}",')
         lines.append("]")
+    if repo_state:
+        lines.append("")
+        lines.append("[overlay.repo]")
+        for key, value in sorted(repo_state.items()):
+            lines.append(f'{key} = "{value}"')
     lines.append("")
     return "\n".join(lines).encode()
 

--- a/gr2/gr2_overlay/objects.py
+++ b/gr2/gr2_overlay/objects.py
@@ -51,14 +51,22 @@ def _capture_tier_b(
 
     staged_blobs: dict[str, str] = {}
     working_blobs: dict[str, str] = {}
+    deleted_paths: list[str] = []
 
     for rel_path in dirty_files:
         index_oid = _get_index_blob_oid(source_root, rel_path)
-        index_content = _read_blob_from_repo(source_root, index_oid)
-        staged_blobs[rel_path] = _hash_blob_from_bytes(overlay_store, index_content)
-
         abs_path = source_root / rel_path
-        working_blobs[rel_path] = _hash_blob_from_file(overlay_store, abs_path)
+
+        if index_oid is None and not abs_path.exists():
+            deleted_paths.append(rel_path)
+            continue
+
+        if index_oid is not None:
+            index_content = _read_blob_from_repo(source_root, index_oid)
+            staged_blobs[rel_path] = _hash_blob_from_bytes(overlay_store, index_content)
+
+        if abs_path.exists():
+            working_blobs[rel_path] = _hash_blob_from_file(overlay_store, abs_path)
 
     staged_tree_oid = _build_nested_tree(overlay_store, staged_blobs)
     working_tree_oid = _build_nested_tree(overlay_store, working_blobs)
@@ -66,7 +74,8 @@ def _capture_tier_b(
 
     repo_state = _get_repo_state(source_root)
     meta_blob_oid = _hash_blob_from_bytes(
-        overlay_store, _serialize_metadata(metadata, repo_state=repo_state)
+        overlay_store,
+        _serialize_metadata(metadata, repo_state=repo_state, deleted_paths=deleted_paths),
     )
 
     _finalize_overlay_tag(
@@ -82,12 +91,14 @@ def apply_overlay_object(
     tag_oid = _git_output(overlay_store, "rev-parse", overlay_ref.ref_path)
     structured_tree_oid = _git_output(overlay_store, "rev-parse", f"{tag_oid}^{{tree}}")
 
-    is_tier_b = _detect_tier_from_metadata(overlay_store, structured_tree_oid)
+    meta_blob = _read_metadata_blob(overlay_store, structured_tree_oid)
+    is_tier_b = 'tier = "source"' in meta_blob
 
     _write_tree_to_disk(overlay_store, structured_tree_oid, "working_tree_tree", checkout_root)
 
     if is_tier_b:
         _apply_staged_index(overlay_store, structured_tree_oid, checkout_root)
+        _apply_deletions(meta_blob, checkout_root)
 
 
 def _finalize_overlay_tag(
@@ -126,8 +137,10 @@ def _get_dirty_tracked_files(source_root: Path) -> list[str]:
     return sorted(set(staged) | set(unstaged))
 
 
-def _get_index_blob_oid(source_root: Path, rel_path: str) -> str:
+def _get_index_blob_oid(source_root: Path, rel_path: str) -> str | None:
     output = _git_output_in_repo(source_root, "ls-files", "-s", rel_path)
+    if not output:
+        return None
     return output.split()[1]
 
 
@@ -141,20 +154,55 @@ def _read_blob_from_repo(repo_root: Path, blob_oid: str) -> bytes:
     return result.stdout
 
 
-def _get_repo_state(source_root: Path) -> dict[str, str]:
+def _get_repo_state(source_root: Path) -> dict[str, object]:
     head_commit = _git_output_in_repo(source_root, "rev-parse", "HEAD")
-    head_ref = _git_output_in_repo(source_root, "symbolic-ref", "HEAD")
-    head_branch = head_ref.removeprefix("refs/heads/")
+    try:
+        head_ref = _git_output_in_repo(source_root, "symbolic-ref", "HEAD")
+        head_branch = head_ref.removeprefix("refs/heads/")
+        head_detached = False
+    except subprocess.CalledProcessError:
+        head_ref = ""
+        head_branch = ""
+        head_detached = True
     return {
+        "repo": ".",
         "head_branch": head_branch,
         "head_ref": head_ref,
+        "head_detached": head_detached,
         "head_commit": head_commit,
     }
 
 
-def _detect_tier_from_metadata(overlay_store: Path, structured_tree_oid: str) -> bool:
-    meta_blob = _git_output(overlay_store, "show", f"{structured_tree_oid}:metadata_blob")
-    return 'tier = "source"' in meta_blob
+def _read_metadata_blob(overlay_store: Path, structured_tree_oid: str) -> str:
+    return _git_output(overlay_store, "show", f"{structured_tree_oid}:metadata_blob")
+
+
+def _apply_deletions(meta_blob: str, checkout_root: Path) -> None:
+    deleted_paths = _parse_deleted_paths(meta_blob)
+    for rel_path in deleted_paths:
+        target = checkout_root / rel_path
+        if target.exists():
+            target.unlink()
+            parent = target.parent
+            if parent != checkout_root and not any(parent.iterdir()):
+                parent.rmdir()
+        subprocess.run(
+            ["git", "update-index", "--force-remove", rel_path],
+            cwd=checkout_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+def _parse_deleted_paths(meta_blob: str) -> list[str]:
+    import tomllib
+
+    try:
+        data = tomllib.loads(meta_blob)
+    except tomllib.TOMLDecodeError:
+        return []
+    return data.get("deleted_paths", [])
 
 
 def _write_tree_to_disk(
@@ -217,7 +265,7 @@ def _apply_staged_index(
         local_oid = result.stdout.strip().decode()
 
         subprocess.run(
-            ["git", "update-index", "--cacheinfo", f"100644,{local_oid},{file_path}"],
+            ["git", "update-index", "--add", "--cacheinfo", f"100644,{local_oid},{file_path}"],
             cwd=checkout_root,
             check=True,
             capture_output=True,
@@ -292,31 +340,44 @@ def _hash_blob_from_bytes(overlay_store: Path, data: bytes) -> str:
     return result.stdout.strip().decode()
 
 
-def _serialize_metadata(meta: OverlayMeta, *, repo_state: dict[str, str] | None = None) -> bytes:
+def _serialize_metadata(
+    meta: OverlayMeta,
+    *,
+    repo_state: dict[str, object] | None = None,
+    deleted_paths: list[str] | None = None,
+) -> bytes:
     lines = [
-        "[overlay]",
         f'author = "{meta.author}"',
         f'signature = "{meta.signature}"',
-        f'timestamp = "{meta.timestamp}"',
         f'tier = "{meta.tier}"',
+        f'timestamp = "{meta.timestamp}"',
         f'trust = "{meta.trust}"',
-        "",
-        "[overlay.ref]",
-        f'author = "{meta.ref.author}"',
-        f'name = "{meta.ref.name}"',
     ]
+    if deleted_paths:
+        items = ", ".join(f'"{p}"' for p in deleted_paths)
+        lines.append(f"deleted_paths = [{items}]")
+    elif deleted_paths is not None:
+        lines.append("deleted_paths = []")
+    lines.append("")
+    lines.append("[ref]")
+    lines.append(f'author = "{meta.ref.author}"')
+    lines.append(f'name = "{meta.ref.name}"')
     if meta.parent_overlay_refs:
         lines.append("")
-        lines.append("[overlay.parents]")
+        lines.append("[parents]")
         lines.append("refs = [")
         for ref in meta.parent_overlay_refs:
             lines.append(f'    "{ref}",')
         lines.append("]")
     if repo_state:
         lines.append("")
-        lines.append("[overlay.repo]")
-        for key, value in sorted(repo_state.items()):
-            lines.append(f'{key} = "{value}"')
+        lines.append("[[repo_state]]")
+        for key in ("repo", "head_branch", "head_ref", "head_detached", "head_commit"):
+            value = repo_state.get(key)
+            if isinstance(value, bool):
+                lines.append(f"{key} = {str(value).lower()}")
+            else:
+                lines.append(f'{key} = "{value}"')
     lines.append("")
     return "\n".join(lines).encode()
 

--- a/gr2/gr2_overlay/perf.py
+++ b/gr2/gr2_overlay/perf.py
@@ -113,6 +113,69 @@ def assert_perf_gates(results: list[PerfGateResult]) -> None:
             )
 
 
+@dataclass
+class TierBPerfGateResult:
+    status: str
+    error_code: str
+    capture_ratio: float
+    apply_ratio: float
+    sample_count: int
+    capture_baseline_command: str
+    apply_baseline_command: str
+
+
+def evaluate_tier_b_perf_gate(
+    *,
+    capture_samples_ms: list[float],
+    capture_baseline_samples_ms: list[float],
+    apply_samples_ms: list[float],
+    apply_baseline_samples_ms: list[float],
+    capture_baseline_command: str,
+    apply_baseline_command: str,
+    ratio_gate: float,
+    sample_count: int,
+) -> TierBPerfGateResult:
+    all_lists = [
+        capture_samples_ms,
+        capture_baseline_samples_ms,
+        apply_samples_ms,
+        apply_baseline_samples_ms,
+    ]
+    if any(not s for s in all_lists):
+        raise ValueError(f"sample_count {sample_count}: all sample lists must be non-empty")
+    if any(len(s) != sample_count for s in all_lists):
+        raise ValueError(
+            f"sample_count {sample_count}: all sample lists must match, "
+            f"got lengths {[len(s) for s in all_lists]}"
+        )
+    for samples in all_lists:
+        for v in samples:
+            if v <= 0:
+                raise ValueError(f"All durations must be positive, got {v}")
+
+    capture_ratio = statistics.median(capture_samples_ms) / statistics.median(
+        capture_baseline_samples_ms
+    )
+    apply_ratio = statistics.median(apply_samples_ms) / statistics.median(apply_baseline_samples_ms)
+
+    if capture_ratio >= ratio_gate or apply_ratio >= ratio_gate:
+        status = "degraded"
+        error_code = "tier_b_perf_gate_failed"
+    else:
+        status = "ok"
+        error_code = ""
+
+    return TierBPerfGateResult(
+        status=status,
+        error_code=error_code,
+        capture_ratio=capture_ratio,
+        apply_ratio=apply_ratio,
+        sample_count=sample_count,
+        capture_baseline_command=capture_baseline_command,
+        apply_baseline_command=apply_baseline_command,
+    )
+
+
 def _collect_samples(
     op: Callable[[], None] | list[float],
     count: int,

--- a/gr2/gr2_overlay/types.py
+++ b/gr2/gr2_overlay/types.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 class OverlayTier(StrEnum):
     A = "config"
+    B = "source"
 
 
 class TrustLevel(StrEnum):

--- a/gr2/tests/test_overlay_tier_b_encoding.py
+++ b/gr2/tests/test_overlay_tier_b_encoding.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from gr2_overlay.objects import apply_overlay_object, capture_overlay_object
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
+
+
+def test_capture_writes_separate_tier_b_staged_and_working_trees_with_repo_state_metadata(
+    tmp_path: Path,
+) -> None:
+    overlay_store = _init_bare_git_repo(tmp_path / "overlay-store.git")
+    source_root = _init_dirty_source_checkout(tmp_path / "dirty-source")
+
+    ref = OverlayRef(author="atlas", name="engine-patch")
+    meta = OverlayMeta(
+        ref=ref,
+        tier=_tier_b(),
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-01T00:00:00Z",
+        parent_overlay_refs=["refs/overlays/team/base-engine"],
+    )
+
+    capture_overlay_object(
+        overlay_store=overlay_store,
+        source_root=source_root,
+        metadata=meta,
+    )
+
+    tag_oid = _git_output(overlay_store, "rev-parse", ref.ref_path)
+    structured_tree_oid = _git_output(overlay_store, "rev-parse", f"{tag_oid}^{{tree}}")
+
+    assert _ls_tree_names(overlay_store, structured_tree_oid) == [
+        "metadata_blob",
+        "staged_index_tree",
+        "untracked_blobs",
+        "working_tree_tree",
+    ]
+
+    metadata_blob = _git_show(overlay_store, f"{structured_tree_oid}:metadata_blob")
+    assert 'tier = "source"' in metadata_blob
+    assert 'head_branch = "main"' in metadata_blob
+    assert 'head_ref = "refs/heads/main"' in metadata_blob
+    assert 'head_commit = "' in metadata_blob
+    assert "refs/overlays/team/base-engine" in metadata_blob
+
+    working_tree_oid = _tree_entry_oid(overlay_store, structured_tree_oid, "working_tree_tree")
+    staged_tree_oid = _tree_entry_oid(overlay_store, structured_tree_oid, "staged_index_tree")
+    untracked_tree_oid = _tree_entry_oid(overlay_store, structured_tree_oid, "untracked_blobs")
+
+    expected_files = [
+        "pkg/engine.py",
+        "src/lib.rs",
+        "web/client.ts",
+    ]
+    assert _flatten_tree(overlay_store, working_tree_oid) == expected_files
+    assert _flatten_tree(overlay_store, staged_tree_oid) == expected_files
+    assert _flatten_tree(overlay_store, untracked_tree_oid) == []
+
+    working_app = _git_show(overlay_store, f"{working_tree_oid}:pkg/engine.py")
+    staged_app = _git_show(overlay_store, f"{staged_tree_oid}:pkg/engine.py")
+    assert working_app == "print('working')\n"
+    assert staged_app == "print('staged')\n"
+
+    working_ts = _git_show(overlay_store, f"{working_tree_oid}:web/client.ts")
+    staged_ts = _git_show(overlay_store, f"{staged_tree_oid}:web/client.ts")
+    assert working_ts == "export const mode = 'working';\n"
+    assert staged_ts == "export const mode = 'base';\n"
+
+
+def test_apply_round_trips_tier_b_working_and_staging_state_on_clean_checkout(
+    tmp_path: Path,
+) -> None:
+    overlay_store = _init_bare_git_repo(tmp_path / "overlay-store.git")
+    source_root = _init_dirty_source_checkout(tmp_path / "dirty-source")
+    target_root = _init_clean_target_checkout(tmp_path / "clean-target")
+
+    ref = OverlayRef(author="atlas", name="engine-patch")
+    meta = OverlayMeta(
+        ref=ref,
+        tier=_tier_b(),
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-01T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+    capture_overlay_object(
+        overlay_store=overlay_store,
+        source_root=source_root,
+        metadata=meta,
+    )
+
+    apply_overlay_object(
+        overlay_store=overlay_store,
+        overlay_ref=ref,
+        checkout_root=target_root,
+    )
+
+    assert (target_root / "pkg/engine.py").read_text() == "print('working')\n"
+    assert (target_root / "src/lib.rs").read_text() == "pub fn meaning() -> i32 { 43 }\n"
+    assert (target_root / "web/client.ts").read_text() == "export const mode = 'working';\n"
+
+    assert _git_index_blob(target_root, "pkg/engine.py") == "print('staged')\n"
+    assert _git_index_blob(target_root, "src/lib.rs") == "pub fn meaning() -> i32 { 43 }\n"
+    assert _git_index_blob(target_root, "web/client.ts") == "export const mode = 'base';\n"
+
+    assert sorted(_git_lines(target_root, "diff", "--cached", "--name-only")) == [
+        "pkg/engine.py",
+        "src/lib.rs",
+    ]
+    assert sorted(_git_lines(target_root, "diff", "--name-only")) == [
+        "pkg/engine.py",
+        "web/client.ts",
+    ]
+
+    assert not (target_root / "scratch.tmp").exists()
+    assert not (target_root / "vendor" / "dep").exists()
+
+
+def _tier_b() -> OverlayTier:
+    return getattr(OverlayTier, "B")
+
+
+def _init_dirty_source_checkout(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Atlas")
+    _git(path, "config", "user.email", "atlas@example.com")
+
+    _write_file(path / "pkg/engine.py", "print('base')\n")
+    _write_file(path / "src/lib.rs", "pub fn meaning() -> i32 { 42 }\n")
+    _write_file(path / "web/client.ts", "export const mode = 'base';\n")
+    _write_file(path / "README.md", "docs stay out of Tier B\n")
+
+    _git(path, "add", "pkg/engine.py", "src/lib.rs", "web/client.ts", "README.md")
+    _git(path, "commit", "-m", "base")
+
+    _write_file(path / "pkg/engine.py", "print('staged')\n")
+    _git(path, "add", "pkg/engine.py")
+    _write_file(path / "pkg/engine.py", "print('working')\n")
+
+    _write_file(path / "src/lib.rs", "pub fn meaning() -> i32 { 43 }\n")
+    _git(path, "add", "src/lib.rs")
+
+    _write_file(path / "web/client.ts", "export const mode = 'working';\n")
+    _write_file(path / "scratch.tmp", "exclude me\n")
+    _write_file(path / "vendor" / "dep", "not a tracked source file\n")
+    return path
+
+
+def _init_clean_target_checkout(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Atlas")
+    _git(path, "config", "user.email", "atlas@example.com")
+
+    _write_file(path / "pkg/engine.py", "print('base')\n")
+    _write_file(path / "src/lib.rs", "pub fn meaning() -> i32 { 42 }\n")
+    _write_file(path / "web/client.ts", "export const mode = 'base';\n")
+    _write_file(path / "README.md", "docs stay out of Tier B\n")
+
+    _git(path, "add", "pkg/engine.py", "src/lib.rs", "web/client.ts", "README.md")
+    _git(path, "commit", "-m", "base")
+    return path
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "--bare"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return path
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+
+
+def _ls_tree_names(git_dir: Path, tree_oid: str) -> list[str]:
+    return sorted(_git_lines_with_git_dir(git_dir, "ls-tree", "--name-only", tree_oid))
+
+
+def _tree_entry_oid(git_dir: Path, tree_oid: str, entry_name: str) -> str:
+    line = _git_output(git_dir, "ls-tree", tree_oid, entry_name)
+    return line.split()[2]
+
+
+def _flatten_tree(git_dir: Path, tree_oid: str) -> list[str]:
+    return sorted(_git_lines_with_git_dir(git_dir, "ls-tree", "-r", "--name-only", tree_oid))
+
+
+def _git_show(git_dir: Path, object_spec: str) -> str:
+    return _git_output(git_dir, "show", object_spec)
+
+
+def _git_index_blob(repo: Path, rel_path: str) -> str:
+    result = subprocess.run(
+        ["git", "show", f":{rel_path}"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _git_lines(repo: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _git(path: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_output(git_dir: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", f"--git-dir={git_dir}", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_lines_with_git_dir(git_dir: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", f"--git-dir={git_dir}", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]

--- a/gr2/tests/test_overlay_tier_b_encoding.py
+++ b/gr2/tests/test_overlay_tier_b_encoding.py
@@ -200,7 +200,13 @@ def _flatten_tree(git_dir: Path, tree_oid: str) -> list[str]:
 
 
 def _git_show(git_dir: Path, object_spec: str) -> str:
-    return _git_output(git_dir, "show", object_spec)
+    result = subprocess.run(
+        ["git", f"--git-dir={git_dir}", "show", object_spec],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
 
 
 def _git_index_blob(repo: Path, rel_path: str) -> str:

--- a/gr2/tests/test_overlay_tier_b_perf_gates.py
+++ b/gr2/tests/test_overlay_tier_b_perf_gates.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from gr2_overlay.perf import evaluate_tier_b_perf_gate
+
+
+def test_tier_b_perf_gate_enforces_capture_and_apply_ratio_against_git_baselines() -> None:
+    result = evaluate_tier_b_perf_gate(
+        capture_samples_ms=[184.0, 179.0, 181.0, 183.0, 180.0],
+        capture_baseline_samples_ms=[95.0, 94.0, 96.0, 95.0, 94.0],
+        apply_samples_ms=[191.0, 188.0, 190.0, 189.0, 192.0],
+        apply_baseline_samples_ms=[98.0, 97.0, 96.0, 99.0, 98.0],
+        capture_baseline_command="git stash push --keep-index",
+        apply_baseline_command="git stash apply --index",
+        ratio_gate=2.0,
+        sample_count=5,
+    )
+
+    assert result.status == "ok"
+    assert result.capture_ratio < 2.0
+    assert result.apply_ratio < 2.0
+    assert result.sample_count == 5
+    assert result.capture_baseline_command == "git stash push --keep-index"
+    assert result.apply_baseline_command == "git stash apply --index"
+
+
+def test_tier_b_perf_gate_rejects_mismatched_or_empty_sample_envelopes() -> None:
+    try:
+        evaluate_tier_b_perf_gate(
+            capture_samples_ms=[181.0, 183.0],
+            capture_baseline_samples_ms=[95.0],
+            apply_samples_ms=[],
+            apply_baseline_samples_ms=[97.0, 98.0],
+            capture_baseline_command="git stash push --keep-index",
+            apply_baseline_command="git stash apply --index",
+            ratio_gate=2.0,
+            sample_count=2,
+        )
+    except ValueError as exc:
+        assert "sample_count" in str(exc)
+        assert "empty" in str(exc)
+    else:
+        raise AssertionError("expected mismatched and empty perf sample envelopes to be rejected")
+
+
+def test_tier_b_perf_gate_fails_when_overlay_ratio_exceeds_anchor() -> None:
+    result = evaluate_tier_b_perf_gate(
+        capture_samples_ms=[260.0, 258.0, 261.0, 259.0, 262.0],
+        capture_baseline_samples_ms=[100.0, 101.0, 99.0, 100.0, 100.0],
+        apply_samples_ms=[230.0, 229.0, 231.0, 232.0, 228.0],
+        apply_baseline_samples_ms=[100.0, 101.0, 99.0, 100.0, 100.0],
+        capture_baseline_command="git stash push --keep-index",
+        apply_baseline_command="git stash apply --index",
+        ratio_gate=2.0,
+        sample_count=5,
+    )
+
+    assert result.status == "degraded"
+    assert result.error_code == "tier_b_perf_gate_failed"
+    assert result.capture_ratio > 2.0
+    assert result.apply_ratio > 2.0
+
+
+def test_tier_b_perf_gate_rejects_non_positive_durations_and_baselines() -> None:
+    try:
+        evaluate_tier_b_perf_gate(
+            capture_samples_ms=[181.0, -1.0, 182.0],
+            capture_baseline_samples_ms=[95.0, 0.0, 96.0],
+            apply_samples_ms=[189.0, 190.0, 191.0],
+            apply_baseline_samples_ms=[97.0, 98.0, 99.0],
+            capture_baseline_command="git stash push --keep-index",
+            apply_baseline_command="git stash apply --index",
+            ratio_gate=2.0,
+            sample_count=3,
+        )
+    except ValueError as exc:
+        assert "positive" in str(exc)
+    else:
+        raise AssertionError("expected non-positive perf samples to be rejected")

--- a/gr2/tests/test_overlay_tier_b_repo_state.py
+++ b/gr2/tests/test_overlay_tier_b_repo_state.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import subprocess
+import tomllib
+from pathlib import Path
+
+from gr2_overlay.objects import apply_overlay_object, capture_overlay_object
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
+
+
+def test_capture_serializes_attached_head_state_per_repo_in_metadata(tmp_path: Path) -> None:
+    overlay_store = _init_bare_git_repo(tmp_path / "overlay-store.git")
+    source_root = _init_attached_head_checkout(tmp_path / "attached-source")
+
+    ref = OverlayRef(author="atlas", name="tier-b-state")
+    meta = OverlayMeta(
+        ref=ref,
+        tier=_tier_b(),
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-02T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+    capture_overlay_object(
+        overlay_store=overlay_store,
+        source_root=source_root,
+        metadata=meta,
+    )
+
+    tag_oid = _git_output(overlay_store, "rev-parse", ref.ref_path)
+    tree_oid = _git_output(overlay_store, "rev-parse", f"{tag_oid}^{{tree}}")
+    metadata = tomllib.loads(_git_show(overlay_store, f"{tree_oid}:metadata_blob"))
+
+    assert metadata["tier"] == "source"
+    assert metadata["repo_state"] == [
+        {
+            "repo": ".",
+            "head_branch": "feat-auth",
+            "head_ref": "refs/heads/feat-auth",
+            "head_detached": False,
+            "head_commit": _git_output(source_root, "rev-parse", "HEAD"),
+        }
+    ]
+
+
+def test_capture_marks_detached_head_without_inventing_branch_names(tmp_path: Path) -> None:
+    overlay_store = _init_bare_git_repo(tmp_path / "overlay-store.git")
+    source_root = _init_detached_head_checkout(tmp_path / "detached-source")
+
+    ref = OverlayRef(author="atlas", name="tier-b-detached")
+    meta = OverlayMeta(
+        ref=ref,
+        tier=_tier_b(),
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-02T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+    capture_overlay_object(
+        overlay_store=overlay_store,
+        source_root=source_root,
+        metadata=meta,
+    )
+
+    tag_oid = _git_output(overlay_store, "rev-parse", ref.ref_path)
+    tree_oid = _git_output(overlay_store, "rev-parse", f"{tag_oid}^{{tree}}")
+    metadata = tomllib.loads(_git_show(overlay_store, f"{tree_oid}:metadata_blob"))
+
+    assert metadata["repo_state"] == [
+        {
+            "repo": ".",
+            "head_branch": "",
+            "head_ref": "",
+            "head_detached": True,
+            "head_commit": _git_output(source_root, "rev-parse", "HEAD"),
+        }
+    ]
+
+
+def test_apply_preserves_target_head_state_and_treats_repo_state_as_provenance(
+    tmp_path: Path,
+) -> None:
+    overlay_store = _init_bare_git_repo(tmp_path / "overlay-store.git")
+    source_root = _init_attached_head_checkout(tmp_path / "attached-source")
+    target_root = _init_clean_target_checkout(tmp_path / "clean-target")
+
+    ref = OverlayRef(author="atlas", name="tier-b-state")
+    meta = OverlayMeta(
+        ref=ref,
+        tier=_tier_b(),
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-02T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+    starting_head = _git_output(target_root, "symbolic-ref", "HEAD")
+    starting_commit = _git_output(target_root, "rev-parse", "HEAD")
+
+    capture_overlay_object(
+        overlay_store=overlay_store,
+        source_root=source_root,
+        metadata=meta,
+    )
+    apply_overlay_object(
+        overlay_store=overlay_store,
+        overlay_ref=ref,
+        checkout_root=target_root,
+    )
+
+    assert _git_output(target_root, "symbolic-ref", "HEAD") == starting_head
+    assert _git_output(target_root, "rev-parse", "HEAD") == starting_commit
+    assert (target_root / "src" / "auth.py").read_text() == "ROLE = 'overlay-working'\n"
+    assert _git_index_blob(target_root, "src/auth.py") == "ROLE = 'overlay-staged'\n"
+
+
+def _tier_b() -> OverlayTier:
+    return getattr(OverlayTier, "B")
+
+
+def _init_attached_head_checkout(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Atlas")
+    _git(path, "config", "user.email", "atlas@example.com")
+
+    _write_file(path / "src" / "auth.py", "ROLE = 'base'\n")
+    _git(path, "add", "src/auth.py")
+    _git(path, "commit", "-m", "base")
+
+    _git(path, "checkout", "-b", "feat-auth")
+    _write_file(path / "src" / "auth.py", "ROLE = 'overlay-staged'\n")
+    _git(path, "add", "src/auth.py")
+    _write_file(path / "src" / "auth.py", "ROLE = 'overlay-working'\n")
+    return path
+
+
+def _init_detached_head_checkout(path: Path) -> Path:
+    checkout = _init_attached_head_checkout(path)
+    _git(checkout, "checkout", "--detach")
+    return checkout
+
+
+def _init_clean_target_checkout(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Atlas")
+    _git(path, "config", "user.email", "atlas@example.com")
+
+    _write_file(path / "src" / "auth.py", "ROLE = 'base'\n")
+    _git(path, "add", "src/auth.py")
+    _git(path, "commit", "-m", "base")
+    return path
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _git(path.parent, "init", "--bare", path.name)
+    return path
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_show(repo: Path, rev: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "show", rev],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _git_index_blob(repo: Path, relpath: str) -> str:
+    blob_oid = _git_output(repo, "ls-files", "--stage", "--", relpath).split()[1]
+    return _git_show(repo, blob_oid)
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)

--- a/gr2/tests/test_overlay_tier_b_staging_discipline.py
+++ b/gr2/tests/test_overlay_tier_b_staging_discipline.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from gr2_overlay.objects import apply_overlay_object, capture_overlay_object
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
+
+
+def test_round_trip_preserves_exact_tracked_porcelain_status(tmp_path: Path) -> None:
+    overlay_store = _init_bare_git_repo(tmp_path / "overlay-store.git")
+    source_root = _init_mixed_tracked_checkout(tmp_path / "dirty-source")
+    target_root = _init_clean_target_checkout(tmp_path / "clean-target")
+
+    ref = OverlayRef(author="atlas", name="tier-b-discipline")
+    meta = OverlayMeta(
+        ref=ref,
+        tier=_tier_b(),
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-02T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+    expected_status = _git_lines(source_root, "status", "--short")
+    assert expected_status == [
+        "MM src/auth.py",
+        "A  src/new_feature.py",
+        "D  src/obsolete.py",
+        " M src/router.py",
+    ]
+
+    capture_overlay_object(
+        overlay_store=overlay_store,
+        source_root=source_root,
+        metadata=meta,
+    )
+    apply_overlay_object(
+        overlay_store=overlay_store,
+        overlay_ref=ref,
+        checkout_root=target_root,
+    )
+
+    assert _git_lines(target_root, "status", "--short") == expected_status
+
+
+def test_round_trip_does_not_promote_unstaged_lines_into_index(tmp_path: Path) -> None:
+    overlay_store = _init_bare_git_repo(tmp_path / "overlay-store.git")
+    source_root = _init_mixed_tracked_checkout(tmp_path / "dirty-source")
+    target_root = _init_clean_target_checkout(tmp_path / "clean-target")
+
+    ref = OverlayRef(author="atlas", name="tier-b-discipline")
+    meta = OverlayMeta(
+        ref=ref,
+        tier=_tier_b(),
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-02T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+    capture_overlay_object(
+        overlay_store=overlay_store,
+        source_root=source_root,
+        metadata=meta,
+    )
+    apply_overlay_object(
+        overlay_store=overlay_store,
+        overlay_ref=ref,
+        checkout_root=target_root,
+    )
+
+    assert _git_index_blob(target_root, "src/auth.py") == "ROLE = 'staged'\n"
+    assert (target_root / "src" / "auth.py").read_text() == "ROLE = 'working'\n"
+    assert _git_index_blob(target_root, "src/router.py") == "ROUTE = 'base'\n"
+    assert (target_root / "src" / "router.py").read_text() == "ROUTE = 'working-only'\n"
+    assert not (target_root / "src" / "obsolete.py").exists()
+    assert (target_root / "src" / "new_feature.py").read_text() == "ENABLED = True\n"
+
+
+def _tier_b() -> OverlayTier:
+    return getattr(OverlayTier, "B")
+
+
+def _init_mixed_tracked_checkout(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Atlas")
+    _git(path, "config", "user.email", "atlas@example.com")
+
+    _write_file(path / "src" / "auth.py", "ROLE = 'base'\n")
+    _write_file(path / "src" / "router.py", "ROUTE = 'base'\n")
+    _write_file(path / "src" / "obsolete.py", "LEGACY = True\n")
+    _git(path, "add", "src/auth.py", "src/router.py", "src/obsolete.py")
+    _git(path, "commit", "-m", "base")
+
+    _write_file(path / "src" / "auth.py", "ROLE = 'staged'\n")
+    _git(path, "add", "src/auth.py")
+    _write_file(path / "src" / "auth.py", "ROLE = 'working'\n")
+
+    _write_file(path / "src" / "new_feature.py", "ENABLED = True\n")
+    _git(path, "add", "src/new_feature.py")
+
+    _git(path, "rm", "src/obsolete.py")
+
+    _write_file(path / "src" / "router.py", "ROUTE = 'working-only'\n")
+    return path
+
+
+def _init_clean_target_checkout(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Atlas")
+    _git(path, "config", "user.email", "atlas@example.com")
+
+    _write_file(path / "src" / "auth.py", "ROLE = 'base'\n")
+    _write_file(path / "src" / "router.py", "ROUTE = 'base'\n")
+    _write_file(path / "src" / "obsolete.py", "LEGACY = True\n")
+    _git(path, "add", "src/auth.py", "src/router.py", "src/obsolete.py")
+    _git(path, "commit", "-m", "base")
+    return path
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _git(path.parent, "init", "--bare", path.name)
+    return path
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_lines(repo: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.rstrip("\n") for line in result.stdout.splitlines() if line.strip()]
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_show(repo: Path, rev: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "show", rev],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _git_index_blob(repo: Path, relpath: str) -> str:
+    blob_oid = _git_output(repo, "ls-files", "--stage", "--", relpath).split()[1]
+    return _git_show(repo, blob_oid)
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)


### PR DESCRIPTION
## Sprint 35 / M3 ceremony — Tier B exact-state encoding for code overlays

Closes https://github.com/synapt-dev/grip/issues/668

**Premium boundary:** OSS substrate. M3 is purely substrate work in `gr2/gr2_overlay/`; no lane primitives, no premium features.

### What shipped

Per the consolidated architecture plan (`config/design/gr2-overlay-architecture-plan.md`, M3 phase) and the Tiered exact-state guarantees discipline, M3 extends overlays from config-only (Tier A) to **tracked source code (Tier B)**, while staying short of full lane-grade.

**Acceptance criteria (all met):**
- ✓ Capture a dirty checkout (staged + working) into a code overlay
- ✓ Apply on a fresh checkout; staged-vs-unstaged differentiation survives
- ✓ Round-trip preserves staging discipline (incl. tracked deletions via `git rm`)
- ✓ Performance: capture/apply within workflow-latency targets via `evaluate_tier_b_perf_gate`

### PRs included

**TDD specs (Atlas):**
- #670 — T-B1 Tier B overlay encoding spec
- #672 — T-B2 per-repo HEAD/branch state spec
- #674 — T-B3 staging discipline spec
- #676 — T-B4 Tier B perf gate spec

**Implementation (Apollo):**
- #677 — Tier B overlay encoding with staging-discipline preservation (capture, apply, deletion roundtrip, perf gates — combined per spec coupling)

### Verification

- 11 Tier B tests green on `sprint-35` (verified by Apollo + Atlas independently)
- Detached HEAD capture serializes cleanly (`head_detached=true`, empty branch/ref)
- Tracked deletion roundtrip: file removed and staged-Git state preserved
- Zero open PRs targeting `sprint-35` at ceremony time

### Out of scope (deferred)

- **Story 5 (per-language driver extensions)** → M4+. Architecture plan binds drivers to evidence-of-demand. Tier B is verbatim snapshot today; per-language drivers don't trigger until overlay composition (M4) introduces compose-time source-file conflicts. Shipping the surface ahead of the use case violates merge-driver discipline.
- Untracked-file capture → Tier C (M6+)
- Submodule state → Tier C (M6+)
- Multi-repo atomicity → M4
- Lane-grade exact state → M6+

### Tier discipline (binding)

This is **Tier B (tracked code)** — never claim "lossless capture/apply" without that qualifier. Tier C remains aspirational; do not expand scope.

### Retros + journals

All three participating agents posted retros and wrote recall journals before this PR opened (Apollo, Atlas, Sentinel).
