### PR TITLE
feat: implement grip object model CLI (grip#606)

### DIFF
--- a/gr2/python_cli/grip_cli.py
+++ b/gr2/python_cli/grip_cli.py
@@ -6,12 +6,14 @@ dependencies (gr2.prototypes, lane_workspace_prototype, etc.).
 from __future__ import annotations
 
 import json
+import tomllib
 from pathlib import Path
 
 import typer
 
 from . import config as config_mod
 from . import grip as grip_mod
+from .gitops import git, repo_dirty
 
 grip_app = typer.Typer(help="Grip object model: workspace snapshots and history")
 config_cli_app = typer.Typer(help="Config base+overlay management")
@@ -25,6 +27,84 @@ def _resolve_repos(workspace: Path, repos_csv: str) -> dict[str, Path]:
             continue
         result[name] = workspace / name
     return result
+
+
+def _discover_repos(workspace: Path) -> dict[str, Path]:
+    """Auto-discover repos from workspace_spec.toml."""
+    spec_path = workspace / ".grip" / "workspace_spec.toml"
+    if not spec_path.exists():
+        typer.echo(
+            f"No .grip/workspace_spec.toml at {workspace}. "
+            "Use --repos or create a workspace spec."
+        )
+        raise typer.Exit(code=1)
+    with spec_path.open("rb") as fh:
+        spec = tomllib.load(fh)
+    result: dict[str, Path] = {}
+    for repo in spec.get("repos", []):
+        name = repo.get("name", "")
+        path = repo.get("path", name)
+        if name:
+            result[name] = workspace / path
+    return result
+
+
+def _validate_grip_dir(workspace: Path) -> None:
+    """Check .grip/ directory exists."""
+    grip_dir = workspace / ".grip"
+    if not grip_dir.exists():
+        typer.echo(f"No .grip/ directory at {workspace}. Run workspace init first.")
+        raise typer.Exit(code=1)
+
+
+def _check_dirty_repos(repos: dict[str, Path]) -> list[str]:
+    """Return list of dirty repo names."""
+    dirty = []
+    for name, path in sorted(repos.items()):
+        if path.is_dir() and repo_dirty(path):
+            dirty.append(name)
+    return dirty
+
+
+def _repo_head_state(repo_path: Path) -> dict[str, object]:
+    """Get head state for a single repo."""
+    head_proc = git(repo_path, "rev-parse", "HEAD")
+    if head_proc.returncode != 0:
+        return {"head": None, "is_empty": True, "head_state": "empty"}
+
+    head_sha = head_proc.stdout.strip()
+    branch = git(repo_path, "branch", "--show-current")
+    branch_name = branch.stdout.strip() if branch.returncode == 0 else ""
+
+    if branch_name:
+        return {
+            "head": head_sha, "is_empty": False,
+            "head_state": "attached", "branch": branch_name,
+        }
+    return {"head": head_sha, "is_empty": False, "head_state": "detached"}
+
+
+def _read_snapshot_index(workspace: Path) -> list[dict[str, object]]:
+    index_path = workspace / ".grip" / "snapshots" / "index.json"
+    if not index_path.exists():
+        return []
+    return json.loads(index_path.read_text())
+
+
+def _write_snapshot_index(workspace: Path, index: list[dict[str, object]]) -> None:
+    snapshots_dir = workspace / ".grip" / "snapshots"
+    snapshots_dir.mkdir(parents=True, exist_ok=True)
+    index_path = snapshots_dir / "index.json"
+    index_path.write_text(json.dumps(index, indent=2) + "\n")
+
+
+def _find_snapshot_by_id(
+    index: list[dict[str, object]], snapshot_id: str,
+) -> dict[str, object] | None:
+    for entry in index:
+        if entry.get("id") == snapshot_id:
+            return entry
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -53,16 +133,47 @@ def grip_init_cmd(
 @grip_app.command("snapshot")
 def grip_snapshot_cmd(
     workspace_root: Path,
-    repos: str = typer.Option(..., "--repos", help="Comma-separated repo names"),
-    message: str = typer.Option("", "--message", "-m", help="Snapshot message"),
-    changeset_type: str = typer.Option("", "--type", help="Changeset type (e.g. ceremony, feature)"),
+    repos: str = typer.Option(
+        "", "--repos",
+        help="Comma-separated repo names (auto from spec if omitted)",
+    ),
+    message: str = typer.Option(
+        "", "--message", "-m", help="Snapshot message",
+    ),
+    changeset_type: str = typer.Option(
+        "", "--type", help="Changeset type (e.g. ceremony, feature)",
+    ),
     sprint: str = typer.Option("", "--sprint", help="Sprint number"),
-    overlay_dir: str = typer.Option("", "--overlay-dir", help="Config overlay directory to include in snapshot"),
+    overlay_dir: str = typer.Option(
+        "", "--overlay-dir", help="Config overlay directory",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Snapshot current workspace into a grip commit."""
     workspace_root = workspace_root.resolve()
-    repo_map = _resolve_repos(workspace_root, repos)
+
+    _validate_grip_dir(workspace_root)
+
+    if repos:
+        repo_map = _resolve_repos(workspace_root, repos)
+    else:
+        repo_map = _discover_repos(workspace_root)
+
+    if not repo_map:
+        typer.echo("No repos found in workspace spec.")
+        raise typer.Exit(code=1)
+
+    dirty = _check_dirty_repos(repo_map)
+    if dirty:
+        typer.echo(f"Dirty repos detected: {', '.join(dirty)}. Commit or stash changes first.")
+        raise typer.Exit(code=1)
+
+    repo_states: dict[str, dict[str, object]] = {}
+    for name, path in sorted(repo_map.items()):
+        repo_states[name] = _repo_head_state(path)
+
+    grip_mod.grip_init(workspace_root)
+
     overlay = Path(overlay_dir).resolve() if overlay_dir else None
     try:
         sha = grip_mod.grip_snapshot(
@@ -76,8 +187,26 @@ def grip_snapshot_cmd(
     except grip_mod.GripInitError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1)
+
+    snapshot_id = sha
+
+    index = _read_snapshot_index(workspace_root)
+    entry: dict[str, object] = {
+        "id": snapshot_id,
+        "sha": sha,
+        "message": message or "grip snapshot",
+        "repos": sorted(repo_map.keys()),
+        "repo_states": repo_states,
+    }
+    if changeset_type:
+        entry["type"] = changeset_type
+    if sprint:
+        entry["sprint"] = sprint
+    index.append(entry)
+    _write_snapshot_index(workspace_root, index)
+
     if json_output:
-        typer.echo(json.dumps({"sha": sha, "repos": sorted(repo_map.keys())}))
+        typer.echo(json.dumps({"sha": sha, "id": snapshot_id, "repos": sorted(repo_map.keys())}))
     else:
         typer.echo(f"grip snapshot {sha[:12]} ({len(repo_map)} repos)")
 
@@ -90,71 +219,127 @@ def grip_log_cmd(
 ) -> None:
     """Show grip commit history."""
     workspace_root = workspace_root.resolve()
-    try:
-        entries = grip_mod.grip_log(workspace_root, max_count=max_count)
-    except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1)
+
+    _validate_grip_dir(workspace_root)
+
+    index = _read_snapshot_index(workspace_root)
+
     if json_output:
-        typer.echo(json.dumps({
-            "entries": [
-                {"sha": e.sha, "message": e.message, "repos": e.repos, "timestamp": e.timestamp}
-                for e in entries
-            ]
-        }))
-    else:
-        if not entries:
-            typer.echo("No grip commits yet.")
-            return
-        for e in entries:
-            typer.echo(f"{e.sha[:12]}  {e.message}  [{', '.join(e.repos)}]")
+        display = list(reversed(index[-max_count:])) if index else []
+        typer.echo(json.dumps({"entries": display}))
+        return
+
+    if not index:
+        typer.echo("No grip snapshots yet.")
+        return
+
+    display = list(reversed(index[-max_count:]))
+    for entry in display:
+            sid = entry.get("id", "?")
+            msg = entry.get("message", "")
+            repos = entry.get("repos", [])
+            typer.echo(f"{msg}  [{', '.join(repos)}]  ({sid[:12]})")
 
 
 @grip_app.command("diff")
 def grip_diff_cmd(
     workspace_root: Path,
-    ref_a: str = typer.Argument(..., help="First grip commit ref"),
-    ref_b: str = typer.Argument(..., help="Second grip commit ref"),
+    ref_a: str = typer.Argument(..., help="First snapshot id"),
+    ref_b: str = typer.Argument(..., help="Second snapshot id"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
-    """Show changes between two grip commits."""
+    """Show changes between two grip snapshots."""
     workspace_root = workspace_root.resolve()
-    try:
-        result = grip_mod.grip_diff(workspace_root, ref_a, ref_b)
-    except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
-        typer.echo(str(exc), err=True)
+
+    _validate_grip_dir(workspace_root)
+
+    index = _read_snapshot_index(workspace_root)
+    snap_a = _find_snapshot_by_id(index, ref_a)
+    snap_b = _find_snapshot_by_id(index, ref_b)
+
+    if snap_a is None:
+        typer.echo(f"Snapshot not found: missing id '{ref_a}'")
         raise typer.Exit(code=1)
+    if snap_b is None:
+        typer.echo(f"Snapshot not found: missing id '{ref_b}'")
+        raise typer.Exit(code=1)
+
+    states_a = snap_a.get("repo_states", {})
+    states_b = snap_b.get("repo_states", {})
+    all_repos = set(states_a.keys()) | set(states_b.keys())
+
+    changed: dict[str, dict[str, str]] = {}
+    added: list[str] = []
+    removed: list[str] = []
+
+    for name in sorted(all_repos):
+        if name in states_a and name not in states_b:
+            removed.append(name)
+        elif name not in states_a and name in states_b:
+            added.append(name)
+        else:
+            head_a = states_a[name].get("head")
+            head_b = states_b[name].get("head")
+            if head_a != head_b:
+                changed[name] = {"old": str(head_a), "new": str(head_b)}
+
     if json_output:
-        typer.echo(json.dumps({
-            "changed": result.changed,
-            "added": result.added,
-            "removed": result.removed,
-        }))
+        typer.echo(json.dumps({"changed": changed, "added": added, "removed": removed}))
     else:
-        if not result.changed and not result.added and not result.removed:
+        if not changed and not added and not removed:
             typer.echo("No changes.")
             return
-        for name, info in result.changed.items():
-            typer.echo(f"  ~ {name}: {info['old_commit'][:12]} -> {info['new_commit'][:12]}")
-        for name in result.added:
+        for name, info in changed.items():
+            old = info["old"][:12] if info["old"] else "None"
+            new = info["new"][:12] if info["new"] else "None"
+            typer.echo(f"  changed {name}: {old} -> {new}")
+        for name in added:
             typer.echo(f"  + {name}")
-        for name in result.removed:
+        for name in removed:
             typer.echo(f"  - {name}")
 
 
 @grip_app.command("checkout")
 def grip_checkout_cmd(
     workspace_root: Path,
-    ref: str = typer.Argument(..., help="Grip commit ref to restore"),
+    ref: str = typer.Argument(..., help="Snapshot id to restore"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
-    """Restore workspace repo HEADs from a grip commit."""
+    """Restore workspace repo HEADs from a grip snapshot."""
     workspace_root = workspace_root.resolve()
-    try:
-        result = grip_mod.grip_checkout(workspace_root, ref)
-    except (grip_mod.GripInitError, grip_mod.GripCorruptError) as exc:
-        typer.echo(str(exc), err=True)
+
+    _validate_grip_dir(workspace_root)
+
+    index = _read_snapshot_index(workspace_root)
+    snapshot = _find_snapshot_by_id(index, ref)
+    if snapshot is None:
+        typer.echo(f"Snapshot not found: {ref}")
         raise typer.Exit(code=1)
+
+    repo_states = snapshot.get("repo_states", {})
+
+    existing_repos: dict[str, Path] = {}
+    for name in repo_states:
+        repo_path = workspace_root / name
+        if repo_path.is_dir():
+            existing_repos[name] = repo_path
+
+    dirty = _check_dirty_repos(existing_repos)
+    if dirty:
+        typer.echo(f"Dirty repos detected: {', '.join(dirty)}. Commit or stash changes first.")
+        raise typer.Exit(code=1)
+
+    result: dict[str, str] = {}
+    for name, state in sorted(repo_states.items()):
+        head_sha = state.get("head")
+        if not head_sha:
+            continue
+        repo_path = workspace_root / name
+        if not repo_path.is_dir():
+            continue
+        git(repo_path, "checkout", head_sha)
+        result[name] = head_sha
+
     if json_output:
         typer.echo(json.dumps({"repos": result}))
     else:
@@ -170,7 +355,10 @@ def grip_checkout_cmd(
 @config_cli_app.command("apply")
 def config_apply_cmd(
     base_path: Path = typer.Argument(..., help="Path to base TOML config file"),
-    overlay_dir: str = typer.Option("", "--overlay-dir", help="Overlay directory (default: sibling overlay/)"),
+    overlay_dir: str = typer.Option(
+        "", "--overlay-dir",
+        help="Overlay directory (default: sibling overlay/)",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Materialize TOML base into JSON runtime overlay."""

--- a/gr2/python_cli/grip_cli.py
+++ b/gr2/python_cli/grip_cli.py
@@ -3,6 +3,7 @@
 Separate module so tests can import without pulling in all of app.py's
 dependencies (gr2.prototypes, lane_workspace_prototype, etc.).
 """
+
 from __future__ import annotations
 
 import json
@@ -34,8 +35,7 @@ def _discover_repos(workspace: Path) -> dict[str, Path]:
     spec_path = workspace / ".grip" / "workspace_spec.toml"
     if not spec_path.exists():
         typer.echo(
-            f"No .grip/workspace_spec.toml at {workspace}. "
-            "Use --repos or create a workspace spec."
+            f"No .grip/workspace_spec.toml at {workspace}. Use --repos or create a workspace spec."
         )
         raise typer.Exit(code=1)
     with spec_path.open("rb") as fh:
@@ -78,8 +78,10 @@ def _repo_head_state(repo_path: Path) -> dict[str, object]:
 
     if branch_name:
         return {
-            "head": head_sha, "is_empty": False,
-            "head_state": "attached", "branch": branch_name,
+            "head": head_sha,
+            "is_empty": False,
+            "head_state": "attached",
+            "branch": branch_name,
         }
     return {"head": head_sha, "is_empty": False, "head_state": "detached"}
 
@@ -99,7 +101,8 @@ def _write_snapshot_index(workspace: Path, index: list[dict[str, object]]) -> No
 
 
 def _find_snapshot_by_id(
-    index: list[dict[str, object]], snapshot_id: str,
+    index: list[dict[str, object]],
+    snapshot_id: str,
 ) -> dict[str, object] | None:
     for entry in index:
         if entry.get("id") == snapshot_id:
@@ -134,18 +137,26 @@ def grip_init_cmd(
 def grip_snapshot_cmd(
     workspace_root: Path,
     repos: str = typer.Option(
-        "", "--repos",
+        "",
+        "--repos",
         help="Comma-separated repo names (auto from spec if omitted)",
     ),
     message: str = typer.Option(
-        "", "--message", "-m", help="Snapshot message",
+        "",
+        "--message",
+        "-m",
+        help="Snapshot message",
     ),
     changeset_type: str = typer.Option(
-        "", "--type", help="Changeset type (e.g. ceremony, feature)",
+        "",
+        "--type",
+        help="Changeset type (e.g. ceremony, feature)",
     ),
     sprint: str = typer.Option("", "--sprint", help="Sprint number"),
     overlay_dir: str = typer.Option(
-        "", "--overlay-dir", help="Config overlay directory",
+        "",
+        "--overlay-dir",
+        help="Config overlay directory",
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
@@ -235,10 +246,10 @@ def grip_log_cmd(
 
     display = list(reversed(index[-max_count:]))
     for entry in display:
-            sid = entry.get("id", "?")
-            msg = entry.get("message", "")
-            repos = entry.get("repos", [])
-            typer.echo(f"{msg}  [{', '.join(repos)}]  ({sid[:12]})")
+        sid = entry.get("id", "?")
+        msg = entry.get("message", "")
+        repos = entry.get("repos", [])
+        typer.echo(f"{msg}  [{', '.join(repos)}]  ({sid[:12]})")
 
 
 @grip_app.command("diff")
@@ -356,7 +367,8 @@ def grip_checkout_cmd(
 def config_apply_cmd(
     base_path: Path = typer.Argument(..., help="Path to base TOML config file"),
     overlay_dir: str = typer.Option(
-        "", "--overlay-dir",
+        "",
+        "--overlay-dir",
         help="Overlay directory (default: sibling overlay/)",
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
@@ -384,7 +396,8 @@ def config_show_cmd(
     overlay = Path(overlay_dir).resolve() if overlay_dir else base_path.parent / "overlay"
     try:
         result = config_mod.config_show(
-            base_path, overlay,
+            base_path,
+            overlay,
             key=key or None,
             strict=strict,
         )

--- a/gr2/tests/test_grip_cli.py
+++ b/gr2/tests/test_grip_cli.py
@@ -5,6 +5,7 @@ in test_grip_snapshot.py, test_config_overlay.py, test_grip_hardening.py).
 
 Focus: argument parsing, exit codes, JSON output format, error messages.
 """
+
 from __future__ import annotations
 
 import json
@@ -93,19 +94,31 @@ class TestGripInitCLI:
 class TestGripSnapshotCLI:
     def test_snapshot_succeeds(self, workspace: Path) -> None:
         runner.invoke(app, ["grip", "init", str(workspace)])
-        result = runner.invoke(app, [
-            "grip", "snapshot", str(workspace),
-            "--repos", "recall",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+            ],
+        )
         assert result.exit_code == 0
 
     def test_snapshot_json_output(self, workspace: Path) -> None:
         runner.invoke(app, ["grip", "init", str(workspace)])
-        result = runner.invoke(app, [
-            "grip", "snapshot", str(workspace),
-            "--repos", "recall",
-            "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert "sha" in data
@@ -113,44 +126,71 @@ class TestGripSnapshotCLI:
 
     def test_snapshot_with_message(self, workspace: Path) -> None:
         runner.invoke(app, ["grip", "init", str(workspace)])
-        result = runner.invoke(app, [
-            "grip", "snapshot", str(workspace),
-            "--repos", "recall",
-            "--message", "Sprint 27 ceremony",
-            "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+                "--message",
+                "Sprint 27 ceremony",
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert "sha" in data
 
     def test_snapshot_with_type_and_sprint(self, workspace: Path) -> None:
         runner.invoke(app, ["grip", "init", str(workspace)])
-        result = runner.invoke(app, [
-            "grip", "snapshot", str(workspace),
-            "--repos", "recall",
-            "--type", "ceremony",
-            "--sprint", "27",
-            "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+                "--type",
+                "ceremony",
+                "--sprint",
+                "27",
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert "sha" in data
 
     def test_snapshot_without_init_fails(self, workspace: Path) -> None:
-        result = runner.invoke(app, [
-            "grip", "snapshot", str(workspace),
-            "--repos", "recall",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+            ],
+        )
         assert result.exit_code != 0
 
     def test_snapshot_multiple_repos(self, workspace: Path) -> None:
         _init_repo(workspace / "premium", name="premium")
         runner.invoke(app, ["grip", "init", str(workspace)])
-        result = runner.invoke(app, [
-            "grip", "snapshot", str(workspace),
-            "--repos", "recall,premium",
-            "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall,premium",
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert "recall" in data["repos"]
@@ -172,10 +212,18 @@ class TestGripLogCLI:
 
     def test_log_after_snapshot(self, workspace: Path) -> None:
         runner.invoke(app, ["grip", "init", str(workspace)])
-        runner.invoke(app, [
-            "grip", "snapshot", str(workspace), "--repos", "recall",
-            "--message", "test snap",
-        ])
+        runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+                "--message",
+                "test snap",
+            ],
+        )
         result = runner.invoke(app, ["grip", "log", str(workspace), "--json"])
         assert result.exit_code == 0
         data = json.loads(result.stdout)
@@ -188,12 +236,27 @@ class TestGripLogCLI:
             (workspace / "recall" / f"f{i}.txt").write_text(str(i))
             git(workspace / "recall", "add", ".")
             git(workspace / "recall", "commit", "-m", f"c{i}")
-            runner.invoke(app, [
-                "grip", "snapshot", str(workspace), "--repos", "recall",
-            ])
-        result = runner.invoke(app, [
-            "grip", "log", str(workspace), "--max-count", "2", "--json",
-        ])
+            runner.invoke(
+                app,
+                [
+                    "grip",
+                    "snapshot",
+                    str(workspace),
+                    "--repos",
+                    "recall",
+                ],
+            )
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "log",
+                str(workspace),
+                "--max-count",
+                "2",
+                "--json",
+            ],
+        )
         data = json.loads(result.stdout)
         assert len(data["entries"]) == 2
 
@@ -210,31 +273,62 @@ class TestGripLogCLI:
 class TestGripDiffCLI:
     def test_diff_json(self, workspace: Path) -> None:
         runner.invoke(app, ["grip", "init", str(workspace)])
-        r1 = runner.invoke(app, [
-            "grip", "snapshot", str(workspace), "--repos", "recall", "--json",
-        ])
+        r1 = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+                "--json",
+            ],
+        )
         sha1 = json.loads(r1.stdout)["sha"]
 
         (workspace / "recall" / "new.txt").write_text("x")
         git(workspace / "recall", "add", ".")
         git(workspace / "recall", "commit", "-m", "change")
 
-        r2 = runner.invoke(app, [
-            "grip", "snapshot", str(workspace), "--repos", "recall", "--json",
-        ])
+        r2 = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+                "--json",
+            ],
+        )
         sha2 = json.loads(r2.stdout)["sha"]
 
-        result = runner.invoke(app, [
-            "grip", "diff", str(workspace), sha1, sha2, "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "diff",
+                str(workspace),
+                sha1,
+                sha2,
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert "recall" in data["changed"]
 
     def test_diff_without_init_fails(self, workspace: Path) -> None:
-        result = runner.invoke(app, [
-            "grip", "diff", str(workspace), "abc", "def",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "diff",
+                str(workspace),
+                "abc",
+                "def",
+            ],
+        )
         assert result.exit_code != 0
 
 
@@ -246,22 +340,43 @@ class TestGripDiffCLI:
 class TestGripCheckoutCLI:
     def test_checkout_json(self, workspace: Path) -> None:
         runner.invoke(app, ["grip", "init", str(workspace)])
-        r1 = runner.invoke(app, [
-            "grip", "snapshot", str(workspace), "--repos", "recall", "--json",
-        ])
+        r1 = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+                "--json",
+            ],
+        )
         sha = json.loads(r1.stdout)["sha"]
 
-        result = runner.invoke(app, [
-            "grip", "checkout", str(workspace), sha, "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "checkout",
+                str(workspace),
+                sha,
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert "recall" in data["repos"]
 
     def test_checkout_without_init_fails(self, workspace: Path) -> None:
-        result = runner.invoke(app, [
-            "grip", "checkout", str(workspace), "HEAD",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "grip",
+                "checkout",
+                str(workspace),
+                "HEAD",
+            ],
+        )
         assert result.exit_code != 0
 
 
@@ -272,20 +387,30 @@ class TestGripCheckoutCLI:
 
 class TestConfigApplyCLI:
     def test_apply_succeeds(self, workspace: Path) -> None:
-        result = runner.invoke(app, [
-            "config", "apply",
-            str(workspace / "config_files" / "agents.toml"),
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "apply",
+                str(workspace / "config_files" / "agents.toml"),
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+            ],
+        )
         assert result.exit_code == 0
 
     def test_apply_json_output(self, workspace: Path) -> None:
-        result = runner.invoke(app, [
-            "config", "apply",
-            str(workspace / "config_files" / "agents.toml"),
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-            "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "apply",
+                str(workspace / "config_files" / "agents.toml"),
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert "agents" in data
@@ -299,33 +424,49 @@ class TestConfigApplyCLI:
 
 class TestConfigShowCLI:
     def _apply_first(self, workspace: Path) -> None:
-        runner.invoke(app, [
-            "config", "apply",
-            str(workspace / "config_files" / "agents.toml"),
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-        ])
+        runner.invoke(
+            app,
+            [
+                "config",
+                "apply",
+                str(workspace / "config_files" / "agents.toml"),
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+            ],
+        )
 
     def test_show_full(self, workspace: Path) -> None:
         self._apply_first(workspace)
-        result = runner.invoke(app, [
-            "config", "show",
-            str(workspace / "config_files" / "agents.toml"),
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-            "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "show",
+                str(workspace / "config_files" / "agents.toml"),
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert "agents" in data
 
     def test_show_with_key(self, workspace: Path) -> None:
         self._apply_first(workspace)
-        result = runner.invoke(app, [
-            "config", "show",
-            str(workspace / "config_files" / "agents.toml"),
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-            "--key", "agents.opus.role",
-            "--json",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "show",
+                str(workspace / "config_files" / "agents.toml"),
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+                "--key",
+                "agents.opus.role",
+                "--json",
+            ],
+        )
         assert result.exit_code == 0
         data = json.loads(result.stdout)
         assert data["value"] == "CEO / product design"
@@ -334,12 +475,17 @@ class TestConfigShowCLI:
         self._apply_first(workspace)
         base = workspace / "config_files" / "agents.toml"
         base.write_text(SAMPLE_TOML + '\n[agents.new]\nrole = "new"\n')
-        result = runner.invoke(app, [
-            "config", "show",
-            str(base),
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-            "--strict",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "show",
+                str(base),
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+                "--strict",
+            ],
+        )
         assert result.exit_code != 0
 
 
@@ -351,22 +497,40 @@ class TestConfigShowCLI:
 class TestConfigRestoreCLI:
     def test_restore_from_grip_commit(self, workspace: Path) -> None:
         runner.invoke(app, ["grip", "init", str(workspace)])
-        runner.invoke(app, [
-            "config", "apply",
-            str(workspace / "config_files" / "agents.toml"),
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-        ])
-        snap = runner.invoke(app, [
-            "grip", "snapshot", str(workspace),
-            "--repos", "recall",
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-            "--json",
-        ])
+        runner.invoke(
+            app,
+            [
+                "config",
+                "apply",
+                str(workspace / "config_files" / "agents.toml"),
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+            ],
+        )
+        snap = runner.invoke(
+            app,
+            [
+                "grip",
+                "snapshot",
+                str(workspace),
+                "--repos",
+                "recall",
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+                "--json",
+            ],
+        )
         sha = json.loads(snap.stdout)["sha"]
 
-        result = runner.invoke(app, [
-            "config", "restore",
-            str(workspace), sha,
-            "--overlay-dir", str(workspace / "config_files" / "overlay"),
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "config",
+                "restore",
+                str(workspace),
+                sha,
+                "--overlay-dir",
+                str(workspace / "config_files" / "overlay"),
+            ],
+        )
         assert result.exit_code == 0

--- a/gr2/tests/test_grip_object_model.py
+++ b/gr2/tests/test_grip_object_model.py
@@ -29,6 +29,7 @@ checkout
 - blocks on dirty repos unless forced semantics are added explicitly later
 - fails cleanly when `.grip/` is missing
 """
+
 from __future__ import annotations
 
 import json
@@ -100,7 +101,7 @@ def _write_workspace_spec(workspace_root: Path, repos: list[tuple[str, str]]) ->
             f"""
             workspace_name = "{workspace_root.name}"
 
-            {'\n\n'.join(repo_blocks)}
+            {"\n\n".join(repo_blocks)}
             """
         ).strip()
         + "\n"
@@ -126,7 +127,9 @@ class TestGripSnapshot:
         """snapshot must capture one entry per repo with current HEAD metadata."""
         workspace_root, app_repo, docs_repo = _workspace_with_repos(tmp_path)
 
-        result = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"])
+        result = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"]
+        )
 
         assert result.exit_code == 0, result.stdout
         index = _read_snapshot_index(workspace_root)
@@ -134,8 +137,14 @@ class TestGripSnapshot:
         snapshot = index[0]
         assert snapshot["message"] == "baseline"
         assert set(snapshot["repos"]) == {"app", "docs"}
-        assert snapshot["repo_states"]["app"]["head"] == _git(app_repo, "rev-parse", "HEAD").stdout.strip()
-        assert snapshot["repo_states"]["docs"]["head"] == _git(docs_repo, "rev-parse", "HEAD").stdout.strip()
+        assert (
+            snapshot["repo_states"]["app"]["head"]
+            == _git(app_repo, "rev-parse", "HEAD").stdout.strip()
+        )
+        assert (
+            snapshot["repo_states"]["docs"]["head"]
+            == _git(docs_repo, "rev-parse", "HEAD").stdout.strip()
+        )
 
     def test_snapshot_accepts_empty_repo_without_commits(self, tmp_path: Path) -> None:
         """snapshot must classify an initialized-but-empty repo without crashing."""
@@ -157,7 +166,9 @@ class TestGripSnapshot:
         detached_sha = _git(app_repo, "rev-parse", "HEAD").stdout.strip()
         assert _git(app_repo, "checkout", detached_sha).returncode == 0
 
-        result = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "detached"])
+        result = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "detached"]
+        )
 
         assert result.exit_code == 0, result.stdout
         snapshot = _read_snapshot_index(workspace_root)[0]
@@ -190,10 +201,14 @@ class TestGripLog:
     def test_log_lists_snapshots_newest_first_with_summary(self, tmp_path: Path) -> None:
         """log must return reverse-chronological snapshots with id and message."""
         workspace_root, app_repo, _docs_repo = _workspace_with_repos(tmp_path)
-        first = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"])
+        first = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"]
+        )
         assert first.exit_code == 0, first.stdout
         _commit_file(app_repo, "CHANGELOG.md", "v2\n", "update")
-        second = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "after-update"])
+        second = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "after-update"]
+        )
         assert second.exit_code == 0, second.stdout
 
         result = runner.invoke(app, ["grip", "log", str(workspace_root)])
@@ -218,11 +233,15 @@ class TestGripDiff:
     def test_diff_reports_per_repo_head_changes_between_snapshots(self, tmp_path: Path) -> None:
         """diff must report changed repos between two snapshots."""
         workspace_root, app_repo, docs_repo = _workspace_with_repos(tmp_path)
-        first = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"])
+        first = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"]
+        )
         assert first.exit_code == 0, first.stdout
         _commit_file(app_repo, "CHANGELOG.md", "v2\n", "app update")
         _commit_file(docs_repo, "guide.md", "hello\n", "docs update")
-        second = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "changed"])
+        second = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "changed"]
+        )
         assert second.exit_code == 0, second.stdout
 
         index = _read_snapshot_index(workspace_root)
@@ -240,7 +259,9 @@ class TestGripDiff:
         workspace_root, _app_repo, _docs_repo = _workspace_with_repos(tmp_path)
         first = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "first"])
         assert first.exit_code == 0, first.stdout
-        second = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "second"])
+        second = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "second"]
+        )
         assert second.exit_code == 0, second.stdout
 
         index = _read_snapshot_index(workspace_root)
@@ -258,7 +279,9 @@ class TestGripDiff:
         assert created.exit_code == 0, created.stdout
         existing_id = _read_snapshot_index(workspace_root)[0]["id"]
 
-        result = runner.invoke(app, ["grip", "diff", str(workspace_root), existing_id, "missing-snapshot"])
+        result = runner.invoke(
+            app, ["grip", "diff", str(workspace_root), existing_id, "missing-snapshot"]
+        )
 
         assert result.exit_code != 0
         assert "missing" in result.stdout.lower()
@@ -268,7 +291,9 @@ class TestGripCheckout:
     def test_checkout_restores_all_repo_heads_to_snapshot(self, tmp_path: Path) -> None:
         """checkout must restore repo HEADs across the whole workspace."""
         workspace_root, app_repo, docs_repo = _workspace_with_repos(tmp_path)
-        baseline = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"])
+        baseline = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"]
+        )
         assert baseline.exit_code == 0, baseline.stdout
         baseline_id = _read_snapshot_index(workspace_root)[0]["id"]
         baseline_app_head = _git(app_repo, "rev-parse", "HEAD").stdout.strip()
@@ -288,7 +313,9 @@ class TestGripCheckout:
         workspace_root, app_repo, _docs_repo = _workspace_with_repos(tmp_path)
         detached_sha = _git(app_repo, "rev-parse", "HEAD").stdout.strip()
         assert _git(app_repo, "checkout", detached_sha).returncode == 0
-        created = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "detached"])
+        created = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "detached"]
+        )
         assert created.exit_code == 0, created.stdout
         snapshot_id = _read_snapshot_index(workspace_root)[0]["id"]
 
@@ -305,7 +332,9 @@ class TestGripCheckout:
     def test_checkout_blocks_when_target_repo_is_dirty(self, tmp_path: Path) -> None:
         """checkout must fail cleanly rather than overwrite uncommitted changes."""
         workspace_root, app_repo, _docs_repo = _workspace_with_repos(tmp_path)
-        created = runner.invoke(app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"])
+        created = runner.invoke(
+            app, ["grip", "snapshot", str(workspace_root), "--message", "baseline"]
+        )
         assert created.exit_code == 0, created.stdout
         snapshot_id = _read_snapshot_index(workspace_root)[0]["id"]
         _commit_file(app_repo, "CHANGELOG.md", "v2\n", "update")

--- a/gr2/tests/test_grip_snapshot.py
+++ b/gr2/tests/test_grip_snapshot.py
@@ -7,6 +7,7 @@ Tests define the interface contract for:
   - gr grip checkout: restore workspace repo HEADs from a grip commit
   - round-trip: snapshot → checkout → verify state matches
 """
+
 from __future__ import annotations
 
 import subprocess
@@ -266,15 +267,11 @@ class TestGripLog:
         assert len(entries) == 3
 
     def test_most_recent_first(self, grip_repo: Path) -> None:
-        sha1 = grip_snapshot(
-            grip_repo, repos={"recall": grip_repo / "recall"}, message="first"
-        )
+        sha1 = grip_snapshot(grip_repo, repos={"recall": grip_repo / "recall"}, message="first")
         (grip_repo / "recall" / "change.txt").write_text("x")
         git(grip_repo / "recall", "add", ".")
         git(grip_repo / "recall", "commit", "-m", "second recall commit")
-        sha2 = grip_snapshot(
-            grip_repo, repos={"recall": grip_repo / "recall"}, message="second"
-        )
+        sha2 = grip_snapshot(grip_repo, repos={"recall": grip_repo / "recall"}, message="second")
         entries = grip_log(grip_repo)
         assert entries[0].sha == sha2
         assert entries[1].sha == sha1
@@ -439,8 +436,7 @@ class TestRoundTrip:
             "config": grip_repo / "config",
         }
         original_heads = {
-            name: git(path, "rev-parse", "HEAD").stdout.strip()
-            for name, path in repos.items()
+            name: git(path, "rev-parse", "HEAD").stdout.strip() for name, path in repos.items()
         }
         snap_sha = grip_snapshot(grip_repo, repos=repos, message="round-trip base")
 


### PR DESCRIPTION
## Summary
- Bridge `grip_cli.py` to match TDD spec contract in `test_grip_object_model.py` (14 tests, all previously failing)
- Auto-discover repos from `workspace_spec.toml` when `--repos` not provided
- Add JSON index layer at `.grip/snapshots/index.json` for O(1) lookup alongside git plumbing storage
- Dirty-repo blocking for snapshot and checkout commands
- Track detached HEAD state and empty repos in snapshot metadata

## Details
The existing `test_grip_snapshot.py` (35 tests) tested the library API directly and all passed. The `test_grip_object_model.py` (14 tests) tested through the CLI via typer CliRunner and expected a different interface:
1. Repo auto-discovery from `workspace_spec.toml` (not `--repos` required)
2. JSON index storage at `.grip/snapshots/index.json`
3. Snapshot entries with `id`, `message`, `repos`, `repo_states` containing `head`, `head_state`, `is_empty`
4. Dirty-repo blocking for both snapshot and checkout
5. Clean error messages for missing `.grip/` state

This implementation reconciles both contracts: keeps git plumbing internally (content-addressable), adds JSON index as a view layer, makes `--repos` optional with workspace_spec fallback.

## Test plan
- [x] All 14 `test_grip_object_model.py` tests pass (previously 0/14)
- [x] All 23 `test_grip_cli.py` tests pass (no regressions)
- [x] All 35 `test_grip_snapshot.py` tests pass (no regressions)
- [x] Full gr2 test suite: 471 passed, 0 failed
- [x] ruff lint clean
- [x] cargo fmt clean

Premium boundary: core OSS (workspace orchestration, git plumbing).

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)