### PR TITLE
feat: add --base flag to gr pr create (grip#622)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -707,6 +707,9 @@ pub enum PrCommands {
         /// Only create PRs for specific repos (comma-separated)
         #[arg(long, value_delimiter = ',')]
         repo: Option<Vec<String>>,
+        /// Base branch for the PR (overrides grip target)
+        #[arg(long)]
+        base: Option<String>,
     },
     /// Show PR status
     Status,

--- a/src/cli/commands/pr/create.rs
+++ b/src/cli/commands/pr/create.rs
@@ -46,6 +46,7 @@ pub async fn run_pr_create(
     push_first: bool,
     dry_run: bool,
     repo_filter: Option<&[String]>,
+    base_override: Option<&str>,
     json: bool,
 ) -> anyhow::Result<()> {
     if !json {
@@ -85,13 +86,15 @@ pub async fn run_pr_create(
                     Err(_) => continue,
                 };
 
+                let target = base_override.unwrap_or_else(|| repo.target_branch());
+
                 // Skip if on target branch
-                if current == repo.target_branch() {
+                if current == target {
                     continue;
                 }
 
                 // Check for changes ahead of target branch
-                if has_commits_ahead(&git_repo, &current, repo.target_branch())? {
+                if has_commits_ahead(&git_repo, &current, target)? {
                     branch_groups.entry(current).or_default().push(repo.clone());
                 }
             }
@@ -106,7 +109,7 @@ pub async fn run_pr_create(
 
     if include_manifest {
         if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
-            match check_manifest_repo_branch(&manifest_repo) {
+            match check_manifest_repo_branch(&manifest_repo, base_override) {
                 Ok(Some((branch, repo_info))) => {
                     branch_groups.entry(branch).or_default().push(repo_info);
                 }
@@ -141,7 +144,8 @@ pub async fn run_pr_create(
         .collect();
 
     // Warn if PRs target main/master — may want a sprint branch (#418)
-    if !json {
+    // Skip warning when --base is explicit (the user knows what they're targeting)
+    if !json && base_override.is_none() {
         let default_targets: Vec<&str> = groups
             .iter()
             .flat_map(|g| g.repos.iter())
@@ -207,12 +211,10 @@ pub async fn run_pr_create(
 
             Output::subheader("Repositories that would create PRs:");
             for repo in &group.repos {
+                let target = base_override.unwrap_or_else(|| repo.target_branch());
                 println!(
                     "  - {} ({}/{}) → {}",
-                    repo.name,
-                    repo.owner,
-                    repo.repo,
-                    repo.target_branch()
+                    repo.name, repo.owner, repo.repo, target
                 );
             }
             println!();
@@ -221,6 +223,7 @@ pub async fn run_pr_create(
 
         // Create PRs for each repo in this branch group
         for repo in &group.repos {
+            let target = base_override.unwrap_or_else(|| repo.target_branch());
             let platform =
                 get_platform_adapter(repo.platform_type, repo.platform_base_url.as_deref());
 
@@ -258,7 +261,7 @@ pub async fn run_pr_create(
                     &repo.owner,
                     &repo.repo,
                     &group.branch,
-                    repo.target_branch(),
+                    target,
                     &pr_title,
                     body,
                     draft,
@@ -308,7 +311,7 @@ pub async fn run_pr_create(
                                 &new_owner,
                                 &new_repo,
                                 &group.branch,
-                                repo.target_branch(),
+                                target,
                                 &pr_title,
                                 body,
                                 draft,
@@ -498,19 +501,24 @@ pub(crate) fn has_commits_ahead(
 }
 
 /// Check if the manifest repo has changes and return its branch name
-fn check_manifest_repo_branch(repo: &RepoInfo) -> anyhow::Result<Option<(String, RepoInfo)>> {
+fn check_manifest_repo_branch(
+    repo: &RepoInfo,
+    base_override: Option<&str>,
+) -> anyhow::Result<Option<(String, RepoInfo)>> {
     let git_repo = open_repo(&repo.absolute_path)
         .map_err(|e| anyhow::anyhow!("Failed to open repo: {}", e))?;
 
     let current = get_current_branch(&git_repo)
         .map_err(|e| anyhow::anyhow!("Failed to get current branch: {}", e))?;
 
+    let target = base_override.unwrap_or_else(|| repo.target_branch());
+
     // Skip if on target branch
-    if current == repo.target_branch() {
+    if current == target {
         return Ok(None);
     }
 
-    let has_commits = has_commits_ahead(&git_repo, &current, repo.target_branch())
+    let has_commits = has_commits_ahead(&git_repo, &current, target)
         .map_err(|e| anyhow::anyhow!("Failed to check commits: {}", e))?;
 
     let has_uncommitted = has_uncommitted_changes(&git_repo)

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -596,6 +596,7 @@ pub async fn run_release(opts: ReleaseOptions<'_>) -> anyhow::Result<()> {
                 false, // push (already pushed)
                 false, // dry_run
                 None,  // repo_filter
+                None,  // base_override
                 opts.json,
             )
             .await?;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -266,6 +266,7 @@ pub async fn dispatch_command(
                     draft,
                     dry_run,
                     repo,
+                    base,
                 } => {
                     crate::cli::commands::pr::run_pr_create(
                         &ctx.workspace_root,
@@ -276,6 +277,7 @@ pub async fn dispatch_command(
                         push,
                         dry_run,
                         repo.as_deref(),
+                        base.as_deref(),
                         ctx.json,
                     )
                     .await?;


### PR DESCRIPTION
## Summary
- Adds `--base` flag to `gr pr create` for overriding the grip target branch
- When `--base` is set, all repos use it instead of `repo.target_branch()`
- Suppresses the "PR targets main" warning when `--base` is explicit
- Unblocks ceremony PRs (sprint-N -> main) without falling back to raw `gh`

Closes #622

## Test plan
- [x] 669/669 existing tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] CLI `--help` shows new `--base` flag
- [ ] Manual test: `gr pr create --base main --dry-run` shows correct target

Premium boundary: core OSS (grip CLI primitive)