### PR TITLE
fix(gr2): binary snapshot crash + propose overwrite

### DIFF
--- a/gr2/gr2_overlay/cross_repo.py
+++ b/gr2/gr2_overlay/cross_repo.py
@@ -93,15 +93,15 @@ def activate_overlays_atomically(
     )
 
 
-def _snapshot(root: Path) -> dict[str, str]:
-    result: dict[str, str] = {}
+def _snapshot(root: Path) -> dict[str, bytes]:
+    result: dict[str, bytes] = {}
     for path in sorted(root.rglob("*")):
         if path.is_file():
-            result[str(path.relative_to(root))] = path.read_text()
+            result[str(path.relative_to(root))] = path.read_bytes()
     return result
 
 
-def _restore_snapshot(root: Path, snapshot: dict[str, str]) -> None:
+def _restore_snapshot(root: Path, snapshot: dict[str, bytes | str]) -> None:
     current_files = set()
     for path in root.rglob("*"):
         if path.is_file():
@@ -114,7 +114,10 @@ def _restore_snapshot(root: Path, snapshot: dict[str, str]) -> None:
     for rel_path, content in snapshot.items():
         target = root / rel_path
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content)
+        if isinstance(content, str):
+            target.write_text(content)
+        else:
+            target.write_bytes(content)
 
     for dirpath in sorted(root.rglob("*"), reverse=True):
         if dirpath.is_dir() and not any(dirpath.iterdir()):

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -232,8 +232,19 @@ def propose_unit_manifest(
     )
 
     path = unit_manifest_path(workspace_root, unit_name)
+    new_content = _serialize_manifest(manifest)
+
+    if path.exists():
+        existing_content = path.read_text()
+        if existing_content == new_content:
+            return manifest
+        raise ValueError(
+            f"Unit manifest '{unit_name}' already exists with different content. "
+            f"Remove the existing manifest before proposing a new one."
+        )
+
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_serialize_manifest(manifest))
+    path.write_text(new_content)
 
     return manifest
 

--- a/gr2/tests/test_overlay_cross_repo_rollback.py
+++ b/gr2/tests/test_overlay_cross_repo_rollback.py
@@ -146,6 +146,30 @@ def test_rollback_does_not_leave_cross_repo_transaction_artifacts_behind(
     assert not any(docs_workspace.rglob("cross-repo-transaction.json"))
 
 
+def test_snapshot_handles_binary_files_without_crashing(tmp_path: Path) -> None:
+    from gr2_overlay.cross_repo import _restore_snapshot, _snapshot
+
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "readme.txt").write_text("hello")
+    binary_dir = root / ".grip" / "overlays"
+    binary_dir.mkdir(parents=True)
+    (binary_dir / "pack.idx").write_bytes(b"\x00\xff\xfe\x80\x90")
+
+    snap = _snapshot(root)
+    assert snap["readme.txt"] == b"hello"
+    assert snap[".grip/overlays/pack.idx"] == b"\x00\xff\xfe\x80\x90"
+
+    (root / "readme.txt").write_text("mutated")
+    (root / "extra.txt").write_text("added")
+
+    _restore_snapshot(root, snap)
+
+    assert (root / "readme.txt").read_bytes() == b"hello"
+    assert not (root / "extra.txt").exists()
+    assert (binary_dir / "pack.idx").read_bytes() == b"\x00\xff\xfe\x80\x90"
+
+
 def _triplet(tmp_path: Path, repo_name: str) -> tuple[Path, Path, Path]:
     overlay_store = _init_bare_git_repo(tmp_path / f"{repo_name}-overlay-store.git")
     checkout_root = tmp_path / repo_name

--- a/gr2/tests/test_unit_propose.py
+++ b/gr2/tests/test_unit_propose.py
@@ -116,6 +116,76 @@ def test_propose_unit_manifest_rejects_multiple_active_overlays_for_single_repo(
         )
 
 
+def test_propose_unit_manifest_rejects_conflicting_existing_manifest(tmp_path: Path) -> None:
+    from gr2_overlay.units import RepoUnitSource, propose_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    _write_active_stack(app_root, ["refs/overlays/team/feature-auth"])
+
+    source_repos = [
+        RepoUnitSource(
+            repo_name="app",
+            repo_root=app_root,
+            overlay_source_kind="path",
+            overlay_source_value="team/feature-auth",
+            overlay_signer=None,
+        )
+    ]
+
+    propose_unit_manifest(
+        workspace_root=workspace_root,
+        unit_name="feature-auth",
+        scope="workspace",
+        target_base_ref="refs/heads/main",
+        source_repos=source_repos,
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    with pytest.raises(ValueError, match="already exists with different content"):
+        propose_unit_manifest(
+            workspace_root=workspace_root,
+            unit_name="feature-auth",
+            scope="repo",
+            target_base_ref="refs/heads/dev",
+            source_repos=source_repos,
+            depends_on=["base-theme"],
+            on_failure="rollback",
+        )
+
+
+def test_propose_unit_manifest_is_idempotent_for_identical_content(tmp_path: Path) -> None:
+    from gr2_overlay.units import RepoUnitSource, propose_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    _write_active_stack(app_root, ["refs/overlays/team/feature-auth"])
+
+    kwargs = dict(
+        workspace_root=workspace_root,
+        unit_name="feature-auth",
+        scope="workspace",
+        target_base_ref="refs/heads/main",
+        source_repos=[
+            RepoUnitSource(
+                repo_name="app",
+                repo_root=app_root,
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            )
+        ],
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    first = propose_unit_manifest(**kwargs)
+    second = propose_unit_manifest(**kwargs)
+
+    assert first.source_overlays[0].overlay_ref.ref_path == second.source_overlays[0].overlay_ref.ref_path
+
+
 def _write_active_stack(repo_root: Path, refs: list[str]) -> None:
     grip_dir = repo_root / ".grip"
     grip_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- **Bug 1 (_snapshot binary crash)**: `cross_repo._snapshot()` used `read_text()` which crashes with `UnicodeDecodeError` on binary git objects in `.grip/overlays` during `apply_unit()`. Switched to `read_bytes()`/`write_bytes()` throughout. `_restore_snapshot()` accepts both `bytes` and `str` for backward compatibility with JSON-deserialized rollback state from `rollback_inflight_unit()`.
- **Bug 2 (propose overwrite)**: `propose_unit_manifest()` silently overwrote existing manifests when called twice with the same unit name but different content. Now raises `ValueError` if content differs; returns idempotently if content is identical.
- **3 new tests**: binary snapshot round-trip, propose conflict rejection, propose idempotency.

Both bugs found by Sentinel's M5 harness wiring (gr2-playground#49), blocking scenarios `m5_unit_apply_integration`, `m5_unit_stacked_topo_order`, and `m5_unit_name_conflict_or_propose_collision`.

Premium boundary: gr2 substrate is OSS (cross-repo overlay machinery).

## Test plan

- [x] `test_snapshot_handles_binary_files_without_crashing` — binary file round-trip through `_snapshot`/`_restore_snapshot`
- [x] `test_propose_unit_manifest_rejects_conflicting_existing_manifest` — different content raises ValueError
- [x] `test_propose_unit_manifest_is_idempotent_for_identical_content` — same content returns cleanly
- [x] Full test suite: 459 passed, 12 pre-existing failures (grip_object_model snapshot CLI tests, unrelated)
- [ ] Sentinel re-runs M5 harness (gr2-playground#49) expecting all 6 scenarios green

Closes https://github.com/synapt-dev/grip/issues/692

🤖 Generated with [Claude Code](https://claude.com/claude-code)