### PR TITLE
feat: SSH-to-HTTPS auto-fallback for gr push

### DIFF
--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -283,10 +283,62 @@ pub fn push_branch(
 
     if !success {
         let stderr = String::from_utf8_lossy(&output.stderr);
+
+        if is_ssh_auth_error(&stderr) {
+            if let Ok(Some(url)) = get_remote_url(repo, remote) {
+                if let Some(https_url) = ssh_url_to_https(&url) {
+                    let mut retry_args = vec!["push", &https_url, branch_name];
+                    if set_upstream {
+                        retry_args.insert(1, "-u");
+                    }
+
+                    let mut retry_cmd = Command::new("git");
+                    retry_cmd.args(&retry_args).current_dir(repo_path);
+                    log_cmd(&retry_cmd);
+                    let retry_output = retry_cmd
+                        .output()
+                        .map_err(|e| GitError::OperationFailed(e.to_string()))?;
+
+                    if retry_output.status.success() {
+                        return Ok(());
+                    }
+                    let retry_stderr = String::from_utf8_lossy(&retry_output.stderr);
+                    return Err(GitError::OperationFailed(interpret_push_error(
+                        &retry_stderr,
+                    )));
+                }
+            }
+        }
+
         return Err(GitError::OperationFailed(interpret_push_error(&stderr)));
     }
 
     Ok(())
+}
+
+/// Check if a git error is an SSH authentication failure.
+fn is_ssh_auth_error(stderr: &str) -> bool {
+    let lower = stderr.to_lowercase();
+    lower.contains("permission denied")
+        || lower.contains("authentication failed")
+        || lower.contains("sign_and_send_pubkey")
+        || lower.contains("signing failed")
+}
+
+/// Convert an SSH git URL to HTTPS.
+///
+/// `git@github.com:org/repo.git` -> `https://github.com/org/repo.git`
+/// `ssh://git@github.com/org/repo.git` -> `https://github.com/org/repo.git`
+pub fn ssh_url_to_https(url: &str) -> Option<String> {
+    if let Some(rest) = url.strip_prefix("git@") {
+        if let Some((host, path)) = rest.split_once(':') {
+            return Some(format!("https://{}/{}", host, path));
+        }
+    }
+    if let Some(rest) = url.strip_prefix("ssh://git@") {
+        return Some(format!("https://{}", rest));
+    }
+    None
 }
 
 /// Interpret common git push/fetch errors into user-friendly messages
@@ -334,6 +386,30 @@ pub fn force_push_branch(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+
+        if is_ssh_auth_error(&stderr) {
+            if let Ok(Some(url)) = get_remote_url(repo, remote) {
+                if let Some(https_url) = ssh_url_to_https(&url) {
+                    let mut retry_cmd = Command::new("git");
+                    retry_cmd
+                        .args(["push", "--force", &https_url, branch_name])
+                        .current_dir(repo_path);
+                    log_cmd(&retry_cmd);
+                    let retry_output = retry_cmd
+                        .output()
+                        .map_err(|e| GitError::OperationFailed(e.to_string()))?;
+
+                    if retry_output.status.success() {
+                        return Ok(());
+                    }
+                    let retry_stderr = String::from_utf8_lossy(&retry_output.stderr);
+                    return Err(GitError::OperationFailed(interpret_push_error(
+                        &retry_stderr,
+                    )));
+                }
+            }
+        }
+
         return Err(GitError::OperationFailed(interpret_push_error(&stderr)));
     }
 
@@ -816,5 +892,62 @@ mod tests {
     fn test_interpret_push_error_unknown() {
         let msg = interpret_push_error("some other error");
         assert_eq!(msg, "some other error");
+    }
+
+    #[test]
+    fn test_ssh_url_to_https_scp_style() {
+        assert_eq!(
+            ssh_url_to_https("git@github.com:synapt-dev/grip.git"),
+            Some("https://github.com/synapt-dev/grip.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ssh_url_to_https_ssh_scheme() {
+        assert_eq!(
+            ssh_url_to_https("ssh://git@github.com/synapt-dev/grip.git"),
+            Some("https://github.com/synapt-dev/grip.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ssh_url_to_https_already_https() {
+        assert_eq!(
+            ssh_url_to_https("https://github.com/synapt-dev/grip.git"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_ssh_url_to_https_gitlab() {
+        assert_eq!(
+            ssh_url_to_https("git@gitlab.com:org/project.git"),
+            Some("https://gitlab.com/org/project.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_ssh_auth_error_permission_denied() {
+        assert!(is_ssh_auth_error("Permission denied (publickey)."));
+    }
+
+    #[test]
+    fn test_is_ssh_auth_error_sign_and_send() {
+        assert!(is_ssh_auth_error(
+            "sign_and_send_pubkey: signing failed for ED25519"
+        ));
+    }
+
+    #[test]
+    fn test_is_ssh_auth_error_authentication_failed() {
+        assert!(is_ssh_auth_error(
+            "Authentication failed for 'git@github.com'"
+        ));
+    }
+
+    #[test]
+    fn test_is_ssh_auth_error_not_auth() {
+        assert!(!is_ssh_auth_error("non-fast-forward"));
+        assert!(!is_ssh_auth_error("repository not found"));
     }
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -329,6 +329,7 @@ fn is_ssh_auth_error(stderr: &str) -> bool {
 ///
 /// `git@github.com:org/repo.git` -> `https://github.com/org/repo.git`
 /// `ssh://git@github.com/org/repo.git` -> `https://github.com/org/repo.git`
+/// `ssh://git@github.com:22/org/repo.git` -> `https://github.com/org/repo.git`
 pub fn ssh_url_to_https(url: &str) -> Option<String> {
     if let Some(rest) = url.strip_prefix("git@") {
         if let Some((host, path)) = rest.split_once(':') {
@@ -336,7 +337,10 @@ pub fn ssh_url_to_https(url: &str) -> Option<String> {
         }
     }
     if let Some(rest) = url.strip_prefix("ssh://git@") {
-        return Some(format!("https://{}", rest));
+        if let Some((host_port, path)) = rest.split_once('/') {
+            let host = host_port.split(':').next().unwrap_or(host_port);
+            return Some(format!("https://{}/{}", host, path));
+        }
     }
     None
 }
@@ -907,6 +911,22 @@ mod tests {
         assert_eq!(
             ssh_url_to_https("ssh://git@github.com/synapt-dev/grip.git"),
             Some("https://github.com/synapt-dev/grip.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ssh_url_to_https_ssh_scheme_with_default_port() {
+        assert_eq!(
+            ssh_url_to_https("ssh://git@github.com:22/synapt-dev/grip.git"),
+            Some("https://github.com/synapt-dev/grip.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ssh_url_to_https_ssh_scheme_with_custom_port() {
+        assert_eq!(
+            ssh_url_to_https("ssh://git@host.example.com:2222/org/repo.git"),
+            Some("https://host.example.com/org/repo.git".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

- When SSH authentication fails during `push_branch()` or `force_push_branch()`, automatically detect the failure, convert the remote URL from SSH to HTTPS, and retry the push
- Adds `ssh_url_to_https()` helper that handles both SCP-style (`git@host:path`) and scheme-style (`ssh://git@host/path`) SSH URLs
- Adds `is_ssh_auth_error()` detection for `permission denied`, `authentication failed`, `sign_and_send_pubkey`, and `signing failed` error strings
- 8 new unit tests covering URL conversion (GitHub, GitLab, SSH scheme, HTTPS passthrough) and auth error detection

**Friction context**: Every `gr push` in this workspace fails with SSH auth errors (1Password-managed keys) and requires manual HTTPS workaround per SSH policy in CLAUDE.md. This eliminates that friction at the transport layer.

**What this doesn't fix**: Friction A (site repo URL mismatch) is a local config issue. The site repo's origin points to `laynepenney/synapt-site.git` (personal fork) instead of `synapt-dev/synapt-site.git` (org repo). Fix: `cd site && git remote set-url origin git@github.com:synapt-dev/synapt-site.git`.

Premium boundary: gitgrip is OSS (MIT). Transport-layer resilience is core infrastructure.

Closes https://github.com/synapt-dev/grip/issues/91

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test` - 662 passed, 0 new failures
- [x] `cargo fmt --all -- --check` passes
- [x] 8 new unit tests: `ssh_url_to_https` (4 variants) + `is_ssh_auth_error` (4 variants)
- [ ] Manual: confirm `gr push` auto-falls-back when SSH key agent is unloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)