### PR TITLE
fix: gr add silent no-op on untracked files

### DIFF
--- a/src/cli/commands/add.rs
+++ b/src/cli/commands/add.rs
@@ -96,7 +96,6 @@ fn stage_files(repo: &Repository, _repo_path: &Path, files: &[String]) -> anyhow
     let before_output = cmd.output()?;
     let before_count = String::from_utf8_lossy(&before_output.stdout)
         .lines()
-        .filter(|l| !l.starts_with("??") || files.contains(&".".to_string()))
         .count();
 
     if before_count == 0 {

--- a/tests/test_add.rs
+++ b/tests/test_add.rs
@@ -75,4 +75,55 @@ fn test_add_specific_file() {
         "add specific file should succeed: {:?}",
         result.err()
     );
+
+    // Verify the specified file is staged
+    let output = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-only"])
+        .current_dir(ws.repo_path("app"))
+        .output()
+        .unwrap();
+    let staged = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        staged.contains("include.txt"),
+        "include.txt should be staged, got: {}",
+        staged
+    );
+
+    // Verify the excluded file is NOT staged
+    assert!(
+        !staged.contains("exclude.txt"),
+        "exclude.txt should not be staged"
+    );
+}
+
+#[test]
+fn test_add_untracked_files_only() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let manifest = ws.load_manifest();
+
+    // Create only untracked files (no modifications to tracked files)
+    std::fs::write(ws.repo_path("app").join("brand_new.txt"), "untracked").unwrap();
+
+    let files = vec!["brand_new.txt".to_string()];
+    let result =
+        gitgrip::cli::commands::add::run_add(&ws.workspace_root, &manifest, &files, None, None);
+    assert!(
+        result.is_ok(),
+        "add untracked file should succeed: {:?}",
+        result.err()
+    );
+
+    // Verify the untracked file is now staged
+    let output = std::process::Command::new("git")
+        .args(["diff", "--cached", "--name-only"])
+        .current_dir(ws.repo_path("app"))
+        .output()
+        .unwrap();
+    let staged = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        staged.contains("brand_new.txt"),
+        "untracked file should be staged after gr add, got: {}",
+        staged
+    );
 }


### PR DESCRIPTION
## Summary

- Fixes the pre-staging guard in `stage_files()` that filtered out untracked files (`??` prefix) from the change count, causing `gr add <file>` to silently return 0 when only untracked files existed
- Adds staging verification assertions to `test_add_specific_file` (was only checking `is_ok()`, not actual staging)
- Adds `test_add_untracked_files_only` test for the exact failure scenario

## Root cause

`add.rs:99` had `.filter(|l| !l.starts_with("??") || files.contains(&".".to_string()))` which excluded untracked files from the pre-staging count unless `gr add .` was used. When all dirty files were untracked (common in agent worktree clones), `before_count` hit 0 and the function returned early without calling `git add`.

## Test plan

- [x] `cargo test --test test_add` -- all 4 tests pass (including new `test_add_untracked_files_only`)
- [x] `cargo test` -- 664 unit tests pass, no regressions (9 pre-existing `test_gr2_team_*` failures unrelated)
- [x] `cargo fmt --all --check` -- clean
- [x] `cargo clippy` -- no new warnings

Premium boundary: core OSS (CLI workspace orchestration).

Closes #715