### PR TITLE
fix: update stale checkout-add filter-error test assertion

### DIFF
--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -760,7 +760,7 @@ fn test_checkout_add_errors_when_filters_match_no_repos() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "no repos matched checkout filters",
+            "repo filter 'missing' not found in local manifest",
         ));
 }
 


### PR DESCRIPTION
## Summary

\`test_checkout_add_errors_when_filters_match_no_repos\` expected the old generic "no repos matched checkout filters" message. 7abf810 (already merged -- Sentinel's d5-gr1-bug-five diagnostics hardening) deliberately wired \`validate_repo_filters_known()\` into \`checkout add\`'s path so an unknown \`--repo\` filter fails fast with a specific, actionable message ("repo filter 'X' not found in local manifest... run \`gr sync\`") instead of silently falling through to the generic bail.

Verified this is intentional, not accidental: \`validate_repo_filters_known\` is deliberately called from \`checkout.rs\` (both call sites), \`sync.rs\`, and \`restore.rs\` -- broad, purposeful hardening, not a stray side-effect. The new behavior is correct; the test assertion just never got updated to match.

No behavior change. Test-only diff.

## Context

Found while re-verifying sprint-39 is fully green ahead of ceremony. My first \`cargo test --all\` check was piped through \`tail\`, which masked cargo's real exit code -- this one pre-existing failure slipped past that. Re-verified with direct (unpiped) exit code capture: sprint-39 is now genuinely 100% green on both \`cargo test\` (692 passed across all suites) and the gr2 python suite (513 passed), following PR#783's revert of the grip#752 add/commit/push RED tests.

Premium boundary: grip is OSS (MIT) -- test-only fix to CLI diagnostics behavior, no identity/org semantics.