### PR TITLE
feat(gr2): Stories 2-6 — complete M5 unit verb implementation

### DIFF
--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from gr2_overlay.cross_repo import (
     RepoOverlayTarget,
+    _restore_snapshot,
     activate_overlays_atomically,
 )
 from gr2_overlay.types import OverlayRef
@@ -163,7 +164,21 @@ def abort_unit(
 def rollback_inflight_unit(
     *, workspace_root: Path, state: dict[str, object]
 ) -> dict[str, object]:
-    raise NotImplementedError("rollback_inflight_unit not yet implemented")
+    snapshots: dict[str, dict[str, str]] = state.get("snapshots", {})
+    rolled_back: list[str] = []
+
+    repos_to_rollback = list(state.get("completed_repos", []))
+    failing = state.get("failing_repo")
+    if failing and failing not in repos_to_rollback:
+        repos_to_rollback.append(failing)
+
+    for repo_name in repos_to_rollback:
+        if repo_name in snapshots:
+            repo_root = workspace_root / "repos" / repo_name
+            _restore_snapshot(repo_root, snapshots[repo_name])
+            rolled_back.append(repo_name)
+
+    return {"status": "rolled_back", "rolled_back_repos": rolled_back}
 
 
 def propose_unit_manifest(

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from gr2_overlay.cross_repo import (
+    RepoOverlayTarget,
+    activate_overlays_atomically,
+)
 from gr2_overlay.types import OverlayRef
 
 _REFS_OVERLAYS_PREFIX = "refs/overlays/"
@@ -30,6 +35,18 @@ class UnitManifest:
     target_base_ref: str
     depends_on: list[str] = field(default_factory=list)
     on_failure: str = "rollback"
+
+
+@dataclass
+class UnitApplyPreview:
+    status: str
+    unit_name: str
+    scope: str
+    target_base_ref: str
+    on_failure: str
+    depends_on: list[str]
+    repo_order: list[str]
+    overlay_refs: list[str]
 
 
 def unit_manifest_path(workspace_root: Path, name: str) -> Path:
@@ -85,3 +102,98 @@ def validate_unit_manifest(manifest: UnitManifest) -> None:
         raise ValueError(
             f"Invalid on_failure '{manifest.on_failure}': must be one of {_VALID_ON_FAILURE}"
         )
+
+
+def preview_unit_apply(*, workspace_root: Path, unit_name: str) -> UnitApplyPreview:
+    manifest = load_unit_manifest(workspace_root, unit_name)
+    validate_unit_manifest(manifest)
+    return UnitApplyPreview(
+        status="ok",
+        unit_name=unit_name,
+        scope=manifest.scope,
+        target_base_ref=manifest.target_base_ref,
+        on_failure=manifest.on_failure,
+        depends_on=manifest.depends_on,
+        repo_order=[s.repo_name for s in manifest.source_overlays],
+        overlay_refs=[s.overlay_ref.ref_path for s in manifest.source_overlays],
+    )
+
+
+def apply_unit(
+    *, workspace_root: Path, unit_name: str
+) -> dict[str, object]:
+    order = _resolve_dependency_order(workspace_root, unit_name)
+    applied: list[str] = []
+    for name in order:
+        _apply_single_unit(workspace_root=workspace_root, unit_name=name)
+        applied.append(name)
+    return {"applied_units": applied, "status": "ok"}
+
+
+def _apply_single_unit(
+    *, workspace_root: Path, unit_name: str
+) -> object:
+    manifest = load_unit_manifest(workspace_root, unit_name)
+    validate_unit_manifest(manifest)
+    targets = _build_targets(workspace_root, manifest)
+    return activate_overlays_atomically(targets=targets)
+
+
+def abort_unit(
+    *, workspace_root: Path, unit_name: str
+) -> dict[str, object]:
+    state_path = (
+        workspace_root / ".grip" / "unit-transactions" / f"{unit_name}.json"
+    )
+    state: dict[str, object] = json.loads(state_path.read_text())
+    result = rollback_inflight_unit(workspace_root=workspace_root, state=state)
+    state_path.unlink()
+    return result
+
+
+def rollback_inflight_unit(
+    *, workspace_root: Path, state: dict[str, object]
+) -> dict[str, object]:
+    raise NotImplementedError("rollback_inflight_unit not yet implemented")
+
+
+def _build_targets(
+    workspace_root: Path, manifest: UnitManifest
+) -> list[RepoOverlayTarget]:
+    targets: list[RepoOverlayTarget] = []
+    for src in manifest.source_overlays:
+        repo_root = workspace_root / "repos" / src.repo_name
+        targets.append(
+            RepoOverlayTarget(
+                repo_name=src.repo_name,
+                checkout_root=repo_root,
+                overlay_store=repo_root / ".grip" / "overlays",
+                overlay_ref=src.overlay_ref,
+                overlay_source_kind=src.overlay_source_kind,
+                overlay_source_value=src.overlay_source_value,
+                overlay_signer=src.overlay_signer,
+            )
+        )
+    return targets
+
+
+def _resolve_dependency_order(workspace_root: Path, unit_name: str) -> list[str]:
+    order: list[str] = []
+    visited: set[str] = set()
+    in_progress: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in in_progress:
+            raise ValueError(f"dependency cycle detected involving '{name}'")
+        if name in visited:
+            return
+        in_progress.add(name)
+        manifest = load_unit_manifest(workspace_root, name)
+        for dep in manifest.depends_on:
+            visit(dep)
+        in_progress.remove(name)
+        visited.add(name)
+        order.append(name)
+
+    visit(unit_name)
+    return order

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -11,6 +12,15 @@ from gr2_overlay.types import OverlayRef
 _REFS_OVERLAYS_PREFIX = "refs/overlays/"
 _VALID_SCOPES = {"workspace", "repo"}
 _VALID_ON_FAILURE = {"rollback"}
+
+
+@dataclass
+class RepoUnitSource:
+    repo_name: str
+    repo_root: Path
+    overlay_source_kind: str
+    overlay_source_value: str
+    overlay_signer: str | None = None
 
 
 @dataclass
@@ -85,3 +95,82 @@ def validate_unit_manifest(manifest: UnitManifest) -> None:
         raise ValueError(
             f"Invalid on_failure '{manifest.on_failure}': must be one of {_VALID_ON_FAILURE}"
         )
+
+
+def propose_unit_manifest(
+    *,
+    workspace_root: Path,
+    unit_name: str,
+    scope: str,
+    target_base_ref: str,
+    source_repos: list[RepoUnitSource],
+    depends_on: list[str],
+    on_failure: str,
+) -> UnitManifest:
+    source_overlays: list[UnitOverlaySource] = []
+
+    for repo_src in source_repos:
+        stack_path = repo_src.repo_root / ".grip" / "overlay-stack.json"
+        if not stack_path.exists():
+            raise ValueError(f"'{repo_src.repo_name}' has no active overlay")
+
+        stack: list[str] = json.loads(stack_path.read_text())
+        if not stack:
+            raise ValueError(f"'{repo_src.repo_name}' has no active overlay")
+        if len(stack) != 1:
+            raise ValueError(
+                f"'{repo_src.repo_name}' must have exactly one active overlay, "
+                f"got {len(stack)}"
+            )
+
+        ref_str = stack[0]
+        if ref_str.startswith(_REFS_OVERLAYS_PREFIX):
+            ref_str = ref_str[len(_REFS_OVERLAYS_PREFIX) :]
+        overlay_ref = OverlayRef.parse(ref_str)
+
+        source_overlays.append(
+            UnitOverlaySource(
+                repo_name=repo_src.repo_name,
+                overlay_ref=overlay_ref,
+                overlay_source_kind=repo_src.overlay_source_kind,
+                overlay_source_value=repo_src.overlay_source_value,
+                overlay_signer=repo_src.overlay_signer,
+            )
+        )
+
+    manifest = UnitManifest(
+        version=1,
+        scope=scope,
+        source_overlays=source_overlays,
+        target_base_ref=target_base_ref,
+        depends_on=depends_on,
+        on_failure=on_failure,
+    )
+
+    path = unit_manifest_path(workspace_root, unit_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_serialize_manifest(manifest))
+
+    return manifest
+
+
+def _serialize_manifest(manifest: UnitManifest) -> str:
+    depends_on_items = ", ".join(f'"{d}"' for d in manifest.depends_on)
+    lines = [
+        f"version = {manifest.version}",
+        f'scope = "{manifest.scope}"',
+        f'target_base_ref = "{manifest.target_base_ref}"',
+        f'on_failure = "{manifest.on_failure}"',
+        f"depends_on = [{depends_on_items}]",
+    ]
+    for src in manifest.source_overlays:
+        lines.append("")
+        lines.append("[[source_overlays]]")
+        lines.append(f'repo_name = "{src.repo_name}"')
+        lines.append(f'overlay_ref = "{src.overlay_ref.ref_path}"')
+        lines.append(f'overlay_source_kind = "{src.overlay_source_kind}"')
+        lines.append(f'overlay_source_value = "{src.overlay_source_value}"')
+        if src.overlay_signer is not None:
+            lines.append(f'overlay_signer = "{src.overlay_signer}"')
+    lines.append("")
+    return "\n".join(lines)

--- a/gr2/tests/test_unit_abort.py
+++ b/gr2/tests/test_unit_abort.py
@@ -79,6 +79,33 @@ def test_abort_unit_preserves_state_file_when_rollback_fails(
     assert state_path.exists()
 
 
+def test_rollback_inflight_unit_restores_repo_snapshots(tmp_path: Path) -> None:
+    from gr2_overlay.units import rollback_inflight_unit
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    app_root.mkdir(parents=True)
+    (app_root / "main.py").write_text("mutated by apply")
+    (app_root / "extra.py").write_text("added by apply")
+
+    state: dict[str, object] = {
+        "unit_name": "feature-auth",
+        "repo_order": ["app"],
+        "completed_repos": ["app"],
+        "failing_repo": None,
+        "snapshots": {
+            "app": {"main.py": "original content"},
+        },
+    }
+
+    result = rollback_inflight_unit(workspace_root=workspace_root, state=state)
+
+    assert result["status"] == "rolled_back"
+    assert result["rolled_back_repos"] == ["app"]
+    assert (app_root / "main.py").read_text() == "original content"
+    assert not (app_root / "extra.py").exists()
+
+
 def _write_inflight_state(
     workspace_root: Path,
     unit_name: str,

--- a/gr2/tests/test_unit_apply.py
+++ b/gr2/tests/test_unit_apply.py
@@ -13,6 +13,23 @@ def test_apply_unit_delegates_manifest_targets_to_atomic_overlay_activation(
     from gr2_overlay.cross_repo import CrossRepoActivationResult
 
     workspace_root = tmp_path / "workspace"
+    _write_named_manifest(
+        workspace_root,
+        "base-theme",
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = []
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/base-theme"
+overlay_source_kind = "path"
+overlay_source_value = "team/base-theme"
+""",
+    )
     _write_manifest(
         workspace_root,
         """
@@ -50,10 +67,10 @@ overlay_source_value = "team/feature-auth"
         unit_name="feature-auth",
     )
 
-    assert result.status == "ok"
-    assert result.completed_repos == ["app", "api"]
-    assert len(calls) == 1
-    delegated = calls[0]
+    assert result["status"] == "ok"
+    assert result["applied_units"] == ["base-theme", "feature-auth"]
+    assert len(calls) == 2
+    delegated = calls[1]
     assert [target.repo_name for target in delegated] == ["app", "api"]
     assert delegated[0].overlay_ref.ref_path == "refs/overlays/team/feature-auth"
     assert delegated[0].overlay_source_kind == "path"
@@ -116,6 +133,10 @@ def test_apply_unit_rejects_missing_manifest(tmp_path: Path) -> None:
 
 
 def _write_manifest(workspace_root: Path, body: str) -> None:
-    path = workspace_root / ".grip" / "units" / "feature-auth.toml"
+    _write_named_manifest(workspace_root, "feature-auth", body)
+
+
+def _write_named_manifest(workspace_root: Path, name: str, body: str) -> None:
+    path = workspace_root / ".grip" / "units" / f"{name}.toml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body.lstrip())


### PR DESCRIPTION
## Summary

Implements all remaining M5 stories in a combined PR (tightly coupled, same module):

- **Story 2** (`propose_unit_manifest`): Reads overlay stacks, validates single-overlay constraint, serializes manifest to TOML. Merged from grip#707 branch.
- **Story 3** (`preview_unit_apply`): Read-only manifest inspection with `UnitApplyPreview` dataclass. No side effects.
- **Story 4** (`_apply_single_unit`): Delegates manifest targets to `activate_overlays_atomically` via `_build_targets`.
- **Story 5** (`abort_unit`): Reads inflight transaction state, delegates to `rollback_inflight_unit`, clears state on success, preserves on failure.
- **Story 6** (`apply_unit` + `_resolve_dependency_order`): Topological DFS-based dependency resolution with cycle detection, cascading failure halt.

**T-U4/T-U6 reconciliation**: T-U4 test 1 was written for an intermediate state (simple delegation). Updated to add the `base-theme` dependency manifest fixture and use dict return type assertions, matching the T-U6-final `apply_unit` behavior.

`gr2_overlay/units.py`: 287 lines. All 26 tests green (T-U1 through T-U6).

Closes #696 #697 #701 #702 #703

Premium boundary: core OSS (workspace overlay orchestration).

## Test plan

- [x] `PYTHONPATH=gr2 python3 -m pytest -q gr2/tests/test_unit_manifest_schema.py` — 10 passed (T-U1)
- [x] `PYTHONPATH=gr2 python3 -m pytest -q gr2/tests/test_unit_propose.py` — 3 passed (T-U2)
- [x] `PYTHONPATH=gr2 python3 -m pytest -q gr2/tests/test_unit_apply_dry_run.py` — 3 passed (T-U3)
- [x] `PYTHONPATH=gr2 python3 -m pytest -q gr2/tests/test_unit_apply.py` — 3 passed (T-U4, updated)
- [x] `PYTHONPATH=gr2 python3 -m pytest -q gr2/tests/test_unit_abort.py` — 3 passed (T-U5)
- [x] `PYTHONPATH=gr2 python3 -m pytest -q gr2/tests/test_unit_topological_apply.py` — 4 passed (T-U6)