### PR TITLE
fix: require explicit scope before gr pr edit/review/merge touch multiple repos

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -745,6 +745,9 @@ pub enum PrCommands {
         /// Skip confirmation prompt (used with --force)
         #[arg(short = 'y', long)]
         yes: bool,
+        /// Proceed even though multiple repos have a matching open PR (without --repo)
+        #[arg(long)]
+        all: bool,
     },
     /// Edit pull request title/body
     Edit {
@@ -754,6 +757,12 @@ pub enum PrCommands {
         /// New PR body/description
         #[arg(short, long)]
         body: Option<String>,
+        /// Only edit PRs for specific repos (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        repo: Option<Vec<String>>,
+        /// Proceed even though multiple repos have a matching open PR (without --repo)
+        #[arg(long)]
+        all: bool,
     },
     /// Check CI status
     Checks {
@@ -795,6 +804,12 @@ pub enum PrCommands {
         /// Review comment body (required for comment and request-changes)
         #[arg(short, long)]
         body: Option<String>,
+        /// Only review PRs for specific repos (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        repo: Option<Vec<String>>,
+        /// Proceed even though multiple repos have a matching open PR (without --repo)
+        #[arg(long)]
+        all: bool,
     },
 }
 

--- a/src/cli/commands/pr/edit.rs
+++ b/src/cli/commands/pr/edit.rs
@@ -2,10 +2,22 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
-use crate::core::repo::{get_manifest_repo_info, RepoInfo};
+use crate::core::repo::{
+    filter_repos, get_manifest_repo_info, require_explicit_multi_repo_scope,
+    validate_repo_filters_known,
+};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::get_platform_adapter;
 use std::path::Path;
+use std::sync::Arc;
+
+struct PRToEdit {
+    repo_name: String,
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    platform: Arc<dyn crate::platform::HostingPlatform>,
+}
 
 /// Run the PR edit command — update title and/or body across linked PRs
 pub async fn run_pr_edit(
@@ -13,40 +25,40 @@ pub async fn run_pr_edit(
     manifest: &Manifest,
     title: Option<&str>,
     body: Option<&str>,
+    repo_filter: Option<&[String]>,
+    allow_all: bool,
     json: bool,
 ) -> anyhow::Result<()> {
     if title.is_none() && body.is_none() {
         anyhow::bail!("At least one of --title or --body must be provided");
     }
 
+    validate_repo_filters_known(manifest, repo_filter)?;
+
     if !json {
         Output::header("Editing pull requests...");
         println!();
     }
 
-    let repos: Vec<RepoInfo> = manifest
-        .repos
-        .iter()
-        .filter_map(|(name, config)| {
-            RepoInfo::from_config(
-                name,
-                config,
-                workspace_root,
-                &manifest.settings,
-                manifest.remotes.as_ref(),
-            )
-        })
-        .filter(|r| !r.reference)
-        .collect();
+    let repos = filter_repos(manifest, workspace_root, repo_filter, None, false);
 
     let mut all_repos = repos;
-    if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
-        all_repos.push(manifest_repo);
+    let manifest_included = match repo_filter {
+        Some(filter) => filter.iter().any(|f| f == "manifest"),
+        None => true,
+    };
+    if manifest_included {
+        if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
+            all_repos.push(manifest_repo);
+        }
     }
 
-    let mut updated = 0u32;
+    // First pass: find which repos actually have a matching open PR, without
+    // editing anything yet. "N repos matched" only becomes safe to act on after
+    // the multi-repo scope guard below has had a chance to refuse it.
+    let mut prs_to_edit: Vec<PRToEdit> = Vec::new();
     let mut skipped = 0u32;
-    let mut errors = Vec::new();
+    let mut find_errors = Vec::new();
 
     for repo in &all_repos {
         if !path_exists(&repo.absolute_path) {
@@ -75,29 +87,13 @@ pub async fn run_pr_edit(
             .await
         {
             Ok(Some(pr)) => {
-                match platform
-                    .update_pull_request(&repo.owner, &repo.repo, pr.number, title, body)
-                    .await
-                {
-                    Ok(()) => {
-                        if !json {
-                            Output::success(&format!(
-                                "{}: updated PR #{} on {}/{}",
-                                repo.name, pr.number, repo.owner, repo.repo
-                            ));
-                        }
-                        updated += 1;
-                    }
-                    Err(e) => {
-                        if !json {
-                            Output::error(&format!(
-                                "{}: failed to update PR #{}: {}",
-                                repo.name, pr.number, e
-                            ));
-                        }
-                        errors.push(format!("{}: {}", repo.name, e));
-                    }
-                }
+                prs_to_edit.push(PRToEdit {
+                    repo_name: repo.name.clone(),
+                    owner: repo.owner.clone(),
+                    repo: repo.repo.clone(),
+                    pr_number: pr.number,
+                    platform,
+                });
             }
             Ok(None) => {
                 if !json {
@@ -112,7 +108,50 @@ pub async fn run_pr_edit(
                 if !json {
                     Output::error(&format!("{}: {}", repo.name, e));
                 }
-                errors.push(format!("{}: {}", repo.name, e));
+                find_errors.push(format!("{}: {}", repo.name, e));
+            }
+        }
+    }
+
+    require_explicit_multi_repo_scope(
+        &prs_to_edit,
+        repo_filter.is_some(),
+        allow_all,
+        "gr pr edit",
+        |pr| {
+            format!(
+                "{} PR #{} on {}/{}",
+                pr.repo_name, pr.pr_number, pr.owner, pr.repo
+            )
+        },
+    )?;
+
+    let mut updated = 0u32;
+    let mut errors = find_errors;
+
+    for pr in &prs_to_edit {
+        match pr
+            .platform
+            .update_pull_request(&pr.owner, &pr.repo, pr.pr_number, title, body)
+            .await
+        {
+            Ok(()) => {
+                if !json {
+                    Output::success(&format!(
+                        "{}: updated PR #{} on {}/{}",
+                        pr.repo_name, pr.pr_number, pr.owner, pr.repo
+                    ));
+                }
+                updated += 1;
+            }
+            Err(e) => {
+                if !json {
+                    Output::error(&format!(
+                        "{}: failed to update PR #{}: {}",
+                        pr.repo_name, pr.pr_number, e
+                    ));
+                }
+                errors.push(format!("{}: {}", pr.repo_name, e));
             }
         }
     }

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -3,7 +3,7 @@
 use super::create::has_commits_ahead;
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
-use crate::core::repo::{get_manifest_repo_info, RepoInfo};
+use crate::core::repo::{get_manifest_repo_info, require_explicit_multi_repo_scope, RepoInfo};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::traits::{HostingPlatform, PlatformError};
 use crate::platform::{get_platform_adapter, CheckState, MergeMethod};
@@ -49,6 +49,7 @@ pub struct MergeOptions<'a> {
     pub delete_branch: bool,
     pub repo_filter: Option<Vec<String>>,
     pub yes: bool,
+    pub allow_all: bool,
 }
 
 /// Run the PR merge command
@@ -235,6 +236,22 @@ pub async fn run_pr_merge(
         println!("Repositories checked: {}", all_repos.len());
         return Ok(());
     }
+
+    // Same guard as `gr pr edit`/`gr pr review`: an unscoped multi-repo match is
+    // ambiguous, not consent. --repo already narrows opts.repo_filter above; --all
+    // is the explicit opt-in when the caller genuinely wants every matched repo.
+    require_explicit_multi_repo_scope(
+        &prs_to_merge,
+        opts.repo_filter.is_some(),
+        opts.allow_all,
+        "gr pr merge",
+        |pr| {
+            format!(
+                "{} PR #{} on {}/{}",
+                pr.repo_name, pr.pr_number, pr.owner, pr.repo
+            )
+        },
+    )?;
 
     // Show which repos have PRs and which don't
     let repos_with_prs: Vec<String> = prs_to_merge.iter().map(|p| p.repo_name.clone()).collect();

--- a/src/cli/commands/pr/review.rs
+++ b/src/cli/commands/pr/review.rs
@@ -2,11 +2,23 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
-use crate::core::repo::{get_manifest_repo_info, RepoInfo};
+use crate::core::repo::{
+    filter_repos, get_manifest_repo_info, require_explicit_multi_repo_scope,
+    validate_repo_filters_known,
+};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::get_platform_adapter;
 use crate::platform::ReviewEvent;
 use std::path::Path;
+use std::sync::Arc;
+
+struct PRToReview {
+    repo_name: String,
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    platform: Arc<dyn crate::platform::HostingPlatform>,
+}
 
 /// Run the PR review command — post a review on PRs across linked repos
 pub async fn run_pr_review(
@@ -14,11 +26,15 @@ pub async fn run_pr_review(
     manifest: &Manifest,
     event: ReviewEvent,
     body: Option<&str>,
+    repo_filter: Option<&[String]>,
+    allow_all: bool,
     json: bool,
 ) -> anyhow::Result<()> {
     if matches!(event, ReviewEvent::RequestChanges | ReviewEvent::Comment) && body.is_none() {
         anyhow::bail!("--body is required for comment and request-changes reviews");
     }
+
+    validate_repo_filters_known(manifest, repo_filter)?;
 
     if !json {
         let action = match event {
@@ -30,29 +46,24 @@ pub async fn run_pr_review(
         println!();
     }
 
-    let repos: Vec<RepoInfo> = manifest
-        .repos
-        .iter()
-        .filter_map(|(name, config)| {
-            RepoInfo::from_config(
-                name,
-                config,
-                workspace_root,
-                &manifest.settings,
-                manifest.remotes.as_ref(),
-            )
-        })
-        .filter(|r| !r.reference)
-        .collect();
+    let repos = filter_repos(manifest, workspace_root, repo_filter, None, false);
 
     let mut all_repos = repos;
-    if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
-        all_repos.push(manifest_repo);
+    let manifest_included = match repo_filter {
+        Some(filter) => filter.iter().any(|f| f == "manifest"),
+        None => true,
+    };
+    if manifest_included {
+        if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
+            all_repos.push(manifest_repo);
+        }
     }
 
-    let mut reviewed = 0u32;
+    // First pass: find which repos actually have a matching open PR, without
+    // reviewing anything yet -- same reasoning as run_pr_edit's find/act split.
+    let mut prs_to_review: Vec<PRToReview> = Vec::new();
     let mut skipped = 0u32;
-    let mut errors = Vec::new();
+    let mut find_errors = Vec::new();
 
     for repo in &all_repos {
         if !path_exists(&repo.absolute_path) {
@@ -81,27 +92,13 @@ pub async fn run_pr_review(
             .await
         {
             Ok(Some(pr)) => {
-                let spinner =
-                    Output::spinner(&format!("Reviewing {} PR #{}...", repo.name, pr.number));
-                match platform
-                    .create_pull_request_review(&repo.owner, &repo.repo, pr.number, event, body)
-                    .await
-                {
-                    Ok(()) => {
-                        spinner.finish_with_message(format!(
-                            "{}: reviewed PR #{} on {}/{}",
-                            repo.name, pr.number, repo.owner, repo.repo
-                        ));
-                        reviewed += 1;
-                    }
-                    Err(e) => {
-                        spinner.finish_with_message(format!(
-                            "{}: failed to review PR #{}: {}",
-                            repo.name, pr.number, e
-                        ));
-                        errors.push(format!("{}: {}", repo.name, e));
-                    }
-                }
+                prs_to_review.push(PRToReview {
+                    repo_name: repo.name.clone(),
+                    owner: repo.owner.clone(),
+                    repo: repo.repo.clone(),
+                    pr_number: pr.number,
+                    platform,
+                });
             }
             Ok(None) => {
                 if !json {
@@ -116,7 +113,50 @@ pub async fn run_pr_review(
                 if !json {
                     Output::error(&format!("{}: {}", repo.name, e));
                 }
-                errors.push(format!("{}: {}", repo.name, e));
+                find_errors.push(format!("{}: {}", repo.name, e));
+            }
+        }
+    }
+
+    require_explicit_multi_repo_scope(
+        &prs_to_review,
+        repo_filter.is_some(),
+        allow_all,
+        "gr pr review",
+        |pr| {
+            format!(
+                "{} PR #{} on {}/{}",
+                pr.repo_name, pr.pr_number, pr.owner, pr.repo
+            )
+        },
+    )?;
+
+    let mut reviewed = 0u32;
+    let mut errors = find_errors;
+
+    for pr in &prs_to_review {
+        let spinner = Output::spinner(&format!(
+            "Reviewing {} PR #{}...",
+            pr.repo_name, pr.pr_number
+        ));
+        match pr
+            .platform
+            .create_pull_request_review(&pr.owner, &pr.repo, pr.pr_number, event, body)
+            .await
+        {
+            Ok(()) => {
+                spinner.finish_with_message(format!(
+                    "{}: reviewed PR #{} on {}/{}",
+                    pr.repo_name, pr.pr_number, pr.owner, pr.repo
+                ));
+                reviewed += 1;
+            }
+            Err(e) => {
+                spinner.finish_with_message(format!(
+                    "{}: failed to review PR #{}: {}",
+                    pr.repo_name, pr.pr_number, e
+                ));
+                errors.push(format!("{}: {}", pr.repo_name, e));
             }
         }
     }

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -632,6 +632,7 @@ pub async fn run_release(opts: ReleaseOptions<'_>) -> anyhow::Result<()> {
                     delete_branch: true,
                     repo_filter: None,
                     yes: false,
+                    allow_all: false,
                 },
             )
             .await?;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -302,6 +302,7 @@ pub async fn dispatch_command(
                     no_delete_branch,
                     repo,
                     yes,
+                    all,
                 } => {
                     crate::cli::commands::pr::run_pr_merge(
                         &ctx.workspace_root,
@@ -317,16 +318,24 @@ pub async fn dispatch_command(
                             delete_branch: !no_delete_branch,
                             repo_filter: repo,
                             yes,
+                            allow_all: all,
                         },
                     )
                     .await?;
                 }
-                PrCommands::Edit { title, body } => {
+                PrCommands::Edit {
+                    title,
+                    body,
+                    repo,
+                    all,
+                } => {
                     crate::cli::commands::pr::run_pr_edit(
                         &ctx.workspace_root,
                         &ctx.manifest,
                         title.as_deref(),
                         body.as_deref(),
+                        repo.as_deref(),
+                        all,
                         ctx.json,
                     )
                     .await?;
@@ -367,12 +376,19 @@ pub async fn dispatch_command(
                     )
                     .await?;
                 }
-                PrCommands::Review { event, body } => {
+                PrCommands::Review {
+                    event,
+                    body,
+                    repo,
+                    all,
+                } => {
                     crate::cli::commands::pr::run_pr_review(
                         &ctx.workspace_root,
                         &ctx.manifest,
                         event,
                         body.as_deref(),
+                        repo.as_deref(),
+                        all,
                         ctx.json,
                     )
                     .await?;

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -301,6 +301,75 @@ pub fn filter_repos(
         .collect()
 }
 
+/// Validate repo filters before command execution so repo-scoped commands do not
+/// silently no-op when the local manifest is stale.
+pub fn validate_repo_filters_known(
+    manifest: &Manifest,
+    repos_filter: Option<&[String]>,
+) -> anyhow::Result<()> {
+    let Some(filters) = repos_filter else {
+        return Ok(());
+    };
+
+    let missing: Vec<&String> = filters
+        .iter()
+        .filter(|name| name.as_str() != "manifest" && !manifest.repos.contains_key(*name))
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let names = missing
+        .iter()
+        .map(|name| format!("'{}'", name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    anyhow::bail!(
+        "repo filter {} not found in local manifest. If it was added upstream, run `gr sync --repo manifest` or plain `gr sync` first, then retry.",
+        names
+    );
+}
+
+/// Refuse an unscoped multi-repo `gr pr <verb>` action rather than silently fan out.
+///
+/// `gr pr edit`/`review`/`merge` act on whichever repos currently have a matching open
+/// PR for their checked-out branch — a much weaker signal of intent than the
+/// diff/status-driven scoping the rest of `gr` uses. A repo's checked-out branch can be
+/// a stale, forgotten one from unrelated past work, so "N repos matched" is not the
+/// same thing as "the user meant N repos." When the caller did not explicitly scope
+/// via `--repo` and more than one repo matched, this is the ambiguous case that has
+/// twice caused real incidents (grip#770, grip#771): a body meant for one PR landing on
+/// someone else's unrelated one. Fail closed and list exactly what would have been
+/// touched, so the caller can either scope precisely with `--repo` or opt into the
+/// full list explicitly with `--all` — never guess silently.
+pub fn require_explicit_multi_repo_scope<T>(
+    matched: &[T],
+    repo_filter_given: bool,
+    allow_all: bool,
+    verb: &str,
+    describe: impl Fn(&T) -> String,
+) -> anyhow::Result<()> {
+    if matched.len() <= 1 || repo_filter_given || allow_all {
+        return Ok(());
+    }
+
+    let listing = matched
+        .iter()
+        .map(|m| format!("  - {}", describe(m)))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    anyhow::bail!(
+        "{} would touch {} repos with a matching branch/PR, but no --repo was given:\n{}\n\n\
+         Pass --repo <name>[,<name>...] to scope this explicitly, or --all to proceed \
+         with every repo listed above.",
+        verb,
+        matched.len(),
+        listing
+    );
+}
+
 /// Get RepoInfo for the manifest repo if it exists.
 ///
 /// This provides a standardized way to include the manifest repository
@@ -1118,5 +1187,56 @@ repos:
         assert_eq!(info.target_branch(), "main");
         assert_eq!(info.sync_remote, "origin");
         assert_eq!(info.push_remote, "origin");
+    }
+
+    #[test]
+    fn test_multi_repo_scope_guard_allows_zero_or_one_match_unconditionally() {
+        let none: Vec<&str> = vec![];
+        assert!(
+            require_explicit_multi_repo_scope(&none, false, false, "edit", |s| s.to_string())
+                .is_ok()
+        );
+
+        let one = vec!["repo-a"];
+        assert!(
+            require_explicit_multi_repo_scope(&one, false, false, "edit", |s| s.to_string())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_multi_repo_scope_guard_bails_on_unscoped_multi_match() {
+        // Mutation-intent guard: grip#770/grip#771 were both an unscoped multi-repo
+        // action silently succeeding. This must go RED under the pre-fix condition
+        // (no --repo, no --all, >1 match) and lists every affected repo by name so
+        // the caller can actually act on the guidance.
+        let matched = vec!["research", "recall"];
+        let err =
+            require_explicit_multi_repo_scope(&matched, false, false, "edit", |s| s.to_string())
+                .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("research"));
+        assert!(message.contains("recall"));
+        assert!(message.contains("--repo"));
+        assert!(message.contains("--all"));
+        assert!(message.contains("edit"));
+    }
+
+    #[test]
+    fn test_multi_repo_scope_guard_allows_explicit_repo_filter() {
+        let matched = vec!["research", "recall"];
+        assert!(
+            require_explicit_multi_repo_scope(&matched, true, false, "edit", |s| s.to_string())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_multi_repo_scope_guard_allows_explicit_all_flag() {
+        let matched = vec!["research", "recall"];
+        assert!(
+            require_explicit_multi_repo_scope(&matched, false, true, "edit", |s| s.to_string())
+                .is_ok()
+        );
     }
 }

--- a/tests/common/mock_platform.rs
+++ b/tests/common/mock_platform.rs
@@ -507,6 +507,17 @@ pub async fn mock_check_runs(
         .await;
 }
 
+/// GitHub API response for updating a PR (PATCH /repos/:owner/:repo/pulls/:number).
+pub async fn mock_update_pull_request(server: &MockServer, number: u64) {
+    let body = github_pr_json(number, "open", "feat/test", "main", false, "");
+
+    Mock::given(method("PATCH"))
+        .and(path(format!("/repos/owner/repo/pulls/{}", number)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
 /// GitHub API response for PR diff (GET /repos/:owner/:repo/pulls/:number with Accept: diff).
 pub async fn mock_pr_diff(server: &MockServer, number: u64, diff_content: &str) {
     Mock::given(method("GET"))
@@ -603,6 +614,24 @@ pub async fn mock_server_error_put(server: &MockServer, path_str: &str) {
         .respond_with(ResponseTemplate::new(500).set_body_json(body))
         .mount(server)
         .await;
+}
+
+/// Point one repo in a loaded manifest at the mock GitHub server, using the
+/// fake "owner/repo" identity every mock helper in this file is hardcoded to
+/// (see the module doc comment). Shared across the pr-command test files
+/// (edit/review/merge) since each needs this same rewrite for every repo
+/// they add to a `WorkspaceBuilder` workspace.
+pub fn point_repo_at_mock(
+    manifest: &mut gitgrip::core::manifest::Manifest,
+    repo_name: &str,
+    server: &MockServer,
+) {
+    let repo_config = manifest.repos.get_mut(repo_name).unwrap();
+    repo_config.url = Some("https://github.com/owner/repo.git".to_string());
+    repo_config.platform = Some(gitgrip::core::manifest::PlatformConfig {
+        platform_type: gitgrip::core::manifest::PlatformType::GitHub,
+        base_url: Some(server.uri()),
+    });
 }
 
 /// Mock a GitHub repo info response (GET /repos/:owner/:repo).

--- a/tests/test_pr_edit.rs
+++ b/tests/test_pr_edit.rs
@@ -1,0 +1,125 @@
+//! Command-orchestration regression for `gr pr edit`'s multi-repo scope guard
+//! (grip#771, grip#773).
+//!
+//! Same reasoning as `test_pr_review.rs`: the committed guard-unit tests all
+//! call `require_explicit_multi_repo_scope` directly, so nothing in the
+//! original suite would notice the guard's call-site being removed from
+//! `run_pr_edit`'s own body. These tests exercise `run_pr_edit` end to end
+//! and assert on the wiremock server's received-request log.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use common::git_helpers;
+use common::mock_platform::{
+    mock_list_prs, mock_update_pull_request, point_repo_at_mock, setup_github_mock,
+};
+use wiremock::http::Method;
+
+// ── grip#771 exact shape: unrelated repo, unscoped edit, zero PATCHes ─────
+
+#[tokio::test]
+async fn test_pr_edit_unscoped_multi_match_sends_zero_update_patches() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("research")
+        .add_repo("recall")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["research", "recall"] {
+        git_helpers::create_branch(
+            &ws.repo_path(repo_name),
+            "test/a7-b3-corroborate-content-discard",
+        );
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(
+        &server,
+        vec![(892, "test/a7-b3-corroborate-content-discard")],
+    )
+    .await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_edit(
+        &ws.workspace_root,
+        &manifest,
+        Some("a title meant for exactly one PR"),
+        Some("a body meant for exactly one PR"),
+        None,  // no --repo
+        false, // no --all
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "unscoped 2-repo match must be refused, not silently edited"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let update_patches: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method == Method::PATCH && r.url.path().contains("/pulls/"))
+        .collect();
+    assert!(
+        update_patches.is_empty(),
+        "expected zero PR-update PATCHes, got {}: {:?}",
+        update_patches.len(),
+        update_patches
+            .iter()
+            .map(|r| r.url.path())
+            .collect::<Vec<_>>()
+    );
+}
+
+// ── --repo explicitly scopes past the guard, edit proceeds normally ───────
+
+#[tokio::test]
+async fn test_pr_edit_explicit_repo_filter_proceeds_and_patches() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["frontend", "backend"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "feat/test");
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(1, "feat/test")]).await;
+    mock_update_pull_request(&server, 1).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_edit(
+        &ws.workspace_root,
+        &manifest,
+        Some("scoped title"),
+        Some("scoped body"),
+        Some(&["frontend".to_string()]), // explicit --repo
+        false,
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "explicit --repo scoping a single match should proceed: {:?}",
+        result.err()
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let update_patches = requests
+        .iter()
+        .filter(|r| r.method == Method::PATCH && r.url.path().contains("/pulls/"))
+        .count();
+    assert_eq!(
+        update_patches, 1,
+        "expected exactly one update PATCH once explicitly scoped"
+    );
+}

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -43,6 +43,7 @@ async fn test_pr_merge_no_open_prs() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -94,6 +95,7 @@ async fn test_pr_merge_skip_default_branch() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -139,6 +141,7 @@ async fn test_pr_merge_skip_reference_repos() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -183,6 +186,7 @@ async fn test_pr_merge_mixed_repos_all_skipped() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -246,6 +250,7 @@ async fn test_pr_merge_force_bypasses_checks() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -315,6 +320,7 @@ async fn test_pr_merge_branch_behind_suggests_update() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -393,6 +399,7 @@ async fn test_pr_merge_repo_filter_excludes_non_target() {
             delete_branch: true,
             repo_filter: Some(vec!["frontend".to_string()]),
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -443,6 +450,7 @@ async fn test_pr_merge_repo_filter_no_match_finds_no_prs() {
             delete_branch: true,
             repo_filter: Some(vec!["nonexistent".to_string()]),
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -500,6 +508,7 @@ async fn test_pr_merge_force_yes_merges_without_prompt() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -10,7 +10,7 @@ use common::fixtures::WorkspaceBuilder;
 use common::git_helpers;
 use common::mock_platform::{
     mock_check_runs, mock_get_pr, mock_list_prs, mock_merge_pr, mock_merge_pr_behind,
-    mock_pr_reviews, setup_github_mock,
+    mock_pr_reviews, point_repo_at_mock, setup_github_mock,
 };
 use gitgrip::core::manifest::{PlatformConfig, PlatformType};
 use wiremock::http::Method;
@@ -529,4 +529,139 @@ async fn test_pr_merge_all_or_nothing_stops_on_failure() {
     // 3. Mock first repo's merge to fail
     // 4. Verify second repo's merge is never called
     // 5. Verify error message mentions all-or-nothing
+}
+
+// ── Command-orchestration regression for the multi-repo scope guard ────────
+// (grip#770/grip#771/grip#773, Sentinel reviewer-2 finding on c650a85): the
+// committed guard-unit tests all call require_explicit_multi_repo_scope
+// directly, so nothing in the original suite would notice the guard's
+// call-site being removed from run_pr_merge's own body. This exercises
+// run_pr_merge end to end and asserts on the wiremock server's received-
+// request log -- the guard must fire before any merge PUT is sent.
+
+#[tokio::test]
+async fn test_pr_merge_unscoped_multi_match_sends_zero_merge_puts() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["frontend", "backend"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "feat/shared-name");
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(1, "feat/shared-name")]).await;
+    mock_get_pr(&server, 1, "open", false).await;
+    mock_pr_reviews(&server, 1, vec![("APPROVED", "alice")]).await;
+    mock_check_runs(
+        &server,
+        "feat/shared-name",
+        vec![("CI", "completed", Some("success"))],
+    )
+    .await;
+    mock_merge_pr(&server, 1, true).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: None, // no --repo
+            yes: true,
+            allow_all: false, // no --all
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "unscoped 2-repo match must be refused, not silently merged"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let merge_puts: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method == Method::PUT && r.url.path().ends_with("/merge"))
+        .collect();
+    assert!(
+        merge_puts.is_empty(),
+        "expected zero merge PUTs, got {}: {:?}",
+        merge_puts.len(),
+        merge_puts.iter().map(|r| r.url.path()).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_pr_merge_all_flag_proceeds_and_merges_every_match() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["frontend", "backend"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "feat/shared-name");
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(1, "feat/shared-name")]).await;
+    mock_get_pr(&server, 1, "open", false).await;
+    mock_pr_reviews(&server, 1, vec![("APPROVED", "alice")]).await;
+    mock_check_runs(
+        &server,
+        "feat/shared-name",
+        vec![("CI", "completed", Some("success"))],
+    )
+    .await;
+    mock_merge_pr(&server, 1, true).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: None,
+            yes: true,
+            allow_all: true, // explicit opt-in
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "--all should proceed past the guard on a genuine multi-match: {:?}",
+        result.err()
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let merge_puts = requests
+        .iter()
+        .filter(|r| r.method == Method::PUT && r.url.path().ends_with("/merge"))
+        .count();
+    assert_eq!(
+        merge_puts, 2,
+        "expected a merge PUT for each of the two --all-confirmed repos"
+    );
 }

--- a/tests/test_pr_review.rs
+++ b/tests/test_pr_review.rs
@@ -1,0 +1,188 @@
+//! Command-orchestration regression for `gr pr review`'s multi-repo scope
+//! guard (grip#770, grip#773).
+//!
+//! Sentinel's reviewer-2 finding on grip#773 (c650a85): the committed guard
+//! tests all called `require_explicit_multi_repo_scope` directly, so nothing
+//! in the suite would notice if the guard's call-site inside
+//! `run_pr_review`'s own body were ever removed — the pure helper would stay
+//! green while the real command silently regained the grip#770 cross-post
+//! behavior. These tests exercise `run_pr_review` itself, end to end, and
+//! assert on the wiremock server's received-request log: the guard must fire
+//! BEFORE any review POST is sent, not just return the right Rust `Result`.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use common::git_helpers;
+use common::mock_platform::{mock_list_prs, point_repo_at_mock, setup_github_mock};
+use gitgrip::platform::ReviewEvent;
+use wiremock::http::Method;
+
+// `find_pr_by_branch`'s mock (`mock_list_prs`) doesn't filter by query string
+// -- every repo's lookup resolves to the same first PR in the mocked list,
+// which is sufficient to prove the "N repos matched" shape this guard cares
+// about; it doesn't require each repo to resolve to a distinct real PR.
+
+// ── grip#770 exact shape: three repos, unscoped review, zero POSTs ────────
+
+#[tokio::test]
+async fn test_pr_review_unscoped_multi_match_sends_zero_review_posts() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("consult-conversa-config")
+        .add_repo("premium")
+        .add_repo("recall")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["consult-conversa-config", "premium", "recall"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "sentinel/d5-gr1-bug-five");
+        git_helpers::commit_file(
+            &ws.repo_path(repo_name),
+            "feature.txt",
+            "feature",
+            "Add feature",
+        );
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(892, "sentinel/d5-gr1-bug-five")]).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_review(
+        &ws.workspace_root,
+        &manifest,
+        ReviewEvent::Comment,
+        Some("a body meant for exactly one PR"),
+        None,  // no --repo
+        false, // no --all
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "unscoped 3-repo match must be refused, not silently reviewed"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let review_posts: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method == Method::POST && r.url.path().ends_with("/reviews"))
+        .collect();
+    assert!(
+        review_posts.is_empty(),
+        "expected zero review POSTs, got {}: {:?}",
+        review_posts.len(),
+        review_posts
+            .iter()
+            .map(|r| r.url.path())
+            .collect::<Vec<_>>()
+    );
+}
+
+// ── --repo explicitly scopes past the guard, review proceeds normally ─────
+
+#[tokio::test]
+async fn test_pr_review_explicit_repo_filter_proceeds_and_posts_review() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["frontend", "backend"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "feat/test");
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(1, "feat/test")]).await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path(
+            "/repos/owner/repo/pulls/1/reviews",
+        ))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 1, "state": "COMMENTED"
+            })),
+        )
+        .mount(&server)
+        .await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_review(
+        &ws.workspace_root,
+        &manifest,
+        ReviewEvent::Comment,
+        Some("scoped review body"),
+        Some(&["frontend".to_string()]), // explicit --repo
+        false,
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "explicit --repo scoping a single match should proceed: {:?}",
+        result.err()
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let review_posts = requests
+        .iter()
+        .filter(|r| r.method == Method::POST && r.url.path().ends_with("/reviews"))
+        .count();
+    assert_eq!(
+        review_posts, 1,
+        "expected exactly one review POST once explicitly scoped"
+    );
+}
+
+// ── validate_repo_filters_known's command-level loud-fail (Opus, non-blocking) ──
+
+#[tokio::test]
+async fn test_pr_review_unknown_repo_filter_fails_loudly_not_silently() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let mut manifest = ws.load_manifest();
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
+    git_helpers::commit_file(&ws.repo_path("app"), "f.txt", "x", "Add f");
+    point_repo_at_mock(&mut manifest, "app", &server);
+
+    let result = gitgrip::cli::commands::pr::run_pr_review(
+        &ws.workspace_root,
+        &manifest,
+        ReviewEvent::Comment,
+        Some("body"),
+        Some(&["this-repo-does-not-exist".to_string()]),
+        false,
+        false,
+    )
+    .await;
+
+    let err = result.expect_err(
+        "an unknown --repo filter value must fail loudly (validate_repo_filters_known), \
+         not silently resolve to zero matched repos",
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("this-repo-does-not-exist"),
+        "error should name the unknown filter, got: {message}"
+    );
+    assert!(
+        message.contains("gr sync"),
+        "error should carry the sync-guidance validate_repo_filters_known provides, got: {message}"
+    );
+
+    // No API calls should happen at all -- the filter validation runs before
+    // any repo is even inspected for a matching PR.
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.is_empty(),
+        "unknown-filter validation should fail before any API call, got {} requests",
+        requests.len()
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the root cause behind two real incidents this sprint: `gr pr edit` and `gr pr review comment`, run without an explicit `--repo`, silently touched PRs in unrelated repos.

- **grip#771** (mine, 2026-07-17): `gr pr edit` meant for recall#892 instead overwrote research#84's title/body — an unrelated PR on a stranded branch from older work. Recovered byte-for-byte via GitHub's `userContentEdits` history.
- **grip#770** (Sentinel's, 2026-07-17, more severe): `gr pr review comment` meant for recall#892 posted the same review body to consult-conversa-config#6 (a client-facing PR) and premium#737. Required manual body replacement to repair the record.

## Root cause (confirmed in the actual source, not inferred from the incidents)

`run_pr_edit` and `run_pr_review` had **no `--repo` parameter at all** — not a flag the user forgot, a flag that didn't exist. Both iterated every non-reference repo in the manifest, opened each repo's local checkout, read whatever branch happened to be checked out there, and acted on any matching open PR — with zero way to scope the action to one repo.

`gr pr merge` and `gr pr create` *do* have `--repo` (`filter_repos()` in `core/repo.rs`, already shared between them) — but confirmed the same unscoped-by-default behavior when `--repo` is omitted: `filter_repos` defaults to matching every repo (`.unwrap_or(true)`). Verified directly: `gr pr merge` without `--repo` reported `Repositories checked: <N>` across the whole gripspace, exactly the same shape of risk, just with an escape hatch that `edit`/`review` lacked entirely.

The shared defect: a checked-out branch is a much weaker signal of intent than the diff/status-driven scoping the rest of `gr` uses (`gr commit`/`gr push` only touch repos with actual local changes). Every repo always has *some* branch checked out — often a stale, forgotten one from unrelated past work — and "N repos matched" was silently treated as "the user meant N repos."

## Fix

**`require_explicit_multi_repo_scope`** (new, `core/repo.rs`, alongside the existing `filter_repos`/`validate_repo_filters_known`): a small, pure, reusable guard. When more than one repo would be touched and the caller passed neither `--repo` nor `--all`, it bails with the full list of repos + PR numbers that would have been affected, and tells the caller exactly how to proceed (`--repo <name>` to scope, `--all` to confirm the full list). Zero or one match is always allowed unconditionally — no friction added to the common case.

Wired into all three commands that act on existing PRs:

- **`edit.rs`** — added `--repo`/`--all`, wired to the shared `filter_repos()` (matching `create.rs`/`merge.rs`'s existing pattern instead of the hand-rolled filter chain it had), restructured into a find-pass (collect matches, act on nothing yet) then the guard then an act-pass.
- **`review.rs`** — identical shape of fix.
- **`merge.rs`** — already had `--repo`; added `--all` and the guard call right after `prs_to_merge` is built, before any merge action. This is a distinct concern from the existing `--force`-gated confirmation prompt (which protects against bypassing readiness checks) — left that logic untouched, it still fires for its own reason even when `--repo`/`--all` already satisfies this guard.

Every fix verified against the shared guard's own unit tests (4 tests: zero/one-match always allowed, unscoped multi-match bails with repo names + `--repo`/`--all` guidance in the message, both explicit-scope escape hatches work) plus the full `test_pr_merge.rs` integration suite (9/9 passing unchanged, confirming the new guard doesn't disturb any single-repo-effective existing test).

## Explicitly out of scope

**`create.rs`** — deliberately not touched. It creates *new* PRs from local branches rather than acting on existing ones; an accidental extra PR opened in an unrelated repo is a different (much lower) severity than silently overwriting or reviewing someone else's PR, and it deserves its own look at whether the same guard even applies cleanly, not a reactive bundle into this pass.

**`gr pr merge --wait` timing out on repos with zero CI checks configured** — a real, separate paper-cut discovered while testing this fix (premium#745's merge waited the full 600s for checks that were never going to appear). Filed as **grip#772**, not bundled here — different root cause (CI-check polling vs. repo-scope defaulting), different fix surface, per explicit instruction not to scope-creep it into this PR.

## Branch note

Created `sprint-41` fresh rather than stacking on `sprint-39` (grip's most recent existing sprint branch). Checked deliberately, not by default: `sprint-39`'s last PR activity was 10 days ago (2026-07-07, all merged, nothing open) — genuinely stale, not a live integration branch. Independently confirmed `sprint-41` is the team's actual current sprint via `recall`'s own most-recent sprint branch and `config`'s own sprint-plan docs (`sprint-41.md`), not just circularly from my own branch creation elsewhere this session.

## Testing

- `cargo build` / `cargo build --tests` — clean.
- `cargo test` — full suite, 1066 passed, 0 failed, 0 unexpected across all 50 test binaries (lib + every integration test file), verified from the complete untruncated log, not a summary claim.
- `cargo clippy --all-targets` — zero warnings in any file this PR touches (confirmed via exact `--> path:line` grep, not just an aggregate scan).
- `cargo fmt --check` — clean.

## Premium boundary

N/A — gitgrip is MIT-licensed OSS workspace tooling, not a premium/OSS boundary decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZMaT1FQJD6rqfN77piMHm