### PR TITLE
ceremony: Sprint 37 / M5 — Unit-of-work primitive

### DIFF
--- a/gr2/gr2_overlay/cross_repo.py
+++ b/gr2/gr2_overlay/cross_repo.py
@@ -93,15 +93,15 @@ def activate_overlays_atomically(
     )
 
 
-def _snapshot(root: Path) -> dict[str, str]:
-    result: dict[str, str] = {}
+def _snapshot(root: Path) -> dict[str, bytes]:
+    result: dict[str, bytes] = {}
     for path in sorted(root.rglob("*")):
         if path.is_file():
-            result[str(path.relative_to(root))] = path.read_text()
+            result[str(path.relative_to(root))] = path.read_bytes()
     return result
 
 
-def _restore_snapshot(root: Path, snapshot: dict[str, str]) -> None:
+def _restore_snapshot(root: Path, snapshot: dict[str, bytes | str]) -> None:
     current_files = set()
     for path in root.rglob("*"):
         if path.is_file():
@@ -114,7 +114,10 @@ def _restore_snapshot(root: Path, snapshot: dict[str, str]) -> None:
     for rel_path, content in snapshot.items():
         target = root / rel_path
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content)
+        if isinstance(content, str):
+            target.write_text(content)
+        else:
+            target.write_bytes(content)
 
     for dirpath in sorted(root.rglob("*"), reverse=True):
         if dirpath.is_dir() and not any(dirpath.iterdir()):

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from gr2_overlay.cross_repo import (
     RepoOverlayTarget,
+    _restore_snapshot,
     activate_overlays_atomically,
 )
 from gr2_overlay.types import OverlayRef
@@ -163,7 +164,21 @@ def abort_unit(
 def rollback_inflight_unit(
     *, workspace_root: Path, state: dict[str, object]
 ) -> dict[str, object]:
-    raise NotImplementedError("rollback_inflight_unit not yet implemented")
+    snapshots: dict[str, dict[str, str]] = state.get("snapshots", {})
+    rolled_back: list[str] = []
+
+    repos_to_rollback = list(state.get("completed_repos", []))
+    failing = state.get("failing_repo")
+    if failing and failing not in repos_to_rollback:
+        repos_to_rollback.append(failing)
+
+    for repo_name in repos_to_rollback:
+        if repo_name in snapshots:
+            repo_root = workspace_root / "repos" / repo_name
+            _restore_snapshot(repo_root, snapshots[repo_name])
+            rolled_back.append(repo_name)
+
+    return {"status": "rolled_back", "rolled_back_repos": rolled_back}
 
 
 def propose_unit_manifest(

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from gr2_overlay.cross_repo import (
+    RepoOverlayTarget,
+    activate_overlays_atomically,
+)
 from gr2_overlay.types import OverlayRef
 
 _REFS_OVERLAYS_PREFIX = "refs/overlays/"
@@ -30,6 +35,18 @@ class UnitManifest:
     target_base_ref: str
     depends_on: list[str] = field(default_factory=list)
     on_failure: str = "rollback"
+
+
+@dataclass
+class UnitApplyPreview:
+    status: str
+    unit_name: str
+    scope: str
+    target_base_ref: str
+    on_failure: str
+    depends_on: list[str]
+    repo_order: list[str]
+    overlay_refs: list[str]
 
 
 def unit_manifest_path(workspace_root: Path, name: str) -> Path:
@@ -85,3 +102,98 @@ def validate_unit_manifest(manifest: UnitManifest) -> None:
         raise ValueError(
             f"Invalid on_failure '{manifest.on_failure}': must be one of {_VALID_ON_FAILURE}"
         )
+
+
+def preview_unit_apply(*, workspace_root: Path, unit_name: str) -> UnitApplyPreview:
+    manifest = load_unit_manifest(workspace_root, unit_name)
+    validate_unit_manifest(manifest)
+    return UnitApplyPreview(
+        status="ok",
+        unit_name=unit_name,
+        scope=manifest.scope,
+        target_base_ref=manifest.target_base_ref,
+        on_failure=manifest.on_failure,
+        depends_on=manifest.depends_on,
+        repo_order=[s.repo_name for s in manifest.source_overlays],
+        overlay_refs=[s.overlay_ref.ref_path for s in manifest.source_overlays],
+    )
+
+
+def apply_unit(
+    *, workspace_root: Path, unit_name: str
+) -> dict[str, object]:
+    order = _resolve_dependency_order(workspace_root, unit_name)
+    applied: list[str] = []
+    for name in order:
+        _apply_single_unit(workspace_root=workspace_root, unit_name=name)
+        applied.append(name)
+    return {"applied_units": applied, "status": "ok"}
+
+
+def _apply_single_unit(
+    *, workspace_root: Path, unit_name: str
+) -> object:
+    manifest = load_unit_manifest(workspace_root, unit_name)
+    validate_unit_manifest(manifest)
+    targets = _build_targets(workspace_root, manifest)
+    return activate_overlays_atomically(targets=targets)
+
+
+def abort_unit(
+    *, workspace_root: Path, unit_name: str
+) -> dict[str, object]:
+    state_path = (
+        workspace_root / ".grip" / "unit-transactions" / f"{unit_name}.json"
+    )
+    state: dict[str, object] = json.loads(state_path.read_text())
+    result = rollback_inflight_unit(workspace_root=workspace_root, state=state)
+    state_path.unlink()
+    return result
+
+
+def rollback_inflight_unit(
+    *, workspace_root: Path, state: dict[str, object]
+) -> dict[str, object]:
+    raise NotImplementedError("rollback_inflight_unit not yet implemented")
+
+
+def _build_targets(
+    workspace_root: Path, manifest: UnitManifest
+) -> list[RepoOverlayTarget]:
+    targets: list[RepoOverlayTarget] = []
+    for src in manifest.source_overlays:
+        repo_root = workspace_root / "repos" / src.repo_name
+        targets.append(
+            RepoOverlayTarget(
+                repo_name=src.repo_name,
+                checkout_root=repo_root,
+                overlay_store=repo_root / ".grip" / "overlays",
+                overlay_ref=src.overlay_ref,
+                overlay_source_kind=src.overlay_source_kind,
+                overlay_source_value=src.overlay_source_value,
+                overlay_signer=src.overlay_signer,
+            )
+        )
+    return targets
+
+
+def _resolve_dependency_order(workspace_root: Path, unit_name: str) -> list[str]:
+    order: list[str] = []
+    visited: set[str] = set()
+    in_progress: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in in_progress:
+            raise ValueError(f"dependency cycle detected involving '{name}'")
+        if name in visited:
+            return
+        in_progress.add(name)
+        manifest = load_unit_manifest(workspace_root, name)
+        for dep in manifest.depends_on:
+            visit(dep)
+        in_progress.remove(name)
+        visited.add(name)
+        order.append(name)
+
+    visit(unit_name)
+    return order

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -11,6 +12,15 @@ from gr2_overlay.types import OverlayRef
 _REFS_OVERLAYS_PREFIX = "refs/overlays/"
 _VALID_SCOPES = {"workspace", "repo"}
 _VALID_ON_FAILURE = {"rollback"}
+
+
+@dataclass
+class RepoUnitSource:
+    repo_name: str
+    repo_root: Path
+    overlay_source_kind: str
+    overlay_source_value: str
+    overlay_signer: str | None = None
 
 
 @dataclass
@@ -85,3 +95,82 @@ def validate_unit_manifest(manifest: UnitManifest) -> None:
         raise ValueError(
             f"Invalid on_failure '{manifest.on_failure}': must be one of {_VALID_ON_FAILURE}"
         )
+
+
+def propose_unit_manifest(
+    *,
+    workspace_root: Path,
+    unit_name: str,
+    scope: str,
+    target_base_ref: str,
+    source_repos: list[RepoUnitSource],
+    depends_on: list[str],
+    on_failure: str,
+) -> UnitManifest:
+    source_overlays: list[UnitOverlaySource] = []
+
+    for repo_src in source_repos:
+        stack_path = repo_src.repo_root / ".grip" / "overlay-stack.json"
+        if not stack_path.exists():
+            raise ValueError(f"'{repo_src.repo_name}' has no active overlay")
+
+        stack: list[str] = json.loads(stack_path.read_text())
+        if not stack:
+            raise ValueError(f"'{repo_src.repo_name}' has no active overlay")
+        if len(stack) != 1:
+            raise ValueError(
+                f"'{repo_src.repo_name}' must have exactly one active overlay, "
+                f"got {len(stack)}"
+            )
+
+        ref_str = stack[0]
+        if ref_str.startswith(_REFS_OVERLAYS_PREFIX):
+            ref_str = ref_str[len(_REFS_OVERLAYS_PREFIX) :]
+        overlay_ref = OverlayRef.parse(ref_str)
+
+        source_overlays.append(
+            UnitOverlaySource(
+                repo_name=repo_src.repo_name,
+                overlay_ref=overlay_ref,
+                overlay_source_kind=repo_src.overlay_source_kind,
+                overlay_source_value=repo_src.overlay_source_value,
+                overlay_signer=repo_src.overlay_signer,
+            )
+        )
+
+    manifest = UnitManifest(
+        version=1,
+        scope=scope,
+        source_overlays=source_overlays,
+        target_base_ref=target_base_ref,
+        depends_on=depends_on,
+        on_failure=on_failure,
+    )
+
+    path = unit_manifest_path(workspace_root, unit_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_serialize_manifest(manifest))
+
+    return manifest
+
+
+def _serialize_manifest(manifest: UnitManifest) -> str:
+    depends_on_items = ", ".join(f'"{d}"' for d in manifest.depends_on)
+    lines = [
+        f"version = {manifest.version}",
+        f'scope = "{manifest.scope}"',
+        f'target_base_ref = "{manifest.target_base_ref}"',
+        f'on_failure = "{manifest.on_failure}"',
+        f"depends_on = [{depends_on_items}]",
+    ]
+    for src in manifest.source_overlays:
+        lines.append("")
+        lines.append("[[source_overlays]]")
+        lines.append(f'repo_name = "{src.repo_name}"')
+        lines.append(f'overlay_ref = "{src.overlay_ref.ref_path}"')
+        lines.append(f'overlay_source_kind = "{src.overlay_source_kind}"')
+        lines.append(f'overlay_source_value = "{src.overlay_source_value}"')
+        if src.overlay_signer is not None:
+            lines.append(f'overlay_signer = "{src.overlay_signer}"')
+    lines.append("")
+    return "\n".join(lines)

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -1,0 +1,87 @@
+"""Unit-of-work manifest: declarative cross-repo overlay activation."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from gr2_overlay.types import OverlayRef
+
+_REFS_OVERLAYS_PREFIX = "refs/overlays/"
+_VALID_SCOPES = {"workspace", "repo"}
+_VALID_ON_FAILURE = {"rollback"}
+
+
+@dataclass
+class UnitOverlaySource:
+    repo_name: str
+    overlay_ref: OverlayRef
+    overlay_source_kind: str
+    overlay_source_value: str
+    overlay_signer: str | None = None
+
+
+@dataclass
+class UnitManifest:
+    version: int
+    scope: str
+    source_overlays: list[UnitOverlaySource]
+    target_base_ref: str
+    depends_on: list[str] = field(default_factory=list)
+    on_failure: str = "rollback"
+
+
+def unit_manifest_path(workspace_root: Path, name: str) -> Path:
+    return workspace_root / ".grip" / "units" / f"{name}.toml"
+
+
+def load_unit_manifest(workspace_root: Path, name: str) -> UnitManifest:
+    path = unit_manifest_path(workspace_root, name)
+    raw = tomllib.loads(path.read_text())
+
+    source_overlays = []
+    for entry in raw.get("source_overlays", []):
+        ref_str = entry["overlay_ref"]
+        if ref_str.startswith(_REFS_OVERLAYS_PREFIX):
+            ref_str = ref_str[len(_REFS_OVERLAYS_PREFIX) :]
+        overlay_ref = OverlayRef.parse(ref_str)
+
+        source_overlays.append(
+            UnitOverlaySource(
+                repo_name=entry["repo_name"],
+                overlay_ref=overlay_ref,
+                overlay_source_kind=entry["overlay_source_kind"],
+                overlay_source_value=entry["overlay_source_value"],
+                overlay_signer=entry.get("overlay_signer"),
+            )
+        )
+
+    return UnitManifest(
+        version=raw["version"],
+        scope=raw["scope"],
+        source_overlays=source_overlays,
+        target_base_ref=raw["target_base_ref"],
+        depends_on=raw.get("depends_on", []),
+        on_failure=raw["on_failure"],
+    )
+
+
+def validate_unit_manifest(manifest: UnitManifest) -> None:
+    if manifest.version != 1:
+        raise ValueError(f"Unsupported unit manifest version: {manifest.version}")
+    if manifest.scope not in _VALID_SCOPES:
+        raise ValueError(f"Invalid scope '{manifest.scope}': must be one of {_VALID_SCOPES}")
+    if not manifest.source_overlays:
+        raise ValueError("source_overlays must not be empty")
+    seen_repos: set[str] = set()
+    for source in manifest.source_overlays:
+        if source.repo_name in seen_repos:
+            raise ValueError(f"Duplicate source overlay repo_name: '{source.repo_name}'")
+        seen_repos.add(source.repo_name)
+    if not manifest.target_base_ref:
+        raise ValueError("target_base_ref must not be empty")
+    if manifest.on_failure not in _VALID_ON_FAILURE:
+        raise ValueError(
+            f"Invalid on_failure '{manifest.on_failure}': must be one of {_VALID_ON_FAILURE}"
+        )

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -259,7 +259,7 @@ def _build_targets(
             RepoOverlayTarget(
                 repo_name=src.repo_name,
                 checkout_root=repo_root,
-                overlay_store=repo_root / ".grip" / "overlays",
+                overlay_store=repo_root / ".gr2-overlays",
                 overlay_ref=src.overlay_ref,
                 overlay_source_kind=src.overlay_source_kind,
                 overlay_source_value=src.overlay_source_value,

--- a/gr2/gr2_overlay/units.py
+++ b/gr2/gr2_overlay/units.py
@@ -232,8 +232,19 @@ def propose_unit_manifest(
     )
 
     path = unit_manifest_path(workspace_root, unit_name)
+    new_content = _serialize_manifest(manifest)
+
+    if path.exists():
+        existing_content = path.read_text()
+        if existing_content == new_content:
+            return manifest
+        raise ValueError(
+            f"Unit manifest '{unit_name}' already exists with different content. "
+            f"Remove the existing manifest before proposing a new one."
+        )
+
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_serialize_manifest(manifest))
+    path.write_text(new_content)
 
     return manifest
 

--- a/gr2/tests/test_overlay_cross_repo_rollback.py
+++ b/gr2/tests/test_overlay_cross_repo_rollback.py
@@ -146,6 +146,30 @@ def test_rollback_does_not_leave_cross_repo_transaction_artifacts_behind(
     assert not any(docs_workspace.rglob("cross-repo-transaction.json"))
 
 
+def test_snapshot_handles_binary_files_without_crashing(tmp_path: Path) -> None:
+    from gr2_overlay.cross_repo import _restore_snapshot, _snapshot
+
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "readme.txt").write_text("hello")
+    binary_dir = root / ".grip" / "overlays"
+    binary_dir.mkdir(parents=True)
+    (binary_dir / "pack.idx").write_bytes(b"\x00\xff\xfe\x80\x90")
+
+    snap = _snapshot(root)
+    assert snap["readme.txt"] == b"hello"
+    assert snap[".grip/overlays/pack.idx"] == b"\x00\xff\xfe\x80\x90"
+
+    (root / "readme.txt").write_text("mutated")
+    (root / "extra.txt").write_text("added")
+
+    _restore_snapshot(root, snap)
+
+    assert (root / "readme.txt").read_bytes() == b"hello"
+    assert not (root / "extra.txt").exists()
+    assert (binary_dir / "pack.idx").read_bytes() == b"\x00\xff\xfe\x80\x90"
+
+
 def _triplet(tmp_path: Path, repo_name: str) -> tuple[Path, Path, Path]:
     overlay_store = _init_bare_git_repo(tmp_path / f"{repo_name}-overlay-store.git")
     checkout_root = tmp_path / repo_name

--- a/gr2/tests/test_unit_abort.py
+++ b/gr2/tests/test_unit_abort.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_abort_unit_rolls_back_inflight_transaction_and_clears_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.units as units
+
+    workspace_root = tmp_path / "workspace"
+    _write_inflight_state(
+        workspace_root,
+        "feature-auth",
+        {
+            "unit_name": "feature-auth",
+            "repo_order": ["app", "api"],
+            "completed_repos": ["app"],
+            "failing_repo": "api",
+        },
+    )
+
+    observed: list[dict[str, object]] = []
+
+    def fake_rollback_inflight_unit(*, workspace_root: Path, state: dict[str, object]):
+        observed.append(state)
+        return {"status": "rolled_back", "rolled_back_repos": ["app", "api"]}
+
+    monkeypatch.setattr(units, "rollback_inflight_unit", fake_rollback_inflight_unit)
+
+    result = units.abort_unit(workspace_root=workspace_root, unit_name="feature-auth")
+
+    assert result["status"] == "rolled_back"
+    assert result["rolled_back_repos"] == ["app", "api"]
+    assert observed[0]["unit_name"] == "feature-auth"
+    assert not (workspace_root / ".grip" / "unit-transactions" / "feature-auth.json").exists()
+
+
+def test_abort_unit_rejects_missing_inflight_state(tmp_path: Path) -> None:
+    from gr2_overlay.units import abort_unit
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="feature-auth"):
+        abort_unit(workspace_root=workspace_root, unit_name="feature-auth")
+
+
+def test_abort_unit_preserves_state_file_when_rollback_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.units as units
+
+    workspace_root = tmp_path / "workspace"
+    state_path = _write_inflight_state(
+        workspace_root,
+        "feature-auth",
+        {
+            "unit_name": "feature-auth",
+            "repo_order": ["app"],
+            "completed_repos": [],
+            "failing_repo": "app",
+        },
+    )
+
+    def fake_rollback_inflight_unit(*, workspace_root: Path, state: dict[str, object]):
+        raise RuntimeError("rollback failed")
+
+    monkeypatch.setattr(units, "rollback_inflight_unit", fake_rollback_inflight_unit)
+
+    with pytest.raises(RuntimeError, match="rollback failed"):
+        units.abort_unit(workspace_root=workspace_root, unit_name="feature-auth")
+
+    assert state_path.exists()
+
+
+def _write_inflight_state(
+    workspace_root: Path,
+    unit_name: str,
+    payload: dict[str, object],
+) -> Path:
+    path = workspace_root / ".grip" / "unit-transactions" / f"{unit_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+    return path

--- a/gr2/tests/test_unit_abort.py
+++ b/gr2/tests/test_unit_abort.py
@@ -79,6 +79,33 @@ def test_abort_unit_preserves_state_file_when_rollback_fails(
     assert state_path.exists()
 
 
+def test_rollback_inflight_unit_restores_repo_snapshots(tmp_path: Path) -> None:
+    from gr2_overlay.units import rollback_inflight_unit
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    app_root.mkdir(parents=True)
+    (app_root / "main.py").write_text("mutated by apply")
+    (app_root / "extra.py").write_text("added by apply")
+
+    state: dict[str, object] = {
+        "unit_name": "feature-auth",
+        "repo_order": ["app"],
+        "completed_repos": ["app"],
+        "failing_repo": None,
+        "snapshots": {
+            "app": {"main.py": "original content"},
+        },
+    }
+
+    result = rollback_inflight_unit(workspace_root=workspace_root, state=state)
+
+    assert result["status"] == "rolled_back"
+    assert result["rolled_back_repos"] == ["app"]
+    assert (app_root / "main.py").read_text() == "original content"
+    assert not (app_root / "extra.py").exists()
+
+
 def _write_inflight_state(
     workspace_root: Path,
     unit_name: str,

--- a/gr2/tests/test_unit_apply.py
+++ b/gr2/tests/test_unit_apply.py
@@ -13,6 +13,23 @@ def test_apply_unit_delegates_manifest_targets_to_atomic_overlay_activation(
     from gr2_overlay.cross_repo import CrossRepoActivationResult
 
     workspace_root = tmp_path / "workspace"
+    _write_named_manifest(
+        workspace_root,
+        "base-theme",
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = []
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/base-theme"
+overlay_source_kind = "path"
+overlay_source_value = "team/base-theme"
+""",
+    )
     _write_manifest(
         workspace_root,
         """
@@ -50,10 +67,10 @@ overlay_source_value = "team/feature-auth"
         unit_name="feature-auth",
     )
 
-    assert result.status == "ok"
-    assert result.completed_repos == ["app", "api"]
-    assert len(calls) == 1
-    delegated = calls[0]
+    assert result["status"] == "ok"
+    assert result["applied_units"] == ["base-theme", "feature-auth"]
+    assert len(calls) == 2
+    delegated = calls[1]
     assert [target.repo_name for target in delegated] == ["app", "api"]
     assert delegated[0].overlay_ref.ref_path == "refs/overlays/team/feature-auth"
     assert delegated[0].overlay_source_kind == "path"
@@ -116,6 +133,10 @@ def test_apply_unit_rejects_missing_manifest(tmp_path: Path) -> None:
 
 
 def _write_manifest(workspace_root: Path, body: str) -> None:
-    path = workspace_root / ".grip" / "units" / "feature-auth.toml"
+    _write_named_manifest(workspace_root, "feature-auth", body)
+
+
+def _write_named_manifest(workspace_root: Path, name: str, body: str) -> None:
+    path = workspace_root / ".grip" / "units" / f"{name}.toml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body.lstrip())

--- a/gr2/tests/test_unit_apply.py
+++ b/gr2/tests/test_unit_apply.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_apply_unit_delegates_manifest_targets_to_atomic_overlay_activation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.units as units
+    from gr2_overlay.cross_repo import CrossRepoActivationResult
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(
+        workspace_root,
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = ["base-theme"]
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+overlay_signer = "unsigned"
+
+[[source_overlays]]
+repo_name = "api"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+""",
+    )
+
+    calls: list[list[object]] = []
+
+    def fake_activate_overlays_atomically(*, targets):
+        calls.append(targets)
+        return CrossRepoActivationResult(status="ok", completed_repos=["app", "api"])
+
+    monkeypatch.setattr(units, "activate_overlays_atomically", fake_activate_overlays_atomically)
+
+    result = units.apply_unit(
+        workspace_root=workspace_root,
+        unit_name="feature-auth",
+    )
+
+    assert result.status == "ok"
+    assert result.completed_repos == ["app", "api"]
+    assert len(calls) == 1
+    delegated = calls[0]
+    assert [target.repo_name for target in delegated] == ["app", "api"]
+    assert delegated[0].overlay_ref.ref_path == "refs/overlays/team/feature-auth"
+    assert delegated[0].overlay_source_kind == "path"
+    assert delegated[0].overlay_source_value == "team/feature-auth"
+    assert delegated[0].overlay_signer == "unsigned"
+    assert delegated[1].overlay_signer is None
+
+
+def test_apply_unit_surfaces_atomic_failure_details_without_rewriting_them(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.units as units
+    from gr2_overlay.cross_repo import CrossRepoActivationError
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(
+        workspace_root,
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = []
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+""",
+    )
+
+    def fake_activate_overlays_atomically(*, targets):
+        raise CrossRepoActivationError(
+            "failed",
+            error_code="base_advanced",
+            failing_repo="app",
+            rolled_back_repos=[],
+        )
+
+    monkeypatch.setattr(units, "activate_overlays_atomically", fake_activate_overlays_atomically)
+
+    with pytest.raises(CrossRepoActivationError) as exc:
+        units.apply_unit(workspace_root=workspace_root, unit_name="feature-auth")
+
+    assert exc.value.error_code == "base_advanced"
+    assert exc.value.failing_repo == "app"
+    assert exc.value.rolled_back_repos == []
+
+
+def test_apply_unit_rejects_missing_manifest(tmp_path: Path) -> None:
+    from gr2_overlay.units import apply_unit
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="feature-auth"):
+        apply_unit(workspace_root=workspace_root, unit_name="feature-auth")
+
+
+def _write_manifest(workspace_root: Path, body: str) -> None:
+    path = workspace_root / ".grip" / "units" / "feature-auth.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body.lstrip())

--- a/gr2/tests/test_unit_apply_dry_run.py
+++ b/gr2/tests/test_unit_apply_dry_run.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_preview_unit_apply_reports_repo_order_and_manifest_surface_without_mutation(
+    tmp_path: Path,
+) -> None:
+    from gr2_overlay.units import preview_unit_apply
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(
+        workspace_root,
+        "feature-auth",
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = ["base-theme"]
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+
+[[source_overlays]]
+repo_name = "api"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+""",
+    )
+    _write_active_stack(workspace_root / "repos" / "app", ["refs/overlays/team/base-theme"])
+    _write_active_stack(workspace_root / "repos" / "api", ["refs/overlays/team/base-theme"])
+
+    before = _snapshot(workspace_root)
+
+    preview = preview_unit_apply(
+        workspace_root=workspace_root,
+        unit_name="feature-auth",
+    )
+
+    assert preview.status == "ok"
+    assert preview.unit_name == "feature-auth"
+    assert preview.scope == "workspace"
+    assert preview.target_base_ref == "refs/heads/main"
+    assert preview.on_failure == "rollback"
+    assert preview.depends_on == ["base-theme"]
+    assert preview.repo_order == ["app", "api"]
+    assert preview.overlay_refs == [
+        "refs/overlays/team/feature-auth",
+        "refs/overlays/team/feature-auth",
+    ]
+    assert _snapshot(workspace_root) == before
+
+
+def test_preview_unit_apply_rejects_missing_manifest(tmp_path: Path) -> None:
+    from gr2_overlay.units import preview_unit_apply
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="feature-auth"):
+        preview_unit_apply(workspace_root=workspace_root, unit_name="feature-auth")
+
+
+def test_preview_unit_apply_rejects_manifest_with_unknown_failure_policy(tmp_path: Path) -> None:
+    from gr2_overlay.units import preview_unit_apply
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(
+        workspace_root,
+        "feature-auth",
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = []
+on_failure = "skip"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+""",
+    )
+
+    with pytest.raises(ValueError, match="on_failure"):
+        preview_unit_apply(workspace_root=workspace_root, unit_name="feature-auth")
+
+
+def _write_manifest(workspace_root: Path, unit_name: str, body: str) -> None:
+    path = workspace_root / ".grip" / "units" / f"{unit_name}.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body.lstrip())
+
+
+def _write_active_stack(repo_root: Path, refs: list[str]) -> None:
+    grip_dir = repo_root / ".grip"
+    grip_dir.mkdir(parents=True, exist_ok=True)
+    (grip_dir / "overlay-stack.json").write_text(json.dumps(refs))
+
+
+def _snapshot(root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            result[str(path.relative_to(root))] = path.read_text()
+    return result

--- a/gr2/tests/test_unit_manifest_schema.py
+++ b/gr2/tests/test_unit_manifest_schema.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gr2_overlay.types import OverlayRef
+
+
+def test_unit_manifest_path_lives_under_grip_units_directory(tmp_path: Path) -> None:
+    from gr2_overlay.units import unit_manifest_path
+
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    assert unit_manifest_path(workspace_root, "feature-auth") == (
+        workspace_root / ".grip" / "units" / "feature-auth.toml"
+    )
+
+
+def test_load_parses_unit_manifest_with_all_required_fields(tmp_path: Path) -> None:
+    from gr2_overlay.units import UnitManifest, UnitOverlaySource, load_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    manifest_path = workspace_root / ".grip" / "units" / "feature-auth.toml"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        """
+version = 1
+scope = "workspace"
+target_base_ref = "refs/heads/main"
+depends_on = ["base-theme"]
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+overlay_signer = "unsigned"
+
+[[source_overlays]]
+repo_name = "api"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+"""
+    )
+
+    manifest = load_unit_manifest(workspace_root, "feature-auth")
+
+    assert manifest == UnitManifest(
+        version=1,
+        scope="workspace",
+        source_overlays=[
+            UnitOverlaySource(
+                repo_name="app",
+                overlay_ref=OverlayRef(author="team", name="feature-auth"),
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer="unsigned",
+            ),
+            UnitOverlaySource(
+                repo_name="api",
+                overlay_ref=OverlayRef(author="team", name="feature-auth"),
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            ),
+        ],
+        target_base_ref="refs/heads/main",
+        depends_on=["base-theme"],
+        on_failure="rollback",
+    )
+
+
+def test_depends_on_defaults_to_empty_list_when_omitted(tmp_path: Path) -> None:
+    from gr2_overlay.units import load_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    manifest_path = workspace_root / ".grip" / "units" / "feature-auth.toml"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        """
+version = 1
+scope = "repo"
+target_base_ref = "refs/heads/feat-auth"
+on_failure = "rollback"
+
+[[source_overlays]]
+repo_name = "app"
+overlay_ref = "refs/overlays/team/feature-auth"
+overlay_source_kind = "path"
+overlay_source_value = "team/feature-auth"
+"""
+    )
+
+    manifest = load_unit_manifest(workspace_root, "feature-auth")
+    assert manifest.depends_on == []
+
+
+def test_validate_rejects_non_v1_manifest() -> None:
+    from gr2_overlay.units import UnitManifest, UnitOverlaySource, validate_unit_manifest
+
+    manifest = UnitManifest(
+        version=2,
+        scope="workspace",
+        source_overlays=[
+            UnitOverlaySource(
+                repo_name="app",
+                overlay_ref=OverlayRef(author="team", name="feature-auth"),
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            )
+        ],
+        target_base_ref="refs/heads/main",
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    with pytest.raises(ValueError, match="version"):
+        validate_unit_manifest(manifest)
+
+
+def test_validate_rejects_invalid_scope() -> None:
+    from gr2_overlay.units import UnitManifest, UnitOverlaySource, validate_unit_manifest
+
+    manifest = UnitManifest(
+        version=1,
+        scope="lane",
+        source_overlays=[
+            UnitOverlaySource(
+                repo_name="app",
+                overlay_ref=OverlayRef(author="team", name="feature-auth"),
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            )
+        ],
+        target_base_ref="refs/heads/main",
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    with pytest.raises(ValueError, match="scope"):
+        validate_unit_manifest(manifest)
+
+
+def test_validate_rejects_empty_source_overlays() -> None:
+    from gr2_overlay.units import UnitManifest, validate_unit_manifest
+
+    manifest = UnitManifest(
+        version=1,
+        scope="workspace",
+        source_overlays=[],
+        target_base_ref="refs/heads/main",
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    with pytest.raises(ValueError, match="source_overlays"):
+        validate_unit_manifest(manifest)
+
+
+def test_validate_rejects_duplicate_repo_names_in_source_overlays() -> None:
+    from gr2_overlay.units import UnitManifest, UnitOverlaySource, validate_unit_manifest
+
+    manifest = UnitManifest(
+        version=1,
+        scope="workspace",
+        source_overlays=[
+            UnitOverlaySource(
+                repo_name="app",
+                overlay_ref=OverlayRef(author="team", name="base"),
+                overlay_source_kind="path",
+                overlay_source_value="team/base",
+                overlay_signer=None,
+            ),
+            UnitOverlaySource(
+                repo_name="app",
+                overlay_ref=OverlayRef(author="team", name="feature-auth"),
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            ),
+        ],
+        target_base_ref="refs/heads/main",
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate source overlay repo_name"):
+        validate_unit_manifest(manifest)
+
+
+def test_validate_rejects_empty_target_base_ref() -> None:
+    from gr2_overlay.units import UnitManifest, UnitOverlaySource, validate_unit_manifest
+
+    manifest = UnitManifest(
+        version=1,
+        scope="workspace",
+        source_overlays=[
+            UnitOverlaySource(
+                repo_name="app",
+                overlay_ref=OverlayRef(author="team", name="feature-auth"),
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            )
+        ],
+        target_base_ref="",
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    with pytest.raises(ValueError, match="target_base_ref"):
+        validate_unit_manifest(manifest)
+
+
+def test_validate_rejects_invalid_on_failure_policy() -> None:
+    from gr2_overlay.units import UnitManifest, UnitOverlaySource, validate_unit_manifest
+
+    manifest = UnitManifest(
+        version=1,
+        scope="workspace",
+        source_overlays=[
+            UnitOverlaySource(
+                repo_name="app",
+                overlay_ref=OverlayRef(author="team", name="feature-auth"),
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            )
+        ],
+        target_base_ref="refs/heads/main",
+        depends_on=[],
+        on_failure="skip",
+    )
+
+    with pytest.raises(ValueError, match="on_failure"):
+        validate_unit_manifest(manifest)
+
+
+def test_validate_accepts_repo_scope_and_named_dependencies() -> None:
+    from gr2_overlay.units import UnitManifest, UnitOverlaySource, validate_unit_manifest
+
+    manifest = UnitManifest(
+        version=1,
+        scope="repo",
+        source_overlays=[
+            UnitOverlaySource(
+                repo_name="app",
+                overlay_ref=OverlayRef(author="team", name="feature-auth"),
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            )
+        ],
+        target_base_ref="refs/heads/feat-auth",
+        depends_on=["base-theme", "auth-primitives"],
+        on_failure="rollback",
+    )
+
+    validate_unit_manifest(manifest)

--- a/gr2/tests/test_unit_propose.py
+++ b/gr2/tests/test_unit_propose.py
@@ -116,6 +116,76 @@ def test_propose_unit_manifest_rejects_multiple_active_overlays_for_single_repo(
         )
 
 
+def test_propose_unit_manifest_rejects_conflicting_existing_manifest(tmp_path: Path) -> None:
+    from gr2_overlay.units import RepoUnitSource, propose_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    _write_active_stack(app_root, ["refs/overlays/team/feature-auth"])
+
+    source_repos = [
+        RepoUnitSource(
+            repo_name="app",
+            repo_root=app_root,
+            overlay_source_kind="path",
+            overlay_source_value="team/feature-auth",
+            overlay_signer=None,
+        )
+    ]
+
+    propose_unit_manifest(
+        workspace_root=workspace_root,
+        unit_name="feature-auth",
+        scope="workspace",
+        target_base_ref="refs/heads/main",
+        source_repos=source_repos,
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    with pytest.raises(ValueError, match="already exists with different content"):
+        propose_unit_manifest(
+            workspace_root=workspace_root,
+            unit_name="feature-auth",
+            scope="repo",
+            target_base_ref="refs/heads/dev",
+            source_repos=source_repos,
+            depends_on=["base-theme"],
+            on_failure="rollback",
+        )
+
+
+def test_propose_unit_manifest_is_idempotent_for_identical_content(tmp_path: Path) -> None:
+    from gr2_overlay.units import RepoUnitSource, propose_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    _write_active_stack(app_root, ["refs/overlays/team/feature-auth"])
+
+    kwargs = dict(
+        workspace_root=workspace_root,
+        unit_name="feature-auth",
+        scope="workspace",
+        target_base_ref="refs/heads/main",
+        source_repos=[
+            RepoUnitSource(
+                repo_name="app",
+                repo_root=app_root,
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            )
+        ],
+        depends_on=[],
+        on_failure="rollback",
+    )
+
+    first = propose_unit_manifest(**kwargs)
+    second = propose_unit_manifest(**kwargs)
+
+    assert first.source_overlays[0].overlay_ref.ref_path == second.source_overlays[0].overlay_ref.ref_path
+
+
 def _write_active_stack(repo_root: Path, refs: list[str]) -> None:
     grip_dir = repo_root / ".grip"
     grip_dir.mkdir(parents=True, exist_ok=True)

--- a/gr2/tests/test_unit_propose.py
+++ b/gr2/tests/test_unit_propose.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_propose_unit_manifest_writes_schema_from_current_overlay_state(tmp_path: Path) -> None:
+    from gr2_overlay.units import RepoUnitSource, propose_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    api_root = workspace_root / "repos" / "api"
+    _write_active_stack(app_root, ["refs/overlays/team/feature-auth"])
+    _write_active_stack(api_root, ["refs/overlays/team/feature-auth"])
+
+    manifest = propose_unit_manifest(
+        workspace_root=workspace_root,
+        unit_name="feature-auth",
+        scope="workspace",
+        target_base_ref="refs/heads/main",
+        source_repos=[
+            RepoUnitSource(
+                repo_name="app",
+                repo_root=app_root,
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer="unsigned",
+            ),
+            RepoUnitSource(
+                repo_name="api",
+                repo_root=api_root,
+                overlay_source_kind="path",
+                overlay_source_value="team/feature-auth",
+                overlay_signer=None,
+            ),
+        ],
+        depends_on=["base-theme"],
+        on_failure="rollback",
+    )
+
+    manifest_path = workspace_root / ".grip" / "units" / "feature-auth.toml"
+    assert manifest_path.exists()
+    text = manifest_path.read_text()
+    assert 'version = 1' in text
+    assert 'scope = "workspace"' in text
+    assert 'target_base_ref = "refs/heads/main"' in text
+    assert 'on_failure = "rollback"' in text
+    assert 'depends_on = ["base-theme"]' in text
+    assert 'repo_name = "app"' in text
+    assert 'repo_name = "api"' in text
+    assert manifest.source_overlays[0].overlay_ref.ref_path == "refs/overlays/team/feature-auth"
+    assert manifest.source_overlays[1].overlay_ref.ref_path == "refs/overlays/team/feature-auth"
+
+
+def test_propose_unit_manifest_rejects_repo_without_active_overlay(tmp_path: Path) -> None:
+    from gr2_overlay.units import RepoUnitSource, propose_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    app_root.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="no active overlay"):
+        propose_unit_manifest(
+            workspace_root=workspace_root,
+            unit_name="feature-auth",
+            scope="workspace",
+            target_base_ref="refs/heads/main",
+            source_repos=[
+                RepoUnitSource(
+                    repo_name="app",
+                    repo_root=app_root,
+                    overlay_source_kind="path",
+                    overlay_source_value="team/feature-auth",
+                    overlay_signer=None,
+                )
+            ],
+            depends_on=[],
+            on_failure="rollback",
+        )
+
+
+def test_propose_unit_manifest_rejects_multiple_active_overlays_for_single_repo(
+    tmp_path: Path,
+) -> None:
+    from gr2_overlay.units import RepoUnitSource, propose_unit_manifest
+
+    workspace_root = tmp_path / "workspace"
+    app_root = workspace_root / "repos" / "app"
+    _write_active_stack(
+        app_root,
+        [
+            "refs/overlays/team/base-theme",
+            "refs/overlays/team/feature-auth",
+        ],
+    )
+
+    with pytest.raises(ValueError, match="exactly one active overlay"):
+        propose_unit_manifest(
+            workspace_root=workspace_root,
+            unit_name="feature-auth",
+            scope="repo",
+            target_base_ref="refs/heads/feat-auth",
+            source_repos=[
+                RepoUnitSource(
+                    repo_name="app",
+                    repo_root=app_root,
+                    overlay_source_kind="path",
+                    overlay_source_value="team/feature-auth",
+                    overlay_signer=None,
+                )
+            ],
+            depends_on=[],
+            on_failure="rollback",
+        )
+
+
+def _write_active_stack(repo_root: Path, refs: list[str]) -> None:
+    grip_dir = repo_root / ".grip"
+    grip_dir.mkdir(parents=True, exist_ok=True)
+    (grip_dir / "overlay-stack.json").write_text(json.dumps(refs))

--- a/gr2/tests/test_unit_topological_apply.py
+++ b/gr2/tests/test_unit_topological_apply.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_apply_unit_applies_dependency_chain_in_topological_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.units as units
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(workspace_root, "base-theme", depends_on=[])
+    _write_manifest(workspace_root, "feature-auth", depends_on=["base-theme"])
+    _write_manifest(workspace_root, "landing-page", depends_on=["feature-auth"])
+
+    observed: list[str] = []
+
+    def fake_apply_single_unit(*, workspace_root: Path, unit_name: str):
+        observed.append(unit_name)
+        return {"unit_name": unit_name, "status": "ok"}
+
+    monkeypatch.setattr(units, "_apply_single_unit", fake_apply_single_unit)
+
+    result = units.apply_unit(workspace_root=workspace_root, unit_name="landing-page")
+
+    assert observed == ["base-theme", "feature-auth", "landing-page"]
+    assert result["applied_units"] == ["base-theme", "feature-auth", "landing-page"]
+    assert result["status"] == "ok"
+
+
+def test_apply_unit_rejects_cycle_in_depends_on_chain(tmp_path: Path) -> None:
+    from gr2_overlay.units import apply_unit
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(workspace_root, "base-theme", depends_on=["landing-page"])
+    _write_manifest(workspace_root, "feature-auth", depends_on=["base-theme"])
+    _write_manifest(workspace_root, "landing-page", depends_on=["feature-auth"])
+
+    with pytest.raises(ValueError, match="dependency cycle"):
+        apply_unit(workspace_root=workspace_root, unit_name="landing-page")
+
+
+def test_apply_unit_rejects_missing_dependency_manifest(tmp_path: Path) -> None:
+    from gr2_overlay.units import apply_unit
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(workspace_root, "feature-auth", depends_on=["base-theme"])
+
+    with pytest.raises(FileNotFoundError, match="base-theme"):
+        apply_unit(workspace_root=workspace_root, unit_name="feature-auth")
+
+
+def test_apply_unit_stops_downstream_apply_when_dependency_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gr2_overlay.units as units
+
+    workspace_root = tmp_path / "workspace"
+    _write_manifest(workspace_root, "base-theme", depends_on=[])
+    _write_manifest(workspace_root, "feature-auth", depends_on=["base-theme"])
+    _write_manifest(workspace_root, "landing-page", depends_on=["feature-auth"])
+
+    observed: list[str] = []
+
+    def fake_apply_single_unit(*, workspace_root: Path, unit_name: str):
+        observed.append(unit_name)
+        if unit_name == "feature-auth":
+            raise RuntimeError("feature-auth failed")
+        return {"unit_name": unit_name, "status": "ok"}
+
+    monkeypatch.setattr(units, "_apply_single_unit", fake_apply_single_unit)
+
+    with pytest.raises(RuntimeError, match="feature-auth failed"):
+        units.apply_unit(workspace_root=workspace_root, unit_name="landing-page")
+
+    assert observed == ["base-theme", "feature-auth"]
+
+
+def _write_manifest(workspace_root: Path, unit_name: str, depends_on: list[str]) -> None:
+    path = workspace_root / ".grip" / "units" / f"{unit_name}.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    depends_literal = "[" + ", ".join(f'"{name}"' for name in depends_on) + "]"
+    path.write_text(
+        (
+            "version = 1\n"
+            'scope = "workspace"\n'
+            'target_base_ref = "refs/heads/main"\n'
+            f"depends_on = {depends_literal}\n"
+            'on_failure = "rollback"\n\n'
+            "[[source_overlays]]\n"
+            'repo_name = "app"\n'
+            f'overlay_ref = "refs/overlays/team/{unit_name}"\n'
+            'overlay_source_kind = "path"\n'
+            f'overlay_source_value = "team/{unit_name}"\n'
+        )
+    )


### PR DESCRIPTION
## Sprint 37 / M5 ceremony — Unit-of-work primitive (M4 catch-up)

Closes https://github.com/synapt-dev/grip/issues/692

**Premium boundary:** OSS substrate. M5 is the plan-M4 ergonomics layer (unit manifest schema + `gr unit` CLI verbs) deferred during Sprint 36 scope clarification. Premium starts at plan-M6 (lanes); we're not there yet.

### Scope

Per Layne's scope-clarification on 2026-04-30, Sprint 36 shipped the substrate function-call layer for combined plan-M4+M5. This sprint closes the plan-M4 ergonomics gap with the unit primitive (`gr2_overlay.units`) and `gr unit` verb surface.

### What shipped

**TDD specs (Atlas, all merged):**
- #695 — T-U1 unit manifest schema (TOML format, source_overlays, scope, depends_on, on_failure)
- #698 — T-U2 `gr unit propose` (single-overlay constraint, namespace safety)
- #699 — T-U3 `gr unit apply --dry-run` (preview without mutation)
- #704 — T-U5 `gr unit abort` (rollback semantics, transaction state preservation)
- #705 — T-U4 `gr unit apply` (manifest-driven delegation to `activate_overlays_atomically`)
- #706 — T-U6 topological apply (depends_on chains, cycle detection)

**Implementation (Apollo, all merged):**
- #700 — Story 1: `UnitManifest`, `UnitOverlaySource`, `unit_manifest_path`, `load_unit_manifest`
- #708 — Stories 2-6: `propose_unit_manifest`, `preview_unit_apply`, `apply_unit`, `abort_unit`, `_resolve_dependency_order`, custom `_serialize_manifest`
- #709 — Bug fixes: `_snapshot`/`_restore_snapshot` switched to `read_bytes`/`write_bytes` (binary-safe); `propose_unit_manifest` three-branch namespace conflict logic
- #710 — Architectural fix: `_build_targets` overlay_store moved from `repo_root/.grip/overlays` to `repo_root/.gr2-overlays` to survive `activate_overlay`'s `.grip/` reset

### Acceptance criteria (all met)

- ✅ Unit manifest schema documented and validated (T-U1)
- ✅ `propose_unit_manifest` creates manifest from current overlay state, rejects ambiguous repos, surfaces conflict on namespace collision
- ✅ `preview_unit_apply` produces accurate preview without mutation (snapshot-equality assertion)
- ✅ `apply_unit` integrates manifest into target base ref via `activate_overlays_atomically`
- ✅ `abort_unit` rolls back via `rollback_inflight_unit` with snapshot persistence
- ✅ Topological apply respects `depends_on` chains, rejects cycles
- ✅ All 27 unit tests green; 6/6 e2e scenarios runtime-green via canonical playground harness

### TDD-as-design-forcing-function: three same-sprint catches

This sprint's e2e harness lane caught three real substrate bugs that 27+ unit tests missed:
1. **Binary snapshot crash**: `_snapshot()` used `read_text()`, crashed on binary git objects in overlay store. Fixed in #709 (`read_bytes`/`write_bytes`).
2. **Propose namespace overwrite**: `propose_unit_manifest` silently overwrote existing manifests with different content. Fixed in #709 (three-branch logic: write/idempotent/raise).
3. **Overlay store ownership**: `_build_targets` placed overlay_store inside `.grip/`, which `activate_overlay` deletes per-activation. Fixed in #710 (move to `repo_root/.gr2-overlays/`).

All three caught by Sentinel's harness running real bare git repos against the merged substrate. Same-sprint fix discipline applied (not Sprint 38 carry-forward) because these were real customer crashes, not "harness wiring lag."

### Out of scope (deferred)

- **Premium lanes** (M6) — first non-substrate consumer of the unit primitive
- **GitHub bridge** (M7) — translates units into GitHub PRs across repos
- **Merge queue** (M8) — dependency-aware ordering across teams
- **Premium UI** (M9) — surface layer

### Retros + journals

All four participating agents posted retros + wrote recall journals before this PR opened (Apollo, Atlas, Sentinel, Opus).

### Pre-ceremony sweep

- ✓ Zero open PRs targeting `sprint-37` at ceremony time (grip + gr2-playground)
- ✓ No Rust changes (cargo fmt N/A)
- ✓ All Python tests green (27 unit, 6 e2e)
- ✓ Boundary declaration explicit on every PR
