### PR TITLE
feat: wire gr overlay CLI stubs to real module functions

### DIFF
--- a/gr2/gr2_overlay/cli.py
+++ b/gr2/gr2_overlay/cli.py
@@ -1,110 +1,181 @@
 """CLI plumbing for `gr overlay` subcommands.
 
-All subcommands are stubs for M1 scaffolding. Implementation comes in Stories 2-12.
+Wires typer commands to gr2_overlay module functions.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import typer
+
+from gr2_overlay import introspection, workspace_spec
+from gr2_overlay.activate import activate_overlay, deactivate_overlay
+from gr2_overlay.types import OverlayRef
 
 overlay_app = typer.Typer(
     help="Config overlay capture, composition, and materialization (Tier A).",
 )
 
 
+def _default_overlay_store(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "overlay-store.git"
+
+
+def _emit(result: str | dict | list, json_output: bool) -> None:
+    if json_output:
+        if isinstance(result, str):
+            typer.echo(result)
+        else:
+            typer.echo(json.dumps(result, indent=2))
+    else:
+        typer.echo(result)
+
+
 @overlay_app.command("activate")
-def overlay_activate(
+def overlay_activate_cmd(
     workspace_root: Path,
     ref: str = typer.Argument(..., help="Overlay ref: <author>/<name>"),
+    source_kind: str = typer.Option("local", help="Overlay source kind (local, git, registry)"),
+    source_value: str | None = typer.Option(None, help="Overlay source value (path or URL)"),
+    signer: str | None = typer.Option(None, help="Expected overlay signer"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Activate an overlay, eagerly materializing its files into the workspace."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    overlay_ref = OverlayRef.parse(ref)
+    overlay_store = _default_overlay_store(workspace_root)
+    result = activate_overlay(
+        workspace_root=workspace_root,
+        overlay_store=overlay_store,
+        overlay_ref=overlay_ref,
+        overlay_source_kind=source_kind,
+        overlay_source_value=source_value,
+        overlay_signer=signer,
+    )
+    if json_output:
+        typer.echo(json.dumps({"status": result.status, "completed": result.completed}))
+    else:
+        typer.echo(f"Activated {ref}: {result.status}")
 
 
 @overlay_app.command("deactivate")
-def overlay_deactivate(
+def overlay_deactivate_cmd(
     workspace_root: Path,
     ref: str = typer.Argument(..., help="Overlay ref: <author>/<name>"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Deactivate an overlay and remove its materialized files."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    overlay_ref = OverlayRef.parse(ref)
+    result = deactivate_overlay(
+        workspace_root=workspace_root,
+        overlay_ref=overlay_ref,
+    )
+    if json_output:
+        typer.echo(json.dumps({"completed": result.completed}))
+    else:
+        typer.echo(f"Deactivated {ref}")
 
 
 @overlay_app.command("diff")
-def overlay_diff(
+def overlay_diff_cmd(
     workspace_root: Path,
     ref: str = typer.Argument(..., help="Overlay ref: <author>/<name>"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Show the diff an overlay would produce if activated."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    overlay_ref = OverlayRef.parse(ref)
+    overlay_store = _default_overlay_store(workspace_root)
+    file_list = introspection._read_overlay_file_list(overlay_store, overlay_ref)
+    if json_output:
+        typer.echo(json.dumps({"ref": ref, "files": file_list}))
+    else:
+        typer.echo(f"Files that would change for {ref}:")
+        for f in file_list:
+            typer.echo(f"  {f}")
 
 
 @overlay_app.command("list")
-def overlay_list(
+def overlay_list_cmd(
     workspace_root: Path,
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
-    """List all known overlays (local and remote refs)."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    """List all declared overlays from workspace spec."""
+    entries = workspace_spec.load_overlay_spec(workspace_root)
+    if json_output:
+        overlay_data = [
+            {
+                "name": e.name,
+                "path": e.path,
+                "applies_to": e.applies_to,
+                "priority": e.priority,
+            }
+            for e in entries
+        ]
+        typer.echo(json.dumps({"overlays": overlay_data}, indent=2))
+    else:
+        if not entries:
+            typer.echo("No overlays declared.")
+        else:
+            typer.echo("Declared overlays:")
+            for e in entries:
+                typer.echo(f"  {e.name} (priority={e.priority}, path={e.path})")
 
 
 @overlay_app.command("stack")
-def overlay_stack(
+def overlay_stack_cmd(
     workspace_root: Path,
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Show the current overlay activation stack with priority ordering."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    overlay_store = _default_overlay_store(workspace_root)
+    result = introspection.overlay_stack(workspace_root, overlay_store, json_output)
+    _emit(result, json_output)
 
 
 @overlay_app.command("status")
-def overlay_status(
+def overlay_status_cmd(
     workspace_root: Path,
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Show overlay materialization status: which overlays are active, stale, or conflicting."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    overlay_store = _default_overlay_store(workspace_root)
+    result = introspection.overlay_status(workspace_root, overlay_store, json_output)
+    _emit(result, json_output)
 
 
 @overlay_app.command("trace")
-def overlay_trace(
+def overlay_trace_cmd(
     workspace_root: Path,
     file_path: str = typer.Argument(..., help="File path to trace overlay provenance for"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Trace which overlay(s) contributed to a specific file's current state."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    overlay_store = _default_overlay_store(workspace_root)
+    result = introspection.overlay_trace(workspace_root, overlay_store, file_path, json_output)
+    _emit(result, json_output)
 
 
 @overlay_app.command("why")
-def overlay_why(
+def overlay_why_cmd(
     workspace_root: Path,
-    key: str = typer.Argument(..., help="Config key (dotted path) to explain"),
+    key: str = typer.Argument(..., help="Config key or file path to explain"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Explain why a config key has its current value (which overlay, base, or merge)."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    overlay_store = _default_overlay_store(workspace_root)
+    result = introspection.overlay_why(workspace_root, overlay_store, key, json_output)
+    _emit(result, json_output)
 
 
 @overlay_app.command("impact")
-def overlay_impact(
+def overlay_impact_cmd(
     workspace_root: Path,
     ref: str = typer.Argument(..., help="Overlay ref: <author>/<name>"),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Show what files and keys would change if this overlay were activated or deactivated."""
-    typer.echo("not implemented", err=True)
-    raise typer.Exit(code=1)
+    overlay_ref = OverlayRef.parse(ref)
+    overlay_store = _default_overlay_store(workspace_root)
+    result = introspection.overlay_impact(overlay_store, overlay_ref, json_output)
+    _emit(result, json_output)

--- a/gr2/tests/test_overlay_cli.py
+++ b/gr2/tests/test_overlay_cli.py
@@ -1,7 +1,7 @@
-"""Scaffold tests for gr overlay CLI stubs.
+"""Tests for gr overlay CLI command registration and argument shapes.
 
-Verifies that every subcommand exists, accepts expected arguments,
-and exits with code 1 + 'not implemented' message (M1 stubs).
+Verifies that all 9 subcommands exist with expected argument signatures.
+The actual wiring behavior is tested in test_overlay_cli_wiring.py.
 """
 
 from __future__ import annotations
@@ -11,70 +11,6 @@ from typer.testing import CliRunner
 from gr2_overlay.cli import overlay_app
 
 runner = CliRunner()
-
-
-def test_activate_stub():
-    result = runner.invoke(overlay_app, ["activate", "/tmp", "alice/theme-dark"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_deactivate_stub():
-    result = runner.invoke(overlay_app, ["deactivate", "/tmp", "alice/theme-dark"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_diff_stub():
-    result = runner.invoke(overlay_app, ["diff", "/tmp", "alice/theme-dark"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_list_stub():
-    result = runner.invoke(overlay_app, ["list", "/tmp"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_stack_stub():
-    result = runner.invoke(overlay_app, ["stack", "/tmp"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_status_stub():
-    result = runner.invoke(overlay_app, ["status", "/tmp"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_trace_stub():
-    result = runner.invoke(overlay_app, ["trace", "/tmp", "some/file.toml"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_why_stub():
-    result = runner.invoke(overlay_app, ["why", "/tmp", "agent.name"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_impact_stub():
-    result = runner.invoke(overlay_app, ["impact", "/tmp", "alice/theme-dark"])
-    assert result.exit_code == 1
-    assert "not implemented" in result.output
-
-
-def test_activate_json_flag():
-    result = runner.invoke(overlay_app, ["activate", "/tmp", "alice/theme-dark", "--json"])
-    assert result.exit_code == 1
-
-
-def test_list_json_flag():
-    result = runner.invoke(overlay_app, ["list", "/tmp", "--json"])
-    assert result.exit_code == 1
 
 
 def test_subcommand_count():
@@ -92,3 +28,48 @@ def test_subcommand_count():
     }
     registered = {cmd.name for cmd in overlay_app.registered_commands}
     assert registered == expected
+
+
+def test_activate_requires_ref_argument():
+    result = runner.invoke(overlay_app, ["activate", "/tmp"])
+    assert result.exit_code != 0
+
+
+def test_deactivate_requires_ref_argument():
+    result = runner.invoke(overlay_app, ["deactivate", "/tmp"])
+    assert result.exit_code != 0
+
+
+def test_diff_requires_ref_argument():
+    result = runner.invoke(overlay_app, ["diff", "/tmp"])
+    assert result.exit_code != 0
+
+
+def test_trace_requires_file_path_argument():
+    result = runner.invoke(overlay_app, ["trace", "/tmp"])
+    assert result.exit_code != 0
+
+
+def test_why_requires_key_argument():
+    result = runner.invoke(overlay_app, ["why", "/tmp"])
+    assert result.exit_code != 0
+
+
+def test_impact_requires_ref_argument():
+    result = runner.invoke(overlay_app, ["impact", "/tmp"])
+    assert result.exit_code != 0
+
+
+def test_list_accepts_workspace_root_only():
+    result = runner.invoke(overlay_app, ["list", "/tmp"])
+    assert result.exit_code == 0
+
+
+def test_stack_accepts_workspace_root_only():
+    result = runner.invoke(overlay_app, ["stack", "/tmp"])
+    assert result.exit_code == 0
+
+
+def test_status_accepts_workspace_root_only():
+    result = runner.invoke(overlay_app, ["status", "/tmp"])
+    assert result.exit_code == 0

--- a/gr2/tests/test_overlay_cli_wiring.py
+++ b/gr2/tests/test_overlay_cli_wiring.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 
 import json
 import subprocess
-import tomli_w
 from pathlib import Path
 
-import pytest
+import tomli_w
 from typer.testing import CliRunner
 
 from gr2_overlay.cli import overlay_app
@@ -44,7 +43,11 @@ def _write_overlay_spec(workspace_root: Path, entries: list[dict]) -> None:
     spec_path.write_bytes(tomli_w.dumps(data).encode())
 
 
-def _write_overlay_stack_toml(workspace_root: Path, active: list[str], available: list[str]) -> None:
+def _write_overlay_stack_toml(
+    workspace_root: Path,
+    active: list[str],
+    available: list[str],
+) -> None:
     stack_path = workspace_root / ".grip" / "overlay-stack.toml"
     stack_path.parent.mkdir(parents=True, exist_ok=True)
     data = {"active": active, "available": available}
@@ -150,10 +153,23 @@ class TestStatusCommand:
 class TestListCommand:
     def test_list_shows_declared_overlays(self, tmp_path: Path):
         workspace_root, _ = _workspace_with_overlay_store(tmp_path)
-        _write_overlay_spec(workspace_root, [
-            {"name": "kanonic-root", "path": "../config-root", "applies_to": ["config"], "priority": 0},
-            {"name": "synapt-core", "path": "../config", "applies_to": ["config"], "priority": 10},
-        ])
+        _write_overlay_spec(
+            workspace_root,
+            [
+                {
+                    "name": "kanonic-root",
+                    "path": "../config-root",
+                    "applies_to": ["config"],
+                    "priority": 0,
+                },
+                {
+                    "name": "synapt-core",
+                    "path": "../config",
+                    "applies_to": ["config"],
+                    "priority": 10,
+                },
+            ],
+        )
 
         result = runner.invoke(overlay_app, ["list", str(workspace_root)])
 
@@ -163,9 +179,17 @@ class TestListCommand:
 
     def test_list_json_output(self, tmp_path: Path):
         workspace_root, _ = _workspace_with_overlay_store(tmp_path)
-        _write_overlay_spec(workspace_root, [
-            {"name": "kanonic-root", "path": "../config-root", "applies_to": ["config"], "priority": 0},
-        ])
+        _write_overlay_spec(
+            workspace_root,
+            [
+                {
+                    "name": "kanonic-root",
+                    "path": "../config-root",
+                    "applies_to": ["config"],
+                    "priority": 0,
+                },
+            ],
+        )
 
         result = runner.invoke(overlay_app, ["list", str(workspace_root), "--json"])
 

--- a/gr2/tests/test_overlay_cli_wiring.py
+++ b/gr2/tests/test_overlay_cli_wiring.py
@@ -1,0 +1,275 @@
+"""TDD spec: gr overlay CLI wiring from stubs to real module functions.
+
+These tests verify that CLI commands call the underlying module functions
+and return real output (exit code 0) instead of "not implemented" (exit code 1).
+
+The test_overlay_cli.py tests verify the stub contract; these tests verify
+the wired contract. Once wired, the stub tests should be updated or removed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tomli_w
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from gr2_overlay.cli import overlay_app
+
+runner = CliRunner()
+
+
+def _init_bare_git_repo(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "--bare", str(path)], check=True, capture_output=True)
+    return path
+
+
+def _workspace_with_overlay_store(tmp_path: Path) -> tuple[Path, Path]:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    grip_dir = workspace_root / ".grip"
+    grip_dir.mkdir()
+    overlay_store = _init_bare_git_repo(grip_dir / "overlay-store.git")
+    return workspace_root, overlay_store
+
+
+def _write_overlay_spec(workspace_root: Path, entries: list[dict]) -> None:
+    spec_path = workspace_root / ".grip" / "overlays.toml"
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"overlays": entries}
+    spec_path.write_bytes(tomli_w.dumps(data).encode())
+
+
+def _write_overlay_stack_toml(workspace_root: Path, active: list[str], available: list[str]) -> None:
+    stack_path = workspace_root / ".grip" / "overlay-stack.toml"
+    stack_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"active": active, "available": available}
+    stack_path.write_bytes(tomli_w.dumps(data).encode())
+
+
+def _write_overlay_status_toml(
+    workspace_root: Path, active: list[str], available: list[str], applied: list[str]
+) -> None:
+    status_path = workspace_root / ".grip" / "overlay-status.toml"
+    status_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"active": active, "available": available, "applied": applied}
+    status_path.write_bytes(tomli_w.dumps(data).encode())
+
+
+# --- stack command ---
+
+
+class TestStackCommand:
+    def test_stack_returns_active_and_available_overlays(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        _write_overlay_stack_toml(
+            workspace_root,
+            active=["refs/overlays/alice/theme-dark"],
+            available=["refs/overlays/bob/theme-light"],
+        )
+
+        result = runner.invoke(overlay_app, ["stack", str(workspace_root)])
+
+        assert result.exit_code == 0
+        assert "alice/theme-dark" in result.output
+        assert "bob/theme-light" in result.output
+
+    def test_stack_json_output(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        _write_overlay_stack_toml(
+            workspace_root,
+            active=["refs/overlays/alice/theme-dark"],
+            available=[],
+        )
+
+        result = runner.invoke(overlay_app, ["stack", str(workspace_root), "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["active"]) == 1
+        assert data["active"][0]["author"] == "alice"
+        assert data["active"][0]["name"] == "theme-dark"
+
+    def test_stack_empty_workspace(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+
+        result = runner.invoke(overlay_app, ["stack", str(workspace_root)])
+
+        assert result.exit_code == 0
+        assert "Active" in result.output
+
+
+# --- status command ---
+
+
+class TestStatusCommand:
+    def test_status_shows_overlay_state(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        _write_overlay_status_toml(
+            workspace_root,
+            active=["theme-dark"],
+            available=["theme-light"],
+            applied=["theme-dark"],
+        )
+
+        result = runner.invoke(overlay_app, ["status", str(workspace_root)])
+
+        assert result.exit_code == 0
+        assert "theme-dark" in result.output
+
+    def test_status_json_output(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        _write_overlay_status_toml(
+            workspace_root,
+            active=["theme-dark"],
+            available=["theme-light"],
+            applied=["theme-dark"],
+        )
+
+        result = runner.invoke(overlay_app, ["status", str(workspace_root), "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "theme-dark" in data["active"]
+
+    def test_status_empty_workspace(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+
+        result = runner.invoke(overlay_app, ["status", str(workspace_root)])
+
+        assert result.exit_code == 0
+
+
+# --- list command ---
+
+
+class TestListCommand:
+    def test_list_shows_declared_overlays(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        _write_overlay_spec(workspace_root, [
+            {"name": "kanonic-root", "path": "../config-root", "applies_to": ["config"], "priority": 0},
+            {"name": "synapt-core", "path": "../config", "applies_to": ["config"], "priority": 10},
+        ])
+
+        result = runner.invoke(overlay_app, ["list", str(workspace_root)])
+
+        assert result.exit_code == 0
+        assert "kanonic-root" in result.output
+        assert "synapt-core" in result.output
+
+    def test_list_json_output(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        _write_overlay_spec(workspace_root, [
+            {"name": "kanonic-root", "path": "../config-root", "applies_to": ["config"], "priority": 0},
+        ])
+
+        result = runner.invoke(overlay_app, ["list", str(workspace_root), "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["overlays"]) == 1
+        assert data["overlays"][0]["name"] == "kanonic-root"
+        assert data["overlays"][0]["priority"] == 0
+
+    def test_list_empty_workspace(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+
+        result = runner.invoke(overlay_app, ["list", str(workspace_root)])
+
+        assert result.exit_code == 0
+
+
+# --- why command ---
+
+
+class TestWhyCommand:
+    def test_why_shows_overlay_attribution(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        why_path = workspace_root / ".grip" / "overlay-why.toml"
+        why_data = {
+            "files": {
+                "agents.toml": {
+                    "rule": "overlay-deep",
+                    "reason": "org overlay extends root agent definitions",
+                    "ref": "refs/overlays/synapt/core",
+                }
+            }
+        }
+        why_path.write_bytes(tomli_w.dumps(why_data).encode())
+
+        result = runner.invoke(overlay_app, ["why", str(workspace_root), "agents.toml"])
+
+        assert result.exit_code == 0
+        assert "overlay-deep" in result.output
+        assert "synapt/core" in result.output
+
+    def test_why_json_output(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        why_path = workspace_root / ".grip" / "overlay-why.toml"
+        why_data = {
+            "files": {
+                "agents.toml": {
+                    "rule": "overlay-deep",
+                    "reason": "extends root",
+                    "ref": "refs/overlays/synapt/core",
+                }
+            }
+        }
+        why_path.write_bytes(tomli_w.dumps(why_data).encode())
+
+        result = runner.invoke(overlay_app, ["why", str(workspace_root), "agents.toml", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["rule"] == "overlay-deep"
+
+
+# --- trace command ---
+
+
+class TestTraceCommand:
+    def test_trace_shows_line_attribution(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        attr_path = workspace_root / ".grip" / "overlay-attribution.toml"
+        attr_data = {
+            "files": {
+                "agents.toml": {
+                    "lines": [
+                        {"start": 1, "end": 10, "ref": "refs/overlays/kanonic/root"},
+                        {"start": 11, "end": 25, "ref": "refs/overlays/synapt/core"},
+                    ]
+                }
+            }
+        }
+        attr_path.write_bytes(tomli_w.dumps(attr_data).encode())
+
+        result = runner.invoke(overlay_app, ["trace", str(workspace_root), "agents.toml"])
+
+        assert result.exit_code == 0
+        assert "kanonic/root" in result.output
+        assert "synapt/core" in result.output
+
+    def test_trace_json_output(self, tmp_path: Path):
+        workspace_root, _ = _workspace_with_overlay_store(tmp_path)
+        attr_path = workspace_root / ".grip" / "overlay-attribution.toml"
+        attr_data = {
+            "files": {
+                "config.toml": {
+                    "lines": [
+                        {"start": 1, "end": 5, "ref": "refs/overlays/alice/base"},
+                    ]
+                }
+            }
+        }
+        attr_path.write_bytes(tomli_w.dumps(attr_data).encode())
+
+        result = runner.invoke(overlay_app, ["trace", str(workspace_root), "config.toml", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["file"] == "config.toml"
+        assert len(data["regions"]) == 1


### PR DESCRIPTION
## Summary

- Wire all 9 `gr overlay` CLI stubs to their underlying module functions (exit code 0 with real output instead of exit code 1 with "not implemented")
- Add `_default_overlay_store()` convention: `workspace_root/.grip/overlay-store.git`
- Update `test_overlay_cli.py` from stub-verification to argument-shape tests
- Add `test_overlay_cli_wiring.py` with 13 tests covering stack/status/list/why/trace in both human and JSON output modes

## Context

PR #168 (config repo) surfaced this as a blocking dependency: the overlay-repo Phase 1 design assumed gr2 CLI readiness that didn't exist. This PR closes the "stub CLI" gap that Sentinel flagged.

165 overlay tests pass, zero regressions.

## Premium boundary

Premium boundary: core OSS (workspace orchestration primitives). CLI commands answer "how do overlays compose?" not "who is this agent?"

## Test plan

- [x] All 13 new wiring tests pass (stack/status/list/why/trace x human+JSON)
- [x] All 10 argument-shape tests pass
- [x] All 165 overlay tests pass (zero regressions)
- [ ] Cross-review from team

🤖 Generated with [Claude Code](https://claude.com/claude-code)