### PR TITLE
ci: wire gr2 Python tests into gitgrip CI as a required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        run: python -m pip install uv
+
       - name: Install gr2 (fresh install, no cache)
         working-directory: gr2
         run: python -m pip install -e ".[dev]" --no-cache-dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,13 +208,40 @@ jobs:
       - name: Run spawn integration tests
         run: GR=./target/debug/gr ./tests/spawn_graceful_shutdown.sh
 
+  gr2_python:
+    name: gr2 Python Tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.11 is the floor declared in gr2/pyproject.toml's requires-python;
+        # test it explicitly rather than only whatever the runner defaults to,
+        # or a floor regression can pass CI while silently no longer installing
+        # for real 3.11 users (see grip#788's own class of masked failure).
+        python-version: ["3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python toolchain
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install gr2 (fresh install, no cache)
+        working-directory: gr2
+        run: python -m pip install -e ".[dev]" --no-cache-dir
+
+      - name: Run gr2 test suite
+        working-directory: gr2
+        run: python -m pytest
+
   # Summary job for branch protection - requires all jobs except Windows to pass.
   # Windows tests run separately (test-windows) and are visible but non-blocking,
   # since they are significantly slower and should not gate PR merges.
   ci:
     name: CI
     runs-on: ubuntu-latest
-    needs: [boundary-lint, check, fmt, clippy, test, build, bench, integration]
+    needs: [boundary-lint, check, fmt, clippy, test, build, bench, integration, gr2_python]
     if: always()
     steps:
       - name: Check all required jobs passed
@@ -226,7 +253,8 @@ jobs:
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
              [[ "${{ needs.bench.result }}" != "success" ]] || \
-             [[ "${{ needs.integration.result }}" != "success" ]]; then
+             [[ "${{ needs.integration.result }}" != "success" ]] || \
+             [[ "${{ needs.gr2_python.result }}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -47,6 +47,13 @@ class LaneMetadata:
     handoff_source: dict[str, str] | None
 
     def as_toml(self) -> str:
+        # repos/shared_with are pre-formatted here, not inlined into the
+        # f-strings below: an f-string expression part can't safely nest a
+        # string literal using the same quote character as the outer
+        # f-string (pre-3.12 tokenizers can't tell a nested string's quote
+        # from the outer delimiter -- see grip#793's Python 3.11 CI catch).
+        repos_toml = ", ".join(f'"{r}"' for r in self.repos)
+        shared_with_toml = ", ".join(f'"{u}"' for u in self.shared_with)
         lines = [
             f"schema_version = {self.schema_version}",
             f'lane_name = "{self.lane_name}"',
@@ -55,8 +62,8 @@ class LaneMetadata:
             f'lane_type = "{self.lane_type}"',
             f'creation_source = "{self.creation_source}"',
             "",
-            f"repos = [{', '.join(f'\"{r}\"' for r in self.repos)}]",
-            f"shared_with = [{', '.join(f'\"{u}\"' for u in self.shared_with)}]",
+            f"repos = [{repos_toml}]",
+            f"shared_with = [{shared_with_toml}]",
             "",
             "[branch_map]",
         ]
@@ -116,6 +123,11 @@ class SharedScratchpad:
     updated_at: str
 
     def as_toml(self) -> str:
+        # See LaneWorkspaceSpec.as_toml's comment above: pre-formatted here
+        # rather than inlined, to avoid nesting a same-quote string literal
+        # inside another f-string's expression part (grip#793).
+        participants_toml = ", ".join(f'"{p}"' for p in self.participants)
+        linked_refs_toml = ", ".join(f'"{r}"' for r in self.linked_refs)
         lines = [
             f"schema_version = {self.schema_version}",
             f'name = "{self.name}"',
@@ -126,8 +138,8 @@ class SharedScratchpad:
             f'created_at = "{self.created_at}"',
             f'updated_at = "{self.updated_at}"',
             "",
-            f'participants = [{", ".join(f"\"{p}\"" for p in self.participants)}]',
-            f'linked_refs = [{", ".join(f"\"{r}\"" for r in self.linked_refs)}]',
+            f"participants = [{participants_toml}]",
+            f"linked_refs = [{linked_refs_toml}]",
             "",
             "[paths]",
             f'docs_root = "{self.docs_root}"',

--- a/gr2/pyproject.toml
+++ b/gr2/pyproject.toml
@@ -27,7 +27,9 @@ dev = [
 packages = ["gr2_overlay", "gr2", "gr2.python_cli", "gr2.prototypes"]
 
 [tool.setuptools.package-dir]
-gr2 = "."
+gr2 = "gr2"
+"gr2.python_cli" = "python_cli"
+"gr2.prototypes" = "prototypes"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "gr2_overlay/tests"]

--- a/gr2/tests/test_ci_gate_smoke.py
+++ b/gr2/tests/test_ci_gate_smoke.py
@@ -1,8 +1,0 @@
-"""Temporary proof-of-gate smoke test -- deliberately fails, will be reverted
-in the very next commit. Exists only to confirm the gr2_python CI job (and
-its wiring into the `ci` aggregate) actually catches a real test failure,
-not just that the job runs and exits 0 regardless of content."""
-
-
-def test_ci_gate_deliberately_fails() -> None:
-    assert False, "PROOF-OF-GATE: this is intentional, see grip PR#795"

--- a/gr2/tests/test_ci_gate_smoke.py
+++ b/gr2/tests/test_ci_gate_smoke.py
@@ -1,0 +1,8 @@
+"""Temporary proof-of-gate smoke test -- deliberately fails, will be reverted
+in the very next commit. Exists only to confirm the gr2_python CI job (and
+its wiring into the `ci` aggregate) actually catches a real test failure,
+not just that the job runs and exits 0 regardless of content."""
+
+
+def test_ci_gate_deliberately_fails() -> None:
+    assert False, "PROOF-OF-GATE: this is intentional, see grip PR#795"

--- a/gr2/tests/test_gr2_packaging.py
+++ b/gr2/tests/test_gr2_packaging.py
@@ -1,14 +1,18 @@
 """Packaging tests: gr2 must be a real installable CLI, not a pytest-only import.
 
-Today, gr2.python_cli and gr2.prototypes only resolve inside pytest, via the
-root conftest.py's sys.modules injection (`gr2/conftest.py`). gr2/pyproject.toml
-packages only gr2_overlay. There is no console_scripts entry point.
+gr2.python_cli and gr2.prototypes are real, independently installable packages
+(grip#788 fixed the self-referential package-dir that used to drop them from
+a fresh install). The root conftest.py's sys.modules injection (`gr2/conftest.py`)
+is still present as a separate, intentional local-dev convenience -- it lets
+`pytest` run in a plain checkout without an editable install first -- but it is
+no longer load-bearing for these tests specifically.
 
 These tests deliberately run each check in a fresh subprocess with cwd pinned to
 a neutral tmp_path (never gr2/ or its parent), so a pass can only mean the
 package is genuinely installed and importable -- not that Python happened to
 find these modules via a cwd-relative accident or pytest's own sys.modules hack,
-which subprocesses don't inherit anyway.
+which subprocesses don't inherit anyway. That property is what makes them the
+regression guard for grip#788's class of bug.
 
 grip#752 slice 1 (D3): pyproject at grip/gr2/... console_scripts entry point.
 Reference path correction: the repo directory is gitgrip/gr2/, not

--- a/gr2/tests/test_grip_object_model.py
+++ b/gr2/tests/test_grip_object_model.py
@@ -96,12 +96,13 @@ def _write_workspace_spec(workspace_root: Path, repos: list[tuple[str, str]]) ->
                 """
             ).strip()
         )
+    joined_repo_blocks = "\n\n".join(repo_blocks)
     spec_path.write_text(
         textwrap.dedent(
             f"""
             workspace_name = "{workspace_root.name}"
 
-            {"\n\n".join(repo_blocks)}
+            {joined_repo_blocks}
             """
         ).strip()
         + "\n"

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -162,17 +162,19 @@ def _write_workspace_spec_multi(workspace_root: Path, repos: list[tuple[str, str
                 """
             ).strip()
         )
+    joined_repo_blocks = "\n\n".join(repo_blocks)
+    unit_repo_names = ", ".join(f'"{name}"' for name, _ in repos)
     spec_path.write_text(
         textwrap.dedent(
             f"""
             workspace_name = "{workspace_root.name}"
 
-            {'\n\n'.join(repo_blocks)}
+            {joined_repo_blocks}
 
             [[units]]
             name = "atlas"
             path = "agents/atlas/home"
-            repos = [{", ".join(f'"{name}"' for name, _ in repos)}]
+            repos = [{unit_repo_names}]
             """
         ).strip()
         + "\n"


### PR DESCRIPTION
## Summary

Closes grip#793: gitgrip's CI (`ci.yml`) ran zero gr2 Python tests — every existing job is Rust-flavored (boundary-lint/check/fmt/clippy/test/build/bench/integration). 516 gr2 tests exist and pass locally, but nothing exercised them on PRs.

This is ZERO-TO-TEAM Slice 1.5 (Stromus's locked build-plan) — reframed from a side-note to a prerequisite: the remaining slices (S3 `gr init` forward, S4 materialize executor, S5 launch primitive) are gr2-Python work, and they'd land on a substrate with no automated safety net.

**Base note**: originally stacked on #794 while it was in flight; #794 merged (commit `6361d507`, r1 Stromus + r2 Sentinel BINDING APPROVE) and this PR now targets `main` directly — clean diff, no leftover stacking artifacts.

## What's added

A `gr2_python` job:
- `actions/setup-python` (no pip cache — deliberately, matching how every GitHub Actions runner is already a fresh VM; caching here specifically would risk reintroducing the exact "warm environment masks a fresh-install regression" failure mode that let grip#788 hide for weeks)
- `pip install -e ".[dev]" --no-cache-dir` from `gr2/`
- `pytest` from `gr2/`
- Matrixed on Python **3.11** (the floor `gr2/pyproject.toml` actually declares via `requires-python`) and **3.13** (what local dev has been using). Testing the floor explicitly, not just whatever the runner defaults to, matters here specifically — grip#788 was a floor-narrowing class of bug, and (see below) this PR caught a second, independent instance of exactly that class.

Wired into the `ci` aggregate job's `needs:` list and its explicit result-check conditional — matching how `boundary-lint`/`check`/`fmt`/etc. already gate merges. A job present in the file without this wiring runs (visible) but blocks nothing, which is exactly the kind of silent non-gate this slice exists to close. (`test-windows` is the existing, deliberate precedent for a job that's excluded on purpose — confirmed I wasn't accidentally following that pattern instead of the gating one.)

## Real bug caught on the gate's first live run — not hypothetical

Before merging this, I proved the gate actually catches failures, not just that it exists:

1. **Deliberate-failure proof (RED)**: pushed a throwaway test with `assert False`. Both matrix legs failed, and critically the aggregate `ci` job failed too — confirming the `needs:`/result-check wiring actually propagates, not just the individual job. Run: https://github.com/synapt-dev/grip/actions/runs/30231609720
2. **Revert (expected GREEN, got RED instead)**: removed the throwaway test — 3.13 passed, but **3.11 failed for real**. `gr2/prototypes/lane_workspace_prototype.py` (imported by `execops.py` and `syncops.py`, both Tier-1 "Done" per GR2-MVP.md) had 4 f-string expressions across 3 files that have never actually parsed on Python 3.11 — they rely on PEP 701 (Python 3.12), which relaxed the pre-3.12 rule against nesting a backslash or a same-quote string literal inside an f-string's `{}` expression part. `gr2/pyproject.toml` declares `requires-python = ">=3.11"`; that's been false for real, load-bearing code the whole time. Nobody's local dev venv had ever run 3.11 (mine included — 3.13), and there was no CI at all before this PR. Run: https://github.com/synapt-dev/grip/actions/runs/30231806350
3. **Fix + verify (real GREEN)**: pre-formatted each nested/joined expression into a plain variable before the f-string (same runtime output, 3.11-compatible syntax). Verified with a real Python 3.11.9 venv locally (516 passed, same count as 3.13) before pushing, then confirmed on the actual gate: both matrix legs + the aggregate `ci` job all green. Run: https://github.com/synapt-dev/grip/actions/runs/30232076250

This is the exact value case for grip#793 landing before the rest of ZERO-TO-TEAM: a gate that's never run before caught a real, previously-invisible compatibility bug on its first meaningful run, in code two Tier-1 "Done" modules directly import.

## Verification

- YAML validated locally (`yaml.safe_load`) before pushing
- Confirmed `gr2_python` appears in `ci`'s resolved `needs` list programmatically, not just by eyeballing the diff
- Full RED → RED (real bug) → GREEN cycle proven on live Actions runs (links above), not just locally
- Comprehensive Python 3.11 syntax sweep across the entire `gr2/` tree (not just the files pytest happened to reach) confirms zero remaining incompatibilities
- Also refreshed `test_gr2_packaging.py`'s docstring per Sentinel's nonblocking note on grip#794 (it described pre-#788-fix state as current)

## Related, NOT included in this PR

While sanity-checking whether `boundary-lint`'s patterns would even parse cleanly against `gr2/` before considering folding a path addition into this PR, found real matches — but all inside `gr2/src/` (a **third** codebase: a Rust crate, `gr2-cli`, a workspace member of root `Cargo.toml`, distinct from gr1's `gitgrip/src/` and gr2's Python `python_cli/`). That crate has a working `TeamCommands::Add/List/Remove` that writes `agent.toml` and a workspace-level `.grip/agents.toml` identity registry — a direct hit on CLAUDE.md's Identity Test, live in CI today (`cargo test`/`cargo build` already compile it) but invisible to `boundary-lint` because its `SEARCH_PATHS` doesn't include `gr2/`.

Update: this is now tracked properly — folded into grip#796 (GR2-MVP Tier-3 alignment, Atlas) and premium#756 (umbrella), with r2 routed to Sentinel's boundary lane. Not touching `boundary-lint`'s scope in this PR; that's a separate, already-owned thread.

## Premium boundary

OSS (grip is MIT) — CI/build tooling only, no identity/org semantics.

Closes #793
