### PR TITLE
fix: spawn down reports accurate exit state (grip#571)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -529,8 +529,8 @@ pub enum SpawnCommands {
         /// Stop only this agent
         #[arg(long)]
         agent: Option<String>,
-        /// Seconds to wait for graceful exit before force-killing (default: 10)
-        #[arg(long, default_value = "10")]
+        /// Seconds to wait for graceful exit before force-killing (default: 30)
+        #[arg(long, default_value = "30")]
         timeout: u64,
     },
     /// List configured agents

--- a/src/cli/commands/spawn.rs
+++ b/src/cli/commands/spawn.rs
@@ -701,8 +701,20 @@ pub fn run_spawn_down(
     // Phase 3: Report per-agent status and clean up tmux windows.
     // Agents that exited gracefully still need their dead pane/window removed.
     // Agents that timed out get force-killed via kill-window.
+    //
+    // For agents still marked Running after Phase 2, recheck before reporting:
+    // the agent may have exited between the polling deadline and now.
     let mut any_error = false;
     for (i, name) in targets.iter().enumerate() {
+        let final_state = if states[i] == PaneState::Running {
+            match pane_exit_state(session, name) {
+                Some(true) => PaneState::Exited,
+                _ => PaneState::Running,
+            }
+        } else {
+            states[i]
+        };
+
         let target = format!("{}:{}", session, name);
         let kill_result = Command::new("tmux")
             .args(["kill-window", "-t", &target])
@@ -711,7 +723,6 @@ pub fn run_spawn_down(
             Ok(o) if o.status.success() => true,
             Ok(o) => {
                 let stderr = String::from_utf8_lossy(&o.stderr);
-                // Window already gone is fine (agent cleaned up fully)
                 stderr.contains("can't find") || stderr.contains("no server running")
             }
             Err(e) => {
@@ -720,7 +731,7 @@ pub fn run_spawn_down(
             }
         };
 
-        match states[i] {
+        match final_state {
             PaneState::Exited => {
                 println!("  {} {} exited gracefully", "✓".green(), name.bold());
             }


### PR DESCRIPTION
## Summary

- Increase default `--timeout` from 10s to 30s so Claude Code shutdown hooks (precompact, journal writes, session save) have time to finish on M2 Air
- Add final `pane_exit_state()` recheck in Phase 3 before reporting: agents that exit between the polling deadline and the kill-window call are now correctly reported as "exited gracefully" instead of "force-killed"

Closes #571

## Premium boundary

Premium boundary: grip is OSS (CLI tooling infrastructure).

## Test plan

- [x] `cargo test --lib` — 669/669 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] Manual: `gr spawn down --agent <name>` with agent that takes 15-20s to exit — should report graceful instead of force-kill