### PR TITLE
fix(gr2): move overlay_store outside .grip

### DIFF
--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -259,7 +259,7 @@ def _build_targets(
             RepoOverlayTarget(
                 repo_name=src.repo_name,
                 checkout_root=repo_root,
-                overlay_store=repo_root / ".grip" / "overlays",
+                overlay_store=repo_root / ".gr2-overlays",
                 overlay_ref=src.overlay_ref,
                 overlay_source_kind=src.overlay_source_kind,
                 overlay_source_value=src.overlay_source_value,


### PR DESCRIPTION
## Summary

- `_build_targets()` pointed `overlay_store` at `repo_root/.grip/overlays`, but `activate_overlay()` deletes the entire `.grip` directory before apply. This caused `apply_overlay_object()` to fail with rev-parse errors because the store was already gone.
- Moved `overlay_store` to `repo_root/.gr2-overlays`. The overlay store holds persistent git objects (tags, trees, blobs) that must survive across activation cycles. `.grip` is ephemeral per-activation state that `activate_overlay` legitimately owns and clears.
- 1-line fix in `_build_targets()`. No test changes needed (apply tests monkeypatch `activate_overlays_atomically`, so the path is transparent).

Found by Sentinel's M5 harness wiring (gr2-playground#49), blocking `m5_unit_apply_integration` and `m5_unit_stacked_topo_order`.

Premium boundary: gr2 substrate is OSS (cross-repo overlay machinery).

## Test plan

- [x] Full test suite: 459 passed, 12 pre-existing failures (grip_object_model, unrelated)
- [x] Zero regressions from path change
- [ ] Sentinel re-runs M5 harness expecting 6/6 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)