### PR TITLE
test: gr unit apply integration contract

### DIFF
--- a/gr2/tests/test_unit_apply.py
+++ b/gr2/tests/test_unit_apply.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_apply_unit_delegates_manifest_targets_to_atomic_overlay_activation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.units as units
+    from gr2_overlay.cross_repo import CrossRepoActivationResult
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(
+        workspace_root,
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = ["base-theme"]
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+overlay_signer = "unsigned"
+
+[[source_overlays]]
+repo_name = "api"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+""",
+    )
+
+    calls: list[list[object]] = []
+
+    def fake_activate_overlays_atomically(*, targets):
+        calls.append(targets)
+        return CrossRepoActivationResult(status="ok", completed_repos=["app", "api"])
+
+    monkeypatch.setattr(units, "activate_overlays_atomically", fake_activate_overlays_atomically)
+
+    result = units.apply_unit(
+        workspace_root=workspace_root,
+        unit_name="feature-auth",
+    )
+
+    assert result.status == "ok"
+    assert result.completed_repos == ["app", "api"]
+    assert len(calls) == 1
+    delegated = calls[0]
+    assert [target.repo_name for target in delegated] == ["app", "api"]
+    assert delegated[0].overlay_ref.ref_path == "refs/overlays/team/feature-auth"
+    assert delegated[0].overlay_source_kind == "path"
+    assert delegated[0].overlay_source_value == "team/feature-auth"
+    assert delegated[0].overlay_signer == "unsigned"
+    assert delegated[1].overlay_signer is None
+
+
+def test_apply_unit_surfaces_atomic_failure_details_without_rewriting_them(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.units as units
+    from gr2_overlay.cross_repo import CrossRepoActivationError
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(
+        workspace_root,
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = []
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+""",
+    )
+
+    def fake_activate_overlays_atomically(*, targets):
+        raise CrossRepoActivationError(
+            "failed",
+            error_code="base_advanced",
+            failing_repo="app",
+            rolled_back_repos=[],
+        )
+
+    monkeypatch.setattr(units, "activate_overlays_atomically", fake_activate_overlays_atomically)
+
+    with pytest.raises(CrossRepoActivationError) as exc:
+        units.apply_unit(workspace_root=workspace_root, unit_name="feature-auth")
+
+    assert exc.value.error_code == "base_advanced"
+    assert exc.value.failing_repo == "app"
+    assert exc.value.rolled_back_repos == []
+
+
+def test_apply_unit_rejects_missing_manifest(tmp_path: Path) -> None:
+    from gr2_overlay.units import apply_unit
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="feature-auth"):
+        apply_unit(workspace_root=workspace_root, unit_name="feature-auth")
+
+
+def _write_manifest(workspace_root: Path, body: str) -> None:
+    path = workspace_root / ".grip" / "units" / "feature-auth.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body.lstrip())


### PR DESCRIPTION
Closes #701

Premium boundary: core OSS substrate because unit apply is workspace orchestration over the existing cross-repo activation substrate.

## Summary
- add failing T-U4 tests for gr unit apply
- require manifest-driven delegation into activate_overlays_atomically()
- preserve atomic failure details without rewriting them

## Red State
- `PYTHONPATH=gr2 python3 -m pytest -q gr2/tests/test_unit_apply.py`
- expected to fail until `gr2_overlay.units.apply_unit()` exists and delegates to the M4 cross-repo substrate