### PR TITLE
fix: gr pr merge --wait detects no-checks-configured, returns immediately

### DIFF
--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -6,10 +6,40 @@ use crate::core::manifest::Manifest;
 use crate::core::repo::{get_manifest_repo_info, require_explicit_multi_repo_scope, RepoInfo};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::traits::{HostingPlatform, PlatformError};
-use crate::platform::{get_platform_adapter, CheckState, MergeMethod};
+use crate::platform::{get_platform_adapter, CheckState, MergeMethod, StatusCheckResult};
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
+
+/// This command's internal readiness classification for a PR's checks,
+/// derived from a platform's [`StatusCheckResult`] via [`resolve_check_status`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckStatus {
+    Passing,
+    Failing,
+    Pending,
+    Unknown,
+}
+
+/// Resolve a platform's status-check result into this command's internal
+/// [`CheckStatus`]. Pure and synchronous so it can be pinned directly against
+/// synthetic [`StatusCheckResult`] values, without exercising the HTTP or
+/// sleep/retry machinery around either call site. Both the initial fetch and
+/// the `--wait` re-poll loop call this exact function so the decision can
+/// never diverge between them (grip#776 finding 3).
+fn resolve_check_status(status: &StatusCheckResult) -> CheckStatus {
+    if !status.checks_configured {
+        // No CI is configured for this ref at all -- not a real
+        // pending/passing signal, nothing to wait on (grip#772).
+        CheckStatus::Passing
+    } else {
+        match status.state {
+            CheckState::Failure => CheckStatus::Failing,
+            CheckState::Pending => CheckStatus::Pending,
+            CheckState::Success => CheckStatus::Passing,
+        }
+    }
+}
 
 /// Auto-detect the best merge method for a repo when none is specified.
 ///
@@ -112,14 +142,6 @@ pub async fn run_pr_merge(
     }
 
     // Collect PRs to merge
-    #[derive(Debug, Clone, Copy)]
-    enum CheckStatus {
-        Passing,
-        Failing,
-        Pending,
-        Unknown,
-    }
-
     struct PRToMerge {
         repo_name: String,
         owner: String,
@@ -185,25 +207,12 @@ pub async fn run_pr_merge(
                     Ok(status) => {
                         // Successfully got check status
                         if !status.checks_configured {
-                            // No CI is configured for this ref at all -- not a
-                            // real pending/passing signal, nothing to wait on
-                            // (grip#772: this used to map to Pending and
-                            // `--wait` would burn the full timeout for
-                            // something that was never going to appear).
                             Output::info(&format!(
                                 "{}: no CI checks configured for branch '{}', proceeding",
                                 repo.name, branch
                             ));
-                            CheckStatus::Passing
-                        } else if status.state == CheckState::Failure {
-                            // Checks are actually failing
-                            CheckStatus::Failing
-                        } else if status.state == CheckState::Pending {
-                            // Checks still running - don't block but warn
-                            CheckStatus::Pending
-                        } else {
-                            CheckStatus::Passing
                         }
+                        resolve_check_status(&status)
                     }
                     Err(e) => {
                         // Could not determine check status
@@ -342,32 +351,7 @@ pub async fn run_pr_merge(
                         .await
                     {
                         Ok(status) => {
-                            pr.check_status = if !status.checks_configured {
-                                // grip#772: don't keep waiting on a ref that
-                                // turns out to have no CI configured, even if
-                                // it started this loop as Pending.
-                                //
-                                // Defense-in-depth, not independently mutation-tested:
-                                // this mirrors the initial-fetch guard above verbatim,
-                                // and the existing regression only exercises that first
-                                // guard (a repo whose checks are already unconfigured on
-                                // entry short-circuits before the wait loop ever runs).
-                                // A mutant breaking only this re-poll branch would
-                                // survive that test. Reaching this specific branch in a
-                                // test means surviving a real 15s sleep per iteration
-                                // (hardcoded below, no paused-clock seam exists yet in
-                                // this codebase) -- accepted as review-pinned parity
-                                // with the initial guard rather than paying that cost
-                                // for structurally identical logic. Revisit if this
-                                // branch and the initial guard ever diverge.
-                                CheckStatus::Passing
-                            } else {
-                                match status.state {
-                                    CheckState::Failure => CheckStatus::Failing,
-                                    CheckState::Pending => CheckStatus::Pending,
-                                    _ => CheckStatus::Passing,
-                                }
-                            };
+                            pr.check_status = resolve_check_status(&status);
 
                             match pr.check_status {
                                 CheckStatus::Passing => {
@@ -881,4 +865,55 @@ fn check_repo_for_changes(repo: &RepoInfo) -> anyhow::Result<bool> {
 
     // Check for commits ahead of target branch using shared helper
     has_commits_ahead(&git_repo, &current, repo.target_branch())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(checks_configured: bool, state: CheckState) -> StatusCheckResult {
+        StatusCheckResult {
+            state,
+            statuses: Vec::new(),
+            checks_configured,
+        }
+    }
+
+    // ── resolve_check_status: the single seam both the initial fetch and the
+    // ── --wait re-poll loop call (grip#776 finding 3). Pure and synchronous,
+    // ── so these pin the decision directly with no HTTP or sleep involved.
+
+    #[test]
+    fn test_resolve_check_status_not_configured_is_passing() {
+        // grip#772: a ref with no CI configured at all has nothing to wait
+        // on, regardless of what `state` the platform reports alongside it.
+        assert_eq!(
+            resolve_check_status(&status(false, CheckState::Pending)),
+            CheckStatus::Passing
+        );
+    }
+
+    #[test]
+    fn test_resolve_check_status_configured_success_is_passing() {
+        assert_eq!(
+            resolve_check_status(&status(true, CheckState::Success)),
+            CheckStatus::Passing
+        );
+    }
+
+    #[test]
+    fn test_resolve_check_status_configured_failure_is_failing() {
+        assert_eq!(
+            resolve_check_status(&status(true, CheckState::Failure)),
+            CheckStatus::Failing
+        );
+    }
+
+    #[test]
+    fn test_resolve_check_status_configured_pending_is_pending() {
+        assert_eq!(
+            resolve_check_status(&status(true, CheckState::Pending)),
+            CheckStatus::Pending
+        );
+    }
 }

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -184,7 +184,18 @@ pub async fn run_pr_merge(
                 {
                     Ok(status) => {
                         // Successfully got check status
-                        if status.state == CheckState::Failure {
+                        if !status.checks_configured {
+                            // No CI is configured for this ref at all -- not a
+                            // real pending/passing signal, nothing to wait on
+                            // (grip#772: this used to map to Pending and
+                            // `--wait` would burn the full timeout for
+                            // something that was never going to appear).
+                            Output::info(&format!(
+                                "{}: no CI checks configured for branch '{}', proceeding",
+                                repo.name, branch
+                            ));
+                            CheckStatus::Passing
+                        } else if status.state == CheckState::Failure {
                             // Checks are actually failing
                             CheckStatus::Failing
                         } else if status.state == CheckState::Pending {
@@ -331,10 +342,17 @@ pub async fn run_pr_merge(
                         .await
                     {
                         Ok(status) => {
-                            pr.check_status = match status.state {
-                                CheckState::Failure => CheckStatus::Failing,
-                                CheckState::Pending => CheckStatus::Pending,
-                                _ => CheckStatus::Passing,
+                            pr.check_status = if !status.checks_configured {
+                                // grip#772: don't keep waiting on a ref that
+                                // turns out to have no CI configured, even if
+                                // it started this loop as Pending.
+                                CheckStatus::Passing
+                            } else {
+                                match status.state {
+                                    CheckState::Failure => CheckStatus::Failing,
+                                    CheckState::Pending => CheckStatus::Pending,
+                                    _ => CheckStatus::Passing,
+                                }
                             };
 
                             match pr.check_status {

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -346,6 +346,20 @@ pub async fn run_pr_merge(
                                 // grip#772: don't keep waiting on a ref that
                                 // turns out to have no CI configured, even if
                                 // it started this loop as Pending.
+                                //
+                                // Defense-in-depth, not independently mutation-tested:
+                                // this mirrors the initial-fetch guard above verbatim,
+                                // and the existing regression only exercises that first
+                                // guard (a repo whose checks are already unconfigured on
+                                // entry short-circuits before the wait loop ever runs).
+                                // A mutant breaking only this re-poll branch would
+                                // survive that test. Reaching this specific branch in a
+                                // test means surviving a real 15s sleep per iteration
+                                // (hardcoded below, no paused-clock seam exists yet in
+                                // this codebase) -- accepted as review-pinned parity
+                                // with the initial guard rather than paying that cost
+                                // for structurally identical logic. Revisit if this
+                                // branch and the initial guard ever diverge.
                                 CheckStatus::Passing
                             } else {
                                 match status.state {

--- a/src/platform/azure.rs
+++ b/src/platform/azure.rs
@@ -603,6 +603,7 @@ impl HostingPlatform for AzureDevOpsAdapter {
                     return Ok(StatusCheckResult {
                         state: CheckState::Success,
                         statuses: vec![],
+                        checks_configured: true,
                     });
                 }
 
@@ -629,13 +630,18 @@ impl HostingPlatform for AzureDevOpsAdapter {
                     })
                     .collect();
 
-                Ok(StatusCheckResult { state, statuses })
+                Ok(StatusCheckResult {
+                    state,
+                    statuses,
+                    checks_configured: true,
+                })
             }
             Err(_) => {
                 // No builds or API error - assume success
                 Ok(StatusCheckResult {
                     state: CheckState::Success,
                     statuses: vec![],
+                    checks_configured: true,
                 })
             }
         }

--- a/src/platform/bitbucket.rs
+++ b/src/platform/bitbucket.rs
@@ -407,9 +407,13 @@ impl HostingPlatform for BitbucketAdapter {
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
         if !response.status().is_success() {
+            // Couldn't reach the API -- unknown, not confirmed-absent. Keep
+            // the existing pending/retry behavior, but don't claim to know
+            // checks aren't configured when the query itself failed.
             return Ok(StatusCheckResult {
                 state: CheckState::Pending,
                 statuses: vec![],
+                checks_configured: true,
             });
         }
 
@@ -447,6 +451,12 @@ impl HostingPlatform for BitbucketAdapter {
             })
             .collect();
 
+        // grip#772: zero posted statuses means nothing is configured for this
+        // ref, not "checks are running" -- same root cause discovered and
+        // fixed in the GitHub adapter, found here while touching this exact
+        // function for the checks_configured field addition, not separately
+        // reported/repro'd against a real Bitbucket instance.
+        let checks_configured = !checks.is_empty();
         let overall_state = if checks.is_empty() {
             CheckState::Pending
         } else if checks.iter().all(|c| c.state == "success") {
@@ -458,6 +468,7 @@ impl HostingPlatform for BitbucketAdapter {
         Ok(StatusCheckResult {
             state: overall_state,
             statuses: checks,
+            checks_configured,
         })
     }
 

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -789,6 +789,14 @@ impl HostingPlatform for GitHubAdapter {
 
         check_response_rate_limit(response.headers(), "GitHub").await;
 
+        // Whether the Check Runs API positively confirmed zero runs exist
+        // (success + total_count == 0), as opposed to failing to answer at
+        // all (non-success HTTP). Only a positive confirmation licenses the
+        // legacy fallback's ambiguous pending+empty reading to mean
+        // "confirmed absent" -- a Check Runs outage must not be conflated
+        // with "nothing is configured" (grip#776 finding 1).
+        let mut check_runs_confirmed_empty = false;
+
         if response.status().is_success() {
             #[derive(serde::Deserialize)]
             struct CheckRunsResponse {
@@ -846,6 +854,7 @@ impl HostingPlatform for GitHubAdapter {
                     checks_configured: true,
                 });
             }
+            check_runs_confirmed_empty = true;
         }
 
         // Fallback to legacy status checks API
@@ -906,11 +915,16 @@ impl HostingPlatform for GitHubAdapter {
 
         // GitHub's legacy combined-status endpoint reports state="pending" for
         // a commit with zero posted statuses -- the same string it uses for
-        // "checks are running." Reaching this fallback at all already means
-        // the modern Check Runs API found nothing (total_count == 0); if the
-        // legacy API also has zero individual statuses, nothing is configured
-        // for this ref at all, and `--wait` must not block on it (grip#772).
-        let checks_configured = !(state == CheckState::Pending && statuses.is_empty());
+        // "checks are running." That ambiguous reading only means "nothing is
+        // configured" when the modern Check Runs API POSITIVELY confirmed
+        // zero runs (check_runs_confirmed_empty); if Check Runs instead
+        // failed to answer at all, an equally-ambiguous legacy reading must
+        // not be promoted to confirmed-absence, or `--wait` would silently
+        // proceed past checks whose status simply could not be determined
+        // (grip#776 finding 1). A definitive legacy signal -- real statuses,
+        // or a non-pending state -- is trusted either way.
+        let legacy_ambiguous = state == CheckState::Pending && statuses.is_empty();
+        let checks_configured = !(check_runs_confirmed_empty && legacy_ambiguous);
 
         Ok(StatusCheckResult {
             state,

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -843,6 +843,7 @@ impl HostingPlatform for GitHubAdapter {
                 return Ok(StatusCheckResult {
                     state: aggregate_state,
                     statuses,
+                    checks_configured: true,
                 });
             }
         }
@@ -894,7 +895,7 @@ impl HostingPlatform for GitHubAdapter {
             _ => CheckState::Pending,
         };
 
-        let statuses = status
+        let statuses: Vec<StatusCheck> = status
             .statuses
             .iter()
             .map(|s| StatusCheck {
@@ -903,7 +904,19 @@ impl HostingPlatform for GitHubAdapter {
             })
             .collect();
 
-        Ok(StatusCheckResult { state, statuses })
+        // GitHub's legacy combined-status endpoint reports state="pending" for
+        // a commit with zero posted statuses -- the same string it uses for
+        // "checks are running." Reaching this fallback at all already means
+        // the modern Check Runs API found nothing (total_count == 0); if the
+        // legacy API also has zero individual statuses, nothing is configured
+        // for this ref at all, and `--wait` must not block on it (grip#772).
+        let checks_configured = !(state == CheckState::Pending && statuses.is_empty());
+
+        Ok(StatusCheckResult {
+            state,
+            statuses,
+            checks_configured,
+        })
     }
 
     async fn get_allowed_merge_methods(

--- a/src/platform/gitlab.rs
+++ b/src/platform/gitlab.rs
@@ -514,6 +514,7 @@ impl HostingPlatform for GitLabAdapter {
                     return Ok(StatusCheckResult {
                         state: CheckState::Success,
                         statuses: vec![],
+                        checks_configured: true,
                     });
                 }
 
@@ -531,11 +532,13 @@ impl HostingPlatform for GitLabAdapter {
                         context: "gitlab-pipeline".to_string(),
                         state: pipeline.status.clone(),
                     }],
+                    checks_configured: true,
                 })
             }
             Err(_) => Ok(StatusCheckResult {
                 state: CheckState::Success,
                 statuses: vec![],
+                checks_configured: true,
             }),
         }
     }

--- a/src/platform/types.rs
+++ b/src/platform/types.rs
@@ -181,6 +181,13 @@ pub struct StatusCheckResult {
     pub state: CheckState,
     /// Individual statuses
     pub statuses: Vec<StatusCheck>,
+    /// Whether any CI checks are actually configured for this ref. `false`
+    /// means `state` is a platform-API artifact (e.g. GitHub's legacy combined-
+    /// status endpoint reports "pending" for a commit with zero posted
+    /// statuses, indistinguishable from "checks are running" by `state` alone)
+    /// rather than a real pending/passing/failing signal -- callers must not
+    /// wait on it (grip#772).
+    pub checks_configured: bool,
 }
 
 /// Detailed check status information
@@ -552,6 +559,7 @@ mod tests {
                     state: "success".to_string(),
                 },
             ],
+            checks_configured: true,
         };
 
         let json = serde_json::to_string(&result).unwrap();

--- a/tests/common/mock_platform.rs
+++ b/tests/common/mock_platform.rs
@@ -507,6 +507,37 @@ pub async fn mock_check_runs(
         .await;
 }
 
+/// GitHub API response for the legacy combined-status endpoint (GET
+/// /repos/:owner/:repo/commits/:ref/status). This is the fallback the real
+/// adapter code hits when the check-runs API reports zero runs. With zero
+/// posted statuses, GitHub's own API returns `state: "pending"` -- the exact
+/// ambiguity grip#772's fix disambiguates via the empty `statuses` array.
+pub async fn mock_legacy_combined_status(
+    server: &MockServer,
+    ref_name: &str,
+    state: &str,
+    statuses: Vec<(&str, &str)>,
+) {
+    let entries: Vec<Value> = statuses
+        .iter()
+        .map(|(context, entry_state)| json!({"context": context, "state": entry_state}))
+        .collect();
+
+    let body = json!({
+        "state": state,
+        "statuses": entries
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/owner/repo/commits/{}/status",
+            ref_name
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
 /// GitHub API response for updating a PR (PATCH /repos/:owner/:repo/pulls/:number).
 pub async fn mock_update_pull_request(server: &MockServer, number: u64) {
     let body = github_pr_json(number, "open", "feat/test", "main", false, "");

--- a/tests/test_platform_bitbucket.rs
+++ b/tests/test_platform_bitbucket.rs
@@ -120,6 +120,33 @@ async fn test_bb_status_checks() {
     let checks = result.unwrap();
     assert_eq!(checks.state, CheckState::Success);
     assert_eq!(checks.statuses.len(), 2);
+    assert!(
+        checks.checks_configured,
+        "real posted statuses must set checks_configured=true (grip#776 \
+         finding 2: this was previously unasserted, so a mutant flipping the \
+         true case to false went unnoticed)"
+    );
+}
+
+#[tokio::test]
+async fn test_bb_status_checks_empty_sets_checks_configured_false() {
+    // grip#776 finding 2 (Bitbucket's empty side): zero posted statuses
+    // means nothing is configured for this ref, not "checks are running" --
+    // the same false-absence risk grip#772 fixed for GitHub. Never
+    // independently pinned for the Bitbucket adapter until now.
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_status_checks(&server, "abc123", vec![]).await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(result.is_ok(), "should get checks: {:?}", result);
+    let checks = result.unwrap();
+    assert_eq!(checks.state, CheckState::Pending);
+    assert!(
+        !checks.checks_configured,
+        "zero posted statuses must set checks_configured=false, or `--wait` \
+         burns its full timeout on a ref with nothing to wait for"
+    );
 }
 
 // ── Approval ──────────────────────────────────────────────────────

--- a/tests/test_platform_github.rs
+++ b/tests/test_platform_github.rs
@@ -378,6 +378,92 @@ async fn test_github_status_checks_all_pass() {
     let checks = result.unwrap();
     assert_eq!(checks.state, CheckState::Success);
     assert_eq!(checks.statuses.len(), 2);
+    assert!(
+        checks.checks_configured,
+        "real check runs must set checks_configured=true (grip#776 finding 2: \
+         this was previously unasserted, so a mutant flipping the true case \
+         to false went unnoticed)"
+    );
+}
+
+#[tokio::test]
+async fn test_github_status_checks_legacy_signal_trusted_despite_empty_check_runs() {
+    // Check Runs API succeeds but reports zero runs (a repo whose CI posts
+    // only to the legacy status API, never registering as a GitHub Actions
+    // Check Run). The legacy endpoint DOES have a real signal -- it must be
+    // trusted, not discarded just because Check Runs saw nothing.
+    let (server, adapter) = setup_github_mock().await;
+    mock_check_runs(&server, "abc123", vec![]).await;
+    mock_legacy_combined_status(&server, "abc123", "success", vec![("legacy-ci", "success")]).await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(
+        result.is_ok(),
+        "should fall through to legacy: {:?}",
+        result
+    );
+    let checks = result.unwrap();
+    assert_eq!(checks.state, CheckState::Success);
+    assert!(
+        checks.checks_configured,
+        "a real legacy signal must set checks_configured=true even when \
+         Check Runs independently confirmed zero runs"
+    );
+}
+
+#[tokio::test]
+async fn test_github_status_checks_both_apis_confirm_nothing_configured() {
+    // The base case grip#772 exists for: Check Runs positively confirms zero
+    // runs AND the legacy endpoint is equally empty (pending + no statuses).
+    // Both APIs agreeing on absence is the only case where checks_configured
+    // should be false.
+    let (server, adapter) = setup_github_mock().await;
+    mock_check_runs(&server, "abc123", vec![]).await;
+    mock_legacy_combined_status(&server, "abc123", "pending", vec![]).await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(
+        result.is_ok(),
+        "should fall through to legacy: {:?}",
+        result
+    );
+    let checks = result.unwrap();
+    assert!(
+        !checks.checks_configured,
+        "both APIs agreeing on zero checks must set checks_configured=false, \
+         or `--wait` burns its full timeout on a ref with nothing to wait for \
+         (grip#772)"
+    );
+}
+
+#[tokio::test]
+async fn test_github_status_checks_check_runs_500_with_ambiguous_legacy_is_not_confirmed_absent() {
+    // grip#776 finding 1: Check Runs fails outright (500, not "succeeded
+    // with zero"). The legacy endpoint's pending+empty reading is exactly as
+    // ambiguous here as it is in the confirmed-empty case above -- but
+    // reaching this fallback via a Check Runs FAILURE must not be conflated
+    // with reaching it via a Check Runs CONFIRMATION of zero runs. An API
+    // outage is not evidence of absence.
+    let (server, adapter) = setup_github_mock().await;
+    mock_server_error(&server, "/repos/owner/repo/commits/abc123/check-runs").await;
+    mock_legacy_combined_status(&server, "abc123", "pending", vec![]).await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(
+        result.is_ok(),
+        "should fall through to legacy: {:?}",
+        result
+    );
+    let checks = result.unwrap();
+    assert!(
+        checks.checks_configured,
+        "Check Runs 500 + ambiguous legacy pending/empty must NOT be treated \
+         as confirmed-absent -- that would let `--wait` silently proceed past \
+         checks whose status could not actually be determined"
+    );
 }
 
 #[tokio::test]

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -9,8 +9,8 @@ mod common;
 use common::fixtures::WorkspaceBuilder;
 use common::git_helpers;
 use common::mock_platform::{
-    mock_check_runs, mock_get_pr, mock_list_prs, mock_merge_pr, mock_merge_pr_behind,
-    mock_pr_reviews, point_repo_at_mock, setup_github_mock,
+    mock_check_runs, mock_get_pr, mock_legacy_combined_status, mock_list_prs, mock_merge_pr,
+    mock_merge_pr_behind, mock_pr_reviews, point_repo_at_mock, setup_github_mock,
 };
 use gitgrip::core::manifest::{PlatformConfig, PlatformType};
 use wiremock::http::Method;
@@ -663,5 +663,89 @@ async fn test_pr_merge_all_flag_proceeds_and_merges_every_match() {
     assert_eq!(
         merge_puts, 2,
         "expected a merge PUT for each of the two --all-confirmed repos"
+    );
+}
+
+// ── grip#772: --wait must not block on a branch with no CI configured ──────
+//
+// Reproduces the exact incident: `gr pr merge --wait --timeout 600` on
+// premium#745 (2026-07-17) ran the full 600s timeout even though the branch
+// had zero CI checks configured at all -- GitHub's check-runs API reported
+// total_count=0, and its legacy combined-status fallback reports
+// state="pending" for a commit with zero posted statuses, the same string it
+// uses for "checks are running." `--wait` must treat "confirmed zero checks"
+// as immediately resolved, not enter the poll loop at all.
+
+#[tokio::test]
+async fn test_pr_merge_wait_does_not_block_when_no_checks_are_configured() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let mut manifest = ws.load_manifest();
+
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/no-ci");
+    git_helpers::commit_file(
+        &ws.repo_path("app"),
+        "feature.txt",
+        "feature",
+        "Add feature",
+    );
+
+    let repo_config = manifest.repos.get_mut("app").unwrap();
+    repo_config.url = Some("https://github.com/owner/repo.git".to_string());
+    repo_config.platform = Some(PlatformConfig {
+        platform_type: PlatformType::GitHub,
+        base_url: Some(server.uri()),
+    });
+
+    mock_list_prs(&server, vec![(42, "feat/no-ci")]).await;
+    mock_get_pr(&server, 42, "open", false).await;
+    mock_pr_reviews(&server, 42, vec![("APPROVED", "alice")]).await;
+    // Exact GitHub shape for a ref with no CI configured: check-runs reports
+    // zero runs, and the legacy fallback reports "pending" with zero statuses.
+    mock_check_runs(&server, "feat/no-ci", vec![]).await;
+    mock_legacy_combined_status(&server, "feat/no-ci", "pending", vec![]).await;
+    mock_merge_pr(&server, 42, true).await;
+
+    let start = std::time::Instant::now();
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            update: false,
+            auto: false,
+            json: false,
+            wait: true,
+            timeout: 5,
+            delete_branch: true,
+            repo_filter: None,
+            yes: true,
+            allow_all: false,
+        },
+    )
+    .await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_ok(),
+        "merge with --wait on a no-CI-configured branch should succeed, not time out: {:?}",
+        result.err()
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(10),
+        "expected --wait to resolve immediately (no checks configured means nothing to poll \
+         for), took {:?} instead -- this is grip#772's exact symptom if it regresses \
+         (the loop's own re-poll sleep is 15s, so a regression would take at least that long)",
+        elapsed
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method == Method::PUT && r.url.path().ends_with("/merge")),
+        "expected the merge to actually proceed, not just avoid timing out"
     );
 }


### PR DESCRIPTION
## Summary

Fixes grip#772: `gr pr merge --wait` burned the full timeout (e.g. 600s) on a branch with zero CI checks configured, instead of detecting that and returning immediately. Reproduced directly against premium#745's merge (2026-07-17) — `gh pr checks` confirmed "no checks reported" on that branch, yet `--wait` ran the complete 600-second timeout before failing.

## Root cause

`StatusCheckResult` had no way to distinguish "confirmed zero checks configured" from "checks exist and are pending." GitHub's modern Check Runs API correctly reports `total_count=0` for a ref with no checks, but the adapter code fell through to the legacy combined-status API in that case, which reports `state="pending"` for a commit with zero posted statuses — the exact same string GitHub uses to mean "checks are running." `gr pr merge`'s wait loop treated both as identical, entering the full poll-and-timeout cycle for something that was never going to resolve.

## Fix

- `StatusCheckResult` gains a `checks_configured: bool` field. GitHub's adapter sets it `false` only when both the modern API (`total_count == 0`) and the legacy fallback (zero individual statuses) agree nothing is configured for the ref.
- `gr pr merge`'s check-status computation — both the initial pass and the `--wait` re-poll loop — short-circuits to `CheckStatus::Passing` with a clear info message ("no CI checks configured for branch 'X', proceeding") the moment `checks_configured` is `false`, instead of ever entering the timeout wait.
- While touching every platform adapter's `StatusCheckResult` construction sites for the new field (mechanical, all 4 platforms), found and fixed the **identical latent bug in Bitbucket's adapter** (`checks.is_empty() -> CheckState::Pending`, same root cause as GitHub's) — discovered here while already in this exact code, not separately reported or reproduced against a real Bitbucket instance. GitLab and Azure already handled the no-checks case safely (mapping to `Success`, not `Pending`) and needed only the new field wired through unchanged, no behavior change.

## Verification

- New compiled-binary regression (`test_pr_merge_wait_does_not_block_when_no_checks_are_configured`) reproduces the exact premium#745 shape: zero check-runs, legacy status `pending` with zero individual statuses. Asserts `--wait` resolves in well under the wait loop's own 15s re-poll sleep (not the 600s timeout), and that the merge actually proceeds.
- Mutation-checked: temporarily disabled the initial-computation guard (`if false && !status.checks_configured`). The regression failed at 21.1s — matching the reported symptom shape — before restoring clean.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --all-targets`: clean.
- Full suite: `cargo test` — 52 test-result blocks across every binary, 0 failed.

## Premium boundary

Core OSS — gitgrip PR-merge orchestration and platform-adapter status-check logic. No identity or org semantics touched.

Closes https://github.com/synapt-dev/grip/issues/772