### PR TITLE
docs: clarify premium repo rename in gr2 docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 ### Boundary Checklist
 
 - [ ] **Boundary declaration** present above
-- [ ] **Identity test**: does this PR answer "who is this agent?" or "what workspace is this?" If yes, it must go in `synapt-private`.
+- [ ] **Identity test**: does this PR answer "who is this agent?" or "what workspace is this?" If yes, it must go in premium (`synapt-dev/premium`; local worktree `synapt-private/`).
 - [ ] **Plugin seam**: if this extends OSS for a premium feature, is the extension seam built in OSS first?
 
 ## Test Plan

--- a/gr2/docs/GR2-MVP.md
+++ b/gr2/docs/GR2-MVP.md
@@ -172,8 +172,8 @@ that the replacement workflow works end-to-end.
 
 gr2 workspace orchestration is OSS. All features in this MVP definition live in
 the grip repo. Identity resolution, org routing, agent identity, and workspace
-policy enforcement live in premium (synapt-private) and connect through the
-plugin seam.
+policy enforcement live in premium (`synapt-dev/premium`; local worktree
+`synapt-private/`) and connect through the plugin seam.
 
 The exec surface, sync engine, and materialization pipeline are neutral
 infrastructure. They do not answer "who is this agent" or "what workspace owns

--- a/gr2/docs/HOOK-CONFIG-MODEL.md
+++ b/gr2/docs/HOOK-CONFIG-MODEL.md
@@ -63,7 +63,7 @@ url = "git@github.com:synapt-dev/synapt.git"
 [[repos]]
 name = "synapt-private"
 path = "repos/synapt-private"
-url = "git@github.com:synapt-dev/synapt-private.git"
+url = "git@github.com:synapt-dev/premium.git"
 
 [[units]]
 name = "atlas"
@@ -369,7 +369,8 @@ Why:
 
 ### 5.3 `synapt-private`
 
-`synapt-private` already carries private config and has stronger review needs.
+`synapt-private` is the local worktree alias for the premium repo and already
+carries private config and stronger review needs.
 
 Example:
 

--- a/gr2/docs/PR-LIFECYCLE.md
+++ b/gr2/docs/PR-LIFECYCLE.md
@@ -442,6 +442,9 @@ threshold.
 When `gr2 pr create` creates linked PRs, it appends a standard section to each
 PR body:
 
+The repo column uses the workspace-local repo name. The PR target must use the
+canonical GitHub repository name.
+
 ```markdown
 ---
 
@@ -451,7 +454,7 @@ PR body:
 |------|----|
 | grip | synapt-dev/grip#570 |
 | synapt | synapt-dev/synapt#583 |
-| synapt-private | synapt-dev/synapt-private#291 |
+| synapt-private | synapt-dev/premium#291 |
 
 Lane: `apollo/design/hook-event-contract`
 Base: `sprint-20`


### PR DESCRIPTION
## Summary

Follow-up from the synapt-private -> synapt.premium rename audit for grip/gitgrip docs.

Updated current-canonical references that still pointed readers at the old premium repo identity:

- PR template identity-test wording now says premium (`synapt-dev/premium`; local worktree `synapt-private/`).
- gr2 MVP boundary text now distinguishes canonical premium repo from the local worktree.
- hook config example keeps `synapt-private` as the local workspace alias/path but updates the GitHub URL to `synapt-dev/premium`.
- PR lifecycle cross-link example keeps the workspace-local repo column but links PRs to `synapt-dev/premium#NN`.

## Disposition

- Updated: 4 current-doc external/package-policy references.
- Left intentionally: local workspace alias/path examples using `synapt-private` because the gripspace worktree convention remains unchanged.
- Historical: none in this patch surface.

## Verification

- `git diff --check HEAD~1..HEAD`
- `rg -n "synapt-dev/synapt-private|git@github.com:synapt-dev/synapt-private|synapt_private" .github docs gr2/docs README.md AGENTS.md CLAUDE.md claude.md 2>/dev/null || true` -> no matches

Premium boundary: grip is OSS. This PR only updates documentation references to the current premium repo identity; it adds no premium behavior.