### PR TITLE
feat: gr sync --rebase flag for linear history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,7 @@ All commands use `gr` (or `gitgrip`):
 - `gr init --from-dirs` - Initialize workspace from existing local directories
 - `gr init --from-repo` - Initialize from existing `.repo/` directory (git-repo coexistence)
 - `gr sync` - Pull all repos in parallel + process links + run hooks (includes manifest)
+  - `gr sync --rebase` - Use rebase instead of merge when pulling (keeps linear history)
   - `gr sync --sequential` - Sync repos sequentially (slower but ordered output)
   - `gr sync --group <name>` - Sync only repos in a group
   - `gr sync --repo <names>` - Sync only specific repos (use "manifest" to target manifest repo)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -81,6 +81,9 @@ pub enum Commands {
         /// Hard reset reference repos to upstream (discard local changes)
         #[arg(long, alias = "reset-ref")]
         reset_refs: bool,
+        /// Use rebase instead of merge when pulling (keeps linear history)
+        #[arg(long)]
+        rebase: bool,
         /// Only sync repos in these groups
         #[arg(long, value_delimiter = ',')]
         group: Option<Vec<String>>,
@@ -94,7 +97,7 @@ pub enum Commands {
         #[arg(long)]
         no_hooks: bool,
         /// Rollback repos to their state before the last sync
-        #[arg(long, conflicts_with_all = ["force", "reset_refs", "group", "repo", "sequential", "no_hooks"])]
+        #[arg(long, conflicts_with_all = ["force", "reset_refs", "rebase", "group", "repo", "sequential", "no_hooks"])]
         rollback: bool,
     },
     /// Show status of all repositories

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -665,6 +665,7 @@ pub async fn run_release(opts: ReleaseOptions<'_>) -> anyhow::Result<()> {
                 None,  // group
                 false, // sequential
                 false, // reset_refs
+                false, // rebase
                 opts.json,
                 false, // no_hooks
             )

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -13,7 +13,8 @@ use crate::core::sync_state::SyncSnapshot;
 use crate::files::process_composefiles;
 use crate::git::branch::{checkout_branch_at_upstream, checkout_detached, has_commits_ahead};
 use crate::git::remote::{
-    fetch_remote, pull_latest_from_upstream, reset_hard, safe_pull_latest, set_branch_upstream_ref,
+    fetch_remote, pull_latest_from_upstream_with_mode, reset_hard, safe_pull_latest_with_mode,
+    set_branch_upstream_ref, PullMode,
 };
 use crate::git::status::has_uncommitted_changes;
 use crate::git::{clone_repo, get_current_branch, open_repo, path_exists};
@@ -150,6 +151,7 @@ pub async fn run_sync(
     group_filter: Option<&[String]>,
     sequential: bool,
     reset_refs: bool,
+    rebase: bool,
     json: bool,
     no_hooks: bool,
 ) -> anyhow::Result<()> {
@@ -199,6 +201,7 @@ pub async fn run_sync(
             griptree_config.as_ref(),
             griptree_branch.as_deref(),
             reset_refs,
+            rebase,
             manifest.remotes.as_ref(),
         )?
     } else {
@@ -209,6 +212,7 @@ pub async fn run_sync(
             griptree_config.clone(),
             griptree_branch.clone(),
             reset_refs,
+            rebase,
             manifest.remotes.clone(),
         )
         .await?
@@ -474,6 +478,7 @@ fn sync_sequential(
     griptree_config: Option<&GriptreeConfig>,
     griptree_branch: Option<&str>,
     reset_refs: bool,
+    rebase: bool,
     manifest_remotes: Option<
         &std::collections::HashMap<String, crate::core::manifest::RemoteConfig>,
     >,
@@ -490,6 +495,7 @@ fn sync_sequential(
                 griptree_config,
                 griptree_branch,
                 reset_refs,
+                rebase,
                 manifest_remotes,
             },
         )?;
@@ -508,6 +514,7 @@ async fn sync_parallel(
     griptree_config: Option<GriptreeConfig>,
     griptree_branch: Option<String>,
     reset_refs: bool,
+    rebase: bool,
     manifest_remotes: Option<
         std::collections::HashMap<String, crate::core::manifest::RemoteConfig>,
     >,
@@ -535,6 +542,7 @@ async fn sync_parallel(
                     griptree_config: griptree_config.as_ref(),
                     griptree_branch: griptree_branch.as_deref(),
                     reset_refs,
+                    rebase,
                     manifest_remotes: manifest_remotes.as_ref().as_ref(),
                 },
             )?;
@@ -577,6 +585,7 @@ fn sync_griptree_upstream(
     griptree_config: Option<&GriptreeConfig>,
     spinner: Option<&ProgressBar>,
     quiet: bool,
+    rebase: bool,
 ) -> SyncResult {
     let upstream = match griptree_config {
         Some(cfg) => match cfg.upstream_for_repo(&repo.name, &repo.revision) {
@@ -659,9 +668,18 @@ fn sync_griptree_upstream(
         }
     }
 
-    match pull_latest_from_upstream(git_repo, &upstream) {
+    let pull_mode = if rebase {
+        PullMode::Rebase
+    } else {
+        PullMode::Merge
+    };
+    match pull_latest_from_upstream_with_mode(git_repo, &upstream, pull_mode) {
         Ok(()) => {
-            let mut msg = format!("pulled ({})", upstream);
+            let mut msg = if rebase {
+                format!("rebased ({})", upstream)
+            } else {
+                format!("pulled ({})", upstream)
+            };
             if let Some(warning) = upstream_set_warning.as_ref() {
                 msg.push_str(&format!(" ({})", warning));
             }
@@ -845,6 +863,7 @@ struct SyncOptions<'a> {
     griptree_config: Option<&'a GriptreeConfig>,
     griptree_branch: Option<&'a str>,
     reset_refs: bool,
+    rebase: bool,
     manifest_remotes:
         Option<&'a std::collections::HashMap<String, crate::core::manifest::RemoteConfig>>,
 }
@@ -980,10 +999,21 @@ fn sync_single_repo(repo: &RepoInfo, opts: &SyncOptions<'_>) -> anyhow::Result<S
                     opts.griptree_config,
                     spinner.as_ref(),
                     opts.quiet,
+                    opts.rebase,
                 );
                 Ok(result)
             } else {
-                let result = safe_pull_latest(&git_repo, repo.target_branch(), &repo.sync_remote);
+                let pull_mode = if opts.rebase {
+                    PullMode::Rebase
+                } else {
+                    PullMode::Merge
+                };
+                let result = safe_pull_latest_with_mode(
+                    &git_repo,
+                    repo.target_branch(),
+                    &repo.sync_remote,
+                    pull_mode,
+                );
 
                 match result {
                     Ok(pull_result) => {

--- a/src/cli/commands/tree.rs
+++ b/src/cli/commands/tree.rs
@@ -579,6 +579,7 @@ pub async fn run_tree_return(
             false,
             false,
             false,
+            false,
         )
         .await;
     }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -39,6 +39,7 @@ pub async fn dispatch_command(
         Some(Commands::Sync {
             force,
             reset_refs,
+            rebase,
             group,
             repo,
             sequential,
@@ -64,6 +65,7 @@ pub async fn dispatch_command(
                     group.as_deref(),
                     sequential,
                     reset_refs,
+                    rebase,
                     ctx.json,
                     no_hooks,
                 )

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -173,6 +173,15 @@ fn pull_latest_with_mode(repo: &Repository, remote: &str, mode: PullMode) -> Res
     instrument(skip(repo), fields(upstream, success))
 )]
 pub fn pull_latest_from_upstream(repo: &Repository, upstream: &str) -> Result<(), GitError> {
+    pull_latest_from_upstream_with_mode(repo, upstream, PullMode::Merge)
+}
+
+/// Pull latest changes from a specific upstream ref with configurable pull mode
+pub fn pull_latest_from_upstream_with_mode(
+    repo: &Repository,
+    upstream: &str,
+    mode: PullMode,
+) -> Result<(), GitError> {
     let repo_path = super::get_workdir(repo);
     let (remote, branch) = split_upstream_ref(upstream)?;
 
@@ -180,7 +189,11 @@ pub fn pull_latest_from_upstream(repo: &Repository, upstream: &str) -> Result<()
     let start = Instant::now();
 
     let mut cmd = Command::new("git");
-    cmd.args(["pull", &remote, &branch]).current_dir(repo_path);
+    cmd.arg("pull");
+    if matches!(mode, PullMode::Rebase) {
+        cmd.arg("--rebase");
+    }
+    cmd.args([&remote, &branch]).current_dir(repo_path);
     log_cmd(&cmd);
     let output = cmd
         .output()

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -248,6 +248,7 @@ async fn test_sync_with_deleted_remote() {
         false,
         false,
         false,
+        false,
     )
     .await;
     // Whether it returns Ok (with per-repo error reports) or Err is acceptable,

--- a/tests/test_sync.rs
+++ b/tests/test_sync.rs
@@ -48,6 +48,7 @@ async fn test_sync_clones_missing_repos() {
         false,
         false,
         false,
+        false,
     )
     .await;
     assert!(result.is_ok(), "sync should succeed: {:?}", result.err());
@@ -76,6 +77,7 @@ async fn test_sync_pulls_existing_repos() {
         false,
         None,
         None,
+        false,
         false,
         false,
         false,
@@ -114,6 +116,7 @@ async fn test_sync_uses_griptree_upstream_mapping() {
         false,
         false,
         false,
+        false,
     )
     .await;
     assert!(result.is_ok(), "sync should succeed: {:?}", result.err());
@@ -145,6 +148,7 @@ async fn test_sync_sets_tracking_upstream_for_griptree_base_branch() {
         false,
         false,
         false,
+        false,
     )
     .await;
     assert!(result.is_ok(), "sync should succeed: {:?}", result.err());
@@ -169,6 +173,7 @@ async fn test_sync_handles_up_to_date() {
         false,
         None,
         None,
+        false,
         false,
         false,
         false,
@@ -213,6 +218,7 @@ async fn test_sync_skips_griptree_base_with_local_commits_ahead() {
         false,
         false,
         false,
+        false,
     )
     .await;
     assert!(result.is_ok(), "sync should succeed: {:?}", result.err());
@@ -253,6 +259,7 @@ async fn test_sync_reset_refs_hard_resets_reference_repo() {
         true,
         false,
         false,
+        false,
     )
     .await;
     assert!(result.is_ok(), "sync should succeed: {:?}", result.err());
@@ -290,6 +297,7 @@ async fn test_sync_reset_refs_checks_out_upstream_branch() {
         None,
         false,
         true,
+        false,
         false,
         false,
     )
@@ -333,6 +341,7 @@ async fn test_sync_reset_refs_falls_back_to_detached_when_branch_locked_in_workt
         None,
         false,
         true,
+        false,
         false,
         false,
     )
@@ -389,6 +398,7 @@ async fn test_sync_multiple_repos() {
         false,
         false,
         false,
+        false,
     )
     .await;
     assert!(result.is_ok(), "sync should succeed: {:?}", result.err());
@@ -416,6 +426,7 @@ async fn test_sync_quiet_mode() {
         true,
         None,
         None,
+        false,
         false,
         false,
         false,
@@ -450,6 +461,7 @@ async fn test_sync_sequential_mode() {
         false,
         false,
         false,
+        false,
     )
     .await;
     assert!(
@@ -481,6 +493,7 @@ async fn test_sync_clone_failure_invalid_url() {
         false,
         false,
         false,
+        false,
     )
     .await;
     assert!(result.is_ok(), "sync should not crash: {:?}", result.err());
@@ -508,6 +521,7 @@ async fn test_sync_existing_repo_missing_git_dir() {
         false,
         None,
         None,
+        false,
         false,
         false,
         false,
@@ -566,6 +580,7 @@ workspace:
         false,
         false,
         false,
+        false,
     )
     .await;
     assert!(result.is_ok(), "sync should succeed: {:?}", result.err());
@@ -595,6 +610,7 @@ workspace:
         true,
         None,
         None,
+        false,
         false,
         false,
         false,
@@ -636,6 +652,7 @@ workspace:
         true,
         None,
         None,
+        false,
         false,
         false,
         false,
@@ -712,6 +729,7 @@ async fn test_sync_reclones_non_git_manifest_dir() {
         true, // quiet
         None,
         None,
+        false,
         false,
         false,
         false,


### PR DESCRIPTION
## Summary

- Adds `--rebase` flag to `gr sync` that uses rebase instead of merge when pulling
- Threads rebase mode through all sync paths: default branch pull, griptree upstream sync, and feature branch pull
- Adds `pull_latest_from_upstream_with_mode()` to support rebase on griptree upstream syncs
- Updates CLAUDE.md command reference with new flag documentation

Closes #734

## Motivation

Friction-log F: when multiple agents share a branch (e.g., `main` on `config`), `gr sync` creates merge commits that clutter history. Agents had to manually `git fetch && git rebase` to keep linear history. This flag eliminates that friction.

## Premium boundary

Premium boundary: core OSS (workspace orchestration primitive). No identity, org, or premium behavior.

## Test plan

- [x] All 173 existing tests pass (0 failures)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `--rebase` conflicts with `--rollback` (clap validation)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)