### PR TITLE
fix: harden gr1 spawn and sync diagnostics

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -532,8 +532,8 @@ pub enum SpawnCommands {
         /// Stop only this agent
         #[arg(long)]
         agent: Option<String>,
-        /// Seconds to wait for graceful exit before force-killing (default: 10)
-        #[arg(long, default_value = "10")]
+        /// Seconds to wait for graceful exit before force-killing (default: 30)
+        #[arg(long, default_value = "30")]
         timeout: u64,
     },
     /// List configured agents

--- a/src/cli/commands/checkout.rs
+++ b/src/cli/commands/checkout.rs
@@ -2,7 +2,9 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
-use crate::core::repo::{filter_repos, get_manifest_repo_info, RepoInfo};
+use crate::core::repo::{
+    filter_repos, get_manifest_repo_info, validate_repo_filters_known, RepoInfo,
+};
 use crate::core::workspace_checkout;
 use crate::git::{
     branch::{branch_exists, checkout_branch, create_and_checkout_branch},
@@ -24,6 +26,8 @@ pub fn run_checkout(
     } else {
         "Checking out"
     };
+
+    validate_repo_filters_known(manifest, repos_filter)?;
 
     let mut repos: Vec<RepoInfo> =
         filter_repos(manifest, workspace_root, repos_filter, group_filter, false);
@@ -126,6 +130,8 @@ pub fn run_checkout_add(
     repos_filter: Option<&[String]>,
     group_filter: Option<&[String]>,
 ) -> anyhow::Result<()> {
+    validate_repo_filters_known(manifest, repos_filter)?;
+
     let mut repos: Vec<RepoInfo> =
         filter_repos(manifest, workspace_root, repos_filter, group_filter, false);
 

--- a/src/cli/commands/restore.rs
+++ b/src/cli/commands/restore.rs
@@ -5,7 +5,7 @@
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
 use crate::core::manifest_paths;
-use crate::core::repo::{filter_repos, RepoInfo};
+use crate::core::repo::{filter_repos, validate_repo_filters_known, RepoInfo};
 use crate::git::cache::invalidate_status_cache;
 use crate::git::{get_workdir, open_repo, path_exists};
 use crate::util::log_cmd;
@@ -28,6 +28,8 @@ pub fn run_restore(
         action
     ));
     println!();
+
+    validate_repo_filters_known(manifest, repos_filter)?;
 
     let repos: Vec<RepoInfo> =
         filter_repos(manifest, workspace_root, repos_filter, group_filter, false);

--- a/src/cli/commands/spawn.rs
+++ b/src/cli/commands/spawn.rs
@@ -13,6 +13,21 @@ use std::process::{Command, Stdio};
 
 const AGENT_HISTORY_LIMIT: &str = "50000";
 const CODEX_STARTUP_MAX_LINE_CHARS: usize = 500;
+const LAUNCH_VERIFY_TIMEOUT_SECS: u64 = 8;
+const LAUNCH_VERIFY_POLL_MS: u64 = 250;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PaneState {
+    Running,
+    Exited,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LaunchTimeoutKind {
+    CodexSelfUpdate,
+    PendingOrShell,
+}
 
 // ---------------------------------------------------------------------------
 // Config types
@@ -207,6 +222,197 @@ fn agent_window_tmux_options() -> [(&'static str, &'static str); 2] {
     ]
 }
 
+fn shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn shell_join(parts: &[String]) -> String {
+    parts
+        .iter()
+        .map(|part| shell_quote(part))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn build_launch_script_content(
+    env: &HashMap<String, String>,
+    worktree_path: &Path,
+    launch_cmd: &str,
+) -> String {
+    let mut keys: Vec<&String> = env.keys().collect();
+    keys.sort();
+
+    let mut lines = vec!["#!/usr/bin/env bash".to_string(), "set -e".to_string()];
+    for key in keys {
+        if let Some(value) = env.get(key) {
+            lines.push(format!("export {}={}", key, shell_quote(value)));
+        }
+    }
+    lines.push(format!(
+        "cd {}",
+        shell_quote(&worktree_path.display().to_string())
+    ));
+    lines.push(format!("exec {}", launch_cmd));
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+fn write_launch_script(
+    workspace_root: &Path,
+    agent_name: &str,
+    env: &HashMap<String, String>,
+    worktree_path: &Path,
+    launch_cmd: &str,
+) -> anyhow::Result<PathBuf> {
+    let script_dir = workspace_root.join(".gitgrip").join("spawn");
+    std::fs::create_dir_all(&script_dir)?;
+    let safe_name = agent_name.replace(['/', '\\', ':'], "-");
+    let script_path = script_dir.join(format!("{}-launch.sh", safe_name));
+    let content = build_launch_script_content(env, worktree_path, launch_cmd);
+    std::fs::write(&script_path, content)?;
+    Ok(script_path)
+}
+
+fn tmux_send_launch_script(target: &str, script_path: &Path) -> anyhow::Result<()> {
+    let command = format!("bash {}", shell_quote(&script_path.display().to_string()));
+    let status = Command::new("tmux")
+        .args(["send-keys", "-t", target, &command, "Enter"])
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("tmux send-keys launch exited with {}", status);
+    }
+    Ok(())
+}
+
+fn expected_process_name(binary: &str) -> String {
+    Path::new(binary)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(binary)
+        .to_string()
+}
+
+fn launch_process_matches(expected: &str, current: &str) -> bool {
+    let expected = expected.to_ascii_lowercase();
+    let current = current.trim().to_ascii_lowercase();
+    if matches!(current.as_str(), "" | "sh" | "bash" | "zsh" | "fish") {
+        return false;
+    }
+    if expected.contains("codex") {
+        return current.contains("codex");
+    }
+    if expected.contains("claude") {
+        // Claude Code's foreground process name can be version-like in tmux.
+        // The failure class we need to reject is a returned shell prompt.
+        return true;
+    }
+    current == expected || current.contains(&expected)
+}
+
+fn current_pane_command(target: &str) -> anyhow::Result<String> {
+    let output = Command::new("tmux")
+        .args([
+            "display-message",
+            "-t",
+            target,
+            "-p",
+            "#{pane_current_command}",
+        ])
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "tmux display-message failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn capture_pane_tail(target: &str, lines: usize) -> String {
+    let start = format!("-{}", lines);
+    Command::new("tmux")
+        .args(["capture-pane", "-t", target, "-p", "-S", &start])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).to_string())
+        .unwrap_or_default()
+}
+
+fn wait_for_launch_process(
+    target: &str,
+    expected_process: &str,
+    timeout: std::time::Duration,
+) -> anyhow::Result<Option<String>> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last = None;
+    while std::time::Instant::now() < deadline {
+        let current = current_pane_command(target)?;
+        if launch_process_matches(expected_process, &current) {
+            return Ok(Some(current));
+        }
+        last = Some(current);
+        std::thread::sleep(std::time::Duration::from_millis(LAUNCH_VERIFY_POLL_MS));
+    }
+    Ok(last)
+}
+
+fn classify_launch_timeout(pane_tail: &str) -> LaunchTimeoutKind {
+    if pane_tail.contains("Please restart Codex")
+        || pane_tail.contains("Update ran successfully")
+        || pane_tail.contains("restart Codex")
+    {
+        LaunchTimeoutKind::CodexSelfUpdate
+    } else {
+        LaunchTimeoutKind::PendingOrShell
+    }
+}
+
+fn verify_launch_started(
+    target: &str,
+    expected_process: &str,
+    script_path: &Path,
+) -> anyhow::Result<()> {
+    let timeout = std::time::Duration::from_secs(LAUNCH_VERIFY_TIMEOUT_SECS);
+    if wait_for_launch_process(target, expected_process, timeout)?.is_some() {
+        return Ok(());
+    }
+
+    let tail = capture_pane_tail(target, 30);
+    match classify_launch_timeout(&tail) {
+        LaunchTimeoutKind::CodexSelfUpdate => {
+            Output::warning("Codex self-update exited during spawn; relaunching once");
+            tmux_send_launch_script(target, script_path)?;
+        }
+        LaunchTimeoutKind::PendingOrShell => {
+            Output::warning(
+                "spawn launch did not reach agent process; clearing pane and retrying once",
+            );
+            let _ = Command::new("tmux")
+                .args(["send-keys", "-t", target, "C-c"])
+                .status();
+            tmux_send_launch_script(target, script_path)?;
+        }
+    }
+
+    if wait_for_launch_process(target, expected_process, timeout)?.is_some() {
+        return Ok(());
+    }
+
+    let current = current_pane_command(target).unwrap_or_else(|_| "unknown".to_string());
+    let tail = capture_pane_tail(target, 30);
+    anyhow::bail!(
+        "spawn launch for {} did not reach expected process '{}' (pane_current_command='{}'). Pane tail:\n{}",
+        target,
+        expected_process,
+        current,
+        tail.trim()
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Subcommand: up
 // ---------------------------------------------------------------------------
@@ -300,39 +506,34 @@ pub fn run_spawn_up(
             }
         };
 
-        // Send environment variables — GRIPSPACE_ROOT + SYNAPT_AGENT_ID first (#418, #510)
+        // Build environment variables for the launch script — GRIPSPACE_ROOT +
+        // SYNAPT_AGENT_ID first (#418, #510), then config/env overrides.
         let grip_root = workspace_root.display();
-        let env_cmd = format!(
-            "export GRIPSPACE_ROOT=\"{}\" SYNAPT_AGENT_ID=\"{}\" AGENT_NAME={} AGENT_ROLE=\"{}\" SYNAPT_CHANNELS={} SYNAPT_LOOP_INTERVAL={}",
-            grip_root, agent_id, name, agent.role, channel, agent.loop_interval
+        let mut launch_env = HashMap::new();
+        launch_env.insert("GRIPSPACE_ROOT".to_string(), grip_root.to_string());
+        launch_env.insert("SYNAPT_AGENT_ID".to_string(), agent_id.clone());
+        launch_env.insert("AGENT_NAME".to_string(), name.to_string());
+        launch_env.insert("AGENT_ROLE".to_string(), agent.role.clone());
+        launch_env.insert("SYNAPT_CHANNELS".to_string(), channel.to_string());
+        launch_env.insert(
+            "SYNAPT_LOOP_INTERVAL".to_string(),
+            agent.loop_interval.clone(),
         );
-        let _ = Command::new("tmux")
-            .args(["send-keys", "-t", &target, &env_cmd, "Enter"])
-            .status();
-
-        // Send global spawn env vars from [spawn] config
-        for (key, val) in &config.spawn.env {
-            let global_env = format!("export {}=\"{}\"", key, val);
-            let _ = Command::new("tmux")
-                .args(["send-keys", "-t", &target, &global_env, "Enter"])
-                .status();
-        }
-
-        // Send per-agent custom env vars
-        for (key, val) in &agent.env {
-            let custom_env = format!("export {}=\"{}\"", key, val);
-            let _ = Command::new("tmux")
-                .args(["send-keys", "-t", &target, &custom_env, "Enter"])
-                .status();
-        }
+        launch_env.extend(config.spawn.env.clone());
+        launch_env.extend(agent.env.clone());
 
         let worktree_path = resolve_worktree_path(&workspace_root, &agent.worktree);
 
         // Build and send launch command
-        let launch_cmd = if mock_mode {
-            format!(
-                "echo \"Agent {} would launch here (role: {}, model: {})\" && sleep 86400",
+        let (launch_cmd, expected_process) = if mock_mode {
+            let message = format!(
+                "Agent {} would launch here (role: {}, model: {})",
                 name, agent.role, agent.model
+            );
+            let inner = format!("printf '%s\\n' {}; exec sleep 86400", shell_quote(&message));
+            (
+                shell_join(&["bash".to_string(), "-lc".to_string(), inner]),
+                None,
             )
         } else {
             // Resolve tool config
@@ -402,19 +603,26 @@ pub fn run_spawn_up(
                 vec![]
             };
 
-            let mut parts: Vec<&str> = vec![binary];
-            parts.extend(cmd_parts.iter().map(|s| s.as_str()));
-            parts.extend(resolved_defaults.iter().map(|s| s.as_str()));
-            parts.extend(model_inject.iter().map(|s| s.as_str()));
-            parts.extend(resolved_args.iter().map(|s| s.as_str()));
+            let mut parts: Vec<String> = vec![binary.to_string()];
+            parts.extend(cmd_parts.iter().cloned());
+            parts.extend(resolved_defaults.iter().cloned());
+            parts.extend(model_inject.iter().cloned());
+            parts.extend(resolved_args.iter().cloned());
 
-            let launch = parts.join(" ");
-            format!("cd {} && {}", worktree_path.display(), launch)
+            (shell_join(&parts), Some(expected_process_name(binary)))
         };
 
-        let _ = Command::new("tmux")
-            .args(["send-keys", "-t", &target, &launch_cmd, "Enter"])
-            .status();
+        let launch_script = write_launch_script(
+            &workspace_root,
+            name,
+            &launch_env,
+            &worktree_path,
+            &launch_cmd,
+        )?;
+        tmux_send_launch_script(&target, &launch_script)?;
+        if let Some(expected_process) = expected_process.as_deref() {
+            verify_launch_started(&target, expected_process, &launch_script)?;
+        }
 
         // Set up pipe-pane for output streaming (#443 Mission Control)
         let log_dir = workspace_root.join(".synapt").join("logs").join(&agent_id);
@@ -871,12 +1079,6 @@ pub fn run_spawn_down(
     let poll_interval = std::time::Duration::from_millis(500);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 
-    #[derive(Clone, Copy, PartialEq)]
-    enum PaneState {
-        Running,
-        Exited,
-        Unknown, // tmux error; state could not be determined
-    }
     let mut states: Vec<PaneState> = vec![PaneState::Running; targets.len()];
 
     while std::time::Instant::now() < deadline && states.contains(&PaneState::Running) {
@@ -902,6 +1104,14 @@ pub fn run_spawn_down(
     let mut any_error = false;
     for (i, name) in targets.iter().enumerate() {
         let target = format!("{}:{}", session, name);
+        let final_state = match states[i] {
+            PaneState::Running => match pane_exit_state(session, name) {
+                Some(true) => PaneState::Exited,
+                Some(false) => PaneState::Running,
+                None => PaneState::Unknown,
+            },
+            other => other,
+        };
         let kill_result = Command::new("tmux")
             .args(["kill-window", "-t", &target])
             .output();
@@ -918,7 +1128,7 @@ pub fn run_spawn_down(
             }
         };
 
-        match states[i] {
+        match final_state {
             PaneState::Exited => {
                 println!("  {} {} exited gracefully", "✓".green(), name.bold());
             }
@@ -1552,6 +1762,48 @@ mod tests {
         let options = agent_window_tmux_options();
         assert!(options.contains(&("history-limit", AGENT_HISTORY_LIMIT)));
         assert_eq!(AGENT_HISTORY_LIMIT, "50000");
+    }
+
+    #[test]
+    fn test_launch_process_match_accepts_codex_runtime_wrappers() {
+        assert!(launch_process_matches(
+            "codex",
+            "codex-aarch64-apple-darwin"
+        ));
+        assert!(!launch_process_matches("codex", "zsh"));
+    }
+
+    #[test]
+    fn test_launch_process_match_for_claude_rejects_shell_prompt() {
+        assert!(launch_process_matches("claude", "2.1.198"));
+        assert!(!launch_process_matches("claude", "zsh"));
+    }
+
+    #[test]
+    fn test_launch_timeout_classifies_codex_self_update() {
+        let tail = "Update ran successfully! Please restart Codex.";
+        assert_eq!(
+            classify_launch_timeout(tail),
+            LaunchTimeoutKind::CodexSelfUpdate
+        );
+    }
+
+    #[test]
+    fn test_launch_script_quotes_env_and_execs_launch() {
+        let mut env = HashMap::new();
+        env.insert("AGENT_NAME".to_string(), "sentinel".to_string());
+        env.insert("ODD".to_string(), "value with ' quote".to_string());
+
+        let script = build_launch_script_content(
+            &env,
+            &PathBuf::from("/tmp/grip space"),
+            "'codex' 'resume'",
+        );
+
+        assert!(script.contains("export AGENT_NAME='sentinel'"));
+        assert!(script.contains("export ODD='value with '\\'' quote'"));
+        assert!(script.contains("cd '/tmp/grip space'"));
+        assert!(script.contains("exec 'codex' 'resume'"));
     }
 
     #[test]

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -8,7 +8,9 @@ use crate::core::gripspace::{
 use crate::core::griptree::GriptreeConfig;
 use crate::core::manifest::{HookCondition, Manifest};
 use crate::core::manifest_paths;
-use crate::core::repo::{filter_repos, get_manifest_repo_info, RepoInfo};
+use crate::core::repo::{
+    filter_repos, get_manifest_repo_info, validate_repo_filters_known, RepoInfo,
+};
 use crate::core::sync_state::SyncSnapshot;
 use crate::files::process_composefiles;
 use crate::git::branch::{checkout_branch_at_upstream, checkout_detached, has_commits_ahead};
@@ -162,6 +164,8 @@ pub async fn run_sync(
     // Re-load and resolve gripspaces before syncing repos
     let manifest = sync_gripspaces(workspace_root, manifest, quiet)?;
     let manifest = &manifest;
+
+    validate_repo_filters_known(manifest, repos_filter)?;
 
     let mut repos: Vec<RepoInfo> =
         filter_repos(manifest, workspace_root, repos_filter, group_filter, true);

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -300,6 +300,55 @@ fn checkout_rev(path: &Path, rev: &str) -> Result<(), ManifestError> {
         )));
     }
 
+    // If `rev` names a fetched remote branch, advance the local branch to it.
+    // A plain `git checkout rev` leaves an existing local branch stale after
+    // `git fetch`, which made `gr sync` report "updated" without seeing new
+    // gripspace manifest content.
+    let remote_ref = format!("refs/remotes/origin/{}", rev);
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", &remote_ref])
+        .current_dir(path)
+        .output()
+        .map_err(|e| {
+            ManifestError::GripspaceError(format!("Failed to inspect rev '{}': {}", rev, e))
+        })?;
+    if output.status.success() {
+        let status = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(path)
+            .output()
+            .map_err(|e| {
+                ManifestError::GripspaceError(format!("Failed to inspect gripspace status: {}", e))
+            })?;
+        if !status.status.success() {
+            return Err(ManifestError::GripspaceError(format!(
+                "Failed to inspect gripspace status: {}",
+                String::from_utf8_lossy(&status.stderr).trim()
+            )));
+        }
+        if !String::from_utf8_lossy(&status.stdout).trim().is_empty() {
+            return Err(ManifestError::GripspaceError(
+                "Cannot advance gripspace: working tree has local changes".to_string(),
+            ));
+        }
+
+        let output = Command::new("git")
+            .args(["checkout", "-B", rev, &format!("origin/{}", rev)])
+            .current_dir(path)
+            .output()
+            .map_err(|e| {
+                ManifestError::GripspaceError(format!("Failed to checkout rev '{}': {}", rev, e))
+            })?;
+        if !output.status.success() {
+            return Err(ManifestError::GripspaceError(format!(
+                "Failed to checkout rev '{}': {}",
+                rev,
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        return Ok(());
+    }
+
     let output = Command::new("git")
         .args(["checkout", rev])
         .current_dir(path)
@@ -805,6 +854,31 @@ mod tests {
             .unwrap();
     }
 
+    fn git(repo_dir: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo_dir)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run git {:?}: {}", args, e));
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {}: {}",
+            args,
+            repo_dir.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn commit_file(repo_dir: &Path, relpath: &str, content: &str, message: &str) {
+        let path = repo_dir.join(relpath);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, content).unwrap();
+        git(repo_dir, &["add", relpath]);
+        git(repo_dir, &["commit", "-m", message]);
+    }
+
     #[test]
     fn test_gripspace_name_https() {
         assert_eq!(
@@ -834,6 +908,59 @@ mod tests {
         assert_eq!(
             gripspace_name("https://github.com/user/my-space/"),
             "my-space"
+        );
+    }
+
+    #[test]
+    fn test_update_gripspace_advances_configured_remote_branch() {
+        let temp = tempfile::tempdir().unwrap();
+        let remote = temp.path().join("base.git");
+        git(
+            temp.path(),
+            &["init", "--bare", "-b", "main", remote.to_str().unwrap()],
+        );
+
+        let staging = temp.path().join("staging");
+        git(
+            temp.path(),
+            &["clone", remote.to_str().unwrap(), staging.to_str().unwrap()],
+        );
+        git(&staging, &["config", "user.email", "test@example.com"]);
+        git(&staging, &["config", "user.name", "Test User"]);
+        commit_file(
+            &staging,
+            "manifest.yaml",
+            "version: 1\n",
+            "initial manifest",
+        );
+        git(&staging, &["push", "origin", "main"]);
+
+        let spaces = temp.path().join("spaces");
+        let config = GripspaceConfig {
+            url: format!("file://{}", remote.display()),
+            rev: Some("main".to_string()),
+        };
+        let gripspace_path = ensure_gripspace(&spaces, &config).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(gripspace_path.join("manifest.yaml")).unwrap(),
+            "version: 1\n"
+        );
+
+        commit_file(
+            &staging,
+            "manifest.yaml",
+            "version: 1\nrepos:\n  app:\n    url: file:///tmp/app.git\n",
+            "add app repo",
+        );
+        git(&staging, &["push", "origin", "main"]);
+
+        update_gripspace(&gripspace_path, &config).unwrap();
+
+        let manifest = std::fs::read_to_string(gripspace_path.join("manifest.yaml")).unwrap();
+        assert!(
+            manifest.contains("app:"),
+            "gripspace did not advance to fetched origin/main: {}",
+            manifest
         );
     }
 

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -301,6 +301,36 @@ pub fn filter_repos(
         .collect()
 }
 
+/// Validate repo filters before command execution so repo-scoped commands do not
+/// silently no-op when the local manifest is stale.
+pub fn validate_repo_filters_known(
+    manifest: &Manifest,
+    repos_filter: Option<&[String]>,
+) -> anyhow::Result<()> {
+    let Some(filters) = repos_filter else {
+        return Ok(());
+    };
+
+    let missing: Vec<&String> = filters
+        .iter()
+        .filter(|name| name.as_str() != "manifest" && !manifest.repos.contains_key(*name))
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let names = missing
+        .iter()
+        .map(|name| format!("'{}'", name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    anyhow::bail!(
+        "repo filter {} not found in local manifest. If it was added upstream, run `gr sync --repo manifest` or plain `gr sync` first, then retry.",
+        names
+    );
+}
+
 /// Get RepoInfo for the manifest repo if it exists.
 ///
 /// This provides a standardized way to include the manifest repository

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -173,6 +173,11 @@ impl HostingPlatform for GitHubAdapter {
 
         let client = self.get_client().await?;
 
+        debug!(
+            owner,
+            repo, head, base, title, draft, "GitHub create PR request"
+        );
+
         let result = client
             .pulls(owner, repo)
             .create(title, head, base)
@@ -199,7 +204,7 @@ impl HostingPlatform for GitHubAdapter {
         }
 
         let pr = result.map_err(|e| {
-            let msg = e.to_string();
+            let msg = format_octocrab_error(&e);
             if msg.contains("Validation Failed") || msg.contains("422") {
                 if msg.contains("head sha") || msg.contains("Head sha") {
                     return PlatformError::HeadBranchNotFound {
@@ -1557,6 +1562,33 @@ impl HostingPlatform for GitHubAdapter {
             tag: release.tag_name,
             url: release.html_url,
         })
+    }
+}
+
+fn format_octocrab_error(error: &octocrab::Error) -> String {
+    match error {
+        octocrab::Error::GitHub { source, .. } => {
+            let mut message = format!(
+                "GitHub API {}: {}",
+                source.status_code.as_u16(),
+                source.message
+            );
+            if let Some(errors) = source.errors.as_ref().filter(|errors| !errors.is_empty()) {
+                let details = errors
+                    .iter()
+                    .map(|error| error.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                message.push_str("; errors: ");
+                message.push_str(&details);
+            }
+            if let Some(url) = &source.documentation_url {
+                message.push_str("; documentation: ");
+                message.push_str(url);
+            }
+            message
+        }
+        other => other.to_string(),
     }
 }
 

--- a/tests/test_platform_github.rs
+++ b/tests/test_platform_github.rs
@@ -517,6 +517,16 @@ async fn test_github_create_pr_validation_error() {
         "error should mention create failure: {}",
         err_str
     );
+    assert!(
+        err_str.contains("422"),
+        "error should include upstream status code: {}",
+        err_str
+    );
+    assert!(
+        err_str.contains("A pull request already exists for owner:feat/test."),
+        "error should include upstream validation detail: {}",
+        err_str
+    );
 }
 
 // ── Rate Limited (403) ──────────────────────────────────────────

--- a/tests/test_sync.rs
+++ b/tests/test_sync.rs
@@ -188,6 +188,41 @@ async fn test_sync_handles_up_to_date() {
 }
 
 #[tokio::test]
+async fn test_sync_repo_filter_unknown_fails_loudly() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+    let filter = vec!["newrepo".to_string()];
+
+    let result = gitgrip::cli::commands::sync::run_sync(
+        &ws.workspace_root,
+        &manifest,
+        false,
+        true,
+        Some(&filter),
+        None,
+        false,
+        false,
+        false,
+        false,
+        true,
+    )
+    .await;
+
+    let err = result.expect_err("unknown --repo filter should fail loudly");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("newrepo"),
+        "missing repo name in error: {}",
+        msg
+    );
+    assert!(
+        msg.contains("local manifest") && msg.contains("gr sync --repo manifest"),
+        "missing manifest-refresh guidance: {}",
+        msg
+    );
+}
+
+#[tokio::test]
 async fn test_sync_skips_griptree_base_with_local_commits_ahead() {
     let ws = WorkspaceBuilder::new().add_repo("app").build();
 


### PR DESCRIPTION
## Summary

D5 gr1 bug-five maintenance pass:

- grip#744: surface raw GitHub create-PR API status/message/error details and debug-log the request params.
- grip#751: launch agents through a generated script, verify `pane_current_command` reaches the expected process, retry pending-shell launches with `C-c`, and retry Codex self-update exits when the pane tail says to restart Codex.
- grip#571: raise `spawn down --timeout` default to 30s and recheck final pane exit state before reporting force-kills.
- grip#741: make gripspace update actually advance configured remote branch revs after fetch, guarded by a clean-tree check.
- grip#748: fail loudly for unknown `--repo` filters across sync/checkout/restore with manifest-refresh guidance instead of silent no-op.

Reviewers named at creation: Apollo + Atlas.

## Boundary

OSS gr1 maintenance only. No gr2 or premium changes.

## Tests

- `cargo test --lib`
- `cargo test test_launch -- --nocapture`
- `cargo test --test test_sync`
- `cargo test --test test_platform_github`
- `cargo test --test test_checkout -- --nocapture`
- `cargo test --test test_spawn_tmux -- --nocapture`
- `git diff --check`
