### PR TITLE
feat: detect repo renames and auto-update remote on PR create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ dependencies = [
  "git2",
  "gix",
  "glob",
+ "gr2-cli",
  "indicatif",
  "octocrab",
  "once_cell",

--- a/src/cli/commands/pr/create.rs
+++ b/src/cli/commands/pr/create.rs
@@ -9,7 +9,7 @@ use crate::cli::output::Output;
 use crate::core::manifest::{Manifest, PlatformType};
 use crate::core::repo::{filter_repos, get_manifest_repo_info, RepoInfo};
 use crate::core::state::StateFile;
-use crate::git::remote::set_remote_url;
+use crate::git::remote::{get_remote_url, set_remote_url};
 use crate::git::status::has_uncommitted_changes;
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::get_platform_adapter;
@@ -258,13 +258,21 @@ pub async fn run_pr_create(
                             repo.name, repo.owner, repo.repo, new_owner, new_repo
                         ));
                         if let Ok(git_repo) = open_repo(&repo.absolute_path) {
-                            let new_url =
-                                format!("https://github.com/{}/{}.git", new_owner, new_repo);
-                            if set_remote_url(&git_repo, &repo.push_remote, &new_url).is_ok() {
-                                Output::success(&format!(
-                                    "{}: updated remote '{}' → {}",
-                                    repo.name, repo.push_remote, new_url
-                                ));
+                            let new_url = rewrite_remote_url(
+                                &git_repo,
+                                &repo.push_remote,
+                                &repo.owner,
+                                &repo.repo,
+                                &new_owner,
+                                &new_repo,
+                            );
+                            if let Some(url) = &new_url {
+                                if set_remote_url(&git_repo, &repo.push_remote, url).is_ok() {
+                                    Output::success(&format!(
+                                        "{}: updated remote '{}' → {}",
+                                        repo.name, repo.push_remote, url
+                                    ));
+                                }
                             }
                         }
                         match platform
@@ -500,6 +508,36 @@ pub fn get_token_for_platform(platform: &PlatformType) -> Option<String> {
     }
 }
 
+/// Rewrite a remote URL to reflect a renamed repository.
+///
+/// Preserves the original scheme (SSH/HTTPS) and host by replacing
+/// `old_owner/old_repo` with `new_owner/new_repo` in the existing URL.
+fn rewrite_remote_url(
+    repo: &Repository,
+    remote_name: &str,
+    old_owner: &str,
+    old_repo: &str,
+    new_owner: &str,
+    new_repo: &str,
+) -> Option<String> {
+    let current = get_remote_url(repo, remote_name).ok()??;
+
+    // SSH URLs use ":" as separator (git@host:owner/repo.git)
+    // HTTPS URLs use "/" as separator (https://host/owner/repo.git)
+    let old_ssh = format!(":{}/{}", old_owner, old_repo);
+    let new_ssh = format!(":{}/{}", new_owner, new_repo);
+    let old_https = format!("/{}/{}", old_owner, old_repo);
+    let new_https = format!("/{}/{}", new_owner, new_repo);
+
+    if current.contains(&old_ssh) {
+        Some(current.replace(&old_ssh, &new_ssh))
+    } else if current.contains(&old_https) {
+        Some(current.replace(&old_https, &new_https))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -643,5 +681,107 @@ mod tests {
         assert_eq!(branch_to_title("fix/bug-fix"), "Bug fix");
         assert_eq!(branch_to_title("chore/cleanup_task"), "Cleanup task");
         assert_eq!(branch_to_title("custom-branch"), "Custom branch");
+    }
+
+    #[test]
+    fn test_rewrite_remote_url_https() {
+        let (temp, repo) = setup_test_repo();
+        Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/oldorg/oldrepo.git",
+            ])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+
+        let result = rewrite_remote_url(&repo, "origin", "oldorg", "oldrepo", "neworg", "newrepo");
+        assert_eq!(
+            result,
+            Some("https://github.com/neworg/newrepo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_remote_url_ssh() {
+        let (temp, repo) = setup_test_repo();
+        Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:oldorg/oldrepo.git",
+            ])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+
+        let result = rewrite_remote_url(&repo, "origin", "oldorg", "oldrepo", "neworg", "newrepo");
+        assert_eq!(
+            result,
+            Some("git@github.com:neworg/newrepo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_remote_url_ghe() {
+        let (temp, repo) = setup_test_repo();
+        Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.example.com/oldorg/oldrepo.git",
+            ])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+
+        let result = rewrite_remote_url(&repo, "origin", "oldorg", "oldrepo", "neworg", "newrepo");
+        assert_eq!(
+            result,
+            Some("https://github.example.com/neworg/newrepo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_remote_url_ghe_ssh() {
+        let (temp, repo) = setup_test_repo();
+        Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@ghe.corp.net:oldorg/oldrepo.git",
+            ])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+
+        let result = rewrite_remote_url(&repo, "origin", "oldorg", "oldrepo", "neworg", "newrepo");
+        assert_eq!(
+            result,
+            Some("git@ghe.corp.net:neworg/newrepo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_remote_url_no_match() {
+        let (temp, repo) = setup_test_repo();
+        Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/different/repo.git",
+            ])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+
+        let result = rewrite_remote_url(&repo, "origin", "oldorg", "oldrepo", "neworg", "newrepo");
+        assert_eq!(result, None);
     }
 }

--- a/src/cli/commands/pr/create.rs
+++ b/src/cli/commands/pr/create.rs
@@ -9,6 +9,7 @@ use crate::cli::output::Output;
 use crate::core::manifest::{Manifest, PlatformType};
 use crate::core::repo::{filter_repos, get_manifest_repo_info, RepoInfo};
 use crate::core::state::StateFile;
+use crate::git::remote::set_remote_url;
 use crate::git::status::has_uncommitted_changes;
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::get_platform_adapter;
@@ -249,8 +250,63 @@ pub async fn run_pr_create(
                     ));
                 }
                 Err(e) => {
-                    spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));
-                    all_failed_repos.push((repo.name.clone(), e.to_string()));
+                    if let Ok(Some((new_owner, new_repo))) =
+                        platform.resolve_repo(&repo.owner, &repo.repo).await
+                    {
+                        spinner.finish_with_message(format!(
+                            "{}: repo renamed {}/{} → {}/{}, retrying...",
+                            repo.name, repo.owner, repo.repo, new_owner, new_repo
+                        ));
+                        if let Ok(git_repo) = open_repo(&repo.absolute_path) {
+                            let new_url =
+                                format!("https://github.com/{}/{}.git", new_owner, new_repo);
+                            if set_remote_url(&git_repo, &repo.push_remote, &new_url).is_ok() {
+                                Output::success(&format!(
+                                    "{}: updated remote '{}' → {}",
+                                    repo.name, repo.push_remote, new_url
+                                ));
+                            }
+                        }
+                        match platform
+                            .create_pull_request(
+                                &new_owner,
+                                &new_repo,
+                                &group.branch,
+                                repo.target_branch(),
+                                &pr_title,
+                                body,
+                                draft,
+                            )
+                            .await
+                        {
+                            Ok(pr) => {
+                                Output::success(&format!(
+                                    "{}: created PR #{} - {}",
+                                    repo.name, pr.number, pr.url
+                                ));
+                                all_created_prs.push((
+                                    group.branch.clone(),
+                                    repo.name.clone(),
+                                    pr.number,
+                                    pr.url.clone(),
+                                ));
+                                Output::warning(&format!(
+                                    "Update gripspace.yml: change {} URL to {}/{}.git",
+                                    repo.name, new_owner, new_repo
+                                ));
+                            }
+                            Err(e2) => {
+                                spinner.finish_with_message(format!(
+                                    "{}: retry failed - {}",
+                                    repo.name, e2
+                                ));
+                                all_failed_repos.push((repo.name.clone(), e2.to_string()));
+                            }
+                        }
+                    } else {
+                        spinner.finish_with_message(format!("{}: failed - {}", repo.name, e));
+                        all_failed_repos.push((repo.name.clone(), e.to_string()));
+                    }
                 }
             }
         }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -358,6 +358,7 @@ fn interpret_push_error(stderr: &str) -> String {
     if lower.contains("could not read from remote") || lower.contains("repository not found") {
         return format!(
             "Cannot reach remote. Check your network connection and repository URL.\n\
+             If the repo was renamed on GitHub, `gr pr create` will auto-detect and update the remote.\n\
              (Original: {})",
             stderr.trim()
         );

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -207,6 +207,34 @@ impl HostingPlatform for GitHubAdapter {
         })
     }
 
+    async fn resolve_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<Option<(String, String)>, PlatformError> {
+        let client = self.get_client().await?;
+
+        match client.repos(owner, repo).get().await {
+            Ok(repo_info) => {
+                let canonical = repo_info.full_name.unwrap_or_default();
+                let parts: Vec<&str> = canonical.splitn(2, '/').collect();
+                if parts.len() == 2 && (parts[0] != owner || parts[1] != repo) {
+                    debug!(
+                        old_owner = owner,
+                        old_repo = repo,
+                        new_owner = parts[0],
+                        new_repo = parts[1],
+                        "Detected repository rename"
+                    );
+                    Ok(Some((parts[0].to_string(), parts[1].to_string())))
+                } else {
+                    Ok(None)
+                }
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
     async fn get_pull_request(
         &self,
         owner: &str,

--- a/src/platform/traits.rs
+++ b/src/platform/traits.rs
@@ -32,6 +32,14 @@ pub enum PlatformError {
 
     #[error("Branch protection prevents merge: {0}")]
     BranchProtected(String),
+
+    #[error("Repository renamed: {old_owner}/{old_repo} → {new_owner}/{new_repo}")]
+    RepoRenamed {
+        old_owner: String,
+        old_repo: String,
+        new_owner: String,
+        new_repo: String,
+    },
 }
 
 /// Linked PR reference for cross-repo tracking
@@ -185,6 +193,19 @@ pub trait HostingPlatform: Send + Sync {
         repo: &str,
         pull_number: u64,
     ) -> Result<String, PlatformError>;
+
+    /// Check if a repository has been renamed by querying the platform API.
+    ///
+    /// Returns `Some((new_owner, new_repo))` if the canonical name differs
+    /// from the requested owner/repo (indicating a rename). Returns `None`
+    /// if the repo exists at the expected location or cannot be resolved.
+    async fn resolve_repo(
+        &self,
+        _owner: &str,
+        _repo: &str,
+    ) -> Result<Option<(String, String)>, PlatformError> {
+        Ok(None)
+    }
 
     /// Parse a git URL to extract owner/repo information
     fn parse_repo_url(&self, url: &str) -> Option<ParsedRepoInfo>;


### PR DESCRIPTION
## Summary

- Adds `resolve_repo()` to the `HostingPlatform` trait that checks if a GitHub repo was renamed by querying the canonical `full_name` via the API
- When `gr pr create` fails, detects renames by comparing the manifest's owner/repo against the canonical name, updates the git remote URL, and retries the PR creation
- Adds `RepoRenamed` variant to `PlatformError` for structured rename errors
- Push error messages now hint about rename detection via `gr pr create`

## Root cause

When a GitHub repo is renamed (e.g., `synapt-dev/synapt-config` -> `synapt-dev/config`), the manifest URL goes stale. PR creation with the old owner/repo slug fails because HTTP 301 redirects on POST requests get converted to GET by HTTP clients. The git remote URL also stays stale, though pushes may still work via GitHub's SSH redirect.

## Detection mechanism

On PR create failure, `resolve_repo()` does `GET /repos/{old_owner}/{old_repo}`. GitHub follows the redirect and returns the canonical `full_name`. If it differs from the requested owner/repo, we know a rename occurred. The git remote is updated via `git remote set-url` and the PR create is retried with the canonical name. A warning is printed to update `gripspace.yml`.

## Test plan

- [x] `cargo test` -- 664 unit tests pass, no regressions
- [x] `cargo fmt --all --check` -- clean
- [x] `cargo clippy --all-targets` -- no new errors
- [x] Empirical: Atlas hit this exact friction on `synapt-dev/synapt-private` -> `synapt-dev/premium` rename during Sprint 33

Premium boundary: core OSS (CLI workspace orchestration).

Closes #716