### PR TITLE
ceremony: Sprint 36 / M4 — Cross-repo atomic apply + composition

### DIFF
--- a/gr2/gr2_overlay/cross_repo.py
+++ b/gr2/gr2_overlay/cross_repo.py
@@ -1,0 +1,121 @@
+"""Cross-repo atomic overlay activation with rollback."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from gr2_overlay.activate import (
+    OverlayActivationError,
+    activate_overlay,
+    deactivate_overlay,
+)
+from gr2_overlay.types import OverlayRef
+
+
+@dataclass(frozen=True)
+class RepoOverlayTarget:
+    repo_name: str
+    checkout_root: Path
+    overlay_store: Path
+    overlay_ref: OverlayRef
+    overlay_source_kind: str
+    overlay_source_value: str | None
+    overlay_signer: str | None
+
+
+@dataclass
+class CrossRepoActivationResult:
+    status: str
+    completed_repos: list[str] = field(default_factory=list)
+    rolled_back_repos: list[str] = field(default_factory=list)
+
+
+class CrossRepoActivationError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_code: str,
+        failing_repo: str,
+        rolled_back_repos: list[str],
+    ) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.failing_repo = failing_repo
+        self.rolled_back_repos = rolled_back_repos
+
+
+def activate_overlays_atomically(
+    targets: list[RepoOverlayTarget],
+) -> CrossRepoActivationResult:
+    snapshots: dict[str, dict[str, str]] = {}
+    applied: list[RepoOverlayTarget] = []
+
+    for target in targets:
+        snapshots[target.repo_name] = _snapshot(target.checkout_root)
+
+    try:
+        for target in targets:
+            activate_overlay(
+                workspace_root=target.checkout_root,
+                overlay_store=target.overlay_store,
+                overlay_ref=target.overlay_ref,
+                overlay_source_kind=target.overlay_source_kind,
+                overlay_source_value=target.overlay_source_value,
+                overlay_signer=target.overlay_signer,
+            )
+            applied.append(target)
+    except OverlayActivationError as e:
+        failing_target = target
+        rolled_back: list[str] = []
+
+        for prev in reversed(applied):
+            _restore_snapshot(prev.checkout_root, snapshots[prev.repo_name])
+            rolled_back.append(prev.repo_name)
+        rolled_back.reverse()
+
+        if _snapshot(failing_target.checkout_root) != snapshots[failing_target.repo_name]:
+            _restore_snapshot(failing_target.checkout_root, snapshots[failing_target.repo_name])
+            rolled_back.append(failing_target.repo_name)
+
+        raise CrossRepoActivationError(
+            str(e),
+            error_code=e.error_code,
+            failing_repo=failing_target.repo_name,
+            rolled_back_repos=rolled_back,
+        ) from e
+
+    return CrossRepoActivationResult(
+        status="ok",
+        completed_repos=[t.repo_name for t in applied],
+    )
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            result[str(path.relative_to(root))] = path.read_text()
+    return result
+
+
+def _restore_snapshot(root: Path, snapshot: dict[str, str]) -> None:
+    current_files = set()
+    for path in root.rglob("*"):
+        if path.is_file():
+            current_files.add(str(path.relative_to(root)))
+
+    for rel_path in current_files - set(snapshot.keys()):
+        target = root / rel_path
+        target.unlink()
+
+    for rel_path, content in snapshot.items():
+        target = root / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+    for dirpath in sorted(root.rglob("*"), reverse=True):
+        if dirpath.is_dir() and not any(dirpath.iterdir()):
+            dirpath.rmdir()

--- a/gr2/gr2_overlay/language_drivers.py
+++ b/gr2/gr2_overlay/language_drivers.py
@@ -1,0 +1,115 @@
+"""AST-based language-aware merge drivers for overlay composition."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+class PythonCompositionConflict(Exception):
+    def __init__(self, symbol: str) -> None:
+        super().__init__(
+            f"Composition conflict: both base and overlay modify '{symbol}'"
+        )
+        self.error_code = "composition_conflict"
+        self.symbol = symbol
+
+
+def merge_python_overlay(
+    *,
+    ancestor: Path,
+    current: Path,
+    other: Path,
+    relative_path: str,
+) -> None:
+    if not relative_path.endswith(".py"):
+        raise ValueError("Python driver only supports .py paths")
+
+    ancestor_tree = ast.parse(ancestor.read_text())
+    current_tree = ast.parse(current.read_text())
+    other_tree = ast.parse(other.read_text())
+
+    ancestor_imports, ancestor_defs = _split_nodes(ancestor_tree)
+    current_imports, current_defs = _split_nodes(current_tree)
+    other_imports, other_defs = _split_nodes(other_tree)
+
+    merged_imports = _union_imports(current_imports, other_imports)
+    merged_defs = _merge_definitions(ancestor_defs, current_defs, other_defs)
+
+    merged_module = ast.Module(body=merged_imports + merged_defs, type_ignores=[])
+    ast.fix_missing_locations(merged_module)
+    current.write_text(ast.unparse(merged_module) + "\n")
+
+
+def _split_nodes(
+    tree: ast.Module,
+) -> tuple[list[ast.stmt], dict[str, ast.stmt]]:
+    imports: list[ast.stmt] = []
+    defs: dict[str, ast.stmt] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(node)
+        else:
+            name = _node_name(node)
+            if name:
+                defs[name] = node
+    return imports, defs
+
+
+def _node_name(node: ast.stmt) -> str | None:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return node.name
+    if isinstance(node, ast.Assign):
+        if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            return node.targets[0].id
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    return None
+
+
+def _union_imports(
+    current: list[ast.stmt], other: list[ast.stmt]
+) -> list[ast.stmt]:
+    seen: set[str] = set()
+    result: list[ast.stmt] = []
+    for node in current + other:
+        key = ast.dump(node)
+        if key not in seen:
+            seen.add(key)
+            result.append(node)
+    return result
+
+
+def _merge_definitions(
+    ancestor: dict[str, ast.stmt],
+    current: dict[str, ast.stmt],
+    other: dict[str, ast.stmt],
+) -> list[ast.stmt]:
+    all_names = list(dict.fromkeys(list(current.keys()) + list(other.keys())))
+    result: list[ast.stmt] = []
+
+    for name in all_names:
+        a_node = ancestor.get(name)
+        c_node = current.get(name)
+        o_node = other.get(name)
+
+        a_dump = ast.dump(a_node) if a_node else None
+        c_dump = ast.dump(c_node) if c_node else None
+        o_dump = ast.dump(o_node) if o_node else None
+
+        current_changed = c_dump != a_dump
+        other_changed = o_dump != a_dump
+
+        if current_changed and other_changed and c_node and o_node:
+            if isinstance(o_node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                result.append(o_node)
+            else:
+                raise PythonCompositionConflict(name)
+        elif o_node and other_changed:
+            result.append(o_node)
+        elif c_node:
+            result.append(c_node)
+        elif o_node:
+            result.append(o_node)
+
+    return result

--- a/gr2/gr2_overlay/perf.py
+++ b/gr2/gr2_overlay/perf.py
@@ -176,6 +176,62 @@ def evaluate_tier_b_perf_gate(
     )
 
 
+@dataclass
+class CrossRepoPerfGateResult:
+    status: str
+    error_code: str
+    apply_ratio: float
+    sample_count: int
+    repo_count: int
+    baseline_command: str
+
+
+def evaluate_cross_repo_perf_gate(
+    *,
+    apply_samples_ms: list[float],
+    baseline_samples_ms: list[float],
+    baseline_command: str,
+    ratio_gate: float,
+    sample_count: int,
+    repo_count: int,
+) -> CrossRepoPerfGateResult:
+    if repo_count <= 0:
+        raise ValueError(f"repo_count must be positive, got {repo_count}")
+    if not baseline_command:
+        raise ValueError("baseline_command must not be empty")
+
+    all_lists = [apply_samples_ms, baseline_samples_ms]
+    if any(not s for s in all_lists):
+        raise ValueError(f"sample_count {sample_count}: all sample lists must be non-empty")
+    if any(len(s) != sample_count for s in all_lists):
+        raise ValueError(
+            f"sample_count {sample_count}: all sample lists must match, "
+            f"got lengths {[len(s) for s in all_lists]}"
+        )
+    for samples in all_lists:
+        for v in samples:
+            if v <= 0:
+                raise ValueError(f"All durations must be positive, got {v}")
+
+    apply_ratio = statistics.median(apply_samples_ms) / statistics.median(baseline_samples_ms)
+
+    if apply_ratio >= ratio_gate:
+        status = "degraded"
+        error_code = "cross_repo_perf_gate_failed"
+    else:
+        status = "ok"
+        error_code = ""
+
+    return CrossRepoPerfGateResult(
+        status=status,
+        error_code=error_code,
+        apply_ratio=apply_ratio,
+        sample_count=sample_count,
+        repo_count=repo_count,
+        baseline_command=baseline_command,
+    )
+
+
 def _collect_samples(
     op: Callable[[], None] | list[float],
     count: int,

--- a/gr2/gr2_overlay/perf.py
+++ b/gr2/gr2_overlay/perf.py
@@ -199,6 +199,8 @@ def evaluate_cross_repo_perf_gate(
         raise ValueError(f"repo_count must be positive, got {repo_count}")
     if not baseline_command:
         raise ValueError("baseline_command must not be empty")
+    if sample_count < 2:
+        raise ValueError(f"sample_count must be >= 2 for statistical validity, got {sample_count}")
 
     all_lists = [apply_samples_ms, baseline_samples_ms]
     if any(not s for s in all_lists):

--- a/gr2/tests/test_overlay_composition_merge.py
+++ b/gr2/tests/test_overlay_composition_merge.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gr2_overlay.objects import capture_overlay_object
+from gr2_overlay.trust import write_workspace_allowlist
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
+
+
+def test_reapplying_same_overlay_stack_is_deterministic_across_remerge(tmp_path: Path) -> None:
+    from gr2_overlay.cross_repo import RepoOverlayTarget, activate_overlays_atomically
+
+    base_ref = OverlayRef(author="atlas", name="base-theme")
+    feature_ref = OverlayRef(author="atlas", name="feature-theme")
+
+    app_store, app_workspace, app_source = _triplet(tmp_path, "app")
+    docs_store, docs_workspace, docs_source = _triplet(tmp_path, "docs")
+
+    _write_file(app_source / "settings.toml", '[ui]\ntheme = "base"\n')
+    _write_file(docs_source / "settings.toml", '[ui]\ntheme = "base"\n')
+    capture_overlay_object(app_store, app_source, _overlay_meta(base_ref))
+    capture_overlay_object(docs_store, docs_source, _overlay_meta(base_ref))
+
+    _write_file(app_source / "settings.toml", '[ui]\ntheme = "feature"\n')
+    _write_file(docs_source / "settings.toml", '[ui]\ntheme = "feature"\n')
+    capture_overlay_object(
+        app_store,
+        app_source,
+        _overlay_meta(feature_ref, parents=[base_ref.ref_path]),
+    )
+    capture_overlay_object(
+        docs_store,
+        docs_source,
+        _overlay_meta(feature_ref, parents=[base_ref.ref_path]),
+    )
+
+    for workspace in (app_workspace, docs_workspace):
+        write_workspace_allowlist(
+            workspace,
+            [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+        )
+
+    targets = [
+        RepoOverlayTarget(
+            repo_name="app",
+            checkout_root=app_workspace,
+            overlay_store=app_store,
+            overlay_ref=feature_ref,
+            overlay_source_kind="path",
+            overlay_source_value="atlas/feature-theme",
+            overlay_signer=None,
+        ),
+        RepoOverlayTarget(
+            repo_name="docs",
+            checkout_root=docs_workspace,
+            overlay_store=docs_store,
+            overlay_ref=feature_ref,
+            overlay_source_kind="path",
+            overlay_source_value="atlas/feature-theme",
+            overlay_signer=None,
+        ),
+    ]
+
+    first = activate_overlays_atomically(targets=targets)
+    first_app = _snapshot(app_workspace)
+    first_docs = _snapshot(docs_workspace)
+
+    second = activate_overlays_atomically(targets=targets)
+    second_app = _snapshot(app_workspace)
+    second_docs = _snapshot(docs_workspace)
+
+    assert first.status == "ok"
+    assert second.status == "ok"
+    assert first.completed_repos == ["app", "docs"]
+    assert second.completed_repos == ["app", "docs"]
+    assert second_app == first_app
+    assert second_docs == first_docs
+
+
+def test_cross_repo_composition_conflict_is_explicit_and_non_partial(tmp_path: Path) -> None:
+    from gr2_overlay.cross_repo import (
+        CrossRepoActivationError,
+        RepoOverlayTarget,
+        activate_overlays_atomically,
+    )
+
+    base_ref = OverlayRef(author="atlas", name="base-theme")
+    feature_ref = OverlayRef(author="atlas", name="feature-theme")
+
+    app_store, app_workspace, app_source = _triplet(tmp_path, "app")
+    docs_store, docs_workspace, docs_source = _triplet(tmp_path, "docs")
+
+    _write_file(app_source / "settings.toml", '[ui]\ntheme = "base"\n')
+    _write_file(docs_source / "settings.toml", '[ui]\ntheme = "base"\n')
+    capture_overlay_object(app_store, app_source, _overlay_meta(base_ref))
+    capture_overlay_object(docs_store, docs_source, _overlay_meta(base_ref))
+
+    _write_file(app_source / "settings.toml", '[ui]\ntheme = "feature"\n')
+    _write_file(docs_source / "settings.toml", '[ui]\ntheme = "feature"\n')
+    capture_overlay_object(
+        app_store,
+        app_source,
+        _overlay_meta(feature_ref, parents=[base_ref.ref_path]),
+    )
+    capture_overlay_object(
+        docs_store,
+        docs_source,
+        _overlay_meta(feature_ref, parents=[base_ref.ref_path]),
+    )
+
+    _write_file(docs_workspace / ".gitattributes", "*.toml merge=overlay-deep\n")
+    _write_file(docs_workspace / ".grip" / "force-conflict.toml", "enabled = true\n")
+
+    for workspace in (app_workspace, docs_workspace):
+        write_workspace_allowlist(
+            workspace,
+            [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+        )
+
+    app_before = _snapshot(app_workspace)
+    docs_before = _snapshot(docs_workspace)
+
+    with pytest.raises(CrossRepoActivationError) as exc:
+        activate_overlays_atomically(
+            targets=[
+                RepoOverlayTarget(
+                    repo_name="app",
+                    checkout_root=app_workspace,
+                    overlay_store=app_store,
+                    overlay_ref=feature_ref,
+                    overlay_source_kind="path",
+                    overlay_source_value="atlas/feature-theme",
+                    overlay_signer=None,
+                ),
+                RepoOverlayTarget(
+                    repo_name="docs",
+                    checkout_root=docs_workspace,
+                    overlay_store=docs_store,
+                    overlay_ref=feature_ref,
+                    overlay_source_kind="path",
+                    overlay_source_value="atlas/feature-theme",
+                    overlay_signer=None,
+                ),
+            ]
+        )
+
+    assert exc.value.error_code == "composition_conflict"
+    assert exc.value.failing_repo == "docs"
+    assert _snapshot(app_workspace) == app_before
+    assert _snapshot(docs_workspace) == docs_before
+
+
+def _triplet(tmp_path: Path, repo_name: str) -> tuple[Path, Path, Path]:
+    overlay_store = _init_bare_git_repo(tmp_path / f"{repo_name}-overlay-store.git")
+    checkout_root = tmp_path / repo_name
+    overlay_source = tmp_path / f"{repo_name}-overlay-source"
+    checkout_root.mkdir()
+    overlay_source.mkdir()
+    return overlay_store, checkout_root, overlay_source
+
+
+def _overlay_meta(overlay_ref: OverlayRef, parents: list[str] | None = None) -> OverlayMeta:
+    return OverlayMeta(
+        ref=overlay_ref,
+        tier=OverlayTier.A,
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-01T00:00:00Z",
+        parent_overlay_refs=parents or [],
+    )
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _git(path.parent, "init", "--bare", path.name)
+    return path
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            snapshot[str(path.relative_to(root))] = path.read_text()
+    return snapshot

--- a/gr2/tests/test_overlay_cross_repo_atomic_apply.py
+++ b/gr2/tests/test_overlay_cross_repo_atomic_apply.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gr2_overlay.activate import read_active_overlay_stack
+from gr2_overlay.objects import capture_overlay_object
+from gr2_overlay.trust import write_workspace_allowlist
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
+
+
+def test_activate_overlays_atomically_applies_to_both_repos_or_none(tmp_path: Path) -> None:
+    from gr2_overlay.cross_repo import RepoOverlayTarget, activate_overlays_atomically
+
+    overlay_ref = OverlayRef(author="atlas", name="workspace-bundle")
+    app_store, app_workspace, app_source = _triplet(tmp_path, "app")
+    docs_store, docs_workspace, docs_source = _triplet(tmp_path, "docs")
+
+    _write_file(app_source / "settings.toml", 'theme = "owl"\n')
+    _write_file(docs_source / "COMPOSE.md", "# Docs overlay\n")
+
+    capture_overlay_object(app_store, app_source, _overlay_meta(overlay_ref))
+    capture_overlay_object(docs_store, docs_source, _overlay_meta(overlay_ref))
+    write_workspace_allowlist(
+        app_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+    )
+    write_workspace_allowlist(
+        docs_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+    )
+
+    result = activate_overlays_atomically(
+        targets=[
+            RepoOverlayTarget(
+                repo_name="app",
+                checkout_root=app_workspace,
+                overlay_store=app_store,
+                overlay_ref=overlay_ref,
+                overlay_source_kind="path",
+                overlay_source_value="atlas/workspace-bundle",
+                overlay_signer=None,
+            ),
+            RepoOverlayTarget(
+                repo_name="docs",
+                checkout_root=docs_workspace,
+                overlay_store=docs_store,
+                overlay_ref=overlay_ref,
+                overlay_source_kind="path",
+                overlay_source_value="atlas/workspace-bundle",
+                overlay_signer=None,
+            ),
+        ]
+    )
+
+    assert result.status == "ok"
+    assert result.completed_repos == ["app", "docs"]
+    assert result.rolled_back_repos == []
+    assert (app_workspace / "settings.toml").read_text() == 'theme = "owl"\n'
+    assert (docs_workspace / "COMPOSE.md").read_text() == "# Docs overlay\n"
+    assert read_active_overlay_stack(app_workspace) == [overlay_ref.ref_path]
+    assert read_active_overlay_stack(docs_workspace) == [overlay_ref.ref_path]
+
+
+def test_atomic_apply_rolls_back_first_repo_when_second_repo_blocks(tmp_path: Path) -> None:
+    from gr2_overlay.cross_repo import (
+        CrossRepoActivationError,
+        RepoOverlayTarget,
+        activate_overlays_atomically,
+    )
+
+    overlay_ref = OverlayRef(author="atlas", name="workspace-bundle")
+    app_store, app_workspace, app_source = _triplet(tmp_path, "app")
+    docs_store, docs_workspace, docs_source = _triplet(tmp_path, "docs")
+
+    _write_file(app_workspace / "keep.txt", "keep me\n")
+    _write_file(app_source / "settings.toml", 'theme = "owl"\n')
+    _write_file(docs_source / "COMPOSE.md", "# Docs overlay\n")
+
+    capture_overlay_object(app_store, app_source, _overlay_meta(overlay_ref))
+    capture_overlay_object(docs_store, docs_source, _overlay_meta(overlay_ref))
+    write_workspace_allowlist(
+        app_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+    )
+    write_workspace_allowlist(
+        docs_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+    )
+    _write_file(docs_workspace / ".grip" / "overlay-base-state.toml", "advanced = true\n")
+
+    app_before = _snapshot(app_workspace)
+    docs_before = _snapshot(docs_workspace)
+
+    with pytest.raises(CrossRepoActivationError) as exc:
+        activate_overlays_atomically(
+            targets=[
+                RepoOverlayTarget(
+                    repo_name="app",
+                    checkout_root=app_workspace,
+                    overlay_store=app_store,
+                    overlay_ref=overlay_ref,
+                    overlay_source_kind="path",
+                    overlay_source_value="atlas/workspace-bundle",
+                    overlay_signer=None,
+                ),
+                RepoOverlayTarget(
+                    repo_name="docs",
+                    checkout_root=docs_workspace,
+                    overlay_store=docs_store,
+                    overlay_ref=overlay_ref,
+                    overlay_source_kind="path",
+                    overlay_source_value="atlas/workspace-bundle",
+                    overlay_signer=None,
+                ),
+            ]
+        )
+
+    assert exc.value.error_code == "base_advanced"
+    assert exc.value.failing_repo == "docs"
+    assert exc.value.rolled_back_repos == ["app"]
+    assert _snapshot(app_workspace) == app_before
+    assert _snapshot(docs_workspace) == docs_before
+    assert read_active_overlay_stack(app_workspace) == []
+    assert read_active_overlay_stack(docs_workspace) == []
+
+
+def _triplet(tmp_path: Path, repo_name: str) -> tuple[Path, Path, Path]:
+    overlay_store = _init_bare_git_repo(tmp_path / f"{repo_name}-overlay-store.git")
+    checkout_root = tmp_path / repo_name
+    overlay_source = tmp_path / f"{repo_name}-overlay-source"
+    checkout_root.mkdir()
+    overlay_source.mkdir()
+    return overlay_store, checkout_root, overlay_source
+
+
+def _overlay_meta(overlay_ref: OverlayRef) -> OverlayMeta:
+    return OverlayMeta(
+        ref=overlay_ref,
+        tier=OverlayTier.A,
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-01T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _git(path.parent, "init", "--bare", path.name)
+    return path
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            snapshot[str(path.relative_to(root))] = path.read_text()
+    return snapshot

--- a/gr2/tests/test_overlay_cross_repo_perf_gate.py
+++ b/gr2/tests/test_overlay_cross_repo_perf_gate.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from gr2_overlay.perf import evaluate_cross_repo_perf_gate
+
+
+def test_cross_repo_perf_gate_passes_when_apply_stays_within_git_baseline_budget() -> None:
+    result = evaluate_cross_repo_perf_gate(
+        apply_samples_ms=[98.0, 101.0, 100.0],
+        baseline_samples_ms=[50.0, 50.0, 49.0],
+        baseline_command="git checkout -- app/settings.toml docs/COMPOSE.md",
+        ratio_gate=2.1,
+        sample_count=3,
+        repo_count=2,
+    )
+
+    assert result.status == "ok"
+    assert result.error_code == ""
+    assert result.repo_count == 2
+    assert result.sample_count == 3
+    assert result.baseline_command == "git checkout -- app/settings.toml docs/COMPOSE.md"
+    assert result.apply_ratio < 2.1
+
+
+def test_cross_repo_perf_gate_fails_when_apply_ratio_exceeds_budget() -> None:
+    result = evaluate_cross_repo_perf_gate(
+        apply_samples_ms=[130.0, 132.0, 131.0],
+        baseline_samples_ms=[50.0, 50.0, 50.0],
+        baseline_command="git checkout -- app/settings.toml docs/COMPOSE.md",
+        ratio_gate=2.0,
+        sample_count=3,
+        repo_count=2,
+    )
+
+    assert result.status == "degraded"
+    assert result.error_code == "cross_repo_perf_gate_failed"
+    assert result.apply_ratio > 2.0
+
+
+def test_cross_repo_perf_gate_rejects_invalid_or_gameable_sample_envelopes() -> None:
+    invalid_cases = [
+        {
+            "apply_samples_ms": [],
+            "baseline_samples_ms": [50.0, 50.0],
+            "baseline_command": "git checkout -- app/settings.toml docs/COMPOSE.md",
+            "ratio_gate": 2.0,
+            "sample_count": 2,
+            "repo_count": 2,
+        },
+        {
+            "apply_samples_ms": [100.0],
+            "baseline_samples_ms": [50.0, 50.0],
+            "baseline_command": "git checkout -- app/settings.toml docs/COMPOSE.md",
+            "ratio_gate": 2.0,
+            "sample_count": 2,
+            "repo_count": 2,
+        },
+        {
+            "apply_samples_ms": [100.0, -1.0],
+            "baseline_samples_ms": [50.0, 50.0],
+            "baseline_command": "git checkout -- app/settings.toml docs/COMPOSE.md",
+            "ratio_gate": 2.0,
+            "sample_count": 2,
+            "repo_count": 2,
+        },
+        {
+            "apply_samples_ms": [100.0, 101.0],
+            "baseline_samples_ms": [50.0, 50.0],
+            "baseline_command": "",
+            "ratio_gate": 2.0,
+            "sample_count": 2,
+            "repo_count": 2,
+        },
+        {
+            "apply_samples_ms": [100.0, 101.0],
+            "baseline_samples_ms": [50.0, 50.0],
+            "baseline_command": "git checkout -- app/settings.toml docs/COMPOSE.md",
+            "ratio_gate": 2.0,
+            "sample_count": 2,
+            "repo_count": 0,
+        },
+    ]
+
+    for case in invalid_cases:
+        try:
+            evaluate_cross_repo_perf_gate(**case)
+        except ValueError:
+            continue
+        raise AssertionError(f"expected invalid perf envelope to be rejected: {case}")

--- a/gr2/tests/test_overlay_cross_repo_rollback.py
+++ b/gr2/tests/test_overlay_cross_repo_rollback.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from gr2_overlay.activate import OverlayActivationError, activate_overlay, deactivate_overlay
+from gr2_overlay.objects import capture_overlay_object
+from gr2_overlay.trust import write_workspace_allowlist
+from gr2_overlay.types import OverlayMeta, OverlayRef, OverlayTier, TrustLevel
+
+
+def test_rollback_restores_every_touched_repo_after_partial_second_repo_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.cross_repo as cross_repo
+
+    overlay_ref = OverlayRef(author="atlas", name="workspace-bundle")
+    app_store, app_workspace, app_source = _triplet(tmp_path, "app")
+    docs_store, docs_workspace, docs_source = _triplet(tmp_path, "docs")
+
+    _write_file(app_workspace / "keep.txt", "keep me\n")
+    _write_file(docs_workspace / "README.md", "docs base\n")
+    _write_file(app_source / "settings.toml", 'theme = "owl"\n')
+    _write_file(docs_source / "COMPOSE.md", "# Docs overlay\n")
+
+    capture_overlay_object(app_store, app_source, _overlay_meta(overlay_ref))
+    capture_overlay_object(docs_store, docs_source, _overlay_meta(overlay_ref))
+    write_workspace_allowlist(
+        app_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+    )
+    write_workspace_allowlist(
+        docs_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+    )
+
+    before_app = _snapshot(app_workspace)
+    before_docs = _snapshot(docs_workspace)
+
+    real_activate = activate_overlay
+
+    def fake_activate_overlay(*, workspace_root: Path, **kwargs):
+        if workspace_root == docs_workspace:
+            _write_file(docs_workspace / "COMPOSE.md", "# partially written\n")
+            _write_file(docs_workspace / ".grip" / "overlay-stack.json", '["corrupt"]\n')
+            raise OverlayActivationError("simulated docs failure", error_code="composition_conflict")
+        return real_activate(workspace_root=workspace_root, **kwargs)
+
+    monkeypatch.setattr(cross_repo, "activate_overlay", fake_activate_overlay)
+    monkeypatch.setattr(cross_repo, "deactivate_overlay", deactivate_overlay)
+
+    with pytest.raises(cross_repo.CrossRepoActivationError) as exc:
+        cross_repo.activate_overlays_atomically(
+            targets=[
+                cross_repo.RepoOverlayTarget(
+                    repo_name="app",
+                    checkout_root=app_workspace,
+                    overlay_store=app_store,
+                    overlay_ref=overlay_ref,
+                    overlay_source_kind="path",
+                    overlay_source_value="atlas/workspace-bundle",
+                    overlay_signer=None,
+                ),
+                cross_repo.RepoOverlayTarget(
+                    repo_name="docs",
+                    checkout_root=docs_workspace,
+                    overlay_store=docs_store,
+                    overlay_ref=overlay_ref,
+                    overlay_source_kind="path",
+                    overlay_source_value="atlas/workspace-bundle",
+                    overlay_signer=None,
+                ),
+            ]
+        )
+
+    assert exc.value.error_code == "composition_conflict"
+    assert exc.value.failing_repo == "docs"
+    assert exc.value.rolled_back_repos == ["app", "docs"]
+    assert _snapshot(app_workspace) == before_app
+    assert _snapshot(docs_workspace) == before_docs
+
+
+def test_rollback_does_not_leave_cross_repo_transaction_artifacts_behind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.cross_repo as cross_repo
+
+    overlay_ref = OverlayRef(author="atlas", name="workspace-bundle")
+    app_store, app_workspace, app_source = _triplet(tmp_path, "app")
+    docs_store, docs_workspace, docs_source = _triplet(tmp_path, "docs")
+
+    _write_file(app_source / "settings.toml", 'theme = "owl"\n')
+    _write_file(docs_source / "COMPOSE.md", "# Docs overlay\n")
+
+    capture_overlay_object(app_store, app_source, _overlay_meta(overlay_ref))
+    capture_overlay_object(docs_store, docs_source, _overlay_meta(overlay_ref))
+    write_workspace_allowlist(
+        app_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+    )
+    write_workspace_allowlist(
+        docs_workspace,
+        [{"kind": "path", "pattern": "atlas/*", "trust_class": "team"}],
+    )
+
+    real_activate = activate_overlay
+
+    def fake_activate_overlay(*, workspace_root: Path, **kwargs):
+        if workspace_root == docs_workspace:
+            _write_file(docs_workspace / ".grip" / "cross-repo-transaction.json", '{"status":"partial"}\n')
+            raise OverlayActivationError("simulated docs failure", error_code="base_advanced")
+        return real_activate(workspace_root=workspace_root, **kwargs)
+
+    monkeypatch.setattr(cross_repo, "activate_overlay", fake_activate_overlay)
+    monkeypatch.setattr(cross_repo, "deactivate_overlay", deactivate_overlay)
+
+    with pytest.raises(cross_repo.CrossRepoActivationError):
+        cross_repo.activate_overlays_atomically(
+            targets=[
+                cross_repo.RepoOverlayTarget(
+                    repo_name="app",
+                    checkout_root=app_workspace,
+                    overlay_store=app_store,
+                    overlay_ref=overlay_ref,
+                    overlay_source_kind="path",
+                    overlay_source_value="atlas/workspace-bundle",
+                    overlay_signer=None,
+                ),
+                cross_repo.RepoOverlayTarget(
+                    repo_name="docs",
+                    checkout_root=docs_workspace,
+                    overlay_store=docs_store,
+                    overlay_ref=overlay_ref,
+                    overlay_source_kind="path",
+                    overlay_source_value="atlas/workspace-bundle",
+                    overlay_signer=None,
+                ),
+            ]
+        )
+
+    assert not any(app_workspace.rglob("cross-repo-transaction.json"))
+    assert not any(docs_workspace.rglob("cross-repo-transaction.json"))
+
+
+def _triplet(tmp_path: Path, repo_name: str) -> tuple[Path, Path, Path]:
+    overlay_store = _init_bare_git_repo(tmp_path / f"{repo_name}-overlay-store.git")
+    checkout_root = tmp_path / repo_name
+    overlay_source = tmp_path / f"{repo_name}-overlay-source"
+    checkout_root.mkdir()
+    overlay_source.mkdir()
+    return overlay_store, checkout_root, overlay_source
+
+
+def _overlay_meta(overlay_ref: OverlayRef) -> OverlayMeta:
+    return OverlayMeta(
+        ref=overlay_ref,
+        tier=OverlayTier.A,
+        trust=TrustLevel.TRUSTED,
+        author="atlas",
+        signature="unsigned",
+        timestamp="2026-05-01T00:00:00Z",
+        parent_overlay_refs=[],
+    )
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _git(path.parent, "init", "--bare", path.name)
+    return path
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            snapshot[str(path.relative_to(root))] = path.read_text()
+    return snapshot

--- a/gr2/tests/test_overlay_python_driver.py
+++ b/gr2/tests/test_overlay_python_driver.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def test_python_driver_unions_imports_and_overlay_wins_conflicting_function_body(
+    tmp_path: Path,
+) -> None:
+    from gr2_overlay.language_drivers import merge_python_overlay
+
+    ancestor = tmp_path / "ancestor.py"
+    current = tmp_path / "current.py"
+    other = tmp_path / "other.py"
+
+    ancestor.write_text("def build_message() -> str:\n    return 'ancestor'\n")
+    current.write_text(
+        "import os\n\n"
+        "def build_message() -> str:\n"
+        "    return 'base'\n"
+    )
+    other.write_text(
+        "from pathlib import Path\n\n"
+        "def build_message() -> str:\n"
+        "    return 'overlay'\n"
+    )
+
+    merge_python_overlay(
+        ancestor=ancestor,
+        current=current,
+        other=other,
+        relative_path="app/main.py",
+    )
+
+    merged = current.read_text()
+    module = ast.parse(merged)
+    namespace: dict[str, object] = {}
+    exec(compile(module, filename="app/main.py", mode="exec"), namespace)
+
+    assert "import os" in merged
+    assert "from pathlib import Path" in merged
+    assert namespace["build_message"]() == "overlay"
+
+
+def test_python_driver_raises_explicit_composition_conflict_for_non_mergeable_symbol_edit(
+    tmp_path: Path,
+) -> None:
+    from gr2_overlay.language_drivers import (
+        PythonCompositionConflict,
+        merge_python_overlay,
+    )
+
+    ancestor = tmp_path / "ancestor.py"
+    current = tmp_path / "current.py"
+    other = tmp_path / "other.py"
+
+    ancestor.write_text("TIMEOUT = 10\n")
+    current.write_text("TIMEOUT = 30\n")
+    other.write_text("TIMEOUT = 60\n")
+
+    before = current.read_text()
+
+    with pytest.raises(PythonCompositionConflict) as exc:
+        merge_python_overlay(
+            ancestor=ancestor,
+            current=current,
+            other=other,
+            relative_path="app/settings.py",
+        )
+
+    assert exc.value.error_code == "composition_conflict"
+    assert current.read_text() == before
+
+
+def test_python_driver_refuses_non_python_paths(tmp_path: Path) -> None:
+    from gr2_overlay.language_drivers import merge_python_overlay
+
+    ancestor = tmp_path / "ancestor.txt"
+    current = tmp_path / "current.txt"
+    other = tmp_path / "other.txt"
+
+    ancestor.write_text("ancestor\n")
+    current.write_text("base\n")
+    other.write_text("overlay\n")
+
+    with pytest.raises(ValueError, match="Python driver only supports .py paths"):
+        merge_python_overlay(
+            ancestor=ancestor,
+            current=current,
+            other=other,
+            relative_path="settings.toml",
+        )


### PR DESCRIPTION
## Sprint 36 / M4 ceremony — Cross-repo atomic apply + composition (combined plan-M4+M5)

Closes https://github.com/synapt-dev/grip/issues/679

**Premium boundary:** OSS substrate. M4 is purely substrate work in `gr2/gr2_overlay/`; no lane primitives, no premium features. Premium starts at plan-M6 (lanes) per `config/design/gr2-overlay-architecture-plan.md`.

### Scope (combined plan-M4+M5)

Per Layne's scope-clarification on 2026-04-30, this milestone ships the substrate function-call layer for both plan-M4 (single-repo unit-of-work) and plan-M5 (cross-repo atomic apply). The CLI surface (`gr unit propose / apply / abort` + unit manifest schema) is deferred to grip#692 (Sprint 37 catch-up before plan-M6 premium lanes).

### What shipped

**TDD specs (Atlas, all merged):**
- #681 — T-CR1 cross-repo atomic apply contract
- #683 — T-CR2 rollback semantics with partial-mutation discipline
- #685 — T-CR3 composition merge contract
- #689 — T-CR4 Python composition driver contract
- #690 — T-CR5 cross-repo perf gate contract

**Implementation (Apollo, all merged):**
- #686 — Story 1: `gr2_overlay.cross_repo` module with `activate_overlays_atomically()`, file-level snapshot/restore for rollback, partial-mutation distinguished from pre-check failure
- #691 — Stories 4 + 5: Python AST three-way merge driver + cross-repo perf gate with median-ratio against git baseline and anti-gaming envelope rejection

### Acceptance criteria (all met)

- ✅ Cross-repo overlay apply touching ≥2 repos: all-or-nothing
- ✅ Rollback restores pre-apply state in every touched repo (including failing repo if it partially mutated)
- ✅ Overlay re-merge against same stack produces deterministic output (T-CR3 idempotency)
- ✅ Explicit `composition_conflict` error class with no partial materialization
- ✅ Python merge driver: union imports, overlay-wins on definitions, raise on assignment conflicts, no partial mutation
- ✅ Cross-repo perf gate: ratio against git baseline, anti-gaming on empty/single/negative/missing/count-mismatch envelopes
- ✅ All 444+ tests green on sprint-36, no regressions

### Out of scope (deferred)

- **`gr unit` CLI verbs + manifest schema** — grip#692 (Sprint 37 catch-up)
- **Untracked-file capture** — Tier C (M6+)
- **Submodule state preservation** — Tier C (M6+)
- **Lane-grade exact state** — M6+
- **Premium lane primitives** — plan-M6+ (lanes layer on top of `activate_overlays_atomically`)

### Tier discipline (binding)

This is **substrate work + composition + per-language driver**. Marketing claims must say "atomic cross-repo apply," "deterministic re-merge," or "Python overlay composition" — never "lossless lane switching" without Tier C qualifier, never "lanes" until plan-M6.

### Two real blocker catches (TDD compounding)

1. **Apollo's design pivot from `git stash create` to file-level snapshot/restore** was forced by reading T-CR2's partial-mutation contract before writing impl code. The original `git stash create` plan would have failed T-CR2's mid-flight failure case; catching it at design time saved a day of debugging.
2. **Single-sample anti-gaming gap** in `evaluate_cross_repo_perf_gate` was caught by Atlas's adversarial review post-impl. T-CR5's "rejects invalid or gameable sample envelopes" assertion enumerated multiple cases; the single-sample case (`sample_count=1`) was missing from impl. Apollo pushed fix as commit 78b4f95.

### Retros + journals

All three participating agents posted retros + wrote recall journals before this PR opened (Apollo, Atlas, Sentinel).

### Pre-ceremony sweep

- ✓ Zero open PRs targeting `sprint-36` at ceremony time (grip + gr2-playground)
- ✓ No Rust changes (cargo fmt N/A)
- ✓ All Python tests green
- ✓ Boundary declaration explicit
