### PR TITLE
fix: gr checkout add produces a self-discoverable child workspace

### DIFF
--- a/src/cli/commands/checkout.rs
+++ b/src/cli/commands/checkout.rs
@@ -143,17 +143,8 @@ pub fn run_checkout_add(
         anyhow::bail!("no repos matched checkout filters");
     }
 
-    let repo_specs: Vec<(&str, &str, &str)> = repos
-        .iter()
-        .map(|repo| (repo.name.as_str(), repo.url.as_str(), repo.path.as_str()))
-        .collect();
-
-    let info = workspace_checkout::create_checkout(
-        workspace_root,
-        checkout_name,
-        repo_specs.into_iter(),
-        None,
-    )?;
+    let info =
+        workspace_checkout::create_checkout(workspace_root, checkout_name, manifest, &repos, None)?;
 
     Output::success(&format!(
         "Created checkout '{}' with {} repo(s)",

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1055,7 +1055,7 @@ fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest
         match crate::core::workspace_checkout::load_checkout_metadata(&search_path) {
             Ok(Some(checkout_info)) => {
                 let manifest =
-                    crate::core::workspace_checkout::manifest_from_checkout(&checkout_info);
+                    crate::core::workspace_checkout::manifest_from_checkout(&checkout_info)?;
                 return Ok((search_path, manifest));
             }
             Ok(None) => {}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1046,11 +1046,25 @@ fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest
             }
         }
 
-        if let Some(checkout_info) =
-            crate::core::workspace_checkout::load_checkout_metadata(&search_path)
-        {
-            let manifest = crate::core::workspace_checkout::manifest_from_checkout(&checkout_info);
-            return Ok((search_path, manifest));
+        // Fail CLOSED, not open: once `.checkout.json` exists at the nearest
+        // boundary, an unreadable/malformed/incomplete marker must stop the
+        // walk here with a clear error, never silently continue climbing to
+        // the parent gripspace (grip#775 round 3 -- that silent continue was
+        // the same cross-scope hazard this PR exists to close, reintroduced
+        // through a corrupted marker instead of a missing one).
+        match crate::core::workspace_checkout::load_checkout_metadata(&search_path) {
+            Ok(Some(checkout_info)) => {
+                let manifest =
+                    crate::core::workspace_checkout::manifest_from_checkout(&checkout_info);
+                return Ok((search_path, manifest));
+            }
+            Ok(None) => {}
+            Err(e) => {
+                return Err(e.context(format!(
+                    "found checkout metadata at {} but it is invalid",
+                    search_path.display()
+                )));
+            }
         }
 
         let gitgrip_dir = search_path.join(".gitgrip");

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1023,19 +1023,73 @@ pub async fn dispatch_command(
     Ok(())
 }
 
-/// Load the gripspace manifest
+/// Load the gripspace manifest.
+///
+/// One unified ancestor walk checking every marker type (griptree pointer,
+/// checkout metadata, gitgrip workspace, legacy manifest, repo-tool manifest)
+/// at each directory level before climbing to the parent. The NEAREST marker
+/// wins, whichever type it is (grip#775: two independent all-ancestors passes
+/// -- griptree-check-everything, then workspace-check-everything -- let a
+/// `.griptree` many levels up eclipse a `.gitgrip` or checkout one level
+/// down, because the griptree pass never stopped climbing to give the nearer
+/// marker a chance).
 fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest::Manifest)> {
     let current = std::env::current_dir()?;
+    let mut search_path = current;
+    loop {
+        let griptree_pointer_path = search_path.join(".griptree");
+        if griptree_pointer_path.exists() {
+            if let Ok(pointer) =
+                crate::core::griptree::GriptreePointer::load(&griptree_pointer_path)
+            {
+                return load_from_griptree(&search_path, &pointer);
+            }
+        }
 
-    // First, check if we're in a griptree (has .griptree pointer file)
-    if let Some((griptree_path, pointer)) =
-        crate::core::griptree::GriptreePointer::find_in_ancestors(&current)
-    {
-        return load_from_griptree(&griptree_path, &pointer);
+        if let Some(checkout_info) =
+            crate::core::workspace_checkout::load_checkout_metadata(&search_path)
+        {
+            let manifest = crate::core::workspace_checkout::manifest_from_checkout(&checkout_info);
+            return Ok((search_path, manifest));
+        }
+
+        let gitgrip_dir = search_path.join(".gitgrip");
+        if gitgrip_dir.exists() {
+            if let Some(manifest_path) =
+                crate::core::manifest_paths::resolve_gripspace_manifest_path(&search_path)
+            {
+                let content = std::fs::read_to_string(&manifest_path)?;
+                let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
+                resolve_gripspace_includes(&mut manifest, &search_path);
+                return Ok((search_path, manifest));
+            }
+        }
+
+        if let Some(repo_yaml) =
+            crate::core::manifest_paths::resolve_repo_manifest_path(&search_path)
+        {
+            let content = std::fs::read_to_string(repo_yaml)?;
+            let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
+            resolve_gripspace_includes(&mut manifest, &search_path);
+            return Ok((search_path, manifest));
+        }
+
+        let repo_xml = search_path.join(".repo").join("manifest.xml");
+        if repo_xml.exists() {
+            let xml_manifest = crate::core::repo_manifest::XmlManifest::parse_file(&repo_xml)?;
+            let result = xml_manifest.to_manifest()?;
+            return Ok((search_path, result.manifest));
+        }
+
+        match search_path.parent() {
+            Some(parent) => search_path = parent.to_path_buf(),
+            None => {
+                anyhow::bail!(
+                    "Not in a gitgrip workspace (no .gitgrip, checkout, griptree, or .repo directory found)"
+                );
+            }
+        }
     }
-
-    // Not in a griptree - search parent directories for workspace root
-    load_from_workspace(&current)
 }
 
 /// Load the gripspace manifest and return a WorkspaceContext with global CLI flags.
@@ -1081,52 +1135,6 @@ fn load_from_griptree(
     let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
     resolve_gripspace_includes(&mut manifest, griptree_path);
     Ok((griptree_path.to_path_buf(), manifest))
-}
-
-/// Search parent directories for a workspace root and load its manifest.
-fn load_from_workspace(
-    start: &std::path::Path,
-) -> anyhow::Result<(std::path::PathBuf, crate::core::manifest::Manifest)> {
-    let mut search_path = start.to_path_buf();
-    loop {
-        // Check for .gitgrip directory with gripspace manifest
-        let gitgrip_dir = search_path.join(".gitgrip");
-        if gitgrip_dir.exists() {
-            if let Some(manifest_path) =
-                crate::core::manifest_paths::resolve_gripspace_manifest_path(&search_path)
-            {
-                let content = std::fs::read_to_string(&manifest_path)?;
-                let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
-                resolve_gripspace_includes(&mut manifest, &search_path);
-                return Ok((search_path, manifest));
-            }
-        }
-
-        // Check for legacy repo.yaml
-        if let Some(repo_yaml) =
-            crate::core::manifest_paths::resolve_repo_manifest_path(&search_path)
-        {
-            let content = std::fs::read_to_string(repo_yaml)?;
-            let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
-            resolve_gripspace_includes(&mut manifest, &search_path);
-            return Ok((search_path, manifest));
-        }
-
-        // Fallback: parse .repo/manifest.xml directly (zero-config — just works)
-        let repo_xml = search_path.join(".repo").join("manifest.xml");
-        if repo_xml.exists() {
-            let xml_manifest = crate::core::repo_manifest::XmlManifest::parse_file(&repo_xml)?;
-            let result = xml_manifest.to_manifest()?;
-            return Ok((search_path, result.manifest));
-        }
-
-        match search_path.parent() {
-            Some(parent) => search_path = parent.to_path_buf(),
-            None => {
-                anyhow::bail!("Not in a gitgrip workspace (no .gitgrip or .repo directory found)");
-            }
-        }
-    }
 }
 
 /// Resolve gripspace includes (merge inherited repos/scripts/env/hooks) if spaces dir exists.

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -10,8 +10,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::core::manifest::{Manifest, PlatformConfig, RepoConfig};
-use crate::core::manifest_paths;
+use crate::core::manifest::{Manifest, ManifestSettings, PlatformConfig, PlatformType, RepoConfig};
 use crate::core::repo::RepoInfo;
 use crate::core::workspace_cache;
 use crate::util::log_cmd;
@@ -19,21 +18,59 @@ use crate::util::log_cmd;
 /// Directory name under .grip/ where checkouts live.
 const CHECKOUTS_DIR: &str = "checkouts";
 
-/// Metadata for a single checkout.
+/// Filename of the per-checkout metadata file, written directly at the
+/// checkout root (never inside a materialized repo's own path -- grip#775's
+/// second blocker: writing a derived manifest into `.gitgrip/spaces/main`
+/// collided with that being the materialized "manifest" pseudo-repo's own
+/// canonical clone location when it was included in the checkout).
+const CHECKOUT_METADATA_FILE: &str = ".checkout.json";
+
+/// Metadata for a single checkout. Carries everything `manifest_from_checkout`
+/// needs to reconstruct a full gripspace `Manifest` in memory -- this file is
+/// the checkout's ONLY self-description; nothing else gets written into any
+/// materialized repo's own directory tree.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckoutInfo {
     pub name: String,
     pub path: PathBuf,
     pub repos: Vec<CheckoutRepo>,
     pub created_at: String,
+    #[serde(default)]
+    pub settings: ManifestSettings,
 }
 
-/// A single repo within a checkout.
+/// A single repo within a checkout, carrying its already-resolved manifest
+/// fields (grip#774/#775) so `manifest_from_checkout` can rebuild a faithful
+/// `RepoConfig` without re-reading anything from the parent gripspace.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckoutRepo {
     pub name: String,
+    /// Absolute materialized path on disk.
     pub path: PathBuf,
     pub branch: Option<String>,
+    #[serde(default)]
+    pub url: String,
+    /// Path relative to the checkout root -- matches `materialize_repo`'s
+    /// clone target exactly, so it doubles as the derived manifest's
+    /// `RepoConfig.path`.
+    #[serde(default)]
+    pub relative_path: String,
+    #[serde(default)]
+    pub revision: String,
+    #[serde(default)]
+    pub target: String,
+    #[serde(default)]
+    pub sync_remote: String,
+    #[serde(default)]
+    pub push_remote: String,
+    #[serde(default)]
+    pub platform_type: PlatformType,
+    #[serde(default)]
+    pub platform_base_url: Option<String>,
+    #[serde(default)]
+    pub reference: bool,
+    #[serde(default)]
+    pub groups: Vec<String>,
 }
 
 /// Resolve the checkout root: `<workspace_root>/.grip/checkouts/<name>/`
@@ -111,10 +148,10 @@ pub fn materialize_repo(
 
 /// Create a full checkout with all provided repos.
 ///
-/// `parent_manifest` supplies `settings` for the derived checkout manifest
-/// (see `write_checkout_manifest`); `repos` supplies the already-resolved
-/// per-repo info (url, path, revision, target, platform, ...) to materialize
-/// and to carry into that derived manifest verbatim.
+/// `parent_manifest` supplies `settings` carried into the checkout metadata;
+/// `repos` supplies the already-resolved per-repo info (url, path, revision,
+/// target, platform, ...) both to materialize AND to record verbatim in
+/// `.checkout.json` for later reconstruction via `manifest_from_checkout`.
 /// Returns info about the created checkout.
 pub fn create_checkout(
     workspace_root: &Path,
@@ -146,6 +183,16 @@ pub fn create_checkout(
             name: repo.name.clone(),
             path: target,
             branch: branch.map(String::from),
+            url: repo.url.clone(),
+            relative_path: repo.path.clone(),
+            revision: repo.revision.clone(),
+            target: repo.target.clone(),
+            sync_remote: repo.sync_remote.clone(),
+            push_remote: repo.push_remote.clone(),
+            platform_type: repo.platform_type,
+            platform_base_url: repo.platform_base_url.clone(),
+            reference: repo.reference,
+            groups: repo.groups.clone(),
         });
     }
 
@@ -155,42 +202,46 @@ pub fn create_checkout(
         path: checkout_root.clone(),
         repos: checkout_repos,
         created_at: now,
+        settings: parent_manifest.settings.clone(),
     };
 
-    // Write checkout metadata
-    let meta_path = checkout_root.join(".checkout.json");
+    // Write checkout metadata -- the ONLY file this function writes outside
+    // materialized repo directories. Nothing is written into any repo's own
+    // path (grip#775 blocker 2: a derived manifest written into
+    // `.gitgrip/spaces/main` collided with that being the "manifest"
+    // pseudo-repo's own canonical clone location when it was included in the
+    // checkout, leaving a materialized repo born dirty).
+    let meta_path = checkout_root.join(CHECKOUT_METADATA_FILE);
     let json = serde_json::to_string_pretty(&info)?;
     std::fs::write(&meta_path, json)
         .with_context(|| format!("writing checkout metadata: {}", meta_path.display()))?;
 
-    // Write a self-contained gripspace manifest so `gr` commands run from
-    // inside the checkout resolve THIS checkout as the workspace root
-    // (grip#774) instead of climbing past it to the parent gripspace --
-    // `load_from_workspace`'s ancestor walk only recognizes a `.gitgrip`
-    // directory, which nothing wrote here before this.
-    write_checkout_manifest(&checkout_root, parent_manifest, repos)?;
-
     Ok(info)
 }
 
-/// Derive and write a `.gitgrip/spaces/main/gripspace.yml` scoped to exactly
-/// the repos materialized into this checkout, so the checkout is a
-/// self-sufficient gripspace discoverable by the same ancestor walk every
-/// other `gr` command already uses (no new discovery path, no special-casing
-/// checkouts anywhere else in the CLI).
-fn write_checkout_manifest(
-    checkout_root: &Path,
-    parent_manifest: &Manifest,
-    repos: &[RepoInfo],
-) -> Result<()> {
-    let mut derived_repos: HashMap<String, RepoConfig> = HashMap::new();
-    for repo in repos {
-        derived_repos.insert(
+/// Load `.checkout.json` directly from `dir` if present, without walking
+/// ancestors -- the caller (the unified discovery walk in `dispatch.rs`)
+/// owns the ancestor traversal so it can check every marker type at each
+/// level before climbing (grip#775 blocker 1: two independent all-ancestors
+/// passes let a farther `.griptree` eclipse a nearer checkout).
+pub fn load_checkout_metadata(dir: &Path) -> Option<CheckoutInfo> {
+    let meta_path = dir.join(CHECKOUT_METADATA_FILE);
+    let content = std::fs::read_to_string(meta_path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Reconstruct a full gripspace `Manifest` from checkout metadata, in memory
+/// -- no file is ever written for this; `.checkout.json` is the single
+/// source of truth a checkout carries about itself.
+pub fn manifest_from_checkout(info: &CheckoutInfo) -> Manifest {
+    let mut repos = HashMap::new();
+    for repo in &info.repos {
+        repos.insert(
             repo.name.clone(),
             RepoConfig {
                 url: Some(repo.url.clone()),
                 remote: None,
-                path: repo.path.clone(),
+                path: repo.relative_path.clone(),
                 revision: Some(repo.revision.clone()),
                 target: Some(repo.target.clone()),
                 sync_remote: Some(repo.sync_remote.clone()),
@@ -209,26 +260,15 @@ fn write_checkout_manifest(
         );
     }
 
-    let derived_manifest = Manifest {
+    Manifest {
         version: 2,
         remotes: None,
         gripspaces: None,
         manifest: None,
-        repos: derived_repos,
-        settings: parent_manifest.settings.clone(),
+        repos,
+        settings: info.settings.clone(),
         workspace: None,
-    };
-
-    let manifest_dir = manifest_paths::main_space_dir(checkout_root);
-    std::fs::create_dir_all(&manifest_dir)
-        .with_context(|| format!("creating checkout manifest dir: {}", manifest_dir.display()))?;
-    let manifest_path = manifest_dir.join(manifest_paths::PRIMARY_FILE_NAME);
-    let yaml = serde_yaml::to_string(&derived_manifest)
-        .context("serializing derived checkout manifest")?;
-    std::fs::write(&manifest_path, yaml)
-        .with_context(|| format!("writing checkout manifest: {}", manifest_path.display()))?;
-
-    Ok(())
+    }
 }
 
 /// List all checkouts under `.grip/checkouts/`.
@@ -244,21 +284,19 @@ pub fn list_checkouts(workspace_root: &Path) -> Result<Vec<CheckoutInfo>> {
         if !entry.path().is_dir() {
             continue;
         }
-        let meta_path = entry.path().join(".checkout.json");
-        if meta_path.is_file() {
-            let content = std::fs::read_to_string(&meta_path)?;
-            if let Ok(info) = serde_json::from_str::<CheckoutInfo>(&content) {
-                checkouts.push(info);
+        match load_checkout_metadata(&entry.path()) {
+            Some(info) => checkouts.push(info),
+            None => {
+                // Checkout dir exists but no metadata — construct minimal info
+                let name = entry.file_name().to_string_lossy().to_string();
+                checkouts.push(CheckoutInfo {
+                    name: name.clone(),
+                    path: entry.path(),
+                    repos: vec![],
+                    created_at: "unknown".to_string(),
+                    settings: ManifestSettings::default(),
+                });
             }
-        } else {
-            // Checkout dir exists but no metadata — construct minimal info
-            let name = entry.file_name().to_string_lossy().to_string();
-            checkouts.push(CheckoutInfo {
-                name: name.clone(),
-                path: entry.path(),
-                repos: vec![],
-                created_at: "unknown".to_string(),
-            });
         }
     }
 
@@ -580,10 +618,11 @@ mod tests {
         });
     }
 
-    // ── grip#774: checkout must be a self-discoverable workspace ──────────
+    // ── grip#774/#775: checkout must be a self-describing workspace, without
+    // writing into any materialized repo's own path ────────────────────────
 
     #[test]
-    fn test_create_checkout_writes_self_contained_gripspace_manifest() {
+    fn test_create_checkout_metadata_reconstructs_a_faithful_manifest() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let cache_dir = tmp.path().join("global-cache");
         with_cache_dir(&cache_dir, || {
@@ -598,26 +637,9 @@ mod tests {
 
             let checkout_root = checkout_path(&workspace, "self-contained");
 
-            // This is the exact marker `load_from_workspace`'s ancestor walk
-            // looks for (dispatch.rs) -- before this fix, nothing wrote it,
-            // so the walk climbed straight past the checkout to the parent.
-            let gitgrip_dir = checkout_root.join(".gitgrip");
-            assert!(
-                gitgrip_dir.is_dir(),
-                "checkout root must contain a .gitgrip marker so gr commands \
-                 discover the checkout itself, not the parent workspace"
-            );
-
-            let manifest_path = manifest_paths::default_gripspace_manifest_path(&checkout_root);
-            assert!(
-                manifest_path.is_file(),
-                "expected a gripspace manifest at {}",
-                manifest_path.display()
-            );
-
-            let content = fs::read_to_string(&manifest_path).expect("read derived manifest");
-            let derived = crate::core::manifest::Manifest::parse(&content)
-                .expect("derived checkout manifest should parse");
+            let info = load_checkout_metadata(&checkout_root)
+                .expect("checkout metadata should load from the checkout root");
+            let derived = manifest_from_checkout(&info);
 
             assert_eq!(
                 derived.repos.len(),
@@ -644,7 +666,7 @@ mod tests {
     }
 
     #[test]
-    fn test_checkout_gripspace_manifest_is_independently_discoverable() {
+    fn test_checkout_metadata_lives_at_checkout_root_not_inside_any_repo() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let cache_dir = tmp.path().join("global-cache");
         with_cache_dir(&cache_dir, || {
@@ -656,32 +678,113 @@ mod tests {
                 .expect("create checkout");
 
             let checkout_root = checkout_path(&workspace, "discoverable");
-            let repo_dir = checkout_root.join("testrepo");
-            assert!(repo_dir.is_dir(), "materialized repo dir must exist");
-
-            // Mirrors dispatch.rs's `load_from_workspace` ancestor walk directly
-            // (that function is private to the CLI crate): starting from a repo
-            // *inside* the checkout, the nearest `.gitgrip` ancestor must be the
-            // checkout root, not the parent workspace root two levels up.
-            let mut search = repo_dir.as_path();
-            let found_root = loop {
-                if search.join(".gitgrip").exists() {
-                    break Some(search.to_path_buf());
-                }
-                match search.parent() {
-                    Some(parent) => search = parent,
-                    None => break None,
-                }
-            };
-
-            assert_eq!(
-                found_root,
-                Some(checkout_root.clone()),
-                "the nearest .gitgrip ancestor from inside the checkout's repo must be \
-                 the checkout root ({}), not the parent workspace ({})",
-                checkout_root.display(),
-                workspace.display()
+            assert!(
+                checkout_root.join(CHECKOUT_METADATA_FILE).is_file(),
+                ".checkout.json must live directly at the checkout root"
+            );
+            assert!(
+                load_checkout_metadata(checkout_root.join("testrepo").as_path()).is_none(),
+                "metadata must not also be discoverable from inside a materialized repo \
+                 (that would mean it was written into repo content, not the checkout root)"
             );
         });
+    }
+
+    #[test]
+    fn test_checkout_including_the_manifest_pseudo_repo_leaves_it_untouched() {
+        // grip#775 blocker 2: the "manifest" pseudo-repo's own canonical clone
+        // path IS `.gitgrip/spaces/main` (core::repo::create_manifest_repo_info).
+        // A checkout that materializes a repo at that exact relative path must
+        // come out of create_checkout with nothing written into it beyond what
+        // `git clone` itself produced -- metadata lives only in .checkout.json
+        // at the checkout root (verified above), never inside a repo's path.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
+            let url = format!("file://{}", remote.to_string_lossy());
+
+            let manifest_pseudo_repo = RepoInfo::from_config(
+                "manifest",
+                &RepoConfig {
+                    url: Some(url.clone()),
+                    remote: None,
+                    path: ".gitgrip/spaces/main".to_string(),
+                    revision: None,
+                    target: None,
+                    sync_remote: None,
+                    push_remote: None,
+                    copyfile: None,
+                    linkfile: None,
+                    platform: None,
+                    reference: false,
+                    groups: vec![],
+                    agent: None,
+                    clone_strategy: None,
+                },
+                &workspace,
+                &ManifestSettings::default(),
+                None,
+            )
+            .expect("from_config should resolve the pseudo manifest repo");
+
+            let repos = vec![manifest_pseudo_repo];
+            let parent_manifest = Manifest {
+                version: 2,
+                remotes: None,
+                gripspaces: None,
+                manifest: None,
+                repos: HashMap::new(),
+                settings: ManifestSettings::default(),
+                workspace: None,
+            };
+
+            create_checkout(
+                &workspace,
+                "with-manifest-repo",
+                &parent_manifest,
+                &repos,
+                None,
+            )
+            .expect("create checkout including the manifest pseudo-repo");
+
+            let checkout_root = checkout_path(&workspace, "with-manifest-repo");
+            let materialized_manifest_clone =
+                checkout_root.join(".gitgrip").join("spaces").join("main");
+            assert!(
+                materialized_manifest_clone.join(".git").is_dir(),
+                "the manifest pseudo-repo should still be cloned at its configured path"
+            );
+            assert!(
+                !materialized_manifest_clone.join("gripspace.yml").exists(),
+                "nothing must be written into the materialized manifest repo's own \
+                 directory -- that would corrupt its tracked content the moment the \
+                 checkout is created, before any user action"
+            );
+
+            let status = Command::new("git")
+                .args(["status", "--porcelain"])
+                .current_dir(&materialized_manifest_clone)
+                .output()
+                .expect("git status");
+            assert!(
+                status.stdout.is_empty(),
+                "materialized manifest repo clone must be born clean, got: {}",
+                String::from_utf8_lossy(&status.stdout)
+            );
+        });
+    }
+
+    #[test]
+    fn test_load_checkout_metadata_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(load_checkout_metadata(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_load_checkout_metadata_returns_none_on_malformed_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join(CHECKOUT_METADATA_FILE), "not valid json").unwrap();
+        assert!(load_checkout_metadata(tmp.path()).is_none());
     }
 }

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -224,10 +224,47 @@ pub fn create_checkout(
 /// owns the ancestor traversal so it can check every marker type at each
 /// level before climbing (grip#775 blocker 1: two independent all-ancestors
 /// passes let a farther `.griptree` eclipse a nearer checkout).
-pub fn load_checkout_metadata(dir: &Path) -> Option<CheckoutInfo> {
+///
+/// Distinguishes "no marker here" (`Ok(None)`, safe to keep climbing) from
+/// "a marker exists but is unreadable, malformed, or structurally incomplete"
+/// (`Err`, must NOT be treated as absence). Sentinel's grip#775 round-3
+/// finding: collapsing both cases to `None` via `.ok()?` let a corrupted
+/// `.checkout.json` fail OPEN to the parent workspace -- recreating the
+/// exact silent cross-scope hazard this whole PR exists to close, just
+/// through a new mechanism (a broken marker instead of a missing one).
+pub fn load_checkout_metadata(dir: &Path) -> Result<Option<CheckoutInfo>> {
     let meta_path = dir.join(CHECKOUT_METADATA_FILE);
-    let content = std::fs::read_to_string(meta_path).ok()?;
-    serde_json::from_str(&content).ok()
+    if !meta_path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&meta_path)
+        .with_context(|| format!("reading checkout metadata: {}", meta_path.display()))?;
+    let info: CheckoutInfo = serde_json::from_str(&content)
+        .with_context(|| format!("parsing checkout metadata: {}", meta_path.display()))?;
+    validate_checkout_info(&info, &meta_path)?;
+    Ok(Some(info))
+}
+
+/// Structural completeness check for metadata that parsed successfully but
+/// may still be unusable -- e.g. a pre-round-2 `.checkout.json` whose
+/// per-repo fields (url, relative_path, ...) all deserialize to their
+/// `#[serde(default)]` empty values because those fields didn't exist yet
+/// when it was written. A `RepoConfig` built from an empty url or path is
+/// not a parse error, but it is not a usable workspace either.
+fn validate_checkout_info(info: &CheckoutInfo, meta_path: &Path) -> Result<()> {
+    for repo in &info.repos {
+        if repo.url.is_empty() || repo.relative_path.is_empty() {
+            anyhow::bail!(
+                "checkout metadata at {} has an incomplete entry for repo '{}' (empty url or \
+                 path) -- this checkout was likely created by an older gitgrip version; remove \
+                 it with `gr checkout remove {}` and recreate it",
+                meta_path.display(),
+                repo.name,
+                info.name
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Reconstruct a full gripspace `Manifest` from checkout metadata, in memory
@@ -284,10 +321,13 @@ pub fn list_checkouts(workspace_root: &Path) -> Result<Vec<CheckoutInfo>> {
         if !entry.path().is_dir() {
             continue;
         }
+        // `gr checkout list` is informational, not a scope-resolution path --
+        // unlike `load_gripspace`'s discovery walk, a broken checkout here
+        // should not fail the whole listing, only fall back to a minimal
+        // entry so the user can see it exists and remove/recreate it.
         match load_checkout_metadata(&entry.path()) {
-            Some(info) => checkouts.push(info),
-            None => {
-                // Checkout dir exists but no metadata — construct minimal info
+            Ok(Some(info)) => checkouts.push(info),
+            Ok(None) | Err(_) => {
                 let name = entry.file_name().to_string_lossy().to_string();
                 checkouts.push(CheckoutInfo {
                     name: name.clone(),
@@ -638,6 +678,7 @@ mod tests {
             let checkout_root = checkout_path(&workspace, "self-contained");
 
             let info = load_checkout_metadata(&checkout_root)
+                .expect("checkout metadata should be readable")
                 .expect("checkout metadata should load from the checkout root");
             let derived = manifest_from_checkout(&info);
 
@@ -683,7 +724,9 @@ mod tests {
                 ".checkout.json must live directly at the checkout root"
             );
             assert!(
-                load_checkout_metadata(checkout_root.join("testrepo").as_path()).is_none(),
+                load_checkout_metadata(checkout_root.join("testrepo").as_path())
+                    .expect("absence is not an error")
+                    .is_none(),
                 "metadata must not also be discoverable from inside a materialized repo \
                  (that would mean it was written into repo content, not the checkout root)"
             );
@@ -778,13 +821,51 @@ mod tests {
     #[test]
     fn test_load_checkout_metadata_returns_none_when_missing() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        assert!(load_checkout_metadata(tmp.path()).is_none());
+        assert!(load_checkout_metadata(tmp.path())
+            .expect("absence is not an error")
+            .is_none());
     }
 
     #[test]
-    fn test_load_checkout_metadata_returns_none_on_malformed_json() {
+    fn test_load_checkout_metadata_errors_on_malformed_json_instead_of_failing_open() {
+        // grip#775 round 3 (Sentinel): a marker that EXISTS but is broken must
+        // never be treated the same as no marker at all -- that collapse is
+        // exactly what let a corrupted `.checkout.json` fail open to the
+        // parent workspace. This replaces the old test that pinned the
+        // unsafe `None`-on-malformed-JSON behavior as if it were correct.
         let tmp = tempfile::tempdir().expect("tempdir");
         fs::write(tmp.path().join(CHECKOUT_METADATA_FILE), "not valid json").unwrap();
-        assert!(load_checkout_metadata(tmp.path()).is_none());
+        let result = load_checkout_metadata(tmp.path());
+        assert!(
+            result.is_err(),
+            "a marker that exists but fails to parse must be an error, not Ok(None) -- \
+             collapsing the two lets the discovery walk silently climb past a broken \
+             checkout to the parent workspace"
+        );
+    }
+
+    #[test]
+    fn test_load_checkout_metadata_errors_on_legacy_metadata_with_empty_repo_fields() {
+        // grip#775 round 3 requirement 3: metadata that parses successfully
+        // but whose per-repo fields deserialize to their #[serde(default)]
+        // empty values (e.g. a pre-round-2 .checkout.json written before url/
+        // relative_path existed on CheckoutRepo) is not a parse error, but a
+        // RepoConfig built from an empty url or path is unusable.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let legacy_json = r#"{
+            "name": "legacy",
+            "path": "/tmp/legacy",
+            "created_at": "2026-01-01T00:00:00Z",
+            "repos": [
+                {"name": "app", "path": "/tmp/legacy/app", "branch": null}
+            ]
+        }"#;
+        fs::write(tmp.path().join(CHECKOUT_METADATA_FILE), legacy_json).unwrap();
+        let result = load_checkout_metadata(tmp.path());
+        assert!(
+            result.is_err(),
+            "metadata with an empty url/relative_path must fail structural validation, \
+             not silently reconstruct a Manifest with an unusable repo config"
+        );
     }
 }

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -270,7 +270,18 @@ fn validate_checkout_info(info: &CheckoutInfo, meta_path: &Path) -> Result<()> {
 /// Reconstruct a full gripspace `Manifest` from checkout metadata, in memory
 /// -- no file is ever written for this; `.checkout.json` is the single
 /// source of truth a checkout carries about itself.
-pub fn manifest_from_checkout(info: &CheckoutInfo) -> Manifest {
+///
+/// Validated with the SAME `Manifest::validate()` path-safety checks
+/// (`path_escapes_boundary`) a YAML manifest goes through via
+/// `Manifest::parse` -- a manifest built in memory is not exempt from them.
+/// grip#775 round 3 (Sentinel): a nonempty but absolute or `..`-escaping
+/// `CheckoutRepo.relative_path` passed `validate_checkout_info`'s
+/// empty-string check yet, once joined onto the checkout root via
+/// `PathBuf::join`, silently replaced it outright (`Path::join` discards the
+/// base when the argument is absolute) -- redirecting authority-bearing
+/// commands like `gr status` at whatever real path the metadata pointed to,
+/// including an unrelated parent repo.
+pub fn manifest_from_checkout(info: &CheckoutInfo) -> Result<Manifest> {
     let mut repos = HashMap::new();
     for repo in &info.repos {
         repos.insert(
@@ -297,7 +308,7 @@ pub fn manifest_from_checkout(info: &CheckoutInfo) -> Manifest {
         );
     }
 
-    Manifest {
+    let manifest = Manifest {
         version: 2,
         remotes: None,
         gripspaces: None,
@@ -305,7 +316,14 @@ pub fn manifest_from_checkout(info: &CheckoutInfo) -> Manifest {
         repos,
         settings: info.settings.clone(),
         workspace: None,
-    }
+    };
+    manifest.validate().with_context(|| {
+        format!(
+            "checkout '{}' has an invalid reconstructed manifest",
+            info.name
+        )
+    })?;
+    Ok(manifest)
 }
 
 /// List all checkouts under `.grip/checkouts/`.
@@ -680,7 +698,8 @@ mod tests {
             let info = load_checkout_metadata(&checkout_root)
                 .expect("checkout metadata should be readable")
                 .expect("checkout metadata should load from the checkout root");
-            let derived = manifest_from_checkout(&info);
+            let derived =
+                manifest_from_checkout(&info).expect("reconstructed manifest should validate");
 
             assert_eq!(
                 derived.repos.len(),

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -6,9 +6,13 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::core::manifest::{Manifest, PlatformConfig, RepoConfig};
+use crate::core::manifest_paths;
+use crate::core::repo::RepoInfo;
 use crate::core::workspace_cache;
 use crate::util::log_cmd;
 
@@ -107,12 +111,16 @@ pub fn materialize_repo(
 
 /// Create a full checkout with all provided repos.
 ///
-/// Takes an iterator of (name, url, path) tuples.
+/// `parent_manifest` supplies `settings` for the derived checkout manifest
+/// (see `write_checkout_manifest`); `repos` supplies the already-resolved
+/// per-repo info (url, path, revision, target, platform, ...) to materialize
+/// and to carry into that derived manifest verbatim.
 /// Returns info about the created checkout.
-pub fn create_checkout<'a>(
+pub fn create_checkout(
     workspace_root: &Path,
     checkout_name: &str,
-    repos: impl Iterator<Item = (&'a str, &'a str, &'a str)>,
+    parent_manifest: &Manifest,
+    repos: &[RepoInfo],
     branch: Option<&str>,
 ) -> Result<CheckoutInfo> {
     if checkout_exists(workspace_root, checkout_name) {
@@ -125,10 +133,17 @@ pub fn create_checkout<'a>(
 
     let mut checkout_repos = Vec::new();
 
-    for (name, url, path) in repos {
-        let target = materialize_repo(workspace_root, checkout_name, name, url, path, branch)?;
+    for repo in repos {
+        let target = materialize_repo(
+            workspace_root,
+            checkout_name,
+            &repo.name,
+            &repo.url,
+            &repo.path,
+            branch,
+        )?;
         checkout_repos.push(CheckoutRepo {
-            name: name.to_string(),
+            name: repo.name.clone(),
             path: target,
             branch: branch.map(String::from),
         });
@@ -148,7 +163,72 @@ pub fn create_checkout<'a>(
     std::fs::write(&meta_path, json)
         .with_context(|| format!("writing checkout metadata: {}", meta_path.display()))?;
 
+    // Write a self-contained gripspace manifest so `gr` commands run from
+    // inside the checkout resolve THIS checkout as the workspace root
+    // (grip#774) instead of climbing past it to the parent gripspace --
+    // `load_from_workspace`'s ancestor walk only recognizes a `.gitgrip`
+    // directory, which nothing wrote here before this.
+    write_checkout_manifest(&checkout_root, parent_manifest, repos)?;
+
     Ok(info)
+}
+
+/// Derive and write a `.gitgrip/spaces/main/gripspace.yml` scoped to exactly
+/// the repos materialized into this checkout, so the checkout is a
+/// self-sufficient gripspace discoverable by the same ancestor walk every
+/// other `gr` command already uses (no new discovery path, no special-casing
+/// checkouts anywhere else in the CLI).
+fn write_checkout_manifest(
+    checkout_root: &Path,
+    parent_manifest: &Manifest,
+    repos: &[RepoInfo],
+) -> Result<()> {
+    let mut derived_repos: HashMap<String, RepoConfig> = HashMap::new();
+    for repo in repos {
+        derived_repos.insert(
+            repo.name.clone(),
+            RepoConfig {
+                url: Some(repo.url.clone()),
+                remote: None,
+                path: repo.path.clone(),
+                revision: Some(repo.revision.clone()),
+                target: Some(repo.target.clone()),
+                sync_remote: Some(repo.sync_remote.clone()),
+                push_remote: Some(repo.push_remote.clone()),
+                copyfile: None,
+                linkfile: None,
+                platform: Some(PlatformConfig {
+                    platform_type: repo.platform_type,
+                    base_url: repo.platform_base_url.clone(),
+                }),
+                reference: repo.reference,
+                groups: repo.groups.clone(),
+                agent: None,
+                clone_strategy: None,
+            },
+        );
+    }
+
+    let derived_manifest = Manifest {
+        version: 2,
+        remotes: None,
+        gripspaces: None,
+        manifest: None,
+        repos: derived_repos,
+        settings: parent_manifest.settings.clone(),
+        workspace: None,
+    };
+
+    let manifest_dir = manifest_paths::main_space_dir(checkout_root);
+    std::fs::create_dir_all(&manifest_dir)
+        .with_context(|| format!("creating checkout manifest dir: {}", manifest_dir.display()))?;
+    let manifest_path = manifest_dir.join(manifest_paths::PRIMARY_FILE_NAME);
+    let yaml = serde_yaml::to_string(&derived_manifest)
+        .context("serializing derived checkout manifest")?;
+    std::fs::write(&manifest_path, yaml)
+        .with_context(|| format!("writing checkout manifest: {}", manifest_path.display()))?;
+
+    Ok(())
 }
 
 /// List all checkouts under `.grip/checkouts/`.
@@ -200,8 +280,65 @@ pub fn remove_checkout(workspace_root: &Path, name: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::manifest::ManifestSettings;
     use crate::core::workspace_cache::test_support;
     use std::fs;
+
+    /// Build a single-repo manifest + resolved `RepoInfo`, matching the shape
+    /// `setup_cached_workspace` produces (one repo named "testrepo" checked
+    /// out at path "testrepo"), for tests exercising `create_checkout`'s
+    /// derived-manifest path without hand-rolling every `RepoInfo` field.
+    fn single_repo_manifest_and_info(
+        workspace: &Path,
+        name: &str,
+        url: &str,
+    ) -> (Manifest, Vec<RepoInfo>) {
+        // parse_git_url only recognizes git@, https://, http://, and file://
+        // -- setup_cached_workspace hands back a bare filesystem path, so it
+        // needs the file:// scheme RepoInfo::from_config requires to resolve
+        // owner/repo. materialize_repo's `git clone` accepts file:// URLs
+        // the same as a bare path, so this doesn't change what gets cloned.
+        let file_url = if url.contains("://") {
+            url.to_string()
+        } else {
+            format!("file://{}", url)
+        };
+
+        let mut repos = HashMap::new();
+        repos.insert(
+            name.to_string(),
+            RepoConfig {
+                url: Some(file_url),
+                remote: None,
+                path: name.to_string(),
+                revision: None,
+                target: None,
+                sync_remote: None,
+                push_remote: None,
+                copyfile: None,
+                linkfile: None,
+                platform: None,
+                reference: false,
+                groups: vec![],
+                agent: None,
+                clone_strategy: None,
+            },
+        );
+        let manifest = Manifest {
+            version: 2,
+            remotes: None,
+            gripspaces: None,
+            manifest: None,
+            repos,
+            settings: ManifestSettings::default(),
+            workspace: None,
+        };
+        let settings = manifest.settings.clone();
+        let config = manifest.repos.get(name).unwrap();
+        let repo_info = RepoInfo::from_config(name, config, workspace, &settings, None)
+            .expect("from_config should resolve a repo with an explicit url");
+        (manifest, vec![repo_info])
+    }
 
     fn with_cache_dir<T>(cache_dir: &Path, f: impl FnOnce() -> T) -> T {
         let _guard = test_support::ENV_LOCK
@@ -367,9 +504,9 @@ mod tests {
             let (workspace, remote) = setup_cached_workspace(tmp.path());
 
             let url = remote.to_string_lossy().to_string();
-            let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
 
-            let info = create_checkout(&workspace, "feat-x", repos.into_iter(), None)
+            let info = create_checkout(&workspace, "feat-x", &manifest, &repos, None)
                 .expect("create checkout");
 
             assert_eq!(info.name, "feat-x");
@@ -390,11 +527,10 @@ mod tests {
             let (workspace, remote) = setup_cached_workspace(tmp.path());
 
             let url = remote.to_string_lossy().to_string();
-            let repos = vec![("testrepo", url.as_str(), "testrepo")];
-            create_checkout(&workspace, "dup", repos.into_iter(), None).expect("first");
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            create_checkout(&workspace, "dup", &manifest, &repos, None).expect("first");
 
-            let repos2 = vec![("testrepo", url.as_str(), "testrepo")];
-            let result = create_checkout(&workspace, "dup", repos2.into_iter(), None);
+            let result = create_checkout(&workspace, "dup", &manifest, &repos, None);
             assert!(result.is_err());
         });
     }
@@ -407,8 +543,8 @@ mod tests {
             let (workspace, remote) = setup_cached_workspace(tmp.path());
 
             let url = remote.to_string_lossy().to_string();
-            let repos = vec![("testrepo", url.as_str(), "testrepo")];
-            create_checkout(&workspace, "removeme", repos.into_iter(), None).expect("create");
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            create_checkout(&workspace, "removeme", &manifest, &repos, None).expect("create");
 
             assert!(checkout_exists(&workspace, "removeme"));
             let removed = remove_checkout(&workspace, "removeme").expect("remove");
@@ -432,14 +568,119 @@ mod tests {
             let (workspace, remote) = setup_cached_workspace(tmp.path());
 
             let url = remote.to_string_lossy().to_string();
-            let repos = vec![("testrepo", url.as_str(), "testrepo")];
-            create_checkout(&workspace, "ephemeral", repos.into_iter(), None).expect("create");
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            create_checkout(&workspace, "ephemeral", &manifest, &repos, None).expect("create");
 
             remove_checkout(&workspace, "ephemeral").expect("remove");
 
             assert!(
                 workspace_cache::cache_exists(&workspace, "testrepo", &url).expect("cache exists"),
                 "cache must survive checkout deletion"
+            );
+        });
+    }
+
+    // ── grip#774: checkout must be a self-discoverable workspace ──────────
+
+    #[test]
+    fn test_create_checkout_writes_self_contained_gripspace_manifest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+            let url = remote.to_string_lossy().to_string();
+            let (mut manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            manifest.settings.pr_prefix = "[from-parent]".to_string();
+
+            create_checkout(&workspace, "self-contained", &manifest, &repos, None)
+                .expect("create checkout");
+
+            let checkout_root = checkout_path(&workspace, "self-contained");
+
+            // This is the exact marker `load_from_workspace`'s ancestor walk
+            // looks for (dispatch.rs) -- before this fix, nothing wrote it,
+            // so the walk climbed straight past the checkout to the parent.
+            let gitgrip_dir = checkout_root.join(".gitgrip");
+            assert!(
+                gitgrip_dir.is_dir(),
+                "checkout root must contain a .gitgrip marker so gr commands \
+                 discover the checkout itself, not the parent workspace"
+            );
+
+            let manifest_path = manifest_paths::default_gripspace_manifest_path(&checkout_root);
+            assert!(
+                manifest_path.is_file(),
+                "expected a gripspace manifest at {}",
+                manifest_path.display()
+            );
+
+            let content = fs::read_to_string(&manifest_path).expect("read derived manifest");
+            let derived = crate::core::manifest::Manifest::parse(&content)
+                .expect("derived checkout manifest should parse");
+
+            assert_eq!(
+                derived.repos.len(),
+                1,
+                "derived manifest should carry exactly the repos materialized into this checkout"
+            );
+            let repo_config = derived.repos.get("testrepo").expect("testrepo entry");
+            assert_eq!(
+                repo_config.url.as_deref(),
+                Some(format!("file://{}", url).as_str()),
+                "derived repo url must match the resolved (file://-scheme) url used to \
+                 materialize the repo"
+            );
+            assert_eq!(
+                repo_config.path, "testrepo",
+                "derived repo path must be relative to the checkout root, matching \
+                 where materialize_repo actually cloned it"
+            );
+            assert_eq!(
+                derived.settings.pr_prefix, "[from-parent]",
+                "derived manifest must carry the parent's settings, not gitgrip's built-in default"
+            );
+        });
+    }
+
+    #[test]
+    fn test_checkout_gripspace_manifest_is_independently_discoverable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+            let url = remote.to_string_lossy().to_string();
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            create_checkout(&workspace, "discoverable", &manifest, &repos, None)
+                .expect("create checkout");
+
+            let checkout_root = checkout_path(&workspace, "discoverable");
+            let repo_dir = checkout_root.join("testrepo");
+            assert!(repo_dir.is_dir(), "materialized repo dir must exist");
+
+            // Mirrors dispatch.rs's `load_from_workspace` ancestor walk directly
+            // (that function is private to the CLI crate): starting from a repo
+            // *inside* the checkout, the nearest `.gitgrip` ancestor must be the
+            // checkout root, not the parent workspace root two levels up.
+            let mut search = repo_dir.as_path();
+            let found_root = loop {
+                if search.join(".gitgrip").exists() {
+                    break Some(search.to_path_buf());
+                }
+                match search.parent() {
+                    Some(parent) => search = parent,
+                    None => break None,
+                }
+            };
+
+            assert_eq!(
+                found_root,
+                Some(checkout_root.clone()),
+                "the nearest .gitgrip ancestor from inside the checkout's repo must be \
+                 the checkout root ({}), not the parent workspace ({})",
+                checkout_root.display(),
+                workspace.display()
             );
         });
     }

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -192,10 +192,23 @@ impl WorkspaceBuilder {
         }
 
         // Generate manifest YAML
-        let manifest_yaml = generate_manifest(&self.repos, &remotes_dir);
+        let mut manifest_yaml = generate_manifest(&self.repos, &remotes_dir);
+
+        let manifest_dir = workspace_root.join(".gitgrip").join("spaces").join("main");
+
+        // Self-tracking `manifest:` block (core::manifest::ManifestRepoConfig),
+        // required by get_manifest_repo_info -- without it, `manifest.manifest`
+        // stays None and any operation that includes the "manifest" pseudo-repo
+        // (e.g. `gr checkout add --repo <x>,manifest`) silently drops it, even
+        // though `with_manifest_repo` already made it a real git repo on disk.
+        if self.with_manifest_repo {
+            manifest_yaml.push_str(&format!(
+                "manifest:\n  url: file://{}\n",
+                manifest_dir.display()
+            ));
+        }
 
         // Write canonical manifest layout.
-        let manifest_dir = workspace_root.join(".gitgrip").join("spaces").join("main");
         fs::create_dir_all(&manifest_dir).unwrap();
         fs::write(manifest_dir.join("gripspace.yml"), &manifest_yaml).unwrap();
 

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -2,6 +2,8 @@
 
 mod common;
 
+use assert_cmd::Command;
+
 use common::assertions::assert_on_branch;
 use common::fixtures::WorkspaceBuilder;
 
@@ -196,4 +198,90 @@ fn test_checkout_skips_non_git_repo() {
     // Healthy repo should switch; corrupted repo remains non-git
     assert_on_branch(&ws.repo_path("frontend"), "feat/checkout-safe");
     assert!(!ws.repo_path("backend").join(".git").exists());
+}
+
+// ── grip#774: `gr checkout add` must produce a self-discoverable workspace ──
+//
+// grip#770/#771/#773 fixed `gr pr edit/review/merge` silently fanning out
+// across every repo in the *correctly resolved* workspace. This is the sibling
+// bug one layer down: `gr checkout add` materializes a disposable child
+// checkout, but (before this fix) wrote no workspace marker inside it, so
+// EVERY `gr` command run from inside that checkout -- including `gr pr
+// review`/`merge` -- silently resolved the *parent* gripspace instead. A
+// reviewer entering the checkout to act on its PR head could unknowingly
+// operate on the parent's unrelated active branch. Found live during
+// grip#773's own review/merge (grip#774).
+
+#[test]
+fn test_checkout_add_makes_the_child_checkout_independently_discoverable() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "review-copy",
+        None,
+        None,
+    )
+    .expect("checkout add should succeed");
+
+    let checkout_repo_dir = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("review-copy")
+        .join("app");
+    assert!(
+        checkout_repo_dir.is_dir(),
+        "materialized checkout repo dir should exist at {}",
+        checkout_repo_dir.display()
+    );
+
+    // This is Sentinel's exact grip#774 repro: run `gr env` from inside a
+    // repo INSIDE the child checkout and check which workspace it reports.
+    let output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    assert!(
+        output.status.success(),
+        "gr env should succeed from inside the checkout: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let workspace_line = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("GITGRIP_WORKSPACE="))
+        .expect("gr env should print GITGRIP_WORKSPACE");
+    let reported = workspace_line
+        .split_once('=')
+        .map(|(_, v)| v.trim())
+        .unwrap_or("");
+
+    let expected_checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("review-copy");
+    let canonical_checkout_root =
+        std::fs::canonicalize(&expected_checkout_root).unwrap_or(expected_checkout_root);
+    let canonical_reported =
+        std::fs::canonicalize(reported).unwrap_or_else(|_| std::path::PathBuf::from(reported));
+
+    assert_eq!(
+        canonical_reported, canonical_checkout_root,
+        "gr env from inside the child checkout must resolve GITGRIP_WORKSPACE to the \
+         checkout root, not the parent workspace -- that is grip#774's exact failure mode"
+    );
+
+    let canonical_parent =
+        std::fs::canonicalize(&ws.workspace_root).unwrap_or_else(|_| ws.workspace_root.clone());
+    assert_ne!(
+        canonical_reported, canonical_parent,
+        "gr env must not resolve to the parent workspace root from inside the checkout"
+    );
 }

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -438,3 +438,105 @@ fn test_checkout_including_manifest_repo_leaves_it_clean_end_to_end() {
         std::fs::canonicalize(reported).unwrap_or_else(|_| std::path::PathBuf::from(reported));
     assert_eq!(canonical_reported, canonical_checkout_root);
 }
+
+// ── grip#775 round 3: malformed checkout metadata must fail closed, never
+// fail open to a parent workspace -- especially a parent that is itself a
+// griptree, Sentinel's exact real-gripspace repro shape. ────────────────────
+
+#[test]
+fn test_corrupted_checkout_metadata_fails_closed_not_open_to_parent() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Match Sentinel's exact repro context: the parent also carries a
+    // .griptree pointer, which is precisely the path a fail-open bug would
+    // silently resolve to once the (corrupted) nearer checkout marker is
+    // wrongly treated as absent.
+    let pointer = gitgrip::core::griptree::GriptreePointer {
+        main_workspace: "/nonexistent/decoy-main-workspace".to_string(),
+        branch: "feat/decoy".to_string(),
+        locked: false,
+        created_at: None,
+        repos: vec![],
+        manifest_branch: None,
+        manifest_worktree_name: None,
+    };
+    std::fs::write(
+        ws.workspace_root.join(".griptree"),
+        serde_json::to_string(&pointer).expect("serialize pointer"),
+    )
+    .expect("write .griptree pointer at the parent gripspace root");
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "sentinel-repro-nomanifest",
+        Some(&["app".to_string()]),
+        None,
+    )
+    .expect("checkout add should succeed with no manifest repo included");
+
+    let checkout_repo_dir = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("sentinel-repro-nomanifest")
+        .join("app");
+
+    // Sanity: gr env correctly reports the child BEFORE corruption (mirrors
+    // step 2 of Sentinel's repro).
+    let good_output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    assert!(
+        good_output.status.success(),
+        "gr env should succeed before corruption: {}",
+        String::from_utf8_lossy(&good_output.stderr)
+    );
+
+    // Corrupt only the child-root .checkout.json (step 3).
+    let checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("sentinel-repro-nomanifest");
+    std::fs::write(checkout_root.join(".checkout.json"), "not valid json{{{")
+        .expect("corrupt checkout metadata");
+
+    // Step 4: gr env again. Must NOT exit 0, and must NOT report the parent
+    // workspace path -- that combination is grip#775 round 3's exact
+    // reported failure mode.
+    let corrupted_output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+
+    assert!(
+        !corrupted_output.status.success(),
+        "gr env must fail (nonzero exit) when the nearest checkout marker exists but is \
+         corrupted -- silently succeeding here means it fell through to some other \
+         workspace instead of failing closed"
+    );
+
+    let stdout = String::from_utf8_lossy(&corrupted_output.stdout);
+    let canonical_parent =
+        std::fs::canonicalize(&ws.workspace_root).unwrap_or_else(|_| ws.workspace_root.clone());
+    assert!(
+        !stdout.contains(&canonical_parent.to_string_lossy().to_string())
+            && !stdout.contains(&ws.workspace_root.to_string_lossy().to_string()),
+        "gr env's output must not emit the parent workspace path at all when the nearer \
+         checkout marker is corrupted -- got stdout: {}",
+        stdout
+    );
+
+    let stderr = String::from_utf8_lossy(&corrupted_output.stderr);
+    assert!(
+        !stderr.is_empty(),
+        "a failed gr env should explain why, not fail silently"
+    );
+}

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -285,3 +285,156 @@ fn test_checkout_add_makes_the_child_checkout_independently_discoverable() {
         "gr env must not resolve to the parent workspace root from inside the checkout"
     );
 }
+
+// ── grip#775 blocker 1: a farther `.griptree` must not eclipse a nearer
+// checkout. Reproduces Sentinel's exact live finding: his real parent
+// gripspace carries a `.griptree` pointer, so `load_gripspace()`'s OLD
+// two-independent-passes structure (check every ancestor for `.griptree`,
+// THEN separately check every ancestor for `.gitgrip`) let that distant
+// pointer win over the checkout one level down every time. ─────────────────
+
+#[test]
+fn test_checkout_wins_over_a_griptree_pointer_at_an_ancestor() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Simulate "this parent gripspace also happens to carry a .griptree
+    // pointer" -- e.g. it was itself created as a griptree at some point.
+    // The pointer's target doesn't need to resolve to anything real: this
+    // test asserts the checkout wins BEFORE that pointer is ever followed.
+    let pointer = gitgrip::core::griptree::GriptreePointer {
+        main_workspace: "/nonexistent/decoy-main-workspace".to_string(),
+        branch: "feat/decoy".to_string(),
+        locked: false,
+        created_at: None,
+        repos: vec![],
+        manifest_branch: None,
+        manifest_worktree_name: None,
+    };
+    let pointer_json = serde_json::to_string(&pointer).expect("serialize pointer");
+    std::fs::write(ws.workspace_root.join(".griptree"), pointer_json)
+        .expect("write .griptree pointer at the parent gripspace root");
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "review-copy",
+        None,
+        None,
+    )
+    .expect("checkout add should succeed even with a parent .griptree present");
+
+    let checkout_repo_dir = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("review-copy")
+        .join("app");
+
+    let output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    assert!(
+        output.status.success(),
+        "gr env should succeed from inside the checkout: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let workspace_line = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("GITGRIP_WORKSPACE="))
+        .expect("gr env should print GITGRIP_WORKSPACE");
+    let reported = workspace_line
+        .split_once('=')
+        .map(|(_, v)| v.trim())
+        .unwrap_or("");
+
+    let expected_checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("review-copy");
+    let canonical_checkout_root =
+        std::fs::canonicalize(&expected_checkout_root).unwrap_or(expected_checkout_root);
+    let canonical_reported =
+        std::fs::canonicalize(reported).unwrap_or_else(|_| std::path::PathBuf::from(reported));
+
+    assert_eq!(
+        canonical_reported, canonical_checkout_root,
+        "the nearer checkout must win over the farther .griptree pointer at the parent \
+         gripspace root -- grip#775 blocker 1's exact failure mode"
+    );
+    assert_ne!(
+        reported, "/nonexistent/decoy-main-workspace",
+        "the griptree pointer must never even be followed when a nearer checkout exists"
+    );
+}
+
+// ── grip#775 blocker 2: creating a checkout that includes the "manifest"
+// pseudo-repo must not corrupt that repo's own materialized clone. ─────────
+
+#[test]
+fn test_checkout_including_manifest_repo_leaves_it_clean_end_to_end() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .with_manifest_repo()
+        .build();
+    let manifest = ws.load_manifest();
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "with-manifest",
+        Some(&["app".to_string(), "manifest".to_string()]),
+        None,
+    )
+    .expect("checkout add including the manifest repo should succeed");
+
+    let checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("with-manifest");
+    let materialized_manifest_dir = checkout_root.join(".gitgrip").join("spaces").join("main");
+    assert!(
+        materialized_manifest_dir.join(".git").is_dir(),
+        "the manifest repo should be materialized at its canonical clone path"
+    );
+
+    let status = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(&materialized_manifest_dir)
+        .output()
+        .expect("git status");
+    assert!(
+        status.stdout.is_empty(),
+        "materialized manifest repo must be born clean, not carry a destructive derived-\
+         manifest diff -- grip#775 blocker 2's exact failure mode. git status --porcelain: {}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+
+    // And discovery still works correctly from inside the OTHER materialized
+    // repo in the same checkout -- proving .checkout.json (not anything
+    // written into the manifest clone) is what makes this checkout resolvable.
+    let output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(checkout_root.join("app"))
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let reported = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("GITGRIP_WORKSPACE="))
+        .and_then(|line| line.split_once('='))
+        .map(|(_, v)| v.trim())
+        .unwrap_or("");
+    let canonical_checkout_root = std::fs::canonicalize(&checkout_root).unwrap_or(checkout_root);
+    let canonical_reported =
+        std::fs::canonicalize(reported).unwrap_or_else(|_| std::path::PathBuf::from(reported));
+    assert_eq!(canonical_reported, canonical_checkout_root);
+}

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -540,3 +540,98 @@ fn test_corrupted_checkout_metadata_fails_closed_not_open_to_parent() {
         "a failed gr env should explain why, not fail silently"
     );
 }
+
+// ── grip#775 round 4: an absolute or escaping repo path inside otherwise-
+// valid checkout metadata must not redirect authority-bearing commands
+// outside the checkout, e.g. onto an unrelated parent repo. ────────────────
+
+#[test]
+fn test_absolute_repo_path_in_metadata_cannot_escape_the_checkout() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let pointer = gitgrip::core::griptree::GriptreePointer {
+        main_workspace: "/nonexistent/decoy-main-workspace".to_string(),
+        branch: "feat/decoy".to_string(),
+        locked: false,
+        created_at: None,
+        repos: vec![],
+        manifest_branch: None,
+        manifest_worktree_name: None,
+    };
+    std::fs::write(
+        ws.workspace_root.join(".griptree"),
+        serde_json::to_string(&pointer).expect("serialize pointer"),
+    )
+    .expect("write .griptree pointer at the parent gripspace root");
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "sentinel-repro-escape",
+        Some(&["app".to_string()]),
+        None,
+    )
+    .expect("checkout add should succeed");
+
+    let checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("sentinel-repro-escape");
+    let checkout_repo_dir = checkout_root.join("app");
+
+    // Sanity: works correctly before corruption.
+    let good_output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    assert!(
+        good_output.status.success(),
+        "gr env should succeed before the metadata is tampered with"
+    );
+
+    // Rewrite .checkout.json's "app" entry to an ABSOLUTE relative_path
+    // pointing at the PARENT's own real "app" repo -- otherwise-valid,
+    // nonempty metadata, exactly Sentinel's repro shape. PathBuf::join
+    // silently discards the checkout-root base when the joined path is
+    // absolute, so an unvalidated reconstruction would resolve authority-
+    // bearing commands onto this unrelated parent repo instead.
+    let meta_path = checkout_root.join(".checkout.json");
+    let raw = std::fs::read_to_string(&meta_path).expect("read checkout metadata");
+    let mut value: serde_json::Value = serde_json::from_str(&raw).expect("parse metadata");
+    let parent_app_path = ws.workspace_root.join("app");
+    value["repos"][0]["relative_path"] =
+        serde_json::Value::String(parent_app_path.to_string_lossy().to_string());
+    std::fs::write(&meta_path, serde_json::to_string_pretty(&value).unwrap())
+        .expect("write tampered metadata");
+
+    let escaped_output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+
+    assert!(
+        !escaped_output.status.success(),
+        "gr env must reject a reconstructed manifest whose repo path is absolute -- silently \
+         succeeding means an authority-bearing command could resolve outside the checkout, \
+         grip#775 round 4's exact scope escape"
+    );
+
+    let stdout = String::from_utf8_lossy(&escaped_output.stdout);
+    assert!(
+        !stdout.contains(&parent_app_path.to_string_lossy().to_string()),
+        "the rejected reconstruction must never surface the escaping absolute path in output: {}",
+        stdout
+    );
+
+    let stderr = String::from_utf8_lossy(&escaped_output.stderr);
+    assert!(
+        !stderr.is_empty(),
+        "a rejected reconstruction should explain why, not fail silently"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes grip#774, found live by Sentinel during grip#773's own review/merge: `gr checkout add` materializes independent clones into `.grip/checkouts/<name>/` but never wrote any workspace marker inside that directory, so gitgrip's ancestor-walk discovery (`load_from_workspace` in `dispatch.rs`) climbed straight past every checkout to the parent gripspace instead. Every `gr` command run from inside a checkout — including `pr review`/`merge` — silently operated on the parent's active branch, not the checkout's own. This is the same class of scope-safety gap as grip#770/#771/#773 (silent cross-scope action), one layer down: workspace *discovery* rather than PR *command scoping*.

## Root cause

`create_checkout` (`core/workspace_checkout.rs`) materializes real repos and writes `.checkout.json` metadata, but that file was never recognized by the ancestor walk — only a `.gitgrip` directory is. Griptrees (`gr tree add`) already solve the analogous problem via a `.griptree` pointer file checked first in `load_gripspace()`; checkouts had no equivalent.

## Fix

`create_checkout` now derives and writes a self-contained `.gitgrip/spaces/main/gripspace.yml` scoped to exactly the repos materialized into the checkout — `settings` cloned from the parent manifest, per-repo entries built from the already-resolved `RepoInfo` passed in (url, revision, target, sync/push remote, platform, groups all carried over faithfully). This reuses the existing `Manifest`/`RepoConfig` machinery and the existing ancestor-walk discovery path completely unchanged — no new discovery branch, no special-casing checkouts anywhere else in the CLI. The checkout becomes just another gripspace root as far as every other `gr` command is concerned.

`create_checkout`'s signature changed from a narrow `(name, url, path)` 3-tuple iterator to `parent_manifest: &Manifest, repos: &[RepoInfo]`, since deriving a faithful sub-manifest needs the fuller already-resolved repo info (revision/target/platform/etc.) that the old narrow tuple discarded.

## Verification

- Two new unit tests in `core/workspace_checkout.rs`: the derived manifest exists, parses, carries the right repo entry (url/path) and the parent's settings (not gitgrip's built-in defaults); and a direct ancestor-walk simulation confirms the nearest `.gitgrip` from inside the checkout's repo is the checkout root, not the parent.
- One binary-level integration test in `tests/test_checkout.rs` that reproduces Sentinel's exact repro: `gr checkout add`, `cd` into the materialized repo, run the real compiled `gr env`, assert `GITGRIP_WORKSPACE` resolves to the checkout root.
- **Mutation-verified**: temporarily disabled the `write_checkout_manifest` call site and re-ran all three tests. The integration test failed with `GITGRIP_WORKSPACE` reporting the parent workspace root — byte-for-byte grip#774's observed symptom — before passing clean once restored. Same discipline as grip#773's round-2 fix.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets`: clean (zero hits on any changed file).
- Full suite: `cargo test` — 700+ tests across every binary, 0 failed.

## Premium boundary

Core OSS — gitgrip workspace orchestration/discovery. No identity or org semantics touched.

Closes https://github.com/synapt-dev/grip/issues/774