### PR TITLE
fix: eliminate self-referential package-dir in gr2 pyproject.toml

### DIFF
--- a/gr2/pyproject.toml
+++ b/gr2/pyproject.toml
@@ -27,7 +27,9 @@ dev = [
 packages = ["gr2_overlay", "gr2", "gr2.python_cli", "gr2.prototypes"]
 
 [tool.setuptools.package-dir]
-gr2 = "."
+gr2 = "gr2"
+"gr2.python_cli" = "python_cli"
+"gr2.prototypes" = "prototypes"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "gr2_overlay/tests"]


### PR DESCRIPTION
## Summary

Fixes grip#788: gr2's `pyproject.toml` mapped `gr2 = "."` in `[tool.setuptools.package-dir]` — the same directory `gr2_overlay/`, `python_cli/`, `prototypes/`, `tests/`, and `pyproject.toml` itself all live under. On a genuinely fresh venv + `pip install -e ".[dev]" --no-cache-dir`, this self-reference could silently drop `gr2`/`gr2.python_cli`/`gr2.prototypes` from the editable install's generated finder, leaving only `gr2_overlay` importable. The console-script entry point (`gr2 = "gr2.python_cli.app:main"`) would then be broken for any real install.

This is Slice 1 of the ZERO-TO-TEAM initiative (build-lane assignment from Stromus, 2026-07-27): a fresh-clone-to-working-package install is the literal first step of "bare clone → living team," so this had to land before anything else in that effort could be meaningfully tested end-to-end.

## Fix

Gave `gr2` its own directory (`gr2/gr2/`, containing just the previously-empty `__init__.py`) with an explicit package-dir entry, matching the pattern `gr2_overlay/` already used cleanly (package name == directory name, no override needed). `python_cli/` and `prototypes/` did **not** move — they get their own explicit `package-dir` entries (`"gr2.python_cli" = "python_cli"`, `"gr2.prototypes" = "prototypes"`) instead of relying on implicit parent-then-relative-child resolution through the self-referencing root mapping. This is a 1-file move (an empty `__init__.py`) + a 3-line `pyproject.toml` change, not a mass restructure — kept deliberately minimal once I confirmed setuptools resolves dotted package-dir entries independently of physical nesting.

Before (buggy): `MAPPING = {'gr2': '<project root>', 'gr2_overlay': '<project root>/gr2_overlay'}` — `gr2` and everything else share one root.
After (fixed): `MAPPING = {'gr2': '<project root>/gr2', 'gr2.python_cli': '<project root>/python_cli', 'gr2.prototypes': '<project root>/prototypes', 'gr2_overlay': '<project root>/gr2_overlay'}` — four disjoint, non-overlapping source directories.

## Honest verification note

I could **not** reproduce the original `ModuleNotFoundError: No module named 'gr2'` — ran the exact repro from grip#788 (`rm -rf .venv gr2_overlay.egg-info`, fresh venv, `pip install -e ".[dev]" --no-cache-dir`, import check from a neutral `/tmp` cwd) **7 times total** (4 before the fix, 3 after), all 7 passed cleanly. This matches the issue's own observation that the failure was non-deterministic across pip versions and "resolved itself... after enough repeated `pip install -e .` invocations" — I just never caught it landing broken in this environment on this day.

Given that, I'm not claiming a red→green diff I personally witnessed. The fix is warranted on the structural evidence instead: the self-referential mapping is a genuine asymmetry (one package gets a dedicated directory, the sibling package claims the whole project root as its own), and I confirmed directly via the generated finder file that this specific collision class is now structurally impossible — every package has its own disjoint directory. If the reader wants stronger proof than that, I don't have it; said so rather than rounding up.

## Verification performed

- 7x fresh venv + `pip install -e ".[dev]" --no-cache-dir` (no pip cache, no reused venv) — clean both before and after; inspected the actual generated `__editable___gr2_overlay_0_1_0_finder.py` MAPPING dict directly in both states (not inferred from behavior alone)
- All 6 tests in `tests/test_gr2_packaging.py` pass (these run in subprocesses from a neutral `tmp_path`, bypassing `conftest.py`'s `sys.modules` injection entirely — the only tests in the suite that would actually catch this class of bug)
- Full suite: `516 passed` (0 failures) after the move
- Repo-wide grep for hardcoded references to the old root-level `__init__.py` location or the old `gr2 = "."` mapping: none found (`docs/`, CI workflows, `MANIFEST.in` — none exists)
- Left `conftest.py`'s `sys.modules` injection in place intentionally — it's a separate, working local-dev convenience (run `pytest` in a plain checkout without an editable install first) orthogonal to install-fidelity, which `test_gr2_packaging.py`'s subprocess-based tests already own correctly

## Related finding (filed separately, not blocking this PR)

While verifying this, found `gitgrip`'s CI (`.github/workflows/ci.yml`) has **zero jobs running gr2's Python test suite** — only Rust caching/build/test steps. Filed grip#793 (New/Backlog) rather than scope-creep it into this PR; flagging here because it's directly relevant to the rest of ZERO-TO-TEAM: every future materialization/spawn slice is currently being built with no automated Python-side safety net.

## Branch target note

`gr target list` shows `gitgrip: main` as both the global default and the per-repo override — sprint-39 and sprint-41 both already ceremony-merged into main (2026-07-23), no new sprint branch open yet. PRing into `main` directly rather than inventing an unauthorized sprint branch; flagging this explicitly to Stromus since opening a new sprint is a coordinator call, not mine to make unilaterally for one bugfix.

## Premium boundary

OSS (grip is MIT) — packaging/build config only, no identity/org semantics.

Closes #788