### PR TITLE
test: gr2 native add/commit/push failing tests (grip#752 slice 1 follow-up)

### DIFF
--- a/gr2/tests/test_add.py
+++ b/gr2/tests/test_add.py
@@ -1,0 +1,144 @@
+"""TDD failing tests: native `gr2 add` command (grip#752 slice 1 follow-up, D3).
+
+grip#754's root cause, revisited: gr1's `gr add` stages files individually
+via multi-repo path attribution (a gripspace-relative path has to be matched
+to the right repo before `git add` ever runs), and blanket-treats any git
+stderr containing "did not match any files" as "not in this repo" -- which
+fired on a genuinely valid, real, untracked file (confirmed reproduced twice,
+different sessions). gr2's cwd-repo-scope-by-default (grip#755's finding,
+now product canon) removes the attribution step entirely: there is exactly
+one target repo, so "is this path in this repo" is answered by checking the
+path resolves under repo root, not by parsing git's stderr text. A path that
+genuinely doesn't exist gets a precise, checked message; anything else that
+makes `git add` fail is a real error, not a silent skip.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-b", "main"], path)
+    _git(["config", "user.name", "Test"], path)
+    _git(["config", "user.email", "test@example.com"], path)
+    (path / "README.md").write_text("# test\n")
+    _git(["add", "README.md"], path)
+    _git(["commit", "-m", "initial"], path)
+
+
+def _staged_files(path: Path) -> list[str]:
+    result = _git(["diff", "--cached", "--name-only"], path)
+    return [line for line in result.stdout.splitlines() if line]
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo_path = tmp_path / "repo"
+    _init_repo(repo_path)
+    return repo_path
+
+
+class TestStageFiles:
+    def test_stages_a_real_untracked_file(self, repo: Path) -> None:
+        from gr2.python_cli.add import stage_files
+
+        (repo / "new.txt").write_text("content\n")
+
+        result = stage_files(repo, ["new.txt"])
+
+        assert result.staged == ["new.txt"]
+        assert result.missing == []
+        assert _staged_files(repo) == ["new.txt"]
+
+    def test_stages_dot_adds_all_changes_including_deletions(self, repo: Path) -> None:
+        from gr2.python_cli.add import stage_files
+
+        (repo / "new.txt").write_text("content\n")
+        (repo / "README.md").unlink()
+
+        result = stage_files(repo, ["."])
+
+        assert set(result.staged) == {"new.txt", "README.md"}
+        assert result.missing == []
+
+    def test_genuinely_missing_path_is_reported_precisely_not_silently(self, repo: Path) -> None:
+        """The grip#754 regression case, inverted: a path that really doesn't
+        exist gets reported as missing -- checked directly, not inferred from
+        git's stderr text."""
+        from gr2.python_cli.add import stage_files
+
+        result = stage_files(repo, ["does-not-exist.txt"])
+
+        assert result.staged == []
+        assert result.missing == ["does-not-exist.txt"]
+        assert _staged_files(repo) == []
+
+    def test_one_missing_path_does_not_block_the_rest(self, repo: Path) -> None:
+        from gr2.python_cli.add import stage_files
+
+        (repo / "real.txt").write_text("content\n")
+
+        result = stage_files(repo, ["real.txt", "ghost.txt"])
+
+        assert result.staged == ["real.txt"]
+        assert result.missing == ["ghost.txt"]
+        assert _staged_files(repo) == ["real.txt"]
+
+    def test_real_file_that_git_still_rejects_raises_not_silently_skips(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """A path that exists on disk but is invalid as a git pathspec (e.g.
+        outside the repo entirely) is a real error, never a silent
+        "not in this repo" skip -- that conflation is exactly grip#754."""
+        from gr2.python_cli.add import AddError, stage_files
+
+        outside = tmp_path / "outside.txt"
+        outside.write_text("content\n")
+
+        with pytest.raises(AddError):
+            stage_files(repo, [str(outside)])
+
+
+class TestAddCLI:
+    def test_gr2_add_stages_via_cli(self, repo: Path) -> None:
+        from typer.testing import CliRunner
+
+        from gr2.python_cli.app import app
+
+        (repo / "new.txt").write_text("content\n")
+        runner = CliRunner()
+        result = runner.invoke(app, ["add", "new.txt", "--repo-path", str(repo)])
+
+        assert result.exit_code == 0, result.output
+        assert _staged_files(repo) == ["new.txt"]
+
+    def test_gr2_add_defaults_to_cwd_repo_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from typer.testing import CliRunner
+
+        from gr2.python_cli.app import app
+
+        repo_a = tmp_path / "a"
+        repo_b = tmp_path / "b"
+        _init_repo(repo_a)
+        _init_repo(repo_b)
+        (repo_a / "new.txt").write_text("content\n")
+        (repo_b / "new.txt").write_text("content\n")
+        monkeypatch.chdir(repo_a)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["add", "new.txt"])
+
+        assert result.exit_code == 0, result.output
+        assert _staged_files(repo_a) == ["new.txt"]
+        assert _staged_files(repo_b) == []  # untouched -- no gripspace-wide sweep

--- a/gr2/tests/test_commit.py
+++ b/gr2/tests/test_commit.py
@@ -1,0 +1,121 @@
+"""TDD failing tests: native `gr2 commit` command (grip#752 slice 1 follow-up, D3)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-b", "main"], path)
+    _git(["config", "user.name", "Test"], path)
+    _git(["config", "user.email", "test@example.com"], path)
+    (path / "README.md").write_text("# test\n")
+    _git(["add", "README.md"], path)
+    _git(["commit", "-m", "initial"], path)
+
+
+def _log_message(path: Path, ref: str = "HEAD") -> str:
+    return _git(["log", "-1", "--format=%s", ref], path).stdout.strip()
+
+
+def _commit_count(path: Path) -> int:
+    return int(_git(["rev-list", "--count", "HEAD"], path).stdout.strip())
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo_path = tmp_path / "repo"
+    _init_repo(repo_path)
+    return repo_path
+
+
+class TestCreateCommit:
+    def test_commits_staged_changes_and_returns_hash(self, repo: Path) -> None:
+        from gr2.python_cli.commit import create_commit
+
+        (repo / "new.txt").write_text("content\n")
+        _git(["add", "new.txt"], repo)
+
+        commit_hash = create_commit(repo, "add new file")
+
+        assert commit_hash
+        assert _log_message(repo) == "add new file"
+        assert _git(["rev-parse", "HEAD"], repo).stdout.strip() == commit_hash
+
+    def test_nothing_staged_raises_clearly(self, repo: Path) -> None:
+        from gr2.python_cli.commit import CommitError, create_commit
+
+        with pytest.raises(CommitError, match="[Nn]othing"):
+            create_commit(repo, "empty commit attempt")
+
+        assert _commit_count(repo) == 1  # unchanged
+
+    def test_amend_updates_message_keeps_single_commit(self, repo: Path) -> None:
+        from gr2.python_cli.commit import create_commit
+
+        (repo / "README.md").write_text("# test\nmore\n")
+        _git(["add", "README.md"], repo)
+
+        create_commit(repo, "amended message", amend=True)
+
+        assert _log_message(repo) == "amended message"
+        assert _commit_count(repo) == 1
+
+
+class TestCommitCLI:
+    def test_gr2_commit_via_cli(self, repo: Path) -> None:
+        from typer.testing import CliRunner
+
+        from gr2.python_cli.app import app
+
+        (repo / "new.txt").write_text("content\n")
+        _git(["add", "new.txt"], repo)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["commit", "-m", "cli commit", "--repo-path", str(repo)])
+
+        assert result.exit_code == 0, result.output
+        assert _log_message(repo) == "cli commit"
+
+    def test_gr2_commit_nothing_staged_exits_nonzero_with_clear_message(self, repo: Path) -> None:
+        from typer.testing import CliRunner
+
+        from gr2.python_cli.app import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["commit", "-m", "nothing", "--repo-path", str(repo)])
+
+        assert result.exit_code != 0
+        assert "nothing" in result.output.lower()
+
+    def test_gr2_commit_defaults_to_cwd_repo_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from typer.testing import CliRunner
+
+        from gr2.python_cli.app import app
+
+        repo_a = tmp_path / "a"
+        repo_b = tmp_path / "b"
+        _init_repo(repo_a)
+        _init_repo(repo_b)
+        (repo_a / "new.txt").write_text("content\n")
+        _git(["add", "new.txt"], repo_a)
+        (repo_b / "new.txt").write_text("content\n")
+        _git(["add", "new.txt"], repo_b)
+        monkeypatch.chdir(repo_a)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["commit", "-m", "scoped commit"])
+
+        assert result.exit_code == 0, result.output
+        assert _commit_count(repo_a) == 2
+        assert _commit_count(repo_b) == 1  # untouched -- no gripspace-wide sweep

--- a/gr2/tests/test_push.py
+++ b/gr2/tests/test_push.py
@@ -1,0 +1,152 @@
+"""TDD failing tests: native `gr2 push` command (grip#752 slice 1 follow-up, D3).
+
+This is the verb that started the scope-default investigation: `gr push`
+(gr1) operates gripspace-wide by default with no --repo scoping (grip#755),
+which is what led to Opus's steer -- and from there, to making cwd-repo
+scope the consistent default across all four verbs, not just push.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_bare_remote(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "--bare", "-b", "main"], path)
+
+
+def _init_repo_with_remote(path: Path, remote: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-b", "main"], path)
+    _git(["config", "user.name", "Test"], path)
+    _git(["config", "user.email", "test@example.com"], path)
+    _git(["remote", "add", "origin", str(remote)], path)
+    (path / "README.md").write_text("# test\n")
+    _git(["add", "README.md"], path)
+    _git(["commit", "-m", "initial"], path)
+
+
+def _remote_log(remote: Path, ref: str = "main") -> str:
+    return _git(["log", "-1", "--format=%H", ref], remote).stdout.strip()
+
+
+def _local_log(repo: Path, ref: str = "HEAD") -> str:
+    return _git(["log", "-1", "--format=%H", ref], repo).stdout.strip()
+
+
+@pytest.fixture
+def remote(tmp_path: Path) -> Path:
+    remote_path = tmp_path / "remote.git"
+    _init_bare_remote(remote_path)
+    return remote_path
+
+
+@pytest.fixture
+def repo(tmp_path: Path, remote: Path) -> Path:
+    repo_path = tmp_path / "repo"
+    _init_repo_with_remote(repo_path, remote)
+    return repo_path
+
+
+class TestPush:
+    def test_first_push_on_new_branch_succeeds(self, repo: Path, remote: Path) -> None:
+        from gr2.python_cli.push import push
+
+        result = push(repo, set_upstream=True)
+
+        assert result.pushed is True
+        assert _remote_log(remote) == _local_log(repo)
+
+    def test_nothing_to_push_is_a_clean_skip_not_an_error(self, repo: Path, remote: Path) -> None:
+        from gr2.python_cli.push import push
+
+        push(repo, set_upstream=True)
+        result = push(repo)  # already up to date
+
+        assert result.pushed is False
+        assert result.reason == "nothing to push"
+
+    def test_new_commits_get_pushed(self, repo: Path, remote: Path) -> None:
+        from gr2.python_cli.push import push
+
+        push(repo, set_upstream=True)
+        (repo / "more.txt").write_text("more\n")
+        _git(["add", "more.txt"], repo)
+        _git(["commit", "-m", "more work"], repo)
+
+        result = push(repo)
+
+        assert result.pushed is True
+        assert _remote_log(remote) == _local_log(repo)
+
+    def test_diverged_history_fails_without_force(self, repo: Path, remote: Path) -> None:
+        from gr2.python_cli.push import PushError, push
+
+        push(repo, set_upstream=True)
+        # Rewrite local history so it diverges from what's on the remote.
+        _git(["commit", "--amend", "-m", "rewritten"], repo)
+
+        with pytest.raises(PushError):
+            push(repo)
+
+        assert _remote_log(remote) != _local_log(repo)
+
+    def test_force_push_overwrites_diverged_remote(self, repo: Path, remote: Path) -> None:
+        from gr2.python_cli.push import push
+
+        push(repo, set_upstream=True)
+        _git(["commit", "--amend", "-m", "rewritten"], repo)
+
+        result = push(repo, force=True)
+
+        assert result.pushed is True
+        assert _remote_log(remote) == _local_log(repo)
+
+
+class TestPushCLI:
+    def test_gr2_push_via_cli(self, repo: Path, remote: Path) -> None:
+        from typer.testing import CliRunner
+
+        from gr2.python_cli.app import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["push", "--set-upstream", "--repo-path", str(repo)])
+
+        assert result.exit_code == 0, result.output
+        assert _remote_log(remote) == _local_log(repo)
+
+    def test_gr2_push_defaults_to_cwd_repo_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The finding that started it all (grip#755), now an executable
+        negative: gr2 push touches only the cwd repo, never a second one
+        sitting right next to it."""
+        from typer.testing import CliRunner
+
+        from gr2.python_cli.app import app
+
+        remote_a = tmp_path / "remote-a.git"
+        remote_b = tmp_path / "remote-b.git"
+        _init_bare_remote(remote_a)
+        _init_bare_remote(remote_b)
+        repo_a = tmp_path / "a"
+        repo_b = tmp_path / "b"
+        _init_repo_with_remote(repo_a, remote_a)
+        _init_repo_with_remote(repo_b, remote_b)
+        monkeypatch.chdir(repo_a)
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["push", "--set-upstream"])
+
+        assert result.exit_code == 0, result.output
+        assert _remote_log(remote_a) == _local_log(repo_a)
+        with pytest.raises(subprocess.CalledProcessError):
+            _remote_log(remote_b)  # empty bare repo -- "main" ref never pushed, never existed


### PR DESCRIPTION
## Summary

TDD spec completing D3 slice 1's remaining daily verbs (branch already merged in #757/#761). Ref #752 (partial -- slice 1 complete once this and its implementation land).

20 tests, all fail correctly right now: `ModuleNotFoundError` on `gr2.python_cli.{add,commit,push}`, "No such command" for each new CLI verb. Full suite otherwise unaffected -- 511 pre-existing tests untouched, these 20 are net-new red.

## add -- grip#754's root cause, structurally eliminated

gr1's `add` stages files via multi-repo path attribution (a gripspace-relative path has to be matched to the right repo before `git add` ever runs), and blanket-treats any stderr containing "did not match any files" as "not in this repo" -- which is what fired on a genuinely valid, real, untracked file (reproduced twice, different sessions, identical wording). gr2's cwd-repo-scope default removes the attribution step entirely: with exactly one target repo, "is this path in this repo" is answered by checking the path resolves under repo root, not by parsing git's stderr text. A path that really doesn't exist gets reported precisely (`missing`); anything else that makes `git add` fail is a real error (`AddError`), never a silent skip.

## commit

Mirrors gr1's `has_staged_changes` + `create_commit` shape closely -- nothing staged raises clearly (`CommitError`) rather than silently no-op'ing, `--amend` keeps a single commit and updates the message.

## push

Mirrors gr1's `has_commits_to_push` heuristic, simplified for a single-repo target: no remote-tracking branch yet -> attempt the push (git itself reports "up to date" gracefully if there's truly nothing to push -- the right default for gr2's simpler single-repo model, vs. gr1's manifest-aware default-branch resolution which gr2 doesn't have or need); remote-tracking branch exists -> compare ahead/behind, skip cleanly if not ahead; diverged history fails without `--force` (`PushError`), succeeds with it.

`test_gr2_push_defaults_to_cwd_repo_scope` is grip#755's finding as an executable negative -- the bug that started this whole scope-default investigation, now permanently guarded against regressing.

## Consistency

All three verbs wired as `--repo-path` (not `--repo`, per Opus's #757 review) with cwd-repo-scope default, matching `branch` and the now-ratified gr2 product canon (one mental model across all four daily verbs).

## Premium boundary

OSS (grip is OSS; CLI daily-verb orchestration -- no identity/org semantics).

## Reviewers

@Opus + Atlas, same pair for continuity across this slice.