### PR TITLE
fix: scope gr pr merge --force to prevent unintended cross-repo merges

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -733,6 +733,12 @@ pub enum PrCommands {
         /// Don't delete the source branch after merging
         #[arg(long)]
         no_delete_branch: bool,
+        /// Only merge PRs for specific repos (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        repo: Option<Vec<String>>,
+        /// Skip confirmation prompt (used with --force)
+        #[arg(short = 'y', long)]
+        yes: bool,
     },
     /// Edit pull request title/body
     Edit {

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -86,19 +86,26 @@ pub async fn run_pr_merge(
 
     let merge_method = opts.method.copied().unwrap_or_default();
 
-    // Also check manifest repo if configured
+    // Also check manifest repo if configured and not filtered out
     let mut all_repos = repos.clone();
     if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
-        // Only add manifest repo if it has changes
-        match check_repo_for_changes(&manifest_repo) {
-            Ok(true) => {
-                all_repos.push(manifest_repo);
-            }
-            Ok(false) => {
-                Output::info("manifest: no changes, skipping");
-            }
-            Err(e) => {
-                Output::warning(&format!("manifest: could not check for changes: {}", e));
+        let manifest_included = match opts.repo_filter {
+            Some(ref filter) => filter
+                .iter()
+                .any(|f| f == &manifest_repo.name || f == "manifest"),
+            None => true,
+        };
+        if manifest_included {
+            match check_repo_for_changes(&manifest_repo) {
+                Ok(true) => {
+                    all_repos.push(manifest_repo);
+                }
+                Ok(false) => {
+                    Output::info("manifest: no changes, skipping");
+                }
+                Err(e) => {
+                    Output::warning(&format!("manifest: could not check for changes: {}", e));
+                }
             }
         }
     }

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -7,6 +7,7 @@ use crate::core::repo::{get_manifest_repo_info, RepoInfo};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::traits::{HostingPlatform, PlatformError};
 use crate::platform::{get_platform_adapter, CheckState, MergeMethod};
+use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -46,6 +47,8 @@ pub struct MergeOptions<'a> {
     pub wait: bool,
     pub timeout: u64,
     pub delete_branch: bool,
+    pub repo_filter: Option<Vec<String>>,
+    pub yes: bool,
 }
 
 /// Run the PR merge command
@@ -72,6 +75,13 @@ pub async fn run_pr_merge(
             )
         })
         .filter(|r| !r.reference) // Skip reference repos
+        .filter(|r| {
+            if let Some(ref filter) = opts.repo_filter {
+                filter.iter().any(|f| f == &r.name)
+            } else {
+                true
+            }
+        })
         .collect();
 
     let merge_method = opts.method.copied().unwrap_or_default();
@@ -329,6 +339,26 @@ pub async fn run_pr_merge(
             spinner.finish_with_message("All checks resolved");
             println!();
         }
+    }
+
+    // When --force is used, confirm which PRs will be merged
+    if opts.force && !opts.yes && !opts.json && prs_to_merge.len() > 1 {
+        Output::warning(&format!(
+            "--force will merge {} PRs across these repos:",
+            prs_to_merge.len()
+        ));
+        for pr in &prs_to_merge {
+            println!("  - {} PR #{}", pr.repo_name, pr.pr_number);
+        }
+        print!("\nProceed? [y/N] ");
+        std::io::stdout().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Aborted. Use --repo to scope to specific repos.");
+            return Ok(());
+        }
+        println!();
     }
 
     // Check readiness if not forcing

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -629,6 +629,8 @@ pub async fn run_release(opts: ReleaseOptions<'_>) -> anyhow::Result<()> {
                     wait: true,
                     timeout: opts.timeout,
                     delete_branch: true,
+                    repo_filter: None,
+                    yes: false,
                 },
             )
             .await?;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -296,6 +296,8 @@ pub async fn dispatch_command(
                     wait,
                     timeout,
                     no_delete_branch,
+                    repo,
+                    yes,
                 } => {
                     crate::cli::commands::pr::run_pr_merge(
                         &ctx.workspace_root,
@@ -309,6 +311,8 @@ pub async fn dispatch_command(
                             wait,
                             timeout,
                             delete_branch: !no_delete_branch,
+                            repo_filter: repo,
+                            yes,
                         },
                     )
                     .await?;

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -41,6 +41,8 @@ async fn test_pr_merge_no_open_prs() {
             wait: false,
             timeout: 600,
             delete_branch: true,
+            repo_filter: None,
+            yes: true,
         },
     )
     .await;
@@ -90,6 +92,8 @@ async fn test_pr_merge_skip_default_branch() {
             wait: false,
             timeout: 600,
             delete_branch: true,
+            repo_filter: None,
+            yes: true,
         },
     )
     .await;
@@ -133,6 +137,8 @@ async fn test_pr_merge_skip_reference_repos() {
             wait: false,
             timeout: 600,
             delete_branch: true,
+            repo_filter: None,
+            yes: true,
         },
     )
     .await;
@@ -175,6 +181,8 @@ async fn test_pr_merge_mixed_repos_all_skipped() {
             wait: false,
             timeout: 600,
             delete_branch: true,
+            repo_filter: None,
+            yes: true,
         },
     )
     .await;
@@ -236,6 +244,8 @@ async fn test_pr_merge_force_bypasses_checks() {
             wait: false,
             timeout: 600,
             delete_branch: true,
+            repo_filter: None,
+            yes: true,
         },
     )
     .await;
@@ -303,6 +313,8 @@ async fn test_pr_merge_branch_behind_suggests_update() {
             wait: false,
             timeout: 600,
             delete_branch: true,
+            repo_filter: None,
+            yes: true,
         },
     )
     .await;

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -337,6 +337,180 @@ async fn test_pr_merge_branch_behind_suggests_update() {
 // ── AllOrNothing Stops on Failure ───────────────────────────────
 // With AllOrNothing merge strategy, first failure should stop all merges.
 
+// ── Repo Filter Scopes Merge ───────────────────────────────────
+// --repo filter should only merge PRs for the named repos.
+
+#[tokio::test]
+async fn test_pr_merge_repo_filter_excludes_non_target() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    // Put both repos on feature branches
+    git_helpers::create_branch(&ws.repo_path("frontend"), "feat/shared");
+    git_helpers::commit_file(&ws.repo_path("frontend"), "f.txt", "f", "Frontend change");
+    git_helpers::create_branch(&ws.repo_path("backend"), "feat/shared");
+    git_helpers::commit_file(&ws.repo_path("backend"), "b.txt", "b", "Backend change");
+
+    // Point both repos at mock GitHub
+    for name in ["frontend", "backend"] {
+        let repo_config = manifest.repos.get_mut(name).unwrap();
+        repo_config.url = Some("https://github.com/owner/repo.git".to_string());
+        repo_config.platform = Some(PlatformConfig {
+            platform_type: PlatformType::GitHub,
+            base_url: Some(server.uri()),
+        });
+    }
+
+    // Only mock PR for frontend (PR #10). Backend should never be queried.
+    mock_list_prs(&server, vec![(10, "feat/shared")]).await;
+    mock_get_pr(&server, 10, "open", true).await;
+    mock_pr_reviews(&server, 10, vec![("APPROVED", "alice")]).await;
+    mock_check_runs(
+        &server,
+        "feat/shared",
+        vec![("CI", "completed", Some("success"))],
+    )
+    .await;
+    mock_merge_pr(&server, 10, true).await;
+
+    // Filter to frontend only, force to bypass readiness checks
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: true,
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: Some(vec!["frontend".to_string()]),
+            yes: true,
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "repo-filtered merge should succeed: {:?}",
+        result.err()
+    );
+
+    // Verify merge was called (for frontend)
+    let requests = server.received_requests().await.unwrap();
+    let merge_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method == Method::PUT && r.url.path().ends_with("/merge"))
+        .collect();
+    assert_eq!(
+        merge_requests.len(),
+        1,
+        "exactly one merge request should be sent (frontend only, not backend)"
+    );
+}
+
+// ── Repo Filter: No Matching Repos ────────────────────────────
+// When --repo names a repo that doesn't exist, all repos are filtered out.
+
+#[tokio::test]
+async fn test_pr_merge_repo_filter_no_match_finds_no_prs() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let manifest = ws.load_manifest();
+
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
+    git_helpers::commit_file(&ws.repo_path("app"), "t.txt", "t", "Test");
+
+    // Filter to nonexistent repo — app should be excluded
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: Some(vec!["nonexistent".to_string()]),
+            yes: true,
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "repo filter with no matches should succeed with 'no PRs found': {:?}",
+        result.err()
+    );
+}
+
+// ── Force + Yes Skips Confirmation ─────────────────────────────
+// --force --yes merges multiple repos without prompting.
+
+#[tokio::test]
+async fn test_pr_merge_force_yes_merges_without_prompt() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let mut manifest = ws.load_manifest();
+
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
+    git_helpers::commit_file(
+        &ws.repo_path("app"),
+        "feature.txt",
+        "feature",
+        "Add feature",
+    );
+
+    let repo_config = manifest.repos.get_mut("app").unwrap();
+    repo_config.url = Some("https://github.com/owner/repo.git".to_string());
+    repo_config.platform = Some(PlatformConfig {
+        platform_type: PlatformType::GitHub,
+        base_url: Some(server.uri()),
+    });
+
+    mock_list_prs(&server, vec![(42, "feat/test")]).await;
+    mock_get_pr(&server, 42, "open", false).await;
+    mock_pr_reviews(&server, 42, vec![]).await;
+    mock_check_runs(&server, "feat/test", vec![("CI", "in_progress", None)]).await;
+    mock_merge_pr(&server, 42, true).await;
+
+    // --force --yes should merge without stdin prompt
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: true,
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: None,
+            yes: true,
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "force+yes merge should succeed: {:?}",
+        result.err()
+    );
+}
+
 #[tokio::test]
 #[ignore = "requires platform injection for API mocking"]
 async fn test_pr_merge_all_or_nothing_stops_on_failure() {


### PR DESCRIPTION
## Summary

`gr pr merge --force` iterated all repos in the workspace and merged any open PR on the current branch, not just the intended one. This caused Atlas to unintentionally merge premium#688 when only trying to force-merge config#62.

Two fixes:
- Add `--repo` filter to `gr pr merge` so users can scope which repos participate (matching `gr pr create --repo`)
- Add confirmation prompt when `--force` would merge 2+ PRs, showing exactly which PRs will be merged. Skip with `--yes` for automation.

Closes https://github.com/synapt-dev/grip/issues/91

## Changes

- `src/cli/args.rs`: Add `--repo` and `--yes` flags to `Merge` variant
- `src/cli/commands/pr/merge.rs`: Add `repo_filter` and `yes` to `MergeOptions`, filter repos by `--repo`, add confirmation prompt for multi-PR `--force`
- `src/cli/dispatch.rs`: Thread new fields through
- `src/cli/commands/release.rs`: Add new fields to release merge callsite
- `tests/test_pr_merge.rs`: Add new fields to all test MergeOptions

## Usage

```bash
# Merge only the PR in a specific repo
gr pr merge --repo config

# Force-merge shows confirmation for 2+ PRs
gr pr merge --force
# ⚠ --force will merge 2 PRs across these repos:
#   - config PR #62
#   - premium PR #688
# Proceed? [y/N]

# Skip confirmation for automation
gr pr merge --force --yes
```

Premium boundary: OSS (gitgrip workspace orchestration).

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --test test_pr_merge` - 6/6 pass
- [x] `cargo test --test test_platform_github` - 32/32 pass
- [x] Full `cargo test` - only pre-existing gr2_team failures (9), all others pass (36)