### PR TITLE
test: gr2 packaging + native branch command failing tests (grip#752 slice 1)

### DIFF
--- a/gr2/tests/test_branch.py
+++ b/gr2/tests/test_branch.py
@@ -1,0 +1,167 @@
+"""TDD failing tests: native `gr2 branch` command (grip#752 slice 1, D3).
+
+Scope decision (2026-07-07 #dev, Opus's steer): gr2's daily verbs default to
+cwd-repo scope, not gr1's gripspace-wide default. gr1's own branch/add/commit/push
+all operate over filter_repos(...) across the whole manifest by default -- that's
+the source of grip#755's surprise (push ran gripspace-wide with no --repo given).
+gr2 departs from that deliberately, consistently across all four verbs, so the
+CLI has one predictable mental model instead of push being single-repo while
+branch is gripspace-wide.
+
+grip#746 (gr1: branch has no --base, forces raw-git fallback) is folded in from
+day one rather than deferred: create_branch(repo, name, base=...) resolves the
+base ref per the target repo, defaults to current HEAD when omitted (backward
+compatible), and raises clearly rather than silently falling back to HEAD when
+the given ref doesn't exist -- this is grip#746's explicit acceptance criteria.
+
+The existing-branch-switches-instead-of-erroring behavior mirrors gr1's own
+grip#401 fix (re-running branch on a name that already exists should not block
+forward progress).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-b", "main"], path)
+    _git(["config", "user.name", "Test"], path)
+    _git(["config", "user.email", "test@example.com"], path)
+    (path / "README.md").write_text("# test\n")
+    _git(["add", "README.md"], path)
+    _git(["commit", "-m", "initial"], path)
+
+
+def _current_branch(path: Path) -> str:
+    return _git(["branch", "--show-current"], path).stdout.strip()
+
+
+def _head_sha(path: Path, ref: str) -> str:
+    return _git(["log", "-1", "--format=%H", ref], path).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo_path = tmp_path / "repo"
+    _init_repo(repo_path)
+    return repo_path
+
+
+class TestCreateBranch:
+    def test_creates_and_switches_to_new_branch(self, repo: Path) -> None:
+        from gr2.python_cli.branch import create_branch
+
+        create_branch(repo, "feat/x")
+        assert _current_branch(repo) == "feat/x"
+
+    def test_existing_branch_switches_instead_of_erroring(self, repo: Path) -> None:
+        """grip#401 UX: re-running branch on an existing name switches, doesn't error."""
+        from gr2.python_cli.branch import create_branch
+
+        create_branch(repo, "feat/x")
+        _git(["checkout", "main"], repo)
+
+        create_branch(repo, "feat/x")  # must not raise
+
+        assert _current_branch(repo) == "feat/x"
+
+    def test_base_ref_creates_branch_off_specified_ref_not_head(self, repo: Path) -> None:
+        """grip#746: --base must branch off the given ref, not current HEAD."""
+        from gr2.python_cli.branch import create_branch
+
+        # Diverge HEAD from main so "off main" and "off HEAD" would disagree.
+        _git(["checkout", "-b", "other"], repo)
+        (repo / "other.txt").write_text("other\n")
+        _git(["add", "other.txt"], repo)
+        _git(["commit", "-m", "other work"], repo)
+
+        create_branch(repo, "feat/based", base="main")
+
+        assert _head_sha(repo, "feat/based") == _head_sha(repo, "main")
+        assert _head_sha(repo, "feat/based") != _head_sha(repo, "other")
+
+    def test_missing_base_ref_errors_clearly_no_silent_head_fallback(self, repo: Path) -> None:
+        """grip#746 acceptance criteria: missing ref errors clearly, never silently falls back to HEAD."""
+        from gr2.python_cli.branch import BranchError, create_branch
+
+        head_before = _head_sha(repo, "HEAD")
+
+        with pytest.raises(BranchError, match="nonexistent-ref"):
+            create_branch(repo, "feat/y", base="nonexistent-ref")
+
+        # No branch should have been created off HEAD as a silent fallback.
+        result = _git(["branch", "--list", "feat/y"], repo)
+        assert result.stdout.strip() == ""
+        assert _head_sha(repo, "HEAD") == head_before
+
+    def test_worktree_conflict_gives_helpful_error(self, repo: Path, tmp_path: Path) -> None:
+        """Mirrors gr1's own worktree-conflict detection (real, cited team pain: grip#750)."""
+        from gr2.python_cli.branch import BranchError, create_branch
+
+        create_branch(repo, "shared-branch")
+        _git(["checkout", "main"], repo)
+
+        worktree_path = tmp_path / "worktree"
+        _git(["worktree", "add", str(worktree_path), "shared-branch"], repo)
+
+        with pytest.raises(BranchError, match="worktree"):
+            create_branch(repo, "shared-branch")
+
+
+class TestBranchCLI:
+    def test_gr2_branch_command_creates_branch(self, repo: Path) -> None:
+        from gr2.python_cli.app import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["branch", "feat/cli-test", "--repo-path", str(repo)])
+
+        assert result.exit_code == 0, result.output
+        assert _current_branch(repo) == "feat/cli-test"
+
+    def test_gr2_branch_supports_base_flag(self, repo: Path) -> None:
+        _git(["checkout", "-b", "other"], repo)
+        (repo / "other.txt").write_text("other\n")
+        _git(["add", "other.txt"], repo)
+        _git(["commit", "-m", "other work"], repo)
+
+        from gr2.python_cli.app import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["branch", "feat/cli-based", "--base", "main", "--repo-path", str(repo)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert _head_sha(repo, "feat/cli-based") == _head_sha(repo, "main")
+
+    def test_gr2_branch_defaults_to_cwd_repo_scope(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gr2 branch operates on the current repo by default -- no gripspace-wide
+        sweep unless explicitly requested. Departs from gr1's default (which
+        operates over filter_repos(...) across the whole manifest); grip#755's
+        finding (push ran gripspace-wide unexpectedly) is folded into this as a
+        deliberate, consistent design choice across all four verbs, not just push.
+        """
+        repo_a = tmp_path / "a"
+        repo_b = tmp_path / "b"
+        _init_repo(repo_a)
+        _init_repo(repo_b)
+        monkeypatch.chdir(repo_a)
+
+        from gr2.python_cli.app import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["branch", "feat/scoped"])
+
+        assert result.exit_code == 0, result.output
+        assert _current_branch(repo_a) == "feat/scoped"
+        assert _current_branch(repo_b) == "main"  # untouched -- no gripspace-wide sweep

--- a/gr2/tests/test_branch.py
+++ b/gr2/tests/test_branch.py
@@ -144,7 +144,9 @@ class TestBranchCLI:
         assert result.exit_code == 0, result.output
         assert _head_sha(repo, "feat/cli-based") == _head_sha(repo, "main")
 
-    def test_gr2_branch_defaults_to_cwd_repo_scope(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_gr2_branch_defaults_to_cwd_repo_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """gr2 branch operates on the current repo by default -- no gripspace-wide
         sweep unless explicitly requested. Departs from gr1's default (which
         operates over filter_repos(...) across the whole manifest); grip#755's

--- a/gr2/tests/test_gr2_packaging.py
+++ b/gr2/tests/test_gr2_packaging.py
@@ -1,0 +1,67 @@
+"""Packaging tests: gr2 must be a real installable CLI, not a pytest-only import.
+
+Today, gr2.python_cli and gr2.prototypes only resolve inside pytest, via the
+root conftest.py's sys.modules injection (`gr2/conftest.py`). gr2/pyproject.toml
+packages only gr2_overlay. There is no console_scripts entry point.
+
+These tests deliberately run each check in a fresh subprocess with cwd pinned to
+a neutral tmp_path (never gr2/ or its parent), so a pass can only mean the
+package is genuinely installed and importable -- not that Python happened to
+find these modules via a cwd-relative accident or pytest's own sys.modules hack,
+which subprocesses don't inherit anyway.
+
+grip#752 slice 1 (D3): pyproject at grip/gr2/... console_scripts entry point.
+Reference path correction: the repo directory is gitgrip/gr2/, not
+gitgrip/grip/gr2/ as CLAUDE.md's layout doc has it (flagged separately, #dev).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, capture_output=True, text=True)
+
+
+def test_gr2_python_cli_imports_without_conftest_injection(tmp_path: Path) -> None:
+    """gr2.python_cli must be importable as a real package, not via sys.modules hack."""
+    result = _run([sys.executable, "-c", "import gr2.python_cli.app"], cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_gr2_prototypes_imports_without_conftest_injection(tmp_path: Path) -> None:
+    """gr2.prototypes -- the load-bearing import in app.py/syncops.py/execops.py -- must resolve for real."""
+    result = _run(
+        [sys.executable, "-c", "import gr2.prototypes.lane_workspace_prototype"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_gr2_prototypes_repo_maintenance_imports(tmp_path: Path) -> None:
+    result = _run(
+        [sys.executable, "-c", "import gr2.prototypes.repo_maintenance_prototype"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_gr2_overlay_still_imports_unprefixed(tmp_path: Path) -> None:
+    """gr2_overlay stays its own top-level package -- the packaging fix must not break it."""
+    result = _run([sys.executable, "-c", "import gr2_overlay"], cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_gr2_console_script_resolves(tmp_path: Path) -> None:
+    """console_scripts entry point `gr2` must be on PATH and runnable after install."""
+    result = _run(["gr2", "--help"], cwd=tmp_path)
+    assert result.returncode == 0, result.stderr
+
+
+def test_gr2_module_invocation_works(tmp_path: Path) -> None:
+    """python -m gr2.python_cli must also work (uses the existing __main__.py)."""
+    result = _run([sys.executable, "-m", "gr2.python_cli", "--help"], cwd=tmp_path)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

TDD failing-tests spec for grip#752 (D3) slice 1's first cut: gr2 packaging + native `branch` command.

Ref #752 (partial -- slice 1 only, packaging + branch; add/commit/push follow in an immediate next PR per TDD's tests-then-implementation discipline).

## What's tested

**Packaging** (`tests/test_gr2_packaging.py`): gr2.python_cli and gr2.prototypes must import as real installed packages, independent of `tests/conftest.py`'s sys.modules injection hack (which subprocesses don't inherit anyway -- every check here runs in a fresh subprocess with cwd pinned to a neutral tmp_path, so a pass can only mean genuine packaging, never a cwd-relative accident). Also covers the `gr2` console_scripts entry point and `python -m gr2.python_cli` (uses the existing `__main__.py`).

One test (`gr2_overlay` import) passes today as a control -- it's already correctly packaged, confirming the suite discriminates real state rather than failing wholesale.

**Native `branch`** (`tests/test_branch.py`): create/switch, `--base` support (grip#746, from day one -- per-repo ref resolution, backward-compatible HEAD default, clear error rather than silent HEAD-fallback on a missing ref), existing-branch-switches-not-errors (mirrors gr1's own grip#401 fix), worktree-conflict detection (mirrors gr1's real, cited pain -- grip#750), and CLI wiring including the scope-default test.

## Design decision: cwd-repo scope by default

gr2's daily verbs default to the **current repo**, not gr1's gripspace-wide default. gr1's own `branch`/`add`/`commit`/`push` all operate over `filter_repos(...)` across the whole manifest (confirmed directly in gr1's source while researching this PR) -- that's the mechanism behind grip#755's push surprise. Opus's steer (2026-07-07 #dev) was to fix this for `push` in gr2; I'm applying it consistently across all four verbs so the CLI has one predictable mental model rather than push being single-repo while branch is gripspace-wide.

## Verified RED state

14 tests, 13 fail for the correct reason (`ModuleNotFoundError: No module named 'gr2.python_cli.branch'`; Typer's `No such command 'branch'`; `ModuleNotFoundError: No module named 'gr2'` on the pre-packaging-fix imports), 1 passes as the control described above. Full output checked line-by-line, not just trusted at the summary level.

## Side finding for the implementation PR

`.venv/bin/gr2` already exists as a stale script from earlier exploration -- imports unprefixed `python_cli.app`, not the ratified `gr2.python_cli.app` convention. Not currently wired through `pyproject.toml` (confirmed: no `[project.scripts]` section exists today). The implementation PR needs to actually overwrite this, not assume a fresh entry point.

## Implementation (follow-up PR, not this one)

pyproject.toml fix (package-dir mapping so `gr2` becomes a real top-level package alongside unprefixed `gr2_overlay`), `gr2/__init__.py`, `gr2/prototypes/__init__.py`, `python_cli/branch.py`, `app.py` command wiring.

## Premium boundary

OSS (grip is OSS; this is CLI daily-verb orchestration -- no identity/org semantics touched).

## Reviewers

@Opus (coordination gate, per sprint-39's first-PR-up convention) + Atlas (D2's lane-adapter seam shares this exact `python_cli` package this sprint -- substantive cross-review value, not just gate-filling).