### PR TITLE
Sprint 41 ceremony: sprint-41 -> main (v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-07-23
+
+### Fixed
+- **`gr pr edit`/`review`/`merge` refuse unscoped multi-repo actions** (#773) — when a caller doesn't pass `--repo` and more than one repo has a matching open PR for its checked-out branch, gr now fails closed and lists exactly what would have been touched instead of silently fanning out. A repo's checked-out branch can be a stale, forgotten one from unrelated past work, so "N repos matched" was never the same thing as "the user meant N repos" — this closed two real incidents (grip#770, grip#771) where a body meant for one PR landed on someone else's unrelated one.
+- **`gr checkout add` produces a self-discoverable child workspace** (#775) — unified the workspace discovery walk so a child checkout's manifest is found the same way regardless of nesting, removed a checkout/manifest-repo collision, and made malformed or reconstructed checkout metadata fail closed rather than silently carrying authority it shouldn't have.
+- **`gr pr merge --wait` detects no-checks-configured and returns immediately** (#776) — previously could hang waiting on checks that were never going to run; now closes the false-absence and mutation-silence gaps in the re-poll guard.
+
 ## [1.0.0] - 2026-04-17
 
 gr1 reaches stable. This release marks the feature-complete gr1 CLI before gr2 takes over as the primary workspace management system.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -745,6 +745,9 @@ pub enum PrCommands {
         /// Skip confirmation prompt (used with --force)
         #[arg(short = 'y', long)]
         yes: bool,
+        /// Proceed even though multiple repos have a matching open PR (without --repo)
+        #[arg(long)]
+        all: bool,
     },
     /// Edit pull request title/body
     Edit {
@@ -754,6 +757,12 @@ pub enum PrCommands {
         /// New PR body/description
         #[arg(short, long)]
         body: Option<String>,
+        /// Only edit PRs for specific repos (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        repo: Option<Vec<String>>,
+        /// Proceed even though multiple repos have a matching open PR (without --repo)
+        #[arg(long)]
+        all: bool,
     },
     /// Check CI status
     Checks {
@@ -795,6 +804,12 @@ pub enum PrCommands {
         /// Review comment body (required for comment and request-changes)
         #[arg(short, long)]
         body: Option<String>,
+        /// Only review PRs for specific repos (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        repo: Option<Vec<String>>,
+        /// Proceed even though multiple repos have a matching open PR (without --repo)
+        #[arg(long)]
+        all: bool,
     },
 }
 

--- a/src/cli/commands/checkout.rs
+++ b/src/cli/commands/checkout.rs
@@ -143,17 +143,8 @@ pub fn run_checkout_add(
         anyhow::bail!("no repos matched checkout filters");
     }
 
-    let repo_specs: Vec<(&str, &str, &str)> = repos
-        .iter()
-        .map(|repo| (repo.name.as_str(), repo.url.as_str(), repo.path.as_str()))
-        .collect();
-
-    let info = workspace_checkout::create_checkout(
-        workspace_root,
-        checkout_name,
-        repo_specs.into_iter(),
-        None,
-    )?;
+    let info =
+        workspace_checkout::create_checkout(workspace_root, checkout_name, manifest, &repos, None)?;
 
     Output::success(&format!(
         "Created checkout '{}' with {} repo(s)",

--- a/src/cli/commands/pr/edit.rs
+++ b/src/cli/commands/pr/edit.rs
@@ -2,10 +2,22 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
-use crate::core::repo::{get_manifest_repo_info, RepoInfo};
+use crate::core::repo::{
+    filter_repos, get_manifest_repo_info, require_explicit_multi_repo_scope,
+    validate_repo_filters_known,
+};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::get_platform_adapter;
 use std::path::Path;
+use std::sync::Arc;
+
+struct PRToEdit {
+    repo_name: String,
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    platform: Arc<dyn crate::platform::HostingPlatform>,
+}
 
 /// Run the PR edit command — update title and/or body across linked PRs
 pub async fn run_pr_edit(
@@ -13,40 +25,40 @@ pub async fn run_pr_edit(
     manifest: &Manifest,
     title: Option<&str>,
     body: Option<&str>,
+    repo_filter: Option<&[String]>,
+    allow_all: bool,
     json: bool,
 ) -> anyhow::Result<()> {
     if title.is_none() && body.is_none() {
         anyhow::bail!("At least one of --title or --body must be provided");
     }
 
+    validate_repo_filters_known(manifest, repo_filter)?;
+
     if !json {
         Output::header("Editing pull requests...");
         println!();
     }
 
-    let repos: Vec<RepoInfo> = manifest
-        .repos
-        .iter()
-        .filter_map(|(name, config)| {
-            RepoInfo::from_config(
-                name,
-                config,
-                workspace_root,
-                &manifest.settings,
-                manifest.remotes.as_ref(),
-            )
-        })
-        .filter(|r| !r.reference)
-        .collect();
+    let repos = filter_repos(manifest, workspace_root, repo_filter, None, false);
 
     let mut all_repos = repos;
-    if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
-        all_repos.push(manifest_repo);
+    let manifest_included = match repo_filter {
+        Some(filter) => filter.iter().any(|f| f == "manifest"),
+        None => true,
+    };
+    if manifest_included {
+        if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
+            all_repos.push(manifest_repo);
+        }
     }
 
-    let mut updated = 0u32;
+    // First pass: find which repos actually have a matching open PR, without
+    // editing anything yet. "N repos matched" only becomes safe to act on after
+    // the multi-repo scope guard below has had a chance to refuse it.
+    let mut prs_to_edit: Vec<PRToEdit> = Vec::new();
     let mut skipped = 0u32;
-    let mut errors = Vec::new();
+    let mut find_errors = Vec::new();
 
     for repo in &all_repos {
         if !path_exists(&repo.absolute_path) {
@@ -75,29 +87,13 @@ pub async fn run_pr_edit(
             .await
         {
             Ok(Some(pr)) => {
-                match platform
-                    .update_pull_request(&repo.owner, &repo.repo, pr.number, title, body)
-                    .await
-                {
-                    Ok(()) => {
-                        if !json {
-                            Output::success(&format!(
-                                "{}: updated PR #{} on {}/{}",
-                                repo.name, pr.number, repo.owner, repo.repo
-                            ));
-                        }
-                        updated += 1;
-                    }
-                    Err(e) => {
-                        if !json {
-                            Output::error(&format!(
-                                "{}: failed to update PR #{}: {}",
-                                repo.name, pr.number, e
-                            ));
-                        }
-                        errors.push(format!("{}: {}", repo.name, e));
-                    }
-                }
+                prs_to_edit.push(PRToEdit {
+                    repo_name: repo.name.clone(),
+                    owner: repo.owner.clone(),
+                    repo: repo.repo.clone(),
+                    pr_number: pr.number,
+                    platform,
+                });
             }
             Ok(None) => {
                 if !json {
@@ -112,7 +108,50 @@ pub async fn run_pr_edit(
                 if !json {
                     Output::error(&format!("{}: {}", repo.name, e));
                 }
-                errors.push(format!("{}: {}", repo.name, e));
+                find_errors.push(format!("{}: {}", repo.name, e));
+            }
+        }
+    }
+
+    require_explicit_multi_repo_scope(
+        &prs_to_edit,
+        repo_filter.is_some(),
+        allow_all,
+        "gr pr edit",
+        |pr| {
+            format!(
+                "{} PR #{} on {}/{}",
+                pr.repo_name, pr.pr_number, pr.owner, pr.repo
+            )
+        },
+    )?;
+
+    let mut updated = 0u32;
+    let mut errors = find_errors;
+
+    for pr in &prs_to_edit {
+        match pr
+            .platform
+            .update_pull_request(&pr.owner, &pr.repo, pr.pr_number, title, body)
+            .await
+        {
+            Ok(()) => {
+                if !json {
+                    Output::success(&format!(
+                        "{}: updated PR #{} on {}/{}",
+                        pr.repo_name, pr.pr_number, pr.owner, pr.repo
+                    ));
+                }
+                updated += 1;
+            }
+            Err(e) => {
+                if !json {
+                    Output::error(&format!(
+                        "{}: failed to update PR #{}: {}",
+                        pr.repo_name, pr.pr_number, e
+                    ));
+                }
+                errors.push(format!("{}: {}", pr.repo_name, e));
             }
         }
     }

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -6,10 +6,40 @@ use crate::core::manifest::Manifest;
 use crate::core::repo::{get_manifest_repo_info, require_explicit_multi_repo_scope, RepoInfo};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::traits::{HostingPlatform, PlatformError};
-use crate::platform::{get_platform_adapter, CheckState, MergeMethod};
+use crate::platform::{get_platform_adapter, CheckState, MergeMethod, StatusCheckResult};
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
+
+/// This command's internal readiness classification for a PR's checks,
+/// derived from a platform's [`StatusCheckResult`] via [`resolve_check_status`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckStatus {
+    Passing,
+    Failing,
+    Pending,
+    Unknown,
+}
+
+/// Resolve a platform's status-check result into this command's internal
+/// [`CheckStatus`]. Pure and synchronous so it can be pinned directly against
+/// synthetic [`StatusCheckResult`] values, without exercising the HTTP or
+/// sleep/retry machinery around either call site. Both the initial fetch and
+/// the `--wait` re-poll loop call this exact function so the decision can
+/// never diverge between them (grip#776 finding 3).
+fn resolve_check_status(status: &StatusCheckResult) -> CheckStatus {
+    if !status.checks_configured {
+        // No CI is configured for this ref at all -- not a real
+        // pending/passing signal, nothing to wait on (grip#772).
+        CheckStatus::Passing
+    } else {
+        match status.state {
+            CheckState::Failure => CheckStatus::Failing,
+            CheckState::Pending => CheckStatus::Pending,
+            CheckState::Success => CheckStatus::Passing,
+        }
+    }
+}
 
 /// Auto-detect the best merge method for a repo when none is specified.
 ///
@@ -112,14 +142,6 @@ pub async fn run_pr_merge(
     }
 
     // Collect PRs to merge
-    #[derive(Debug, Clone, Copy)]
-    enum CheckStatus {
-        Passing,
-        Failing,
-        Pending,
-        Unknown,
-    }
-
     struct PRToMerge {
         repo_name: String,
         owner: String,
@@ -185,25 +207,12 @@ pub async fn run_pr_merge(
                     Ok(status) => {
                         // Successfully got check status
                         if !status.checks_configured {
-                            // No CI is configured for this ref at all -- not a
-                            // real pending/passing signal, nothing to wait on
-                            // (grip#772: this used to map to Pending and
-                            // `--wait` would burn the full timeout for
-                            // something that was never going to appear).
                             Output::info(&format!(
                                 "{}: no CI checks configured for branch '{}', proceeding",
                                 repo.name, branch
                             ));
-                            CheckStatus::Passing
-                        } else if status.state == CheckState::Failure {
-                            // Checks are actually failing
-                            CheckStatus::Failing
-                        } else if status.state == CheckState::Pending {
-                            // Checks still running - don't block but warn
-                            CheckStatus::Pending
-                        } else {
-                            CheckStatus::Passing
                         }
+                        resolve_check_status(&status)
                     }
                     Err(e) => {
                         // Could not determine check status
@@ -342,32 +351,7 @@ pub async fn run_pr_merge(
                         .await
                     {
                         Ok(status) => {
-                            pr.check_status = if !status.checks_configured {
-                                // grip#772: don't keep waiting on a ref that
-                                // turns out to have no CI configured, even if
-                                // it started this loop as Pending.
-                                //
-                                // Defense-in-depth, not independently mutation-tested:
-                                // this mirrors the initial-fetch guard above verbatim,
-                                // and the existing regression only exercises that first
-                                // guard (a repo whose checks are already unconfigured on
-                                // entry short-circuits before the wait loop ever runs).
-                                // A mutant breaking only this re-poll branch would
-                                // survive that test. Reaching this specific branch in a
-                                // test means surviving a real 15s sleep per iteration
-                                // (hardcoded below, no paused-clock seam exists yet in
-                                // this codebase) -- accepted as review-pinned parity
-                                // with the initial guard rather than paying that cost
-                                // for structurally identical logic. Revisit if this
-                                // branch and the initial guard ever diverge.
-                                CheckStatus::Passing
-                            } else {
-                                match status.state {
-                                    CheckState::Failure => CheckStatus::Failing,
-                                    CheckState::Pending => CheckStatus::Pending,
-                                    _ => CheckStatus::Passing,
-                                }
-                            };
+                            pr.check_status = resolve_check_status(&status);
 
                             match pr.check_status {
                                 CheckStatus::Passing => {
@@ -881,4 +865,55 @@ fn check_repo_for_changes(repo: &RepoInfo) -> anyhow::Result<bool> {
 
     // Check for commits ahead of target branch using shared helper
     has_commits_ahead(&git_repo, &current, repo.target_branch())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(checks_configured: bool, state: CheckState) -> StatusCheckResult {
+        StatusCheckResult {
+            state,
+            statuses: Vec::new(),
+            checks_configured,
+        }
+    }
+
+    // ── resolve_check_status: the single seam both the initial fetch and the
+    // ── --wait re-poll loop call (grip#776 finding 3). Pure and synchronous,
+    // ── so these pin the decision directly with no HTTP or sleep involved.
+
+    #[test]
+    fn test_resolve_check_status_not_configured_is_passing() {
+        // grip#772: a ref with no CI configured at all has nothing to wait
+        // on, regardless of what `state` the platform reports alongside it.
+        assert_eq!(
+            resolve_check_status(&status(false, CheckState::Pending)),
+            CheckStatus::Passing
+        );
+    }
+
+    #[test]
+    fn test_resolve_check_status_configured_success_is_passing() {
+        assert_eq!(
+            resolve_check_status(&status(true, CheckState::Success)),
+            CheckStatus::Passing
+        );
+    }
+
+    #[test]
+    fn test_resolve_check_status_configured_failure_is_failing() {
+        assert_eq!(
+            resolve_check_status(&status(true, CheckState::Failure)),
+            CheckStatus::Failing
+        );
+    }
+
+    #[test]
+    fn test_resolve_check_status_configured_pending_is_pending() {
+        assert_eq!(
+            resolve_check_status(&status(true, CheckState::Pending)),
+            CheckStatus::Pending
+        );
+    }
 }

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -3,7 +3,7 @@
 use super::create::has_commits_ahead;
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
-use crate::core::repo::{get_manifest_repo_info, RepoInfo};
+use crate::core::repo::{get_manifest_repo_info, require_explicit_multi_repo_scope, RepoInfo};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::traits::{HostingPlatform, PlatformError};
 use crate::platform::{get_platform_adapter, CheckState, MergeMethod};
@@ -49,6 +49,7 @@ pub struct MergeOptions<'a> {
     pub delete_branch: bool,
     pub repo_filter: Option<Vec<String>>,
     pub yes: bool,
+    pub allow_all: bool,
 }
 
 /// Run the PR merge command
@@ -235,6 +236,22 @@ pub async fn run_pr_merge(
         println!("Repositories checked: {}", all_repos.len());
         return Ok(());
     }
+
+    // Same guard as `gr pr edit`/`gr pr review`: an unscoped multi-repo match is
+    // ambiguous, not consent. --repo already narrows opts.repo_filter above; --all
+    // is the explicit opt-in when the caller genuinely wants every matched repo.
+    require_explicit_multi_repo_scope(
+        &prs_to_merge,
+        opts.repo_filter.is_some(),
+        opts.allow_all,
+        "gr pr merge",
+        |pr| {
+            format!(
+                "{} PR #{} on {}/{}",
+                pr.repo_name, pr.pr_number, pr.owner, pr.repo
+            )
+        },
+    )?;
 
     // Show which repos have PRs and which don't
     let repos_with_prs: Vec<String> = prs_to_merge.iter().map(|p| p.repo_name.clone()).collect();

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -184,7 +184,18 @@ pub async fn run_pr_merge(
                 {
                     Ok(status) => {
                         // Successfully got check status
-                        if status.state == CheckState::Failure {
+                        if !status.checks_configured {
+                            // No CI is configured for this ref at all -- not a
+                            // real pending/passing signal, nothing to wait on
+                            // (grip#772: this used to map to Pending and
+                            // `--wait` would burn the full timeout for
+                            // something that was never going to appear).
+                            Output::info(&format!(
+                                "{}: no CI checks configured for branch '{}', proceeding",
+                                repo.name, branch
+                            ));
+                            CheckStatus::Passing
+                        } else if status.state == CheckState::Failure {
                             // Checks are actually failing
                             CheckStatus::Failing
                         } else if status.state == CheckState::Pending {
@@ -331,10 +342,17 @@ pub async fn run_pr_merge(
                         .await
                     {
                         Ok(status) => {
-                            pr.check_status = match status.state {
-                                CheckState::Failure => CheckStatus::Failing,
-                                CheckState::Pending => CheckStatus::Pending,
-                                _ => CheckStatus::Passing,
+                            pr.check_status = if !status.checks_configured {
+                                // grip#772: don't keep waiting on a ref that
+                                // turns out to have no CI configured, even if
+                                // it started this loop as Pending.
+                                CheckStatus::Passing
+                            } else {
+                                match status.state {
+                                    CheckState::Failure => CheckStatus::Failing,
+                                    CheckState::Pending => CheckStatus::Pending,
+                                    _ => CheckStatus::Passing,
+                                }
                             };
 
                             match pr.check_status {

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -346,6 +346,20 @@ pub async fn run_pr_merge(
                                 // grip#772: don't keep waiting on a ref that
                                 // turns out to have no CI configured, even if
                                 // it started this loop as Pending.
+                                //
+                                // Defense-in-depth, not independently mutation-tested:
+                                // this mirrors the initial-fetch guard above verbatim,
+                                // and the existing regression only exercises that first
+                                // guard (a repo whose checks are already unconfigured on
+                                // entry short-circuits before the wait loop ever runs).
+                                // A mutant breaking only this re-poll branch would
+                                // survive that test. Reaching this specific branch in a
+                                // test means surviving a real 15s sleep per iteration
+                                // (hardcoded below, no paused-clock seam exists yet in
+                                // this codebase) -- accepted as review-pinned parity
+                                // with the initial guard rather than paying that cost
+                                // for structurally identical logic. Revisit if this
+                                // branch and the initial guard ever diverge.
                                 CheckStatus::Passing
                             } else {
                                 match status.state {

--- a/src/cli/commands/pr/review.rs
+++ b/src/cli/commands/pr/review.rs
@@ -2,11 +2,23 @@
 
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
-use crate::core::repo::{get_manifest_repo_info, RepoInfo};
+use crate::core::repo::{
+    filter_repos, get_manifest_repo_info, require_explicit_multi_repo_scope,
+    validate_repo_filters_known,
+};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::get_platform_adapter;
 use crate::platform::ReviewEvent;
 use std::path::Path;
+use std::sync::Arc;
+
+struct PRToReview {
+    repo_name: String,
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    platform: Arc<dyn crate::platform::HostingPlatform>,
+}
 
 /// Run the PR review command — post a review on PRs across linked repos
 pub async fn run_pr_review(
@@ -14,11 +26,15 @@ pub async fn run_pr_review(
     manifest: &Manifest,
     event: ReviewEvent,
     body: Option<&str>,
+    repo_filter: Option<&[String]>,
+    allow_all: bool,
     json: bool,
 ) -> anyhow::Result<()> {
     if matches!(event, ReviewEvent::RequestChanges | ReviewEvent::Comment) && body.is_none() {
         anyhow::bail!("--body is required for comment and request-changes reviews");
     }
+
+    validate_repo_filters_known(manifest, repo_filter)?;
 
     if !json {
         let action = match event {
@@ -30,29 +46,24 @@ pub async fn run_pr_review(
         println!();
     }
 
-    let repos: Vec<RepoInfo> = manifest
-        .repos
-        .iter()
-        .filter_map(|(name, config)| {
-            RepoInfo::from_config(
-                name,
-                config,
-                workspace_root,
-                &manifest.settings,
-                manifest.remotes.as_ref(),
-            )
-        })
-        .filter(|r| !r.reference)
-        .collect();
+    let repos = filter_repos(manifest, workspace_root, repo_filter, None, false);
 
     let mut all_repos = repos;
-    if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
-        all_repos.push(manifest_repo);
+    let manifest_included = match repo_filter {
+        Some(filter) => filter.iter().any(|f| f == "manifest"),
+        None => true,
+    };
+    if manifest_included {
+        if let Some(manifest_repo) = get_manifest_repo_info(manifest, workspace_root) {
+            all_repos.push(manifest_repo);
+        }
     }
 
-    let mut reviewed = 0u32;
+    // First pass: find which repos actually have a matching open PR, without
+    // reviewing anything yet -- same reasoning as run_pr_edit's find/act split.
+    let mut prs_to_review: Vec<PRToReview> = Vec::new();
     let mut skipped = 0u32;
-    let mut errors = Vec::new();
+    let mut find_errors = Vec::new();
 
     for repo in &all_repos {
         if !path_exists(&repo.absolute_path) {
@@ -81,27 +92,13 @@ pub async fn run_pr_review(
             .await
         {
             Ok(Some(pr)) => {
-                let spinner =
-                    Output::spinner(&format!("Reviewing {} PR #{}...", repo.name, pr.number));
-                match platform
-                    .create_pull_request_review(&repo.owner, &repo.repo, pr.number, event, body)
-                    .await
-                {
-                    Ok(()) => {
-                        spinner.finish_with_message(format!(
-                            "{}: reviewed PR #{} on {}/{}",
-                            repo.name, pr.number, repo.owner, repo.repo
-                        ));
-                        reviewed += 1;
-                    }
-                    Err(e) => {
-                        spinner.finish_with_message(format!(
-                            "{}: failed to review PR #{}: {}",
-                            repo.name, pr.number, e
-                        ));
-                        errors.push(format!("{}: {}", repo.name, e));
-                    }
-                }
+                prs_to_review.push(PRToReview {
+                    repo_name: repo.name.clone(),
+                    owner: repo.owner.clone(),
+                    repo: repo.repo.clone(),
+                    pr_number: pr.number,
+                    platform,
+                });
             }
             Ok(None) => {
                 if !json {
@@ -116,7 +113,50 @@ pub async fn run_pr_review(
                 if !json {
                     Output::error(&format!("{}: {}", repo.name, e));
                 }
-                errors.push(format!("{}: {}", repo.name, e));
+                find_errors.push(format!("{}: {}", repo.name, e));
+            }
+        }
+    }
+
+    require_explicit_multi_repo_scope(
+        &prs_to_review,
+        repo_filter.is_some(),
+        allow_all,
+        "gr pr review",
+        |pr| {
+            format!(
+                "{} PR #{} on {}/{}",
+                pr.repo_name, pr.pr_number, pr.owner, pr.repo
+            )
+        },
+    )?;
+
+    let mut reviewed = 0u32;
+    let mut errors = find_errors;
+
+    for pr in &prs_to_review {
+        let spinner = Output::spinner(&format!(
+            "Reviewing {} PR #{}...",
+            pr.repo_name, pr.pr_number
+        ));
+        match pr
+            .platform
+            .create_pull_request_review(&pr.owner, &pr.repo, pr.pr_number, event, body)
+            .await
+        {
+            Ok(()) => {
+                spinner.finish_with_message(format!(
+                    "{}: reviewed PR #{} on {}/{}",
+                    pr.repo_name, pr.pr_number, pr.owner, pr.repo
+                ));
+                reviewed += 1;
+            }
+            Err(e) => {
+                spinner.finish_with_message(format!(
+                    "{}: failed to review PR #{}: {}",
+                    pr.repo_name, pr.pr_number, e
+                ));
+                errors.push(format!("{}: {}", pr.repo_name, e));
             }
         }
     }

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -632,6 +632,7 @@ pub async fn run_release(opts: ReleaseOptions<'_>) -> anyhow::Result<()> {
                     delete_branch: true,
                     repo_filter: None,
                     yes: false,
+                    allow_all: false,
                 },
             )
             .await?;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1055,7 +1055,7 @@ fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest
         match crate::core::workspace_checkout::load_checkout_metadata(&search_path) {
             Ok(Some(checkout_info)) => {
                 let manifest =
-                    crate::core::workspace_checkout::manifest_from_checkout(&checkout_info);
+                    crate::core::workspace_checkout::manifest_from_checkout(&checkout_info)?;
                 return Ok((search_path, manifest));
             }
             Ok(None) => {}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -302,6 +302,7 @@ pub async fn dispatch_command(
                     no_delete_branch,
                     repo,
                     yes,
+                    all,
                 } => {
                     crate::cli::commands::pr::run_pr_merge(
                         &ctx.workspace_root,
@@ -317,16 +318,24 @@ pub async fn dispatch_command(
                             delete_branch: !no_delete_branch,
                             repo_filter: repo,
                             yes,
+                            allow_all: all,
                         },
                     )
                     .await?;
                 }
-                PrCommands::Edit { title, body } => {
+                PrCommands::Edit {
+                    title,
+                    body,
+                    repo,
+                    all,
+                } => {
                     crate::cli::commands::pr::run_pr_edit(
                         &ctx.workspace_root,
                         &ctx.manifest,
                         title.as_deref(),
                         body.as_deref(),
+                        repo.as_deref(),
+                        all,
                         ctx.json,
                     )
                     .await?;
@@ -367,12 +376,19 @@ pub async fn dispatch_command(
                     )
                     .await?;
                 }
-                PrCommands::Review { event, body } => {
+                PrCommands::Review {
+                    event,
+                    body,
+                    repo,
+                    all,
+                } => {
                     crate::cli::commands::pr::run_pr_review(
                         &ctx.workspace_root,
                         &ctx.manifest,
                         event,
                         body.as_deref(),
+                        repo.as_deref(),
+                        all,
                         ctx.json,
                     )
                     .await?;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1046,11 +1046,25 @@ fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest
             }
         }
 
-        if let Some(checkout_info) =
-            crate::core::workspace_checkout::load_checkout_metadata(&search_path)
-        {
-            let manifest = crate::core::workspace_checkout::manifest_from_checkout(&checkout_info);
-            return Ok((search_path, manifest));
+        // Fail CLOSED, not open: once `.checkout.json` exists at the nearest
+        // boundary, an unreadable/malformed/incomplete marker must stop the
+        // walk here with a clear error, never silently continue climbing to
+        // the parent gripspace (grip#775 round 3 -- that silent continue was
+        // the same cross-scope hazard this PR exists to close, reintroduced
+        // through a corrupted marker instead of a missing one).
+        match crate::core::workspace_checkout::load_checkout_metadata(&search_path) {
+            Ok(Some(checkout_info)) => {
+                let manifest =
+                    crate::core::workspace_checkout::manifest_from_checkout(&checkout_info);
+                return Ok((search_path, manifest));
+            }
+            Ok(None) => {}
+            Err(e) => {
+                return Err(e.context(format!(
+                    "found checkout metadata at {} but it is invalid",
+                    search_path.display()
+                )));
+            }
         }
 
         let gitgrip_dir = search_path.join(".gitgrip");

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -1023,19 +1023,73 @@ pub async fn dispatch_command(
     Ok(())
 }
 
-/// Load the gripspace manifest
+/// Load the gripspace manifest.
+///
+/// One unified ancestor walk checking every marker type (griptree pointer,
+/// checkout metadata, gitgrip workspace, legacy manifest, repo-tool manifest)
+/// at each directory level before climbing to the parent. The NEAREST marker
+/// wins, whichever type it is (grip#775: two independent all-ancestors passes
+/// -- griptree-check-everything, then workspace-check-everything -- let a
+/// `.griptree` many levels up eclipse a `.gitgrip` or checkout one level
+/// down, because the griptree pass never stopped climbing to give the nearer
+/// marker a chance).
 fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest::Manifest)> {
     let current = std::env::current_dir()?;
+    let mut search_path = current;
+    loop {
+        let griptree_pointer_path = search_path.join(".griptree");
+        if griptree_pointer_path.exists() {
+            if let Ok(pointer) =
+                crate::core::griptree::GriptreePointer::load(&griptree_pointer_path)
+            {
+                return load_from_griptree(&search_path, &pointer);
+            }
+        }
 
-    // First, check if we're in a griptree (has .griptree pointer file)
-    if let Some((griptree_path, pointer)) =
-        crate::core::griptree::GriptreePointer::find_in_ancestors(&current)
-    {
-        return load_from_griptree(&griptree_path, &pointer);
+        if let Some(checkout_info) =
+            crate::core::workspace_checkout::load_checkout_metadata(&search_path)
+        {
+            let manifest = crate::core::workspace_checkout::manifest_from_checkout(&checkout_info);
+            return Ok((search_path, manifest));
+        }
+
+        let gitgrip_dir = search_path.join(".gitgrip");
+        if gitgrip_dir.exists() {
+            if let Some(manifest_path) =
+                crate::core::manifest_paths::resolve_gripspace_manifest_path(&search_path)
+            {
+                let content = std::fs::read_to_string(&manifest_path)?;
+                let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
+                resolve_gripspace_includes(&mut manifest, &search_path);
+                return Ok((search_path, manifest));
+            }
+        }
+
+        if let Some(repo_yaml) =
+            crate::core::manifest_paths::resolve_repo_manifest_path(&search_path)
+        {
+            let content = std::fs::read_to_string(repo_yaml)?;
+            let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
+            resolve_gripspace_includes(&mut manifest, &search_path);
+            return Ok((search_path, manifest));
+        }
+
+        let repo_xml = search_path.join(".repo").join("manifest.xml");
+        if repo_xml.exists() {
+            let xml_manifest = crate::core::repo_manifest::XmlManifest::parse_file(&repo_xml)?;
+            let result = xml_manifest.to_manifest()?;
+            return Ok((search_path, result.manifest));
+        }
+
+        match search_path.parent() {
+            Some(parent) => search_path = parent.to_path_buf(),
+            None => {
+                anyhow::bail!(
+                    "Not in a gitgrip workspace (no .gitgrip, checkout, griptree, or .repo directory found)"
+                );
+            }
+        }
     }
-
-    // Not in a griptree - search parent directories for workspace root
-    load_from_workspace(&current)
 }
 
 /// Load the gripspace manifest and return a WorkspaceContext with global CLI flags.
@@ -1081,52 +1135,6 @@ fn load_from_griptree(
     let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
     resolve_gripspace_includes(&mut manifest, griptree_path);
     Ok((griptree_path.to_path_buf(), manifest))
-}
-
-/// Search parent directories for a workspace root and load its manifest.
-fn load_from_workspace(
-    start: &std::path::Path,
-) -> anyhow::Result<(std::path::PathBuf, crate::core::manifest::Manifest)> {
-    let mut search_path = start.to_path_buf();
-    loop {
-        // Check for .gitgrip directory with gripspace manifest
-        let gitgrip_dir = search_path.join(".gitgrip");
-        if gitgrip_dir.exists() {
-            if let Some(manifest_path) =
-                crate::core::manifest_paths::resolve_gripspace_manifest_path(&search_path)
-            {
-                let content = std::fs::read_to_string(&manifest_path)?;
-                let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
-                resolve_gripspace_includes(&mut manifest, &search_path);
-                return Ok((search_path, manifest));
-            }
-        }
-
-        // Check for legacy repo.yaml
-        if let Some(repo_yaml) =
-            crate::core::manifest_paths::resolve_repo_manifest_path(&search_path)
-        {
-            let content = std::fs::read_to_string(repo_yaml)?;
-            let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
-            resolve_gripspace_includes(&mut manifest, &search_path);
-            return Ok((search_path, manifest));
-        }
-
-        // Fallback: parse .repo/manifest.xml directly (zero-config — just works)
-        let repo_xml = search_path.join(".repo").join("manifest.xml");
-        if repo_xml.exists() {
-            let xml_manifest = crate::core::repo_manifest::XmlManifest::parse_file(&repo_xml)?;
-            let result = xml_manifest.to_manifest()?;
-            return Ok((search_path, result.manifest));
-        }
-
-        match search_path.parent() {
-            Some(parent) => search_path = parent.to_path_buf(),
-            None => {
-                anyhow::bail!("Not in a gitgrip workspace (no .gitgrip or .repo directory found)");
-            }
-        }
-    }
 }
 
 /// Resolve gripspace includes (merge inherited repos/scripts/env/hooks) if spaces dir exists.

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -301,6 +301,75 @@ pub fn filter_repos(
         .collect()
 }
 
+/// Validate repo filters before command execution so repo-scoped commands do not
+/// silently no-op when the local manifest is stale.
+pub fn validate_repo_filters_known(
+    manifest: &Manifest,
+    repos_filter: Option<&[String]>,
+) -> anyhow::Result<()> {
+    let Some(filters) = repos_filter else {
+        return Ok(());
+    };
+
+    let missing: Vec<&String> = filters
+        .iter()
+        .filter(|name| name.as_str() != "manifest" && !manifest.repos.contains_key(*name))
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let names = missing
+        .iter()
+        .map(|name| format!("'{}'", name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    anyhow::bail!(
+        "repo filter {} not found in local manifest. If it was added upstream, run `gr sync --repo manifest` or plain `gr sync` first, then retry.",
+        names
+    );
+}
+
+/// Refuse an unscoped multi-repo `gr pr <verb>` action rather than silently fan out.
+///
+/// `gr pr edit`/`review`/`merge` act on whichever repos currently have a matching open
+/// PR for their checked-out branch — a much weaker signal of intent than the
+/// diff/status-driven scoping the rest of `gr` uses. A repo's checked-out branch can be
+/// a stale, forgotten one from unrelated past work, so "N repos matched" is not the
+/// same thing as "the user meant N repos." When the caller did not explicitly scope
+/// via `--repo` and more than one repo matched, this is the ambiguous case that has
+/// twice caused real incidents (grip#770, grip#771): a body meant for one PR landing on
+/// someone else's unrelated one. Fail closed and list exactly what would have been
+/// touched, so the caller can either scope precisely with `--repo` or opt into the
+/// full list explicitly with `--all` — never guess silently.
+pub fn require_explicit_multi_repo_scope<T>(
+    matched: &[T],
+    repo_filter_given: bool,
+    allow_all: bool,
+    verb: &str,
+    describe: impl Fn(&T) -> String,
+) -> anyhow::Result<()> {
+    if matched.len() <= 1 || repo_filter_given || allow_all {
+        return Ok(());
+    }
+
+    let listing = matched
+        .iter()
+        .map(|m| format!("  - {}", describe(m)))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    anyhow::bail!(
+        "{} would touch {} repos with a matching branch/PR, but no --repo was given:\n{}\n\n\
+         Pass --repo <name>[,<name>...] to scope this explicitly, or --all to proceed \
+         with every repo listed above.",
+        verb,
+        matched.len(),
+        listing
+    );
+}
+
 /// Get RepoInfo for the manifest repo if it exists.
 ///
 /// This provides a standardized way to include the manifest repository
@@ -1118,5 +1187,56 @@ repos:
         assert_eq!(info.target_branch(), "main");
         assert_eq!(info.sync_remote, "origin");
         assert_eq!(info.push_remote, "origin");
+    }
+
+    #[test]
+    fn test_multi_repo_scope_guard_allows_zero_or_one_match_unconditionally() {
+        let none: Vec<&str> = vec![];
+        assert!(
+            require_explicit_multi_repo_scope(&none, false, false, "edit", |s| s.to_string())
+                .is_ok()
+        );
+
+        let one = vec!["repo-a"];
+        assert!(
+            require_explicit_multi_repo_scope(&one, false, false, "edit", |s| s.to_string())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_multi_repo_scope_guard_bails_on_unscoped_multi_match() {
+        // Mutation-intent guard: grip#770/grip#771 were both an unscoped multi-repo
+        // action silently succeeding. This must go RED under the pre-fix condition
+        // (no --repo, no --all, >1 match) and lists every affected repo by name so
+        // the caller can actually act on the guidance.
+        let matched = vec!["research", "recall"];
+        let err =
+            require_explicit_multi_repo_scope(&matched, false, false, "edit", |s| s.to_string())
+                .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("research"));
+        assert!(message.contains("recall"));
+        assert!(message.contains("--repo"));
+        assert!(message.contains("--all"));
+        assert!(message.contains("edit"));
+    }
+
+    #[test]
+    fn test_multi_repo_scope_guard_allows_explicit_repo_filter() {
+        let matched = vec!["research", "recall"];
+        assert!(
+            require_explicit_multi_repo_scope(&matched, true, false, "edit", |s| s.to_string())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_multi_repo_scope_guard_allows_explicit_all_flag() {
+        let matched = vec!["research", "recall"];
+        assert!(
+            require_explicit_multi_repo_scope(&matched, false, true, "edit", |s| s.to_string())
+                .is_ok()
+        );
     }
 }

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -10,8 +10,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::core::manifest::{Manifest, PlatformConfig, RepoConfig};
-use crate::core::manifest_paths;
+use crate::core::manifest::{Manifest, ManifestSettings, PlatformConfig, PlatformType, RepoConfig};
 use crate::core::repo::RepoInfo;
 use crate::core::workspace_cache;
 use crate::util::log_cmd;
@@ -19,21 +18,59 @@ use crate::util::log_cmd;
 /// Directory name under .grip/ where checkouts live.
 const CHECKOUTS_DIR: &str = "checkouts";
 
-/// Metadata for a single checkout.
+/// Filename of the per-checkout metadata file, written directly at the
+/// checkout root (never inside a materialized repo's own path -- grip#775's
+/// second blocker: writing a derived manifest into `.gitgrip/spaces/main`
+/// collided with that being the materialized "manifest" pseudo-repo's own
+/// canonical clone location when it was included in the checkout).
+const CHECKOUT_METADATA_FILE: &str = ".checkout.json";
+
+/// Metadata for a single checkout. Carries everything `manifest_from_checkout`
+/// needs to reconstruct a full gripspace `Manifest` in memory -- this file is
+/// the checkout's ONLY self-description; nothing else gets written into any
+/// materialized repo's own directory tree.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckoutInfo {
     pub name: String,
     pub path: PathBuf,
     pub repos: Vec<CheckoutRepo>,
     pub created_at: String,
+    #[serde(default)]
+    pub settings: ManifestSettings,
 }
 
-/// A single repo within a checkout.
+/// A single repo within a checkout, carrying its already-resolved manifest
+/// fields (grip#774/#775) so `manifest_from_checkout` can rebuild a faithful
+/// `RepoConfig` without re-reading anything from the parent gripspace.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckoutRepo {
     pub name: String,
+    /// Absolute materialized path on disk.
     pub path: PathBuf,
     pub branch: Option<String>,
+    #[serde(default)]
+    pub url: String,
+    /// Path relative to the checkout root -- matches `materialize_repo`'s
+    /// clone target exactly, so it doubles as the derived manifest's
+    /// `RepoConfig.path`.
+    #[serde(default)]
+    pub relative_path: String,
+    #[serde(default)]
+    pub revision: String,
+    #[serde(default)]
+    pub target: String,
+    #[serde(default)]
+    pub sync_remote: String,
+    #[serde(default)]
+    pub push_remote: String,
+    #[serde(default)]
+    pub platform_type: PlatformType,
+    #[serde(default)]
+    pub platform_base_url: Option<String>,
+    #[serde(default)]
+    pub reference: bool,
+    #[serde(default)]
+    pub groups: Vec<String>,
 }
 
 /// Resolve the checkout root: `<workspace_root>/.grip/checkouts/<name>/`
@@ -111,10 +148,10 @@ pub fn materialize_repo(
 
 /// Create a full checkout with all provided repos.
 ///
-/// `parent_manifest` supplies `settings` for the derived checkout manifest
-/// (see `write_checkout_manifest`); `repos` supplies the already-resolved
-/// per-repo info (url, path, revision, target, platform, ...) to materialize
-/// and to carry into that derived manifest verbatim.
+/// `parent_manifest` supplies `settings` carried into the checkout metadata;
+/// `repos` supplies the already-resolved per-repo info (url, path, revision,
+/// target, platform, ...) both to materialize AND to record verbatim in
+/// `.checkout.json` for later reconstruction via `manifest_from_checkout`.
 /// Returns info about the created checkout.
 pub fn create_checkout(
     workspace_root: &Path,
@@ -146,6 +183,16 @@ pub fn create_checkout(
             name: repo.name.clone(),
             path: target,
             branch: branch.map(String::from),
+            url: repo.url.clone(),
+            relative_path: repo.path.clone(),
+            revision: repo.revision.clone(),
+            target: repo.target.clone(),
+            sync_remote: repo.sync_remote.clone(),
+            push_remote: repo.push_remote.clone(),
+            platform_type: repo.platform_type,
+            platform_base_url: repo.platform_base_url.clone(),
+            reference: repo.reference,
+            groups: repo.groups.clone(),
         });
     }
 
@@ -155,42 +202,46 @@ pub fn create_checkout(
         path: checkout_root.clone(),
         repos: checkout_repos,
         created_at: now,
+        settings: parent_manifest.settings.clone(),
     };
 
-    // Write checkout metadata
-    let meta_path = checkout_root.join(".checkout.json");
+    // Write checkout metadata -- the ONLY file this function writes outside
+    // materialized repo directories. Nothing is written into any repo's own
+    // path (grip#775 blocker 2: a derived manifest written into
+    // `.gitgrip/spaces/main` collided with that being the "manifest"
+    // pseudo-repo's own canonical clone location when it was included in the
+    // checkout, leaving a materialized repo born dirty).
+    let meta_path = checkout_root.join(CHECKOUT_METADATA_FILE);
     let json = serde_json::to_string_pretty(&info)?;
     std::fs::write(&meta_path, json)
         .with_context(|| format!("writing checkout metadata: {}", meta_path.display()))?;
 
-    // Write a self-contained gripspace manifest so `gr` commands run from
-    // inside the checkout resolve THIS checkout as the workspace root
-    // (grip#774) instead of climbing past it to the parent gripspace --
-    // `load_from_workspace`'s ancestor walk only recognizes a `.gitgrip`
-    // directory, which nothing wrote here before this.
-    write_checkout_manifest(&checkout_root, parent_manifest, repos)?;
-
     Ok(info)
 }
 
-/// Derive and write a `.gitgrip/spaces/main/gripspace.yml` scoped to exactly
-/// the repos materialized into this checkout, so the checkout is a
-/// self-sufficient gripspace discoverable by the same ancestor walk every
-/// other `gr` command already uses (no new discovery path, no special-casing
-/// checkouts anywhere else in the CLI).
-fn write_checkout_manifest(
-    checkout_root: &Path,
-    parent_manifest: &Manifest,
-    repos: &[RepoInfo],
-) -> Result<()> {
-    let mut derived_repos: HashMap<String, RepoConfig> = HashMap::new();
-    for repo in repos {
-        derived_repos.insert(
+/// Load `.checkout.json` directly from `dir` if present, without walking
+/// ancestors -- the caller (the unified discovery walk in `dispatch.rs`)
+/// owns the ancestor traversal so it can check every marker type at each
+/// level before climbing (grip#775 blocker 1: two independent all-ancestors
+/// passes let a farther `.griptree` eclipse a nearer checkout).
+pub fn load_checkout_metadata(dir: &Path) -> Option<CheckoutInfo> {
+    let meta_path = dir.join(CHECKOUT_METADATA_FILE);
+    let content = std::fs::read_to_string(meta_path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Reconstruct a full gripspace `Manifest` from checkout metadata, in memory
+/// -- no file is ever written for this; `.checkout.json` is the single
+/// source of truth a checkout carries about itself.
+pub fn manifest_from_checkout(info: &CheckoutInfo) -> Manifest {
+    let mut repos = HashMap::new();
+    for repo in &info.repos {
+        repos.insert(
             repo.name.clone(),
             RepoConfig {
                 url: Some(repo.url.clone()),
                 remote: None,
-                path: repo.path.clone(),
+                path: repo.relative_path.clone(),
                 revision: Some(repo.revision.clone()),
                 target: Some(repo.target.clone()),
                 sync_remote: Some(repo.sync_remote.clone()),
@@ -209,26 +260,15 @@ fn write_checkout_manifest(
         );
     }
 
-    let derived_manifest = Manifest {
+    Manifest {
         version: 2,
         remotes: None,
         gripspaces: None,
         manifest: None,
-        repos: derived_repos,
-        settings: parent_manifest.settings.clone(),
+        repos,
+        settings: info.settings.clone(),
         workspace: None,
-    };
-
-    let manifest_dir = manifest_paths::main_space_dir(checkout_root);
-    std::fs::create_dir_all(&manifest_dir)
-        .with_context(|| format!("creating checkout manifest dir: {}", manifest_dir.display()))?;
-    let manifest_path = manifest_dir.join(manifest_paths::PRIMARY_FILE_NAME);
-    let yaml = serde_yaml::to_string(&derived_manifest)
-        .context("serializing derived checkout manifest")?;
-    std::fs::write(&manifest_path, yaml)
-        .with_context(|| format!("writing checkout manifest: {}", manifest_path.display()))?;
-
-    Ok(())
+    }
 }
 
 /// List all checkouts under `.grip/checkouts/`.
@@ -244,21 +284,19 @@ pub fn list_checkouts(workspace_root: &Path) -> Result<Vec<CheckoutInfo>> {
         if !entry.path().is_dir() {
             continue;
         }
-        let meta_path = entry.path().join(".checkout.json");
-        if meta_path.is_file() {
-            let content = std::fs::read_to_string(&meta_path)?;
-            if let Ok(info) = serde_json::from_str::<CheckoutInfo>(&content) {
-                checkouts.push(info);
+        match load_checkout_metadata(&entry.path()) {
+            Some(info) => checkouts.push(info),
+            None => {
+                // Checkout dir exists but no metadata — construct minimal info
+                let name = entry.file_name().to_string_lossy().to_string();
+                checkouts.push(CheckoutInfo {
+                    name: name.clone(),
+                    path: entry.path(),
+                    repos: vec![],
+                    created_at: "unknown".to_string(),
+                    settings: ManifestSettings::default(),
+                });
             }
-        } else {
-            // Checkout dir exists but no metadata — construct minimal info
-            let name = entry.file_name().to_string_lossy().to_string();
-            checkouts.push(CheckoutInfo {
-                name: name.clone(),
-                path: entry.path(),
-                repos: vec![],
-                created_at: "unknown".to_string(),
-            });
         }
     }
 
@@ -580,10 +618,11 @@ mod tests {
         });
     }
 
-    // ── grip#774: checkout must be a self-discoverable workspace ──────────
+    // ── grip#774/#775: checkout must be a self-describing workspace, without
+    // writing into any materialized repo's own path ────────────────────────
 
     #[test]
-    fn test_create_checkout_writes_self_contained_gripspace_manifest() {
+    fn test_create_checkout_metadata_reconstructs_a_faithful_manifest() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let cache_dir = tmp.path().join("global-cache");
         with_cache_dir(&cache_dir, || {
@@ -598,26 +637,9 @@ mod tests {
 
             let checkout_root = checkout_path(&workspace, "self-contained");
 
-            // This is the exact marker `load_from_workspace`'s ancestor walk
-            // looks for (dispatch.rs) -- before this fix, nothing wrote it,
-            // so the walk climbed straight past the checkout to the parent.
-            let gitgrip_dir = checkout_root.join(".gitgrip");
-            assert!(
-                gitgrip_dir.is_dir(),
-                "checkout root must contain a .gitgrip marker so gr commands \
-                 discover the checkout itself, not the parent workspace"
-            );
-
-            let manifest_path = manifest_paths::default_gripspace_manifest_path(&checkout_root);
-            assert!(
-                manifest_path.is_file(),
-                "expected a gripspace manifest at {}",
-                manifest_path.display()
-            );
-
-            let content = fs::read_to_string(&manifest_path).expect("read derived manifest");
-            let derived = crate::core::manifest::Manifest::parse(&content)
-                .expect("derived checkout manifest should parse");
+            let info = load_checkout_metadata(&checkout_root)
+                .expect("checkout metadata should load from the checkout root");
+            let derived = manifest_from_checkout(&info);
 
             assert_eq!(
                 derived.repos.len(),
@@ -644,7 +666,7 @@ mod tests {
     }
 
     #[test]
-    fn test_checkout_gripspace_manifest_is_independently_discoverable() {
+    fn test_checkout_metadata_lives_at_checkout_root_not_inside_any_repo() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let cache_dir = tmp.path().join("global-cache");
         with_cache_dir(&cache_dir, || {
@@ -656,32 +678,113 @@ mod tests {
                 .expect("create checkout");
 
             let checkout_root = checkout_path(&workspace, "discoverable");
-            let repo_dir = checkout_root.join("testrepo");
-            assert!(repo_dir.is_dir(), "materialized repo dir must exist");
-
-            // Mirrors dispatch.rs's `load_from_workspace` ancestor walk directly
-            // (that function is private to the CLI crate): starting from a repo
-            // *inside* the checkout, the nearest `.gitgrip` ancestor must be the
-            // checkout root, not the parent workspace root two levels up.
-            let mut search = repo_dir.as_path();
-            let found_root = loop {
-                if search.join(".gitgrip").exists() {
-                    break Some(search.to_path_buf());
-                }
-                match search.parent() {
-                    Some(parent) => search = parent,
-                    None => break None,
-                }
-            };
-
-            assert_eq!(
-                found_root,
-                Some(checkout_root.clone()),
-                "the nearest .gitgrip ancestor from inside the checkout's repo must be \
-                 the checkout root ({}), not the parent workspace ({})",
-                checkout_root.display(),
-                workspace.display()
+            assert!(
+                checkout_root.join(CHECKOUT_METADATA_FILE).is_file(),
+                ".checkout.json must live directly at the checkout root"
+            );
+            assert!(
+                load_checkout_metadata(checkout_root.join("testrepo").as_path()).is_none(),
+                "metadata must not also be discoverable from inside a materialized repo \
+                 (that would mean it was written into repo content, not the checkout root)"
             );
         });
+    }
+
+    #[test]
+    fn test_checkout_including_the_manifest_pseudo_repo_leaves_it_untouched() {
+        // grip#775 blocker 2: the "manifest" pseudo-repo's own canonical clone
+        // path IS `.gitgrip/spaces/main` (core::repo::create_manifest_repo_info).
+        // A checkout that materializes a repo at that exact relative path must
+        // come out of create_checkout with nothing written into it beyond what
+        // `git clone` itself produced -- metadata lives only in .checkout.json
+        // at the checkout root (verified above), never inside a repo's path.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
+            let url = format!("file://{}", remote.to_string_lossy());
+
+            let manifest_pseudo_repo = RepoInfo::from_config(
+                "manifest",
+                &RepoConfig {
+                    url: Some(url.clone()),
+                    remote: None,
+                    path: ".gitgrip/spaces/main".to_string(),
+                    revision: None,
+                    target: None,
+                    sync_remote: None,
+                    push_remote: None,
+                    copyfile: None,
+                    linkfile: None,
+                    platform: None,
+                    reference: false,
+                    groups: vec![],
+                    agent: None,
+                    clone_strategy: None,
+                },
+                &workspace,
+                &ManifestSettings::default(),
+                None,
+            )
+            .expect("from_config should resolve the pseudo manifest repo");
+
+            let repos = vec![manifest_pseudo_repo];
+            let parent_manifest = Manifest {
+                version: 2,
+                remotes: None,
+                gripspaces: None,
+                manifest: None,
+                repos: HashMap::new(),
+                settings: ManifestSettings::default(),
+                workspace: None,
+            };
+
+            create_checkout(
+                &workspace,
+                "with-manifest-repo",
+                &parent_manifest,
+                &repos,
+                None,
+            )
+            .expect("create checkout including the manifest pseudo-repo");
+
+            let checkout_root = checkout_path(&workspace, "with-manifest-repo");
+            let materialized_manifest_clone =
+                checkout_root.join(".gitgrip").join("spaces").join("main");
+            assert!(
+                materialized_manifest_clone.join(".git").is_dir(),
+                "the manifest pseudo-repo should still be cloned at its configured path"
+            );
+            assert!(
+                !materialized_manifest_clone.join("gripspace.yml").exists(),
+                "nothing must be written into the materialized manifest repo's own \
+                 directory -- that would corrupt its tracked content the moment the \
+                 checkout is created, before any user action"
+            );
+
+            let status = Command::new("git")
+                .args(["status", "--porcelain"])
+                .current_dir(&materialized_manifest_clone)
+                .output()
+                .expect("git status");
+            assert!(
+                status.stdout.is_empty(),
+                "materialized manifest repo clone must be born clean, got: {}",
+                String::from_utf8_lossy(&status.stdout)
+            );
+        });
+    }
+
+    #[test]
+    fn test_load_checkout_metadata_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(load_checkout_metadata(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_load_checkout_metadata_returns_none_on_malformed_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fs::write(tmp.path().join(CHECKOUT_METADATA_FILE), "not valid json").unwrap();
+        assert!(load_checkout_metadata(tmp.path()).is_none());
     }
 }

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -224,10 +224,47 @@ pub fn create_checkout(
 /// owns the ancestor traversal so it can check every marker type at each
 /// level before climbing (grip#775 blocker 1: two independent all-ancestors
 /// passes let a farther `.griptree` eclipse a nearer checkout).
-pub fn load_checkout_metadata(dir: &Path) -> Option<CheckoutInfo> {
+///
+/// Distinguishes "no marker here" (`Ok(None)`, safe to keep climbing) from
+/// "a marker exists but is unreadable, malformed, or structurally incomplete"
+/// (`Err`, must NOT be treated as absence). Sentinel's grip#775 round-3
+/// finding: collapsing both cases to `None` via `.ok()?` let a corrupted
+/// `.checkout.json` fail OPEN to the parent workspace -- recreating the
+/// exact silent cross-scope hazard this whole PR exists to close, just
+/// through a new mechanism (a broken marker instead of a missing one).
+pub fn load_checkout_metadata(dir: &Path) -> Result<Option<CheckoutInfo>> {
     let meta_path = dir.join(CHECKOUT_METADATA_FILE);
-    let content = std::fs::read_to_string(meta_path).ok()?;
-    serde_json::from_str(&content).ok()
+    if !meta_path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&meta_path)
+        .with_context(|| format!("reading checkout metadata: {}", meta_path.display()))?;
+    let info: CheckoutInfo = serde_json::from_str(&content)
+        .with_context(|| format!("parsing checkout metadata: {}", meta_path.display()))?;
+    validate_checkout_info(&info, &meta_path)?;
+    Ok(Some(info))
+}
+
+/// Structural completeness check for metadata that parsed successfully but
+/// may still be unusable -- e.g. a pre-round-2 `.checkout.json` whose
+/// per-repo fields (url, relative_path, ...) all deserialize to their
+/// `#[serde(default)]` empty values because those fields didn't exist yet
+/// when it was written. A `RepoConfig` built from an empty url or path is
+/// not a parse error, but it is not a usable workspace either.
+fn validate_checkout_info(info: &CheckoutInfo, meta_path: &Path) -> Result<()> {
+    for repo in &info.repos {
+        if repo.url.is_empty() || repo.relative_path.is_empty() {
+            anyhow::bail!(
+                "checkout metadata at {} has an incomplete entry for repo '{}' (empty url or \
+                 path) -- this checkout was likely created by an older gitgrip version; remove \
+                 it with `gr checkout remove {}` and recreate it",
+                meta_path.display(),
+                repo.name,
+                info.name
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Reconstruct a full gripspace `Manifest` from checkout metadata, in memory
@@ -284,10 +321,13 @@ pub fn list_checkouts(workspace_root: &Path) -> Result<Vec<CheckoutInfo>> {
         if !entry.path().is_dir() {
             continue;
         }
+        // `gr checkout list` is informational, not a scope-resolution path --
+        // unlike `load_gripspace`'s discovery walk, a broken checkout here
+        // should not fail the whole listing, only fall back to a minimal
+        // entry so the user can see it exists and remove/recreate it.
         match load_checkout_metadata(&entry.path()) {
-            Some(info) => checkouts.push(info),
-            None => {
-                // Checkout dir exists but no metadata — construct minimal info
+            Ok(Some(info)) => checkouts.push(info),
+            Ok(None) | Err(_) => {
                 let name = entry.file_name().to_string_lossy().to_string();
                 checkouts.push(CheckoutInfo {
                     name: name.clone(),
@@ -638,6 +678,7 @@ mod tests {
             let checkout_root = checkout_path(&workspace, "self-contained");
 
             let info = load_checkout_metadata(&checkout_root)
+                .expect("checkout metadata should be readable")
                 .expect("checkout metadata should load from the checkout root");
             let derived = manifest_from_checkout(&info);
 
@@ -683,7 +724,9 @@ mod tests {
                 ".checkout.json must live directly at the checkout root"
             );
             assert!(
-                load_checkout_metadata(checkout_root.join("testrepo").as_path()).is_none(),
+                load_checkout_metadata(checkout_root.join("testrepo").as_path())
+                    .expect("absence is not an error")
+                    .is_none(),
                 "metadata must not also be discoverable from inside a materialized repo \
                  (that would mean it was written into repo content, not the checkout root)"
             );
@@ -778,13 +821,51 @@ mod tests {
     #[test]
     fn test_load_checkout_metadata_returns_none_when_missing() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        assert!(load_checkout_metadata(tmp.path()).is_none());
+        assert!(load_checkout_metadata(tmp.path())
+            .expect("absence is not an error")
+            .is_none());
     }
 
     #[test]
-    fn test_load_checkout_metadata_returns_none_on_malformed_json() {
+    fn test_load_checkout_metadata_errors_on_malformed_json_instead_of_failing_open() {
+        // grip#775 round 3 (Sentinel): a marker that EXISTS but is broken must
+        // never be treated the same as no marker at all -- that collapse is
+        // exactly what let a corrupted `.checkout.json` fail open to the
+        // parent workspace. This replaces the old test that pinned the
+        // unsafe `None`-on-malformed-JSON behavior as if it were correct.
         let tmp = tempfile::tempdir().expect("tempdir");
         fs::write(tmp.path().join(CHECKOUT_METADATA_FILE), "not valid json").unwrap();
-        assert!(load_checkout_metadata(tmp.path()).is_none());
+        let result = load_checkout_metadata(tmp.path());
+        assert!(
+            result.is_err(),
+            "a marker that exists but fails to parse must be an error, not Ok(None) -- \
+             collapsing the two lets the discovery walk silently climb past a broken \
+             checkout to the parent workspace"
+        );
+    }
+
+    #[test]
+    fn test_load_checkout_metadata_errors_on_legacy_metadata_with_empty_repo_fields() {
+        // grip#775 round 3 requirement 3: metadata that parses successfully
+        // but whose per-repo fields deserialize to their #[serde(default)]
+        // empty values (e.g. a pre-round-2 .checkout.json written before url/
+        // relative_path existed on CheckoutRepo) is not a parse error, but a
+        // RepoConfig built from an empty url or path is unusable.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let legacy_json = r#"{
+            "name": "legacy",
+            "path": "/tmp/legacy",
+            "created_at": "2026-01-01T00:00:00Z",
+            "repos": [
+                {"name": "app", "path": "/tmp/legacy/app", "branch": null}
+            ]
+        }"#;
+        fs::write(tmp.path().join(CHECKOUT_METADATA_FILE), legacy_json).unwrap();
+        let result = load_checkout_metadata(tmp.path());
+        assert!(
+            result.is_err(),
+            "metadata with an empty url/relative_path must fail structural validation, \
+             not silently reconstruct a Manifest with an unusable repo config"
+        );
     }
 }

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -270,7 +270,18 @@ fn validate_checkout_info(info: &CheckoutInfo, meta_path: &Path) -> Result<()> {
 /// Reconstruct a full gripspace `Manifest` from checkout metadata, in memory
 /// -- no file is ever written for this; `.checkout.json` is the single
 /// source of truth a checkout carries about itself.
-pub fn manifest_from_checkout(info: &CheckoutInfo) -> Manifest {
+///
+/// Validated with the SAME `Manifest::validate()` path-safety checks
+/// (`path_escapes_boundary`) a YAML manifest goes through via
+/// `Manifest::parse` -- a manifest built in memory is not exempt from them.
+/// grip#775 round 3 (Sentinel): a nonempty but absolute or `..`-escaping
+/// `CheckoutRepo.relative_path` passed `validate_checkout_info`'s
+/// empty-string check yet, once joined onto the checkout root via
+/// `PathBuf::join`, silently replaced it outright (`Path::join` discards the
+/// base when the argument is absolute) -- redirecting authority-bearing
+/// commands like `gr status` at whatever real path the metadata pointed to,
+/// including an unrelated parent repo.
+pub fn manifest_from_checkout(info: &CheckoutInfo) -> Result<Manifest> {
     let mut repos = HashMap::new();
     for repo in &info.repos {
         repos.insert(
@@ -297,7 +308,7 @@ pub fn manifest_from_checkout(info: &CheckoutInfo) -> Manifest {
         );
     }
 
-    Manifest {
+    let manifest = Manifest {
         version: 2,
         remotes: None,
         gripspaces: None,
@@ -305,7 +316,14 @@ pub fn manifest_from_checkout(info: &CheckoutInfo) -> Manifest {
         repos,
         settings: info.settings.clone(),
         workspace: None,
-    }
+    };
+    manifest.validate().with_context(|| {
+        format!(
+            "checkout '{}' has an invalid reconstructed manifest",
+            info.name
+        )
+    })?;
+    Ok(manifest)
 }
 
 /// List all checkouts under `.grip/checkouts/`.
@@ -680,7 +698,8 @@ mod tests {
             let info = load_checkout_metadata(&checkout_root)
                 .expect("checkout metadata should be readable")
                 .expect("checkout metadata should load from the checkout root");
-            let derived = manifest_from_checkout(&info);
+            let derived =
+                manifest_from_checkout(&info).expect("reconstructed manifest should validate");
 
             assert_eq!(
                 derived.repos.len(),

--- a/src/core/workspace_checkout.rs
+++ b/src/core/workspace_checkout.rs
@@ -6,9 +6,13 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::core::manifest::{Manifest, PlatformConfig, RepoConfig};
+use crate::core::manifest_paths;
+use crate::core::repo::RepoInfo;
 use crate::core::workspace_cache;
 use crate::util::log_cmd;
 
@@ -107,12 +111,16 @@ pub fn materialize_repo(
 
 /// Create a full checkout with all provided repos.
 ///
-/// Takes an iterator of (name, url, path) tuples.
+/// `parent_manifest` supplies `settings` for the derived checkout manifest
+/// (see `write_checkout_manifest`); `repos` supplies the already-resolved
+/// per-repo info (url, path, revision, target, platform, ...) to materialize
+/// and to carry into that derived manifest verbatim.
 /// Returns info about the created checkout.
-pub fn create_checkout<'a>(
+pub fn create_checkout(
     workspace_root: &Path,
     checkout_name: &str,
-    repos: impl Iterator<Item = (&'a str, &'a str, &'a str)>,
+    parent_manifest: &Manifest,
+    repos: &[RepoInfo],
     branch: Option<&str>,
 ) -> Result<CheckoutInfo> {
     if checkout_exists(workspace_root, checkout_name) {
@@ -125,10 +133,17 @@ pub fn create_checkout<'a>(
 
     let mut checkout_repos = Vec::new();
 
-    for (name, url, path) in repos {
-        let target = materialize_repo(workspace_root, checkout_name, name, url, path, branch)?;
+    for repo in repos {
+        let target = materialize_repo(
+            workspace_root,
+            checkout_name,
+            &repo.name,
+            &repo.url,
+            &repo.path,
+            branch,
+        )?;
         checkout_repos.push(CheckoutRepo {
-            name: name.to_string(),
+            name: repo.name.clone(),
             path: target,
             branch: branch.map(String::from),
         });
@@ -148,7 +163,72 @@ pub fn create_checkout<'a>(
     std::fs::write(&meta_path, json)
         .with_context(|| format!("writing checkout metadata: {}", meta_path.display()))?;
 
+    // Write a self-contained gripspace manifest so `gr` commands run from
+    // inside the checkout resolve THIS checkout as the workspace root
+    // (grip#774) instead of climbing past it to the parent gripspace --
+    // `load_from_workspace`'s ancestor walk only recognizes a `.gitgrip`
+    // directory, which nothing wrote here before this.
+    write_checkout_manifest(&checkout_root, parent_manifest, repos)?;
+
     Ok(info)
+}
+
+/// Derive and write a `.gitgrip/spaces/main/gripspace.yml` scoped to exactly
+/// the repos materialized into this checkout, so the checkout is a
+/// self-sufficient gripspace discoverable by the same ancestor walk every
+/// other `gr` command already uses (no new discovery path, no special-casing
+/// checkouts anywhere else in the CLI).
+fn write_checkout_manifest(
+    checkout_root: &Path,
+    parent_manifest: &Manifest,
+    repos: &[RepoInfo],
+) -> Result<()> {
+    let mut derived_repos: HashMap<String, RepoConfig> = HashMap::new();
+    for repo in repos {
+        derived_repos.insert(
+            repo.name.clone(),
+            RepoConfig {
+                url: Some(repo.url.clone()),
+                remote: None,
+                path: repo.path.clone(),
+                revision: Some(repo.revision.clone()),
+                target: Some(repo.target.clone()),
+                sync_remote: Some(repo.sync_remote.clone()),
+                push_remote: Some(repo.push_remote.clone()),
+                copyfile: None,
+                linkfile: None,
+                platform: Some(PlatformConfig {
+                    platform_type: repo.platform_type,
+                    base_url: repo.platform_base_url.clone(),
+                }),
+                reference: repo.reference,
+                groups: repo.groups.clone(),
+                agent: None,
+                clone_strategy: None,
+            },
+        );
+    }
+
+    let derived_manifest = Manifest {
+        version: 2,
+        remotes: None,
+        gripspaces: None,
+        manifest: None,
+        repos: derived_repos,
+        settings: parent_manifest.settings.clone(),
+        workspace: None,
+    };
+
+    let manifest_dir = manifest_paths::main_space_dir(checkout_root);
+    std::fs::create_dir_all(&manifest_dir)
+        .with_context(|| format!("creating checkout manifest dir: {}", manifest_dir.display()))?;
+    let manifest_path = manifest_dir.join(manifest_paths::PRIMARY_FILE_NAME);
+    let yaml = serde_yaml::to_string(&derived_manifest)
+        .context("serializing derived checkout manifest")?;
+    std::fs::write(&manifest_path, yaml)
+        .with_context(|| format!("writing checkout manifest: {}", manifest_path.display()))?;
+
+    Ok(())
 }
 
 /// List all checkouts under `.grip/checkouts/`.
@@ -200,8 +280,65 @@ pub fn remove_checkout(workspace_root: &Path, name: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::manifest::ManifestSettings;
     use crate::core::workspace_cache::test_support;
     use std::fs;
+
+    /// Build a single-repo manifest + resolved `RepoInfo`, matching the shape
+    /// `setup_cached_workspace` produces (one repo named "testrepo" checked
+    /// out at path "testrepo"), for tests exercising `create_checkout`'s
+    /// derived-manifest path without hand-rolling every `RepoInfo` field.
+    fn single_repo_manifest_and_info(
+        workspace: &Path,
+        name: &str,
+        url: &str,
+    ) -> (Manifest, Vec<RepoInfo>) {
+        // parse_git_url only recognizes git@, https://, http://, and file://
+        // -- setup_cached_workspace hands back a bare filesystem path, so it
+        // needs the file:// scheme RepoInfo::from_config requires to resolve
+        // owner/repo. materialize_repo's `git clone` accepts file:// URLs
+        // the same as a bare path, so this doesn't change what gets cloned.
+        let file_url = if url.contains("://") {
+            url.to_string()
+        } else {
+            format!("file://{}", url)
+        };
+
+        let mut repos = HashMap::new();
+        repos.insert(
+            name.to_string(),
+            RepoConfig {
+                url: Some(file_url),
+                remote: None,
+                path: name.to_string(),
+                revision: None,
+                target: None,
+                sync_remote: None,
+                push_remote: None,
+                copyfile: None,
+                linkfile: None,
+                platform: None,
+                reference: false,
+                groups: vec![],
+                agent: None,
+                clone_strategy: None,
+            },
+        );
+        let manifest = Manifest {
+            version: 2,
+            remotes: None,
+            gripspaces: None,
+            manifest: None,
+            repos,
+            settings: ManifestSettings::default(),
+            workspace: None,
+        };
+        let settings = manifest.settings.clone();
+        let config = manifest.repos.get(name).unwrap();
+        let repo_info = RepoInfo::from_config(name, config, workspace, &settings, None)
+            .expect("from_config should resolve a repo with an explicit url");
+        (manifest, vec![repo_info])
+    }
 
     fn with_cache_dir<T>(cache_dir: &Path, f: impl FnOnce() -> T) -> T {
         let _guard = test_support::ENV_LOCK
@@ -367,9 +504,9 @@ mod tests {
             let (workspace, remote) = setup_cached_workspace(tmp.path());
 
             let url = remote.to_string_lossy().to_string();
-            let repos = vec![("testrepo", url.as_str(), "testrepo")];
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
 
-            let info = create_checkout(&workspace, "feat-x", repos.into_iter(), None)
+            let info = create_checkout(&workspace, "feat-x", &manifest, &repos, None)
                 .expect("create checkout");
 
             assert_eq!(info.name, "feat-x");
@@ -390,11 +527,10 @@ mod tests {
             let (workspace, remote) = setup_cached_workspace(tmp.path());
 
             let url = remote.to_string_lossy().to_string();
-            let repos = vec![("testrepo", url.as_str(), "testrepo")];
-            create_checkout(&workspace, "dup", repos.into_iter(), None).expect("first");
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            create_checkout(&workspace, "dup", &manifest, &repos, None).expect("first");
 
-            let repos2 = vec![("testrepo", url.as_str(), "testrepo")];
-            let result = create_checkout(&workspace, "dup", repos2.into_iter(), None);
+            let result = create_checkout(&workspace, "dup", &manifest, &repos, None);
             assert!(result.is_err());
         });
     }
@@ -407,8 +543,8 @@ mod tests {
             let (workspace, remote) = setup_cached_workspace(tmp.path());
 
             let url = remote.to_string_lossy().to_string();
-            let repos = vec![("testrepo", url.as_str(), "testrepo")];
-            create_checkout(&workspace, "removeme", repos.into_iter(), None).expect("create");
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            create_checkout(&workspace, "removeme", &manifest, &repos, None).expect("create");
 
             assert!(checkout_exists(&workspace, "removeme"));
             let removed = remove_checkout(&workspace, "removeme").expect("remove");
@@ -432,14 +568,119 @@ mod tests {
             let (workspace, remote) = setup_cached_workspace(tmp.path());
 
             let url = remote.to_string_lossy().to_string();
-            let repos = vec![("testrepo", url.as_str(), "testrepo")];
-            create_checkout(&workspace, "ephemeral", repos.into_iter(), None).expect("create");
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            create_checkout(&workspace, "ephemeral", &manifest, &repos, None).expect("create");
 
             remove_checkout(&workspace, "ephemeral").expect("remove");
 
             assert!(
                 workspace_cache::cache_exists(&workspace, "testrepo", &url).expect("cache exists"),
                 "cache must survive checkout deletion"
+            );
+        });
+    }
+
+    // ── grip#774: checkout must be a self-discoverable workspace ──────────
+
+    #[test]
+    fn test_create_checkout_writes_self_contained_gripspace_manifest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+            let url = remote.to_string_lossy().to_string();
+            let (mut manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            manifest.settings.pr_prefix = "[from-parent]".to_string();
+
+            create_checkout(&workspace, "self-contained", &manifest, &repos, None)
+                .expect("create checkout");
+
+            let checkout_root = checkout_path(&workspace, "self-contained");
+
+            // This is the exact marker `load_from_workspace`'s ancestor walk
+            // looks for (dispatch.rs) -- before this fix, nothing wrote it,
+            // so the walk climbed straight past the checkout to the parent.
+            let gitgrip_dir = checkout_root.join(".gitgrip");
+            assert!(
+                gitgrip_dir.is_dir(),
+                "checkout root must contain a .gitgrip marker so gr commands \
+                 discover the checkout itself, not the parent workspace"
+            );
+
+            let manifest_path = manifest_paths::default_gripspace_manifest_path(&checkout_root);
+            assert!(
+                manifest_path.is_file(),
+                "expected a gripspace manifest at {}",
+                manifest_path.display()
+            );
+
+            let content = fs::read_to_string(&manifest_path).expect("read derived manifest");
+            let derived = crate::core::manifest::Manifest::parse(&content)
+                .expect("derived checkout manifest should parse");
+
+            assert_eq!(
+                derived.repos.len(),
+                1,
+                "derived manifest should carry exactly the repos materialized into this checkout"
+            );
+            let repo_config = derived.repos.get("testrepo").expect("testrepo entry");
+            assert_eq!(
+                repo_config.url.as_deref(),
+                Some(format!("file://{}", url).as_str()),
+                "derived repo url must match the resolved (file://-scheme) url used to \
+                 materialize the repo"
+            );
+            assert_eq!(
+                repo_config.path, "testrepo",
+                "derived repo path must be relative to the checkout root, matching \
+                 where materialize_repo actually cloned it"
+            );
+            assert_eq!(
+                derived.settings.pr_prefix, "[from-parent]",
+                "derived manifest must carry the parent's settings, not gitgrip's built-in default"
+            );
+        });
+    }
+
+    #[test]
+    fn test_checkout_gripspace_manifest_is_independently_discoverable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cache_dir = tmp.path().join("global-cache");
+        with_cache_dir(&cache_dir, || {
+            let (workspace, remote) = setup_cached_workspace(tmp.path());
+
+            let url = remote.to_string_lossy().to_string();
+            let (manifest, repos) = single_repo_manifest_and_info(&workspace, "testrepo", &url);
+            create_checkout(&workspace, "discoverable", &manifest, &repos, None)
+                .expect("create checkout");
+
+            let checkout_root = checkout_path(&workspace, "discoverable");
+            let repo_dir = checkout_root.join("testrepo");
+            assert!(repo_dir.is_dir(), "materialized repo dir must exist");
+
+            // Mirrors dispatch.rs's `load_from_workspace` ancestor walk directly
+            // (that function is private to the CLI crate): starting from a repo
+            // *inside* the checkout, the nearest `.gitgrip` ancestor must be the
+            // checkout root, not the parent workspace root two levels up.
+            let mut search = repo_dir.as_path();
+            let found_root = loop {
+                if search.join(".gitgrip").exists() {
+                    break Some(search.to_path_buf());
+                }
+                match search.parent() {
+                    Some(parent) => search = parent,
+                    None => break None,
+                }
+            };
+
+            assert_eq!(
+                found_root,
+                Some(checkout_root.clone()),
+                "the nearest .gitgrip ancestor from inside the checkout's repo must be \
+                 the checkout root ({}), not the parent workspace ({})",
+                checkout_root.display(),
+                workspace.display()
             );
         });
     }

--- a/src/platform/azure.rs
+++ b/src/platform/azure.rs
@@ -603,6 +603,7 @@ impl HostingPlatform for AzureDevOpsAdapter {
                     return Ok(StatusCheckResult {
                         state: CheckState::Success,
                         statuses: vec![],
+                        checks_configured: true,
                     });
                 }
 
@@ -629,13 +630,18 @@ impl HostingPlatform for AzureDevOpsAdapter {
                     })
                     .collect();
 
-                Ok(StatusCheckResult { state, statuses })
+                Ok(StatusCheckResult {
+                    state,
+                    statuses,
+                    checks_configured: true,
+                })
             }
             Err(_) => {
                 // No builds or API error - assume success
                 Ok(StatusCheckResult {
                     state: CheckState::Success,
                     statuses: vec![],
+                    checks_configured: true,
                 })
             }
         }

--- a/src/platform/bitbucket.rs
+++ b/src/platform/bitbucket.rs
@@ -407,9 +407,13 @@ impl HostingPlatform for BitbucketAdapter {
             .map_err(|e| PlatformError::NetworkError(e.to_string()))?;
 
         if !response.status().is_success() {
+            // Couldn't reach the API -- unknown, not confirmed-absent. Keep
+            // the existing pending/retry behavior, but don't claim to know
+            // checks aren't configured when the query itself failed.
             return Ok(StatusCheckResult {
                 state: CheckState::Pending,
                 statuses: vec![],
+                checks_configured: true,
             });
         }
 
@@ -447,6 +451,12 @@ impl HostingPlatform for BitbucketAdapter {
             })
             .collect();
 
+        // grip#772: zero posted statuses means nothing is configured for this
+        // ref, not "checks are running" -- same root cause discovered and
+        // fixed in the GitHub adapter, found here while touching this exact
+        // function for the checks_configured field addition, not separately
+        // reported/repro'd against a real Bitbucket instance.
+        let checks_configured = !checks.is_empty();
         let overall_state = if checks.is_empty() {
             CheckState::Pending
         } else if checks.iter().all(|c| c.state == "success") {
@@ -458,6 +468,7 @@ impl HostingPlatform for BitbucketAdapter {
         Ok(StatusCheckResult {
             state: overall_state,
             statuses: checks,
+            checks_configured,
         })
     }
 

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -789,6 +789,14 @@ impl HostingPlatform for GitHubAdapter {
 
         check_response_rate_limit(response.headers(), "GitHub").await;
 
+        // Whether the Check Runs API positively confirmed zero runs exist
+        // (success + total_count == 0), as opposed to failing to answer at
+        // all (non-success HTTP). Only a positive confirmation licenses the
+        // legacy fallback's ambiguous pending+empty reading to mean
+        // "confirmed absent" -- a Check Runs outage must not be conflated
+        // with "nothing is configured" (grip#776 finding 1).
+        let mut check_runs_confirmed_empty = false;
+
         if response.status().is_success() {
             #[derive(serde::Deserialize)]
             struct CheckRunsResponse {
@@ -846,6 +854,7 @@ impl HostingPlatform for GitHubAdapter {
                     checks_configured: true,
                 });
             }
+            check_runs_confirmed_empty = true;
         }
 
         // Fallback to legacy status checks API
@@ -906,11 +915,16 @@ impl HostingPlatform for GitHubAdapter {
 
         // GitHub's legacy combined-status endpoint reports state="pending" for
         // a commit with zero posted statuses -- the same string it uses for
-        // "checks are running." Reaching this fallback at all already means
-        // the modern Check Runs API found nothing (total_count == 0); if the
-        // legacy API also has zero individual statuses, nothing is configured
-        // for this ref at all, and `--wait` must not block on it (grip#772).
-        let checks_configured = !(state == CheckState::Pending && statuses.is_empty());
+        // "checks are running." That ambiguous reading only means "nothing is
+        // configured" when the modern Check Runs API POSITIVELY confirmed
+        // zero runs (check_runs_confirmed_empty); if Check Runs instead
+        // failed to answer at all, an equally-ambiguous legacy reading must
+        // not be promoted to confirmed-absence, or `--wait` would silently
+        // proceed past checks whose status simply could not be determined
+        // (grip#776 finding 1). A definitive legacy signal -- real statuses,
+        // or a non-pending state -- is trusted either way.
+        let legacy_ambiguous = state == CheckState::Pending && statuses.is_empty();
+        let checks_configured = !(check_runs_confirmed_empty && legacy_ambiguous);
 
         Ok(StatusCheckResult {
             state,

--- a/src/platform/github.rs
+++ b/src/platform/github.rs
@@ -843,6 +843,7 @@ impl HostingPlatform for GitHubAdapter {
                 return Ok(StatusCheckResult {
                     state: aggregate_state,
                     statuses,
+                    checks_configured: true,
                 });
             }
         }
@@ -894,7 +895,7 @@ impl HostingPlatform for GitHubAdapter {
             _ => CheckState::Pending,
         };
 
-        let statuses = status
+        let statuses: Vec<StatusCheck> = status
             .statuses
             .iter()
             .map(|s| StatusCheck {
@@ -903,7 +904,19 @@ impl HostingPlatform for GitHubAdapter {
             })
             .collect();
 
-        Ok(StatusCheckResult { state, statuses })
+        // GitHub's legacy combined-status endpoint reports state="pending" for
+        // a commit with zero posted statuses -- the same string it uses for
+        // "checks are running." Reaching this fallback at all already means
+        // the modern Check Runs API found nothing (total_count == 0); if the
+        // legacy API also has zero individual statuses, nothing is configured
+        // for this ref at all, and `--wait` must not block on it (grip#772).
+        let checks_configured = !(state == CheckState::Pending && statuses.is_empty());
+
+        Ok(StatusCheckResult {
+            state,
+            statuses,
+            checks_configured,
+        })
     }
 
     async fn get_allowed_merge_methods(

--- a/src/platform/gitlab.rs
+++ b/src/platform/gitlab.rs
@@ -514,6 +514,7 @@ impl HostingPlatform for GitLabAdapter {
                     return Ok(StatusCheckResult {
                         state: CheckState::Success,
                         statuses: vec![],
+                        checks_configured: true,
                     });
                 }
 
@@ -531,11 +532,13 @@ impl HostingPlatform for GitLabAdapter {
                         context: "gitlab-pipeline".to_string(),
                         state: pipeline.status.clone(),
                     }],
+                    checks_configured: true,
                 })
             }
             Err(_) => Ok(StatusCheckResult {
                 state: CheckState::Success,
                 statuses: vec![],
+                checks_configured: true,
             }),
         }
     }

--- a/src/platform/types.rs
+++ b/src/platform/types.rs
@@ -181,6 +181,13 @@ pub struct StatusCheckResult {
     pub state: CheckState,
     /// Individual statuses
     pub statuses: Vec<StatusCheck>,
+    /// Whether any CI checks are actually configured for this ref. `false`
+    /// means `state` is a platform-API artifact (e.g. GitHub's legacy combined-
+    /// status endpoint reports "pending" for a commit with zero posted
+    /// statuses, indistinguishable from "checks are running" by `state` alone)
+    /// rather than a real pending/passing/failing signal -- callers must not
+    /// wait on it (grip#772).
+    pub checks_configured: bool,
 }
 
 /// Detailed check status information
@@ -552,6 +559,7 @@ mod tests {
                     state: "success".to_string(),
                 },
             ],
+            checks_configured: true,
         };
 
         let json = serde_json::to_string(&result).unwrap();

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -192,10 +192,23 @@ impl WorkspaceBuilder {
         }
 
         // Generate manifest YAML
-        let manifest_yaml = generate_manifest(&self.repos, &remotes_dir);
+        let mut manifest_yaml = generate_manifest(&self.repos, &remotes_dir);
+
+        let manifest_dir = workspace_root.join(".gitgrip").join("spaces").join("main");
+
+        // Self-tracking `manifest:` block (core::manifest::ManifestRepoConfig),
+        // required by get_manifest_repo_info -- without it, `manifest.manifest`
+        // stays None and any operation that includes the "manifest" pseudo-repo
+        // (e.g. `gr checkout add --repo <x>,manifest`) silently drops it, even
+        // though `with_manifest_repo` already made it a real git repo on disk.
+        if self.with_manifest_repo {
+            manifest_yaml.push_str(&format!(
+                "manifest:\n  url: file://{}\n",
+                manifest_dir.display()
+            ));
+        }
 
         // Write canonical manifest layout.
-        let manifest_dir = workspace_root.join(".gitgrip").join("spaces").join("main");
         fs::create_dir_all(&manifest_dir).unwrap();
         fs::write(manifest_dir.join("gripspace.yml"), &manifest_yaml).unwrap();
 

--- a/tests/common/mock_platform.rs
+++ b/tests/common/mock_platform.rs
@@ -507,6 +507,37 @@ pub async fn mock_check_runs(
         .await;
 }
 
+/// GitHub API response for the legacy combined-status endpoint (GET
+/// /repos/:owner/:repo/commits/:ref/status). This is the fallback the real
+/// adapter code hits when the check-runs API reports zero runs. With zero
+/// posted statuses, GitHub's own API returns `state: "pending"` -- the exact
+/// ambiguity grip#772's fix disambiguates via the empty `statuses` array.
+pub async fn mock_legacy_combined_status(
+    server: &MockServer,
+    ref_name: &str,
+    state: &str,
+    statuses: Vec<(&str, &str)>,
+) {
+    let entries: Vec<Value> = statuses
+        .iter()
+        .map(|(context, entry_state)| json!({"context": context, "state": entry_state}))
+        .collect();
+
+    let body = json!({
+        "state": state,
+        "statuses": entries
+    });
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/owner/repo/commits/{}/status",
+            ref_name
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
 /// GitHub API response for updating a PR (PATCH /repos/:owner/:repo/pulls/:number).
 pub async fn mock_update_pull_request(server: &MockServer, number: u64) {
     let body = github_pr_json(number, "open", "feat/test", "main", false, "");

--- a/tests/common/mock_platform.rs
+++ b/tests/common/mock_platform.rs
@@ -507,6 +507,17 @@ pub async fn mock_check_runs(
         .await;
 }
 
+/// GitHub API response for updating a PR (PATCH /repos/:owner/:repo/pulls/:number).
+pub async fn mock_update_pull_request(server: &MockServer, number: u64) {
+    let body = github_pr_json(number, "open", "feat/test", "main", false, "");
+
+    Mock::given(method("PATCH"))
+        .and(path(format!("/repos/owner/repo/pulls/{}", number)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
 /// GitHub API response for PR diff (GET /repos/:owner/:repo/pulls/:number with Accept: diff).
 pub async fn mock_pr_diff(server: &MockServer, number: u64, diff_content: &str) {
     Mock::given(method("GET"))
@@ -603,6 +614,24 @@ pub async fn mock_server_error_put(server: &MockServer, path_str: &str) {
         .respond_with(ResponseTemplate::new(500).set_body_json(body))
         .mount(server)
         .await;
+}
+
+/// Point one repo in a loaded manifest at the mock GitHub server, using the
+/// fake "owner/repo" identity every mock helper in this file is hardcoded to
+/// (see the module doc comment). Shared across the pr-command test files
+/// (edit/review/merge) since each needs this same rewrite for every repo
+/// they add to a `WorkspaceBuilder` workspace.
+pub fn point_repo_at_mock(
+    manifest: &mut gitgrip::core::manifest::Manifest,
+    repo_name: &str,
+    server: &MockServer,
+) {
+    let repo_config = manifest.repos.get_mut(repo_name).unwrap();
+    repo_config.url = Some("https://github.com/owner/repo.git".to_string());
+    repo_config.platform = Some(gitgrip::core::manifest::PlatformConfig {
+        platform_type: gitgrip::core::manifest::PlatformType::GitHub,
+        base_url: Some(server.uri()),
+    });
 }
 
 /// Mock a GitHub repo info response (GET /repos/:owner/:repo).

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -2,6 +2,8 @@
 
 mod common;
 
+use assert_cmd::Command;
+
 use common::assertions::assert_on_branch;
 use common::fixtures::WorkspaceBuilder;
 
@@ -196,4 +198,90 @@ fn test_checkout_skips_non_git_repo() {
     // Healthy repo should switch; corrupted repo remains non-git
     assert_on_branch(&ws.repo_path("frontend"), "feat/checkout-safe");
     assert!(!ws.repo_path("backend").join(".git").exists());
+}
+
+// ── grip#774: `gr checkout add` must produce a self-discoverable workspace ──
+//
+// grip#770/#771/#773 fixed `gr pr edit/review/merge` silently fanning out
+// across every repo in the *correctly resolved* workspace. This is the sibling
+// bug one layer down: `gr checkout add` materializes a disposable child
+// checkout, but (before this fix) wrote no workspace marker inside it, so
+// EVERY `gr` command run from inside that checkout -- including `gr pr
+// review`/`merge` -- silently resolved the *parent* gripspace instead. A
+// reviewer entering the checkout to act on its PR head could unknowingly
+// operate on the parent's unrelated active branch. Found live during
+// grip#773's own review/merge (grip#774).
+
+#[test]
+fn test_checkout_add_makes_the_child_checkout_independently_discoverable() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "review-copy",
+        None,
+        None,
+    )
+    .expect("checkout add should succeed");
+
+    let checkout_repo_dir = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("review-copy")
+        .join("app");
+    assert!(
+        checkout_repo_dir.is_dir(),
+        "materialized checkout repo dir should exist at {}",
+        checkout_repo_dir.display()
+    );
+
+    // This is Sentinel's exact grip#774 repro: run `gr env` from inside a
+    // repo INSIDE the child checkout and check which workspace it reports.
+    let output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    assert!(
+        output.status.success(),
+        "gr env should succeed from inside the checkout: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let workspace_line = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("GITGRIP_WORKSPACE="))
+        .expect("gr env should print GITGRIP_WORKSPACE");
+    let reported = workspace_line
+        .split_once('=')
+        .map(|(_, v)| v.trim())
+        .unwrap_or("");
+
+    let expected_checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("review-copy");
+    let canonical_checkout_root =
+        std::fs::canonicalize(&expected_checkout_root).unwrap_or(expected_checkout_root);
+    let canonical_reported =
+        std::fs::canonicalize(reported).unwrap_or_else(|_| std::path::PathBuf::from(reported));
+
+    assert_eq!(
+        canonical_reported, canonical_checkout_root,
+        "gr env from inside the child checkout must resolve GITGRIP_WORKSPACE to the \
+         checkout root, not the parent workspace -- that is grip#774's exact failure mode"
+    );
+
+    let canonical_parent =
+        std::fs::canonicalize(&ws.workspace_root).unwrap_or_else(|_| ws.workspace_root.clone());
+    assert_ne!(
+        canonical_reported, canonical_parent,
+        "gr env must not resolve to the parent workspace root from inside the checkout"
+    );
 }

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -438,3 +438,105 @@ fn test_checkout_including_manifest_repo_leaves_it_clean_end_to_end() {
         std::fs::canonicalize(reported).unwrap_or_else(|_| std::path::PathBuf::from(reported));
     assert_eq!(canonical_reported, canonical_checkout_root);
 }
+
+// ── grip#775 round 3: malformed checkout metadata must fail closed, never
+// fail open to a parent workspace -- especially a parent that is itself a
+// griptree, Sentinel's exact real-gripspace repro shape. ────────────────────
+
+#[test]
+fn test_corrupted_checkout_metadata_fails_closed_not_open_to_parent() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Match Sentinel's exact repro context: the parent also carries a
+    // .griptree pointer, which is precisely the path a fail-open bug would
+    // silently resolve to once the (corrupted) nearer checkout marker is
+    // wrongly treated as absent.
+    let pointer = gitgrip::core::griptree::GriptreePointer {
+        main_workspace: "/nonexistent/decoy-main-workspace".to_string(),
+        branch: "feat/decoy".to_string(),
+        locked: false,
+        created_at: None,
+        repos: vec![],
+        manifest_branch: None,
+        manifest_worktree_name: None,
+    };
+    std::fs::write(
+        ws.workspace_root.join(".griptree"),
+        serde_json::to_string(&pointer).expect("serialize pointer"),
+    )
+    .expect("write .griptree pointer at the parent gripspace root");
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "sentinel-repro-nomanifest",
+        Some(&["app".to_string()]),
+        None,
+    )
+    .expect("checkout add should succeed with no manifest repo included");
+
+    let checkout_repo_dir = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("sentinel-repro-nomanifest")
+        .join("app");
+
+    // Sanity: gr env correctly reports the child BEFORE corruption (mirrors
+    // step 2 of Sentinel's repro).
+    let good_output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    assert!(
+        good_output.status.success(),
+        "gr env should succeed before corruption: {}",
+        String::from_utf8_lossy(&good_output.stderr)
+    );
+
+    // Corrupt only the child-root .checkout.json (step 3).
+    let checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("sentinel-repro-nomanifest");
+    std::fs::write(checkout_root.join(".checkout.json"), "not valid json{{{")
+        .expect("corrupt checkout metadata");
+
+    // Step 4: gr env again. Must NOT exit 0, and must NOT report the parent
+    // workspace path -- that combination is grip#775 round 3's exact
+    // reported failure mode.
+    let corrupted_output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+
+    assert!(
+        !corrupted_output.status.success(),
+        "gr env must fail (nonzero exit) when the nearest checkout marker exists but is \
+         corrupted -- silently succeeding here means it fell through to some other \
+         workspace instead of failing closed"
+    );
+
+    let stdout = String::from_utf8_lossy(&corrupted_output.stdout);
+    let canonical_parent =
+        std::fs::canonicalize(&ws.workspace_root).unwrap_or_else(|_| ws.workspace_root.clone());
+    assert!(
+        !stdout.contains(&canonical_parent.to_string_lossy().to_string())
+            && !stdout.contains(&ws.workspace_root.to_string_lossy().to_string()),
+        "gr env's output must not emit the parent workspace path at all when the nearer \
+         checkout marker is corrupted -- got stdout: {}",
+        stdout
+    );
+
+    let stderr = String::from_utf8_lossy(&corrupted_output.stderr);
+    assert!(
+        !stderr.is_empty(),
+        "a failed gr env should explain why, not fail silently"
+    );
+}

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -285,3 +285,156 @@ fn test_checkout_add_makes_the_child_checkout_independently_discoverable() {
         "gr env must not resolve to the parent workspace root from inside the checkout"
     );
 }
+
+// ── grip#775 blocker 1: a farther `.griptree` must not eclipse a nearer
+// checkout. Reproduces Sentinel's exact live finding: his real parent
+// gripspace carries a `.griptree` pointer, so `load_gripspace()`'s OLD
+// two-independent-passes structure (check every ancestor for `.griptree`,
+// THEN separately check every ancestor for `.gitgrip`) let that distant
+// pointer win over the checkout one level down every time. ─────────────────
+
+#[test]
+fn test_checkout_wins_over_a_griptree_pointer_at_an_ancestor() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    // Simulate "this parent gripspace also happens to carry a .griptree
+    // pointer" -- e.g. it was itself created as a griptree at some point.
+    // The pointer's target doesn't need to resolve to anything real: this
+    // test asserts the checkout wins BEFORE that pointer is ever followed.
+    let pointer = gitgrip::core::griptree::GriptreePointer {
+        main_workspace: "/nonexistent/decoy-main-workspace".to_string(),
+        branch: "feat/decoy".to_string(),
+        locked: false,
+        created_at: None,
+        repos: vec![],
+        manifest_branch: None,
+        manifest_worktree_name: None,
+    };
+    let pointer_json = serde_json::to_string(&pointer).expect("serialize pointer");
+    std::fs::write(ws.workspace_root.join(".griptree"), pointer_json)
+        .expect("write .griptree pointer at the parent gripspace root");
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "review-copy",
+        None,
+        None,
+    )
+    .expect("checkout add should succeed even with a parent .griptree present");
+
+    let checkout_repo_dir = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("review-copy")
+        .join("app");
+
+    let output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    assert!(
+        output.status.success(),
+        "gr env should succeed from inside the checkout: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let workspace_line = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("GITGRIP_WORKSPACE="))
+        .expect("gr env should print GITGRIP_WORKSPACE");
+    let reported = workspace_line
+        .split_once('=')
+        .map(|(_, v)| v.trim())
+        .unwrap_or("");
+
+    let expected_checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("review-copy");
+    let canonical_checkout_root =
+        std::fs::canonicalize(&expected_checkout_root).unwrap_or(expected_checkout_root);
+    let canonical_reported =
+        std::fs::canonicalize(reported).unwrap_or_else(|_| std::path::PathBuf::from(reported));
+
+    assert_eq!(
+        canonical_reported, canonical_checkout_root,
+        "the nearer checkout must win over the farther .griptree pointer at the parent \
+         gripspace root -- grip#775 blocker 1's exact failure mode"
+    );
+    assert_ne!(
+        reported, "/nonexistent/decoy-main-workspace",
+        "the griptree pointer must never even be followed when a nearer checkout exists"
+    );
+}
+
+// ── grip#775 blocker 2: creating a checkout that includes the "manifest"
+// pseudo-repo must not corrupt that repo's own materialized clone. ─────────
+
+#[test]
+fn test_checkout_including_manifest_repo_leaves_it_clean_end_to_end() {
+    let ws = WorkspaceBuilder::new()
+        .add_repo("app")
+        .with_manifest_repo()
+        .build();
+    let manifest = ws.load_manifest();
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "with-manifest",
+        Some(&["app".to_string(), "manifest".to_string()]),
+        None,
+    )
+    .expect("checkout add including the manifest repo should succeed");
+
+    let checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("with-manifest");
+    let materialized_manifest_dir = checkout_root.join(".gitgrip").join("spaces").join("main");
+    assert!(
+        materialized_manifest_dir.join(".git").is_dir(),
+        "the manifest repo should be materialized at its canonical clone path"
+    );
+
+    let status = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(&materialized_manifest_dir)
+        .output()
+        .expect("git status");
+    assert!(
+        status.stdout.is_empty(),
+        "materialized manifest repo must be born clean, not carry a destructive derived-\
+         manifest diff -- grip#775 blocker 2's exact failure mode. git status --porcelain: {}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+
+    // And discovery still works correctly from inside the OTHER materialized
+    // repo in the same checkout -- proving .checkout.json (not anything
+    // written into the manifest clone) is what makes this checkout resolvable.
+    let output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(checkout_root.join("app"))
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let reported = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("GITGRIP_WORKSPACE="))
+        .and_then(|line| line.split_once('='))
+        .map(|(_, v)| v.trim())
+        .unwrap_or("");
+    let canonical_checkout_root = std::fs::canonicalize(&checkout_root).unwrap_or(checkout_root);
+    let canonical_reported =
+        std::fs::canonicalize(reported).unwrap_or_else(|_| std::path::PathBuf::from(reported));
+    assert_eq!(canonical_reported, canonical_checkout_root);
+}

--- a/tests/test_checkout.rs
+++ b/tests/test_checkout.rs
@@ -540,3 +540,98 @@ fn test_corrupted_checkout_metadata_fails_closed_not_open_to_parent() {
         "a failed gr env should explain why, not fail silently"
     );
 }
+
+// ── grip#775 round 4: an absolute or escaping repo path inside otherwise-
+// valid checkout metadata must not redirect authority-bearing commands
+// outside the checkout, e.g. onto an unrelated parent repo. ────────────────
+
+#[test]
+fn test_absolute_repo_path_in_metadata_cannot_escape_the_checkout() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let manifest = ws.load_manifest();
+
+    let pointer = gitgrip::core::griptree::GriptreePointer {
+        main_workspace: "/nonexistent/decoy-main-workspace".to_string(),
+        branch: "feat/decoy".to_string(),
+        locked: false,
+        created_at: None,
+        repos: vec![],
+        manifest_branch: None,
+        manifest_worktree_name: None,
+    };
+    std::fs::write(
+        ws.workspace_root.join(".griptree"),
+        serde_json::to_string(&pointer).expect("serialize pointer"),
+    )
+    .expect("write .griptree pointer at the parent gripspace root");
+
+    gitgrip::cli::commands::checkout::run_checkout_add(
+        &ws.workspace_root,
+        &manifest,
+        "sentinel-repro-escape",
+        Some(&["app".to_string()]),
+        None,
+    )
+    .expect("checkout add should succeed");
+
+    let checkout_root = ws
+        .workspace_root
+        .join(".grip")
+        .join("checkouts")
+        .join("sentinel-repro-escape");
+    let checkout_repo_dir = checkout_root.join("app");
+
+    // Sanity: works correctly before corruption.
+    let good_output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+    assert!(
+        good_output.status.success(),
+        "gr env should succeed before the metadata is tampered with"
+    );
+
+    // Rewrite .checkout.json's "app" entry to an ABSOLUTE relative_path
+    // pointing at the PARENT's own real "app" repo -- otherwise-valid,
+    // nonempty metadata, exactly Sentinel's repro shape. PathBuf::join
+    // silently discards the checkout-root base when the joined path is
+    // absolute, so an unvalidated reconstruction would resolve authority-
+    // bearing commands onto this unrelated parent repo instead.
+    let meta_path = checkout_root.join(".checkout.json");
+    let raw = std::fs::read_to_string(&meta_path).expect("read checkout metadata");
+    let mut value: serde_json::Value = serde_json::from_str(&raw).expect("parse metadata");
+    let parent_app_path = ws.workspace_root.join("app");
+    value["repos"][0]["relative_path"] =
+        serde_json::Value::String(parent_app_path.to_string_lossy().to_string());
+    std::fs::write(&meta_path, serde_json::to_string_pretty(&value).unwrap())
+        .expect("write tampered metadata");
+
+    let escaped_output = Command::cargo_bin("gr")
+        .expect("gr binary should build")
+        .current_dir(&checkout_repo_dir)
+        .arg("env")
+        .output()
+        .expect("gr env should run");
+
+    assert!(
+        !escaped_output.status.success(),
+        "gr env must reject a reconstructed manifest whose repo path is absolute -- silently \
+         succeeding means an authority-bearing command could resolve outside the checkout, \
+         grip#775 round 4's exact scope escape"
+    );
+
+    let stdout = String::from_utf8_lossy(&escaped_output.stdout);
+    assert!(
+        !stdout.contains(&parent_app_path.to_string_lossy().to_string()),
+        "the rejected reconstruction must never surface the escaping absolute path in output: {}",
+        stdout
+    );
+
+    let stderr = String::from_utf8_lossy(&escaped_output.stderr);
+    assert!(
+        !stderr.is_empty(),
+        "a rejected reconstruction should explain why, not fail silently"
+    );
+}

--- a/tests/test_platform_bitbucket.rs
+++ b/tests/test_platform_bitbucket.rs
@@ -120,6 +120,33 @@ async fn test_bb_status_checks() {
     let checks = result.unwrap();
     assert_eq!(checks.state, CheckState::Success);
     assert_eq!(checks.statuses.len(), 2);
+    assert!(
+        checks.checks_configured,
+        "real posted statuses must set checks_configured=true (grip#776 \
+         finding 2: this was previously unasserted, so a mutant flipping the \
+         true case to false went unnoticed)"
+    );
+}
+
+#[tokio::test]
+async fn test_bb_status_checks_empty_sets_checks_configured_false() {
+    // grip#776 finding 2 (Bitbucket's empty side): zero posted statuses
+    // means nothing is configured for this ref, not "checks are running" --
+    // the same false-absence risk grip#772 fixed for GitHub. Never
+    // independently pinned for the Bitbucket adapter until now.
+    let (server, adapter) = setup_bitbucket_mock().await;
+    mock_bb_status_checks(&server, "abc123", vec![]).await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(result.is_ok(), "should get checks: {:?}", result);
+    let checks = result.unwrap();
+    assert_eq!(checks.state, CheckState::Pending);
+    assert!(
+        !checks.checks_configured,
+        "zero posted statuses must set checks_configured=false, or `--wait` \
+         burns its full timeout on a ref with nothing to wait for"
+    );
 }
 
 // ── Approval ──────────────────────────────────────────────────────

--- a/tests/test_platform_github.rs
+++ b/tests/test_platform_github.rs
@@ -378,6 +378,92 @@ async fn test_github_status_checks_all_pass() {
     let checks = result.unwrap();
     assert_eq!(checks.state, CheckState::Success);
     assert_eq!(checks.statuses.len(), 2);
+    assert!(
+        checks.checks_configured,
+        "real check runs must set checks_configured=true (grip#776 finding 2: \
+         this was previously unasserted, so a mutant flipping the true case \
+         to false went unnoticed)"
+    );
+}
+
+#[tokio::test]
+async fn test_github_status_checks_legacy_signal_trusted_despite_empty_check_runs() {
+    // Check Runs API succeeds but reports zero runs (a repo whose CI posts
+    // only to the legacy status API, never registering as a GitHub Actions
+    // Check Run). The legacy endpoint DOES have a real signal -- it must be
+    // trusted, not discarded just because Check Runs saw nothing.
+    let (server, adapter) = setup_github_mock().await;
+    mock_check_runs(&server, "abc123", vec![]).await;
+    mock_legacy_combined_status(&server, "abc123", "success", vec![("legacy-ci", "success")]).await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(
+        result.is_ok(),
+        "should fall through to legacy: {:?}",
+        result
+    );
+    let checks = result.unwrap();
+    assert_eq!(checks.state, CheckState::Success);
+    assert!(
+        checks.checks_configured,
+        "a real legacy signal must set checks_configured=true even when \
+         Check Runs independently confirmed zero runs"
+    );
+}
+
+#[tokio::test]
+async fn test_github_status_checks_both_apis_confirm_nothing_configured() {
+    // The base case grip#772 exists for: Check Runs positively confirms zero
+    // runs AND the legacy endpoint is equally empty (pending + no statuses).
+    // Both APIs agreeing on absence is the only case where checks_configured
+    // should be false.
+    let (server, adapter) = setup_github_mock().await;
+    mock_check_runs(&server, "abc123", vec![]).await;
+    mock_legacy_combined_status(&server, "abc123", "pending", vec![]).await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(
+        result.is_ok(),
+        "should fall through to legacy: {:?}",
+        result
+    );
+    let checks = result.unwrap();
+    assert!(
+        !checks.checks_configured,
+        "both APIs agreeing on zero checks must set checks_configured=false, \
+         or `--wait` burns its full timeout on a ref with nothing to wait for \
+         (grip#772)"
+    );
+}
+
+#[tokio::test]
+async fn test_github_status_checks_check_runs_500_with_ambiguous_legacy_is_not_confirmed_absent() {
+    // grip#776 finding 1: Check Runs fails outright (500, not "succeeded
+    // with zero"). The legacy endpoint's pending+empty reading is exactly as
+    // ambiguous here as it is in the confirmed-empty case above -- but
+    // reaching this fallback via a Check Runs FAILURE must not be conflated
+    // with reaching it via a Check Runs CONFIRMATION of zero runs. An API
+    // outage is not evidence of absence.
+    let (server, adapter) = setup_github_mock().await;
+    mock_server_error(&server, "/repos/owner/repo/commits/abc123/check-runs").await;
+    mock_legacy_combined_status(&server, "abc123", "pending", vec![]).await;
+
+    let result = adapter.get_status_checks("owner", "repo", "abc123").await;
+
+    assert!(
+        result.is_ok(),
+        "should fall through to legacy: {:?}",
+        result
+    );
+    let checks = result.unwrap();
+    assert!(
+        checks.checks_configured,
+        "Check Runs 500 + ambiguous legacy pending/empty must NOT be treated \
+         as confirmed-absent -- that would let `--wait` silently proceed past \
+         checks whose status could not actually be determined"
+    );
 }
 
 #[tokio::test]

--- a/tests/test_pr_edit.rs
+++ b/tests/test_pr_edit.rs
@@ -1,0 +1,125 @@
+//! Command-orchestration regression for `gr pr edit`'s multi-repo scope guard
+//! (grip#771, grip#773).
+//!
+//! Same reasoning as `test_pr_review.rs`: the committed guard-unit tests all
+//! call `require_explicit_multi_repo_scope` directly, so nothing in the
+//! original suite would notice the guard's call-site being removed from
+//! `run_pr_edit`'s own body. These tests exercise `run_pr_edit` end to end
+//! and assert on the wiremock server's received-request log.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use common::git_helpers;
+use common::mock_platform::{
+    mock_list_prs, mock_update_pull_request, point_repo_at_mock, setup_github_mock,
+};
+use wiremock::http::Method;
+
+// ── grip#771 exact shape: unrelated repo, unscoped edit, zero PATCHes ─────
+
+#[tokio::test]
+async fn test_pr_edit_unscoped_multi_match_sends_zero_update_patches() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("research")
+        .add_repo("recall")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["research", "recall"] {
+        git_helpers::create_branch(
+            &ws.repo_path(repo_name),
+            "test/a7-b3-corroborate-content-discard",
+        );
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(
+        &server,
+        vec![(892, "test/a7-b3-corroborate-content-discard")],
+    )
+    .await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_edit(
+        &ws.workspace_root,
+        &manifest,
+        Some("a title meant for exactly one PR"),
+        Some("a body meant for exactly one PR"),
+        None,  // no --repo
+        false, // no --all
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "unscoped 2-repo match must be refused, not silently edited"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let update_patches: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method == Method::PATCH && r.url.path().contains("/pulls/"))
+        .collect();
+    assert!(
+        update_patches.is_empty(),
+        "expected zero PR-update PATCHes, got {}: {:?}",
+        update_patches.len(),
+        update_patches
+            .iter()
+            .map(|r| r.url.path())
+            .collect::<Vec<_>>()
+    );
+}
+
+// ── --repo explicitly scopes past the guard, edit proceeds normally ───────
+
+#[tokio::test]
+async fn test_pr_edit_explicit_repo_filter_proceeds_and_patches() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["frontend", "backend"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "feat/test");
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(1, "feat/test")]).await;
+    mock_update_pull_request(&server, 1).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_edit(
+        &ws.workspace_root,
+        &manifest,
+        Some("scoped title"),
+        Some("scoped body"),
+        Some(&["frontend".to_string()]), // explicit --repo
+        false,
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "explicit --repo scoping a single match should proceed: {:?}",
+        result.err()
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let update_patches = requests
+        .iter()
+        .filter(|r| r.method == Method::PATCH && r.url.path().contains("/pulls/"))
+        .count();
+    assert_eq!(
+        update_patches, 1,
+        "expected exactly one update PATCH once explicitly scoped"
+    );
+}

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -9,8 +9,8 @@ mod common;
 use common::fixtures::WorkspaceBuilder;
 use common::git_helpers;
 use common::mock_platform::{
-    mock_check_runs, mock_get_pr, mock_list_prs, mock_merge_pr, mock_merge_pr_behind,
-    mock_pr_reviews, point_repo_at_mock, setup_github_mock,
+    mock_check_runs, mock_get_pr, mock_legacy_combined_status, mock_list_prs, mock_merge_pr,
+    mock_merge_pr_behind, mock_pr_reviews, point_repo_at_mock, setup_github_mock,
 };
 use gitgrip::core::manifest::{PlatformConfig, PlatformType};
 use wiremock::http::Method;
@@ -663,5 +663,89 @@ async fn test_pr_merge_all_flag_proceeds_and_merges_every_match() {
     assert_eq!(
         merge_puts, 2,
         "expected a merge PUT for each of the two --all-confirmed repos"
+    );
+}
+
+// ── grip#772: --wait must not block on a branch with no CI configured ──────
+//
+// Reproduces the exact incident: `gr pr merge --wait --timeout 600` on
+// premium#745 (2026-07-17) ran the full 600s timeout even though the branch
+// had zero CI checks configured at all -- GitHub's check-runs API reported
+// total_count=0, and its legacy combined-status fallback reports
+// state="pending" for a commit with zero posted statuses, the same string it
+// uses for "checks are running." `--wait` must treat "confirmed zero checks"
+// as immediately resolved, not enter the poll loop at all.
+
+#[tokio::test]
+async fn test_pr_merge_wait_does_not_block_when_no_checks_are_configured() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let mut manifest = ws.load_manifest();
+
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/no-ci");
+    git_helpers::commit_file(
+        &ws.repo_path("app"),
+        "feature.txt",
+        "feature",
+        "Add feature",
+    );
+
+    let repo_config = manifest.repos.get_mut("app").unwrap();
+    repo_config.url = Some("https://github.com/owner/repo.git".to_string());
+    repo_config.platform = Some(PlatformConfig {
+        platform_type: PlatformType::GitHub,
+        base_url: Some(server.uri()),
+    });
+
+    mock_list_prs(&server, vec![(42, "feat/no-ci")]).await;
+    mock_get_pr(&server, 42, "open", false).await;
+    mock_pr_reviews(&server, 42, vec![("APPROVED", "alice")]).await;
+    // Exact GitHub shape for a ref with no CI configured: check-runs reports
+    // zero runs, and the legacy fallback reports "pending" with zero statuses.
+    mock_check_runs(&server, "feat/no-ci", vec![]).await;
+    mock_legacy_combined_status(&server, "feat/no-ci", "pending", vec![]).await;
+    mock_merge_pr(&server, 42, true).await;
+
+    let start = std::time::Instant::now();
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            update: false,
+            auto: false,
+            json: false,
+            wait: true,
+            timeout: 5,
+            delete_branch: true,
+            repo_filter: None,
+            yes: true,
+            allow_all: false,
+        },
+    )
+    .await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_ok(),
+        "merge with --wait on a no-CI-configured branch should succeed, not time out: {:?}",
+        result.err()
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(10),
+        "expected --wait to resolve immediately (no checks configured means nothing to poll \
+         for), took {:?} instead -- this is grip#772's exact symptom if it regresses \
+         (the loop's own re-poll sleep is 15s, so a regression would take at least that long)",
+        elapsed
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method == Method::PUT && r.url.path().ends_with("/merge")),
+        "expected the merge to actually proceed, not just avoid timing out"
     );
 }

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -43,6 +43,7 @@ async fn test_pr_merge_no_open_prs() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -94,6 +95,7 @@ async fn test_pr_merge_skip_default_branch() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -139,6 +141,7 @@ async fn test_pr_merge_skip_reference_repos() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -183,6 +186,7 @@ async fn test_pr_merge_mixed_repos_all_skipped() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -246,6 +250,7 @@ async fn test_pr_merge_force_bypasses_checks() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -315,6 +320,7 @@ async fn test_pr_merge_branch_behind_suggests_update() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -393,6 +399,7 @@ async fn test_pr_merge_repo_filter_excludes_non_target() {
             delete_branch: true,
             repo_filter: Some(vec!["frontend".to_string()]),
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -443,6 +450,7 @@ async fn test_pr_merge_repo_filter_no_match_finds_no_prs() {
             delete_branch: true,
             repo_filter: Some(vec!["nonexistent".to_string()]),
             yes: true,
+            allow_all: false,
         },
     )
     .await;
@@ -500,6 +508,7 @@ async fn test_pr_merge_force_yes_merges_without_prompt() {
             delete_branch: true,
             repo_filter: None,
             yes: true,
+            allow_all: false,
         },
     )
     .await;

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -10,7 +10,7 @@ use common::fixtures::WorkspaceBuilder;
 use common::git_helpers;
 use common::mock_platform::{
     mock_check_runs, mock_get_pr, mock_list_prs, mock_merge_pr, mock_merge_pr_behind,
-    mock_pr_reviews, setup_github_mock,
+    mock_pr_reviews, point_repo_at_mock, setup_github_mock,
 };
 use gitgrip::core::manifest::{PlatformConfig, PlatformType};
 use wiremock::http::Method;
@@ -529,4 +529,139 @@ async fn test_pr_merge_all_or_nothing_stops_on_failure() {
     // 3. Mock first repo's merge to fail
     // 4. Verify second repo's merge is never called
     // 5. Verify error message mentions all-or-nothing
+}
+
+// ── Command-orchestration regression for the multi-repo scope guard ────────
+// (grip#770/grip#771/grip#773, Sentinel reviewer-2 finding on c650a85): the
+// committed guard-unit tests all call require_explicit_multi_repo_scope
+// directly, so nothing in the original suite would notice the guard's
+// call-site being removed from run_pr_merge's own body. This exercises
+// run_pr_merge end to end and asserts on the wiremock server's received-
+// request log -- the guard must fire before any merge PUT is sent.
+
+#[tokio::test]
+async fn test_pr_merge_unscoped_multi_match_sends_zero_merge_puts() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["frontend", "backend"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "feat/shared-name");
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(1, "feat/shared-name")]).await;
+    mock_get_pr(&server, 1, "open", false).await;
+    mock_pr_reviews(&server, 1, vec![("APPROVED", "alice")]).await;
+    mock_check_runs(
+        &server,
+        "feat/shared-name",
+        vec![("CI", "completed", Some("success"))],
+    )
+    .await;
+    mock_merge_pr(&server, 1, true).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: None, // no --repo
+            yes: true,
+            allow_all: false, // no --all
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "unscoped 2-repo match must be refused, not silently merged"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let merge_puts: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method == Method::PUT && r.url.path().ends_with("/merge"))
+        .collect();
+    assert!(
+        merge_puts.is_empty(),
+        "expected zero merge PUTs, got {}: {:?}",
+        merge_puts.len(),
+        merge_puts.iter().map(|r| r.url.path()).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_pr_merge_all_flag_proceeds_and_merges_every_match() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["frontend", "backend"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "feat/shared-name");
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(1, "feat/shared-name")]).await;
+    mock_get_pr(&server, 1, "open", false).await;
+    mock_pr_reviews(&server, 1, vec![("APPROVED", "alice")]).await;
+    mock_check_runs(
+        &server,
+        "feat/shared-name",
+        vec![("CI", "completed", Some("success"))],
+    )
+    .await;
+    mock_merge_pr(&server, 1, true).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: None,
+            yes: true,
+            allow_all: true, // explicit opt-in
+        },
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "--all should proceed past the guard on a genuine multi-match: {:?}",
+        result.err()
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let merge_puts = requests
+        .iter()
+        .filter(|r| r.method == Method::PUT && r.url.path().ends_with("/merge"))
+        .count();
+    assert_eq!(
+        merge_puts, 2,
+        "expected a merge PUT for each of the two --all-confirmed repos"
+    );
 }

--- a/tests/test_pr_review.rs
+++ b/tests/test_pr_review.rs
@@ -1,0 +1,188 @@
+//! Command-orchestration regression for `gr pr review`'s multi-repo scope
+//! guard (grip#770, grip#773).
+//!
+//! Sentinel's reviewer-2 finding on grip#773 (c650a85): the committed guard
+//! tests all called `require_explicit_multi_repo_scope` directly, so nothing
+//! in the suite would notice if the guard's call-site inside
+//! `run_pr_review`'s own body were ever removed — the pure helper would stay
+//! green while the real command silently regained the grip#770 cross-post
+//! behavior. These tests exercise `run_pr_review` itself, end to end, and
+//! assert on the wiremock server's received-request log: the guard must fire
+//! BEFORE any review POST is sent, not just return the right Rust `Result`.
+
+mod common;
+
+use common::fixtures::WorkspaceBuilder;
+use common::git_helpers;
+use common::mock_platform::{mock_list_prs, point_repo_at_mock, setup_github_mock};
+use gitgrip::platform::ReviewEvent;
+use wiremock::http::Method;
+
+// `find_pr_by_branch`'s mock (`mock_list_prs`) doesn't filter by query string
+// -- every repo's lookup resolves to the same first PR in the mocked list,
+// which is sufficient to prove the "N repos matched" shape this guard cares
+// about; it doesn't require each repo to resolve to a distinct real PR.
+
+// ── grip#770 exact shape: three repos, unscoped review, zero POSTs ────────
+
+#[tokio::test]
+async fn test_pr_review_unscoped_multi_match_sends_zero_review_posts() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("consult-conversa-config")
+        .add_repo("premium")
+        .add_repo("recall")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["consult-conversa-config", "premium", "recall"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "sentinel/d5-gr1-bug-five");
+        git_helpers::commit_file(
+            &ws.repo_path(repo_name),
+            "feature.txt",
+            "feature",
+            "Add feature",
+        );
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(892, "sentinel/d5-gr1-bug-five")]).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_review(
+        &ws.workspace_root,
+        &manifest,
+        ReviewEvent::Comment,
+        Some("a body meant for exactly one PR"),
+        None,  // no --repo
+        false, // no --all
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "unscoped 3-repo match must be refused, not silently reviewed"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let review_posts: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method == Method::POST && r.url.path().ends_with("/reviews"))
+        .collect();
+    assert!(
+        review_posts.is_empty(),
+        "expected zero review POSTs, got {}: {:?}",
+        review_posts.len(),
+        review_posts
+            .iter()
+            .map(|r| r.url.path())
+            .collect::<Vec<_>>()
+    );
+}
+
+// ── --repo explicitly scopes past the guard, review proceeds normally ─────
+
+#[tokio::test]
+async fn test_pr_review_explicit_repo_filter_proceeds_and_posts_review() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new()
+        .add_repo("frontend")
+        .add_repo("backend")
+        .build();
+    let mut manifest = ws.load_manifest();
+
+    for repo_name in ["frontend", "backend"] {
+        git_helpers::create_branch(&ws.repo_path(repo_name), "feat/test");
+        git_helpers::commit_file(&ws.repo_path(repo_name), "f.txt", "x", "Add f");
+        point_repo_at_mock(&mut manifest, repo_name, &server);
+    }
+
+    mock_list_prs(&server, vec![(1, "feat/test")]).await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path(
+            "/repos/owner/repo/pulls/1/reviews",
+        ))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": 1, "state": "COMMENTED"
+            })),
+        )
+        .mount(&server)
+        .await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_review(
+        &ws.workspace_root,
+        &manifest,
+        ReviewEvent::Comment,
+        Some("scoped review body"),
+        Some(&["frontend".to_string()]), // explicit --repo
+        false,
+        false,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "explicit --repo scoping a single match should proceed: {:?}",
+        result.err()
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    let review_posts = requests
+        .iter()
+        .filter(|r| r.method == Method::POST && r.url.path().ends_with("/reviews"))
+        .count();
+    assert_eq!(
+        review_posts, 1,
+        "expected exactly one review POST once explicitly scoped"
+    );
+}
+
+// ── validate_repo_filters_known's command-level loud-fail (Opus, non-blocking) ──
+
+#[tokio::test]
+async fn test_pr_review_unknown_repo_filter_fails_loudly_not_silently() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let mut manifest = ws.load_manifest();
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
+    git_helpers::commit_file(&ws.repo_path("app"), "f.txt", "x", "Add f");
+    point_repo_at_mock(&mut manifest, "app", &server);
+
+    let result = gitgrip::cli::commands::pr::run_pr_review(
+        &ws.workspace_root,
+        &manifest,
+        ReviewEvent::Comment,
+        Some("body"),
+        Some(&["this-repo-does-not-exist".to_string()]),
+        false,
+        false,
+    )
+    .await;
+
+    let err = result.expect_err(
+        "an unknown --repo filter value must fail loudly (validate_repo_filters_known), \
+         not silently resolve to zero matched repos",
+    );
+    let message = err.to_string();
+    assert!(
+        message.contains("this-repo-does-not-exist"),
+        "error should name the unknown filter, got: {message}"
+    );
+    assert!(
+        message.contains("gr sync"),
+        "error should carry the sync-guidance validate_repo_filters_known provides, got: {message}"
+    );
+
+    // No API calls should happen at all -- the filter validation runs before
+    // any repo is even inspected for a matching PR.
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests.is_empty(),
+        "unknown-filter validation should fail before any API call, got {} requests",
+        requests.len()
+    );
+}


### PR DESCRIPTION
## Summary

- `gr pr edit`/`review`/`merge` refuse unscoped multi-repo actions (#773) -- fails closed and lists what would be touched when no `--repo` given and >1 repo has a matching open PR, instead of silently fanning out. Closes grip#770, grip#771 incident class.
- `gr checkout add` produces a self-discoverable child workspace (#775) -- unified workspace discovery walk, removed checkout/manifest-repo collision, fail-closed on malformed/reconstructed checkout metadata.
- `gr pr merge --wait` detects no-checks-configured and returns immediately (#776) -- previously could hang; closes false-absence + mutation-silence gaps in the re-poll guard.

## Version

Cargo.toml + Cargo.lock bumped 1.0.0 -> 1.0.1. CHANGELOG.md entry added.

## Merge conflict resolution

sprint-41 and sprint-39 both modified `src/core/repo.rs` independently: sprint-39 added `validate_repo_filters_known`, sprint-41 added `require_explicit_multi_repo_scope`, both inserted at the same location. Purely additive, non-overlapping functions -- resolution keeps both (also true of `checkout.rs`, which auto-merged cleanly). Landed via PR#786 into sprint-41 first (this repo's sprint branches are ruleset-protected, PR-required).

## Verification

- `cargo test --all`: fully green, real exit code 0
- gr2 python suite: 513 passed, real exit code 0
- Both re-verified via absolute venv path (`.venv/bin/python -m pytest`, not `source activate` + bare `pytest`) per this session's venv-verification discipline, confirming `gr2_overlay` imports from this checkout specifically

## Premium boundary

grip is OSS (MIT) -- PR/checkout/merge workflow orchestration behavior. No identity/org semantics.

## Merge gate note

`main`'s ruleset requires a pull_request but has no required_status_checks -- the synapt-dev org billing lock (Actions jobs failing org-wide) blocks CI display but not the merge itself. Per Layne (2026-07-23): local-green is the merge gate. Regular merge, no squash.

## Explicitly NOT in this PR

No crates.io publish, no homebrew-tap bump, no `gh release`. Opus fires that separately after the Anchor v1.0.1 coordination check.