### PR TITLE
feat: S4 materialize executor -- MaterializationPlan + grip#539 + gr2.overlay alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        run: python -m pip install uv
+
       - name: Install gr2 (fresh install, no cache)
         working-directory: gr2
         run: python -m pip install -e ".[dev]" --no-cache-dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,13 +208,40 @@ jobs:
       - name: Run spawn integration tests
         run: GR=./target/debug/gr ./tests/spawn_graceful_shutdown.sh
 
+  gr2_python:
+    name: gr2 Python Tests (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.11 is the floor declared in gr2/pyproject.toml's requires-python;
+        # test it explicitly rather than only whatever the runner defaults to,
+        # or a floor regression can pass CI while silently no longer installing
+        # for real 3.11 users (see grip#788's own class of masked failure).
+        python-version: ["3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python toolchain
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install gr2 (fresh install, no cache)
+        working-directory: gr2
+        run: python -m pip install -e ".[dev]" --no-cache-dir
+
+      - name: Run gr2 test suite
+        working-directory: gr2
+        run: python -m pytest
+
   # Summary job for branch protection - requires all jobs except Windows to pass.
   # Windows tests run separately (test-windows) and are visible but non-blocking,
   # since they are significantly slower and should not gate PR merges.
   ci:
     name: CI
     runs-on: ubuntu-latest
-    needs: [boundary-lint, check, fmt, clippy, test, build, bench, integration]
+    needs: [boundary-lint, check, fmt, clippy, test, build, bench, integration, gr2_python]
     if: always()
     steps:
       - name: Check all required jobs passed
@@ -226,7 +253,8 @@ jobs:
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
              [[ "${{ needs.bench.result }}" != "success" ]] || \
-             [[ "${{ needs.integration.result }}" != "success" ]]; then
+             [[ "${{ needs.integration.result }}" != "success" ]] || \
+             [[ "${{ needs.gr2_python.result }}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/gr2/gr2/schemas/gr2-materialization-plan-v1.schema.json
+++ b/gr2/gr2/schemas/gr2-materialization-plan-v1.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:synapt:gr2:materialization-plan:v1",
+  "title": "gr2 MaterializationPlan v1",
+  "description": "Identity-free, one-opaque-unit materialization plan consumed by the neutral gr2 executor.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "plan_id",
+    "unit_key",
+    "workspace_spec_sha256",
+    "operations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "plan_id": {
+      "$ref": "#/$defs/opaqueToken"
+    },
+    "unit_key": {
+      "$ref": "#/$defs/opaqueToken"
+    },
+    "workspace_spec_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "operations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/cloneOperation"
+          },
+          {
+            "$ref": "#/$defs/venvOperation"
+          },
+          {
+            "$ref": "#/$defs/editableInstallOperation"
+          },
+          {
+            "$ref": "#/$defs/projectFileOperation"
+          }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "opaqueToken": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048,
+      "pattern": "^[^\\u0000]+$"
+    },
+    "workspaceRelativePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "pattern": "^(?![~/])(?!.*\\\\)(?!.*//)(?!.*(?:^|/)\\.{1,2}(?:/|$))[^\\u0000]+$"
+    },
+    "cacheReferencePath": {
+      "type": "string",
+      "pattern": "^\\.grip/cache/repos/[A-Za-z0-9][A-Za-z0-9._-]{0,127}\\.git$"
+    },
+    "stagedInputPath": {
+      "type": "string",
+      "pattern": "^\\.grip/staging/inputs/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "cloneOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "repo_url",
+        "dest_path",
+        "branch"
+      ],
+      "properties": {
+        "kind": {
+          "const": "clone"
+        },
+        "repo_url": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "dest_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "branch": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "reference_base": {
+          "$ref": "#/$defs/cacheReferencePath"
+        }
+      }
+    },
+    "venvOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "dest_path",
+        "engine",
+        "python"
+      ],
+      "properties": {
+        "kind": {
+          "const": "venv"
+        },
+        "dest_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "engine": {
+          "const": "uv"
+        },
+        "python": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "editableInstallOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "venv_path",
+        "source_path",
+        "extras"
+      ],
+      "properties": {
+        "kind": {
+          "const": "editable_install"
+        },
+        "venv_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "source_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "extras": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          }
+        }
+      }
+    },
+    "projectFileOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "source_path",
+        "source_sha256",
+        "dest_path",
+        "mode"
+      ],
+      "properties": {
+        "kind": {
+          "const": "project_file"
+        },
+        "source_path": {
+          "$ref": "#/$defs/stagedInputPath"
+        },
+        "source_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "dest_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "mode": {
+          "const": "copy"
+        }
+      }
+    }
+  }
+}

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -47,6 +47,13 @@ class LaneMetadata:
     handoff_source: dict[str, str] | None
 
     def as_toml(self) -> str:
+        # repos/shared_with are pre-formatted here, not inlined into the
+        # f-strings below: an f-string expression part can't safely nest a
+        # string literal using the same quote character as the outer
+        # f-string (pre-3.12 tokenizers can't tell a nested string's quote
+        # from the outer delimiter -- see grip#793's Python 3.11 CI catch).
+        repos_toml = ", ".join(f'"{r}"' for r in self.repos)
+        shared_with_toml = ", ".join(f'"{u}"' for u in self.shared_with)
         lines = [
             f"schema_version = {self.schema_version}",
             f'lane_name = "{self.lane_name}"',
@@ -55,8 +62,8 @@ class LaneMetadata:
             f'lane_type = "{self.lane_type}"',
             f'creation_source = "{self.creation_source}"',
             "",
-            f"repos = [{', '.join(f'\"{r}\"' for r in self.repos)}]",
-            f"shared_with = [{', '.join(f'\"{u}\"' for u in self.shared_with)}]",
+            f"repos = [{repos_toml}]",
+            f"shared_with = [{shared_with_toml}]",
             "",
             "[branch_map]",
         ]
@@ -116,6 +123,11 @@ class SharedScratchpad:
     updated_at: str
 
     def as_toml(self) -> str:
+        # See LaneWorkspaceSpec.as_toml's comment above: pre-formatted here
+        # rather than inlined, to avoid nesting a same-quote string literal
+        # inside another f-string's expression part (grip#793).
+        participants_toml = ", ".join(f'"{p}"' for p in self.participants)
+        linked_refs_toml = ", ".join(f'"{r}"' for r in self.linked_refs)
         lines = [
             f"schema_version = {self.schema_version}",
             f'name = "{self.name}"',
@@ -126,8 +138,8 @@ class SharedScratchpad:
             f'created_at = "{self.created_at}"',
             f'updated_at = "{self.updated_at}"',
             "",
-            f'participants = [{", ".join(f"\"{p}\"" for p in self.participants)}]',
-            f'linked_refs = [{", ".join(f"\"{r}\"" for r in self.linked_refs)}]',
+            f"participants = [{participants_toml}]",
+            f"linked_refs = [{linked_refs_toml}]",
             "",
             "[paths]",
             f'docs_root = "{self.docs_root}"',

--- a/gr2/pyproject.toml
+++ b/gr2/pyproject.toml
@@ -24,12 +24,19 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["gr2_overlay", "gr2", "gr2.python_cli", "gr2.prototypes"]
+# gr2_overlay is a time-bounded compat alias for gr2.overlay (grip config#491
+# gap#13): same physical directory, two import names. New materialization
+# code must import gr2.overlay; gr2_overlay stays for existing consumers
+# until they're migrated separately. Don't mix the two names for the same
+# object within one execution path -- Python treats them as distinct module
+# identities even though the underlying files are identical.
+packages = ["gr2_overlay", "gr2", "gr2.python_cli", "gr2.prototypes", "gr2.overlay"]
 
 [tool.setuptools.package-dir]
 gr2 = "gr2"
 "gr2.python_cli" = "python_cli"
 "gr2.prototypes" = "prototypes"
+"gr2.overlay" = "gr2_overlay"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "gr2_overlay/tests"]

--- a/gr2/pyproject.toml
+++ b/gr2/pyproject.toml
@@ -12,6 +12,14 @@ dependencies = [
     "tomli_w>=1.0",
     "pyyaml>=6.0",
     "toml>=0.10",
+    # Draft 2020-12 validation of the pinned MaterializationPlan v1 schema
+    # (config#492). 4.18 is the first release with the modern referencing
+    # stack; anything older silently falls back to a legacy resolver.
+    "jsonschema>=4.18",
+    # PEP 440 specifier evaluation for the venv probe (config#492 §6.2.1
+    # #6): an existing venv must satisfy the plan's declared `python`
+    # constraint, not merely exist.
+    "packaging>=23",
 ]
 
 [project.scripts]
@@ -37,6 +45,12 @@ gr2 = "gr2"
 "gr2.python_cli" = "python_cli"
 "gr2.prototypes" = "prototypes"
 "gr2.overlay" = "gr2_overlay"
+
+[tool.setuptools.package-data]
+# The pinned MaterializationPlan v1 schema (config#492) ships inside the
+# gr2 package -- spec_apply verifies its bytes against the pinned SHA-256
+# at load and fails closed on any mismatch.
+gr2 = ["schemas/*.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "gr2_overlay/tests"]

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -61,6 +61,12 @@ _FORBIDDEN_IDENTITY_KEYS = frozenset(
 
 
 def _reject_identity_fields_recursive(value: object, *, path: str) -> None:
+    """Defense in depth alongside the per-kind field allowlist below: even
+    an allowed field's VALUE should never carry an identity-shaped key.
+    The allowlist is what actually PROVES identity-freedom (round 2,
+    Atlas/Sentinel: "a blacklist cannot prove identity-free construction"
+    -- display_name, or any field name nobody enumerated, sails through a
+    blacklist undetected); this stays as a second layer, not the primary one."""
     if isinstance(value, dict):
         present = _FORBIDDEN_IDENTITY_KEYS & value.keys()
         if present:
@@ -86,23 +92,31 @@ def _validate_path_safe_token(value: object, *, field_name: str) -> str:
     return value
 
 
-def _resolve_contained(workspace_root: Path, relative: str, *, field_name: str) -> Path:
-    """config#491 §3: absolute paths, .., symlink escapes, and duplicate
-    destinations are blockers. Path.resolve() normalizes .. lexically and
-    follows any existing symlinks, so a single containment check after
-    resolving catches all three escape shapes. Shared by dest_path,
-    reference_base, and (via _resolve_staging_source) source_path."""
+def _canonicalize_workspace_path(workspace_root: Path, relative: str, *, field_name: str) -> Path:
+    """config#491 §3: absolute paths, .., symlink escapes, and duplicate/
+    case-folded-colliding destinations are blockers. Round 2 (Atlas): a
+    literal '..' segment that happens to resolve back inside the workspace
+    was being accepted -- the spec forbids '..' appearing at all, not just
+    "does it escape after resolution." Checked as a literal path-part scan
+    BEFORE resolving, in addition to the post-resolve containment check
+    (which independently catches symlink escapes resolve() reveals).
+    Returns the fully resolved (symlink-dereferenced) canonical path --
+    callers needing the original relative string for receipts/display keep
+    that separately; this return value is for filesystem operations and
+    ALL comparison (duplicate detection, cache-namespace checks)."""
     if not relative or relative.startswith("/") or relative.startswith("~"):
         raise MaterializationPlanError(f"{field_name} must be relative to the workspace root: {relative!r}")
+    if ".." in Path(relative).parts:
+        raise MaterializationPlanError(f"{field_name} must not contain '..' segments: {relative!r}")
     workspace_resolved = workspace_root.resolve()
     candidate = (workspace_root / relative).resolve()
     if candidate != workspace_resolved and workspace_resolved not in candidate.parents:
         raise MaterializationPlanError(f"{field_name} escapes the workspace root: {relative!r}")
-    return workspace_root / relative
+    return candidate
 
 
 def _resolve_safe_dest(workspace_root: Path, dest_path: str) -> Path:
-    return _resolve_contained(workspace_root, dest_path, field_name="dest_path")
+    return _canonicalize_workspace_path(workspace_root, dest_path, field_name="dest_path")
 
 
 _STAGING_INPUTS_SUBPATH = Path(".grip") / "staging" / "inputs"
@@ -112,14 +126,45 @@ def _resolve_staging_source(workspace_root: Path, source_path: str) -> Path:
     """config#491 §6.2, Sentinel r2 P4 ruling: source_path MUST be
     workspace-relative AND resolve beneath .grip/staging/inputs/ specifically
     -- not just anywhere in the workspace. The normative example is
-    `.grip/staging/inputs/f_01`; S7 emits `.grip/staging/inputs/<opaque-key>`."""
-    resolved = _resolve_contained(workspace_root, source_path, field_name="source_path").resolve()
+    `.grip/staging/inputs/f_01`; S7 emits `.grip/staging/inputs/<opaque-key>`.
+    _canonicalize_workspace_path already follows symlinks via .resolve(), so
+    a symlink planted inside staging/inputs pointing outside it is caught by
+    the same containment check -- pinned by a real symlink test, not just
+    reasoned about."""
+    resolved = _canonicalize_workspace_path(workspace_root, source_path, field_name="source_path")
     staging_root = (workspace_root / _STAGING_INPUTS_SUBPATH).resolve()
     if resolved != staging_root and staging_root not in resolved.parents:
         raise MaterializationPlanError(
             f"source_path must resolve beneath .grip/staging/inputs/: {source_path!r}"
         )
-    return workspace_root / source_path
+    return resolved
+
+
+_CACHE_NAMESPACE_SUBPATH = Path(".grip") / "cache" / "repos"
+
+
+def _validate_reference_base(workspace_root: Path, reference_base: str, *, repo_url: str) -> Path:
+    """config#491 §8.2, round 2 (Atlas/Sentinel): reference_base must be
+    bound to the declared cache NAMESPACE (.grip/cache/repos/*.git), not
+    just anywhere inside the workspace -- a real in-workspace mirror
+    outside that namespace was being accepted and retained as the clone's
+    alternate. Separately, if the referenced cache already exists, its own
+    canonical origin must equal repo_url -- otherwise a cache seeded from a
+    different remote could be used as if it were the right one."""
+    resolved = _canonicalize_workspace_path(workspace_root, reference_base, field_name="reference_base")
+    cache_namespace = (workspace_root / _CACHE_NAMESPACE_SUBPATH).resolve()
+    if resolved.parent != cache_namespace or resolved.suffix != ".git":
+        raise MaterializationPlanError(
+            f"reference_base must be a *.git cache directly inside .grip/cache/repos/: {reference_base!r}"
+        )
+    if resolved.exists():
+        cache_origin = remote_origin_url(resolved)
+        if cache_origin is not None and cache_origin != repo_url:
+            raise MaterializationPlanError(
+                f"reference_base {reference_base!r} has canonical origin {cache_origin!r}, "
+                f"expected {repo_url!r} -- a cache seeded from a different remote cannot be reused"
+            )
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -175,18 +220,26 @@ def _validate_clone_isolation(
         text=True,
         check=False,
     )
-    if common_dir_proc.returncode == 0:
-        common_dir_raw = common_dir_proc.stdout.strip()
-        common_dir = Path(common_dir_raw)
-        if not common_dir.is_absolute():
-            common_dir = (repo_root / common_dir).resolve()
-        else:
-            common_dir = common_dir.resolve()
-        if common_dir != git_path.resolve():
-            raise MaterializationPlanError(
-                f"clone at {repo_root} has git-common-dir {common_dir} that is not its own .git "
-                "-- it shares mutable git metadata with another checkout (config#491 §8.1)"
-            )
+    if common_dir_proc.returncode != 0:
+        # Round 2 (Sentinel): fail CLOSED, not open. The prior version
+        # silently skipped this whole check when the subprocess itself
+        # failed -- "cannot verify isolation" must reject, not be treated
+        # as "assume it's fine."
+        raise MaterializationPlanError(
+            f"clone at {repo_root}: git rev-parse --git-common-dir failed, cannot verify isolation "
+            f"(config#491 §8.1): {common_dir_proc.stderr or common_dir_proc.stdout}"
+        )
+    common_dir_raw = common_dir_proc.stdout.strip()
+    common_dir = Path(common_dir_raw)
+    if not common_dir.is_absolute():
+        common_dir = (repo_root / common_dir).resolve()
+    else:
+        common_dir = common_dir.resolve()
+    if common_dir != git_path.resolve():
+        raise MaterializationPlanError(
+            f"clone at {repo_root} has git-common-dir {common_dir} that is not its own .git "
+            "-- it shares mutable git metadata with another checkout (config#491 §8.1)"
+        )
 
     actual_origin = remote_origin_url(repo_root)
     if actual_origin != expected_origin:
@@ -526,15 +579,31 @@ def build_plan(workspace_root: Path) -> tuple[dict[str, object], list[PlanOperat
         # write_unit_metadata in this loop, so apply_plan's execution (which
         # processes operations in list order) creates the directory before
         # trying to clone into it.
+        #
+        # Round 2 (Atlas/Sentinel P1): scheduled whenever a unit has ANY
+        # declared repos, not only when build_plan's cheap existence check
+        # finds something missing. A unit whose repos are all PRESENT but
+        # one has the wrong origin was never getting converge_unit_repos
+        # scheduled at all -- build_plan can't detect an origin mismatch
+        # without running real git commands, which it deliberately avoids
+        # (planning stays cheap); the fix is to always schedule the check
+        # and let apply-time's real _clone_isolated validation (cheap
+        # existence check bypassed) catch it, not to make planning itself
+        # do git work.
         declared_repos = [str(r) for r in unit.get("repos", [])]
         missing_repos = [r for r in declared_repos if not (unit_root / r).exists()]
-        if missing_repos:
+        if declared_repos:
+            reason = (
+                f"missing repo checkouts: {', '.join(missing_repos)}"
+                if missing_repos
+                else "validate declared repo checkouts (origin/isolation) on every pass"
+            )
             operations.append(
                 PlanOperation(
                     kind="converge_unit_repos",
                     subject=unit_name,
                     target_path=str(unit_root),
-                    reason=f"missing repo checkouts: {', '.join(missing_repos)}",
+                    reason=reason,
                     details={"missing_repos": missing_repos, "all_repos": declared_repos},
                 )
             )
@@ -563,13 +632,21 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
             repo_spec = _find_repo(spec, op.subject)
             repo_root = workspace_root / str(repo_spec["path"])
             cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
-            result = _clone_isolated(
+            # Round 2 (Atlas P1): routed through the SAME operation-dict
+            # dispatch the MaterializationPlan path uses, not a manually
+            # invoked _clone_isolated -- "one executor" means one dispatch
+            # path, not just a shared leaf clone primitive underneath two
+            # separate call sites.
+            clone_result = _apply_clone_operation(
                 workspace_root,
-                repo_url=str(repo_spec["url"]),
-                dest=repo_root,
-                reference_repo_root=cache_path,
+                {
+                    "kind": "clone",
+                    "repo_url": str(repo_spec["url"]),
+                    "dest_path": _relative_workspace_path(workspace_root, repo_root),
+                    "reference_base": _relative_workspace_path(workspace_root, cache_path),
+                },
             )
-            first_materialize = result.first_materialize
+            first_materialize = bool(clone_result["first_materialize"])
             hook_payload = _run_materialize_hooks(
                 workspace_root,
                 repo_root,
@@ -628,13 +705,16 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
                 repo_spec = _find_repo(spec, repo_name)
                 clone_dest = unit_root / repo_name
                 cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
-                result = _clone_isolated(
+                clone_result = _apply_clone_operation(
                     workspace_root,
-                    repo_url=str(repo_spec["url"]),
-                    dest=clone_dest,
-                    reference_repo_root=cache_path,
+                    {
+                        "kind": "clone",
+                        "repo_url": str(repo_spec["url"]),
+                        "dest_path": _relative_workspace_path(workspace_root, clone_dest),
+                        "reference_base": _relative_workspace_path(workspace_root, cache_path),
+                    },
                 )
-                if result.first_materialize:
+                if clone_result["first_materialize"]:
                     converged.append(repo_name)
                     materialized_repos.append({"repo": repo_name, "first_materialize": True})
             unit_toml = unit_root / "unit.toml"
@@ -779,9 +859,9 @@ def _apply_clone_operation(workspace_root: Path, op: dict[str, object]) -> dict[
     reference_base = op.get("reference_base")
     reference_repo_root: Path | None = None
     if reference_base:
-        reference_repo_root = _resolve_contained(
-            workspace_root, str(reference_base), field_name="reference_base"
-        )
+        # Bound to the declared cache namespace + canonical-origin verified
+        # (round 2 §8.2), not just "somewhere in the workspace."
+        reference_repo_root = _validate_reference_base(workspace_root, str(reference_base), repo_url=repo_url)
 
     branch = op.get("branch")
     result = _clone_isolated(
@@ -792,30 +872,49 @@ def _apply_clone_operation(workspace_root: Path, op: dict[str, object]) -> dict[
         reference_repo_root=reference_repo_root,
     )
 
+    # config#491 §12.1 evidence: repo URL, destination, HEAD, and
+    # clone-state evidence; cache path and approved-alternate evidence.
     return {
         "kind": "clone",
         "repo_url": repo_url,
         "dest_path": dest_path,
         "first_materialize": result.first_materialize,
         "head_sha": result.head_sha,
+        "observed_origin": result.origin_url,
+        "cache_path": str(reference_base) if reference_base else None,
+        "alternate_approved": reference_repo_root is not None,
     }
 
 
-def _is_real_venv(dest: Path) -> bool:
-    return (dest / "pyvenv.cfg").is_file()
+def _real_venv_interpreter(dest: Path) -> Path | None:
+    """Round 2 (Sentinel): a forged pyvenv.cfg with no actual interpreter
+    was being accepted as a valid existing venv. pyvenv.cfg's presence
+    alone proves nothing -- an executable interpreter binary must exist."""
+    if not (dest / "pyvenv.cfg").is_file():
+        return None
+    for candidate_name in ("python3", "python"):
+        candidate = dest / "bin" / candidate_name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
 
 
 def _apply_venv_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
     dest_path = str(op["dest_path"])
     dest = _resolve_safe_dest(workspace_root, dest_path)
     if dest.exists():
-        # Sentinel r2 P5: an arbitrary existing directory must not be
-        # accepted as a valid venv just because a path exists there.
-        if not _is_real_venv(dest):
+        interpreter = _real_venv_interpreter(dest)
+        if interpreter is None:
             raise MaterializationPlanError(
-                f"venv dest {dest} exists but is not a real venv (no pyvenv.cfg)"
+                f"venv dest {dest} exists but is not a real venv "
+                "(no pyvenv.cfg, or no executable interpreter under bin/)"
             )
-        return {"kind": "venv", "dest_path": dest_path, "created": False}
+        return {
+            "kind": "venv",
+            "dest_path": dest_path,
+            "created": False,
+            "interpreter_path": str(interpreter.relative_to(dest)),
+        }
 
     python_constraint = str(op.get("python", ">=3.11"))
     staging = dest.parent / f".{dest.name}.staging-{os.getpid()}-{id(dest)}"
@@ -828,16 +927,30 @@ def _apply_venv_operation(workspace_root: Path, op: dict[str, object]) -> dict[s
         text=True,
         check=False,
     )
-    if proc.returncode != 0 or not _is_real_venv(staging):
+    interpreter = _real_venv_interpreter(staging)
+    if proc.returncode != 0 or interpreter is None:
         shutil.rmtree(staging, ignore_errors=True)
         raise MaterializationPlanError(f"uv venv failed for {dest}:\n{proc.stderr or proc.stdout}")
+    interpreter_relative = interpreter.relative_to(staging)
     staging.rename(dest)
-    return {"kind": "venv", "dest_path": dest_path, "created": True}
+    # config#491 §12.1 evidence: venv interpreter.
+    return {
+        "kind": "venv",
+        "dest_path": dest_path,
+        "created": True,
+        "interpreter_path": str(interpreter_relative),
+    }
 
 
-def _find_direct_url_evidence(venv_path: Path) -> str | None:
+def _find_direct_url_evidence(venv_path: Path) -> tuple[str, str] | None:
+    """Returns (relative direct_url.json path, distribution name) or None.
+    Distribution name is parsed from the *.dist-info directory name itself
+    (e.g. "product-0.1.0.dist-info" -> "product") -- config#491 §12.1 wants
+    distribution evidence, not just "the command exited 0"."""
     for candidate in sorted(venv_path.glob("lib/*/site-packages/*.dist-info/direct_url.json")):
-        return str(candidate.relative_to(venv_path))
+        dist_info_name = candidate.parent.name
+        distribution = dist_info_name.removesuffix(".dist-info").split("-")[0]
+        return str(candidate.relative_to(venv_path)), distribution
     return None
 
 
@@ -864,11 +977,15 @@ def _apply_editable_install_operation(workspace_root: Path, op: dict[str, object
             f"uv pip install --editable reported success for {source_path}, but no PEP 610 "
             f"direct_url.json evidence was found under {venv_path}"
         )
+    pep610_path, distribution = evidence
+    # config#491 §12.1 evidence: editable source path, extras, distribution.
     return {
         "kind": "editable_install",
         "venv_path": str(op["venv_path"]),
         "source_path": str(op["source_path"]),
-        "pep610_evidence": evidence,
+        "extras": extras,
+        "distribution": distribution,
+        "pep610_evidence": pep610_path,
     }
 
 
@@ -897,11 +1014,21 @@ def _apply_project_file_operation(workspace_root: Path, op: dict[str, object]) -
     dest.write_bytes(content)
     dest.chmod(0o600)
 
-    # config#491 §6.2: the staged input is a run-scoped opaque artifact,
-    # deleted after acknowledgement -- it must not linger once copied.
-    source_path.unlink()
-
-    return {"kind": "project_file", "dest_path": dest_path, "source_sha256": expected_sha256}
+    # config#491 §6.2: "the staging artifact is removed only after the
+    # hash-verified projection has durable acknowledgement." Round 2
+    # (Sentinel): unlinking here, immediately, meant a receipt-write
+    # failure right after this operation left the source gone with no
+    # receipt proving the projection ever happened -- deleting evidence
+    # before the transaction durably committed. _pending_unlink is an
+    # internal-only key (stripped before the result becomes receipt
+    # content): apply_materialization_plan performs the actual unlink only
+    # after _write_materialization_receipt succeeds.
+    return {
+        "kind": "project_file",
+        "dest_path": dest_path,
+        "source_sha256": expected_sha256,
+        "_pending_unlink": str(source_path),
+    }
 
 
 _MATERIALIZATION_HANDLERS = {
@@ -912,6 +1039,29 @@ _MATERIALIZATION_HANDLERS = {
 }
 
 
+# Round 2 (Atlas/Sentinel P5): exact per-kind ALLOWLISTS, not a blacklist
+# scan. "kind" is included in each set since every operation carries it.
+# Any field not on its kind's list is rejected -- this is what actually
+# proves identity-freedom: a field name nobody thought to blacklist
+# (display_name, or anything else) cannot exist on an operation at all,
+# rather than merely not being on a list of names someone enumerated.
+_CLONE_FIELDS = frozenset({"kind", "repo_url", "dest_path", "branch", "reference_base"})
+_VENV_FIELDS = frozenset({"kind", "dest_path", "engine", "python"})
+_EDITABLE_INSTALL_FIELDS = frozenset({"kind", "venv_path", "source_path", "extras"})
+_PROJECT_FILE_FIELDS = frozenset({"kind", "source_path", "dest_path", "source_sha256", "mode"})
+
+_OPERATION_ALLOWED_FIELDS: dict[str, frozenset[str]] = {
+    "clone": _CLONE_FIELDS,
+    "venv": _VENV_FIELDS,
+    "editable_install": _EDITABLE_INSTALL_FIELDS,
+    "project_file": _PROJECT_FILE_FIELDS,
+}
+
+_PLAN_ALLOWED_TOP_LEVEL_FIELDS = frozenset(
+    {"schema_version", "plan_id", "unit_key", "workspace_spec_sha256", "operations"}
+)
+
+
 def _require_str(op: dict[str, object], key: str, prefix: str) -> str:
     value = op.get(key)
     if not isinstance(value, str) or not value:
@@ -919,72 +1069,115 @@ def _require_str(op: dict[str, object], key: str, prefix: str) -> str:
     return value
 
 
-def _validate_operation_schema(op: dict[str, object], *, idx: int, workspace_root: Path) -> None:
-    """Sentinel r2 P5: schema AND containment are validated for every
-    operation up front -- not just type-checked, and not deferred to
-    execution time. A plan whose op[2] has an unsafe dest_path must never
-    let op[0]/op[1] mutate anything first."""
+def _validate_operation_schema(
+    op: dict[str, object], *, idx: int, workspace_root: Path
+) -> Path | None:
+    """Round 2 (Atlas/Sentinel P5): schema AND containment are validated
+    for every operation up front, via an exact allowlist -- not just
+    type-checked, not deferred to execution time, and not a blacklist that
+    only catches enumerated field names. Returns the canonical (resolved)
+    dest_path for duplicate/collision detection by the caller, or None for
+    operation kinds without one."""
     kind = op.get("kind")
     prefix = f"operations[{idx}] (kind={kind!r})"
     if kind not in _MATERIALIZATION_HANDLERS:
         raise MaterializationPlanError(f"{prefix}: unknown operation kind")
 
+    allowed = _OPERATION_ALLOWED_FIELDS[kind]
+    unknown = op.keys() - allowed
+    if unknown:
+        raise MaterializationPlanError(f"{prefix}: unknown field(s) {sorted(unknown)}")
+
     if kind == "clone":
         _require_str(op, "repo_url", prefix)
         dest_path = _require_str(op, "dest_path", prefix)
-        _resolve_safe_dest(workspace_root, dest_path)
+        canonical_dest = _resolve_safe_dest(workspace_root, dest_path)
         reference_base = op.get("reference_base")
-        if reference_base:
-            _resolve_contained(workspace_root, str(reference_base), field_name=f"{prefix}.reference_base")
+        if reference_base is not None:
+            if not isinstance(reference_base, str) or not reference_base:
+                raise MaterializationPlanError(f"{prefix}: reference_base must be a non-empty string")
+            _validate_reference_base(workspace_root, reference_base, repo_url=str(op["repo_url"]))
+        branch = op.get("branch")
+        if branch is not None and (not isinstance(branch, str) or not branch):
+            raise MaterializationPlanError(f"{prefix}: branch must be a non-empty string")
+        return canonical_dest
     elif kind == "venv":
         dest_path = _require_str(op, "dest_path", prefix)
-        _resolve_safe_dest(workspace_root, dest_path)
+        canonical_dest = _resolve_safe_dest(workspace_root, dest_path)
         engine = op.get("engine", "uv")
         if engine != "uv":
             raise MaterializationPlanError(f"{prefix}: engine must be 'uv', got {engine!r}")
+        python_constraint = op.get("python")
+        if python_constraint is not None and not isinstance(python_constraint, str):
+            raise MaterializationPlanError(f"{prefix}: python must be a string")
+        return canonical_dest
     elif kind == "editable_install":
         venv_path = _require_str(op, "venv_path", prefix)
         source_path = _require_str(op, "source_path", prefix)
         _resolve_safe_dest(workspace_root, venv_path)
         _resolve_safe_dest(workspace_root, source_path)
+        extras = op.get("extras", [])
+        if not isinstance(extras, list) or not all(isinstance(e, str) for e in extras):
+            raise MaterializationPlanError(f"{prefix}: extras must be a list of strings")
+        return None
     elif kind == "project_file":
         source_path = _require_str(op, "source_path", prefix)
         dest_path = _require_str(op, "dest_path", prefix)
         _require_str(op, "source_sha256", prefix)
         _resolve_staging_source(workspace_root, source_path)
-        _resolve_safe_dest(workspace_root, dest_path)
+        canonical_dest = _resolve_safe_dest(workspace_root, dest_path)
         mode = op.get("mode", "copy")
         if mode != "copy":
             raise MaterializationPlanError(f"{prefix}: mode must be 'copy' for v1, got {mode!r}")
+        return canonical_dest
+    return None
 
 
 def _validate_plan_shape(plan: dict[str, object], *, workspace_root: Path) -> None:
-    """Sentinel r2 P5: validate the COMPLETE plan before the first
-    filesystem mutation -- not one operation validated immediately before
-    its own execution, which lets earlier operations mutate state before a
-    later operation's invalid shape is ever discovered."""
+    """Round 2 (Atlas/Sentinel P5): validate the COMPLETE plan before the
+    first filesystem mutation -- not one operation validated immediately
+    before its own execution, which lets earlier operations mutate state
+    before a later operation's invalid shape is ever discovered."""
+    unknown_top_level = plan.keys() - _PLAN_ALLOWED_TOP_LEVEL_FIELDS
+    if unknown_top_level:
+        raise MaterializationPlanError(f"plan: unknown top-level field(s) {sorted(unknown_top_level)}")
+
+    if plan.get("schema_version") != 1:
+        raise MaterializationPlanError(f"plan.schema_version must be exactly 1, got {plan.get('schema_version')!r}")
+
     _validate_path_safe_token(plan.get("plan_id"), field_name="plan_id")
     # Sentinel/Atlas r2 ruling: one MaterializationPlan is scoped to one
     # opaque unit and carries a required top-level unit_key. gr2 validates
     # it as a path-safe opaque token without interpreting identity.
     _validate_path_safe_token(plan.get("unit_key"), field_name="unit_key")
 
+    workspace_spec_sha256 = plan.get("workspace_spec_sha256")
+    if not isinstance(workspace_spec_sha256, str) or not workspace_spec_sha256:
+        raise MaterializationPlanError("plan.workspace_spec_sha256 is required and must be a non-empty string")
+
     operations = plan.get("operations")
     if not isinstance(operations, list) or not operations:
         raise MaterializationPlanError("plan.operations must be a non-empty list")
 
-    seen_dest_paths: set[str] = set()
+    # Round 2 (Atlas/Sentinel): canonical (resolved, case-folded)
+    # comparison, not raw strings -- "units/u1/.venv" and
+    # "units/u1/./.venv" are the same real path and must collide, as must
+    # case-folded collisions on case-insensitive filesystems (config#491 §3).
+    seen_canonical_dests: dict[str, int] = {}
     for idx, op in enumerate(operations):
         if not isinstance(op, dict):
             raise MaterializationPlanError(f"operations[{idx}] must be an object, got {type(op).__name__}")
         _reject_identity_fields_recursive(op, path=f"operations[{idx}]")
-        _validate_operation_schema(op, idx=idx, workspace_root=workspace_root)
+        canonical_dest = _validate_operation_schema(op, idx=idx, workspace_root=workspace_root)
 
-        dest_path = op.get("dest_path")
-        if isinstance(dest_path, str):
-            if dest_path in seen_dest_paths:
-                raise MaterializationPlanError(f"duplicate dest_path across operations: {dest_path!r}")
-            seen_dest_paths.add(dest_path)
+        if canonical_dest is not None:
+            key = str(canonical_dest).casefold()
+            if key in seen_canonical_dests:
+                raise MaterializationPlanError(
+                    f"operations[{idx}] dest_path collides (case-folded/normalized) with "
+                    f"operations[{seen_canonical_dests[key]}]: {canonical_dest}"
+                )
+            seen_canonical_dests[key] = idx
 
 
 def _materialization_receipt_path(workspace_root: Path, plan_id: str) -> Path:
@@ -1000,14 +1193,18 @@ def _write_materialization_receipt(
     key, and per-operation structural evidence -- no identity, org, channel,
     secret, or memory content. Written atomically (temp file + rename), not
     directly, matching the same publish-don't-partially-write discipline as
-    _clone_isolated's staging rename."""
+    _clone_isolated's staging rename. Round 2 (Sentinel): a test asserting
+    only "no temp file left behind" doesn't distinguish this from a direct
+    write, since a direct write also trivially leaves no temp file --
+    proven instead by a test that fails the rename itself and confirms no
+    final receipt file exists."""
     plan_hash = hashlib.sha256(json.dumps(plan, sort_keys=True).encode()).hexdigest()
     receipt = {
         "plan_id": plan["plan_id"],
         "unit_key": plan["unit_key"],
         "plan_hash": plan_hash,
-        "schema_version": plan.get("schema_version", 1),
-        "workspace_spec_sha256": plan.get("workspace_spec_sha256"),
+        "schema_version": plan["schema_version"],
+        "workspace_spec_sha256": plan["workspace_spec_sha256"],
         "applied_at": datetime.now(UTC).isoformat(),
         "operations": op_results,
     }
@@ -1045,12 +1242,27 @@ def apply_materialization_plan(
     _validate_plan_shape(plan, workspace_root=workspace_root)
 
     op_results: list[dict[str, object]] = []
+    pending_unlinks: list[Path] = []
     for op in plan["operations"]:
         kind = str(op["kind"])
         handler = _MATERIALIZATION_HANDLERS[kind]
-        op_results.append(handler(workspace_root, op))
+        result = handler(workspace_root, op)
+        # _pending_unlink is orchestration-only, never receipt content --
+        # popped before this result is handed to the receipt writer.
+        pending_unlink = result.pop("_pending_unlink", None)
+        if pending_unlink is not None:
+            pending_unlinks.append(Path(pending_unlink))
+        op_results.append(result)
 
     receipt_path = _write_materialization_receipt(workspace_root, plan, op_results)
+
+    # config#491 §6.2: staged inputs are deleted only after durable
+    # acknowledgement -- i.e. only after the receipt above has been
+    # written successfully. A receipt-write failure now leaves the staged
+    # source intact rather than silently deleting evidence of a projection
+    # nothing durably confirms happened.
+    for source in pending_unlinks:
+        source.unlink(missing_ok=True)
 
     return {
         "workspace_root": str(workspace_root),

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import json
 import os
+import shutil
+import subprocess
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 
 from .events import EventType, emit
-from .gitops import clone_repo, ensure_repo_cache, is_git_dir, is_git_repo, repo_dirty
+from .gitops import checkout_branch, clone_repo, ensure_repo_cache, is_git_dir, is_git_repo, repo_dirty
 from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
 
 
@@ -475,3 +478,273 @@ def _record_apply_state(workspace_root: Path, actions: list[str]) -> None:
         state_path.write_text(existing + "\n\n" + "\n".join(content))
     else:
         state_path.write_text("\n".join(content))
+
+
+# ---------------------------------------------------------------------------
+# Neutral MaterializationPlan executor (config#491 §6.2, S4)
+#
+# Consumes the plan JSON directly (clone/venv/editable_install/project_file
+# operations), rather than workspace_spec.toml's repo/unit model above. Both
+# entry points share the same clone/validation primitives -- one executor,
+# not a second materializer, per config#491 §7.3.
+# ---------------------------------------------------------------------------
+
+
+class MaterializationPlanError(Exception):
+    pass
+
+
+# config#491 §6.2: "The production plan must not contain: agent display
+# name, persistent agent ID, role, org or project, channel, entitlement
+# result or reason, secret reference or value, memory body." Checked on
+# every operation dict as a structural safety net -- gr2 must not become
+# somewhere identity data could leak through even accidentally.
+_FORBIDDEN_IDENTITY_KEYS = frozenset(
+    {
+        "agent_name",
+        "agent_id",
+        "persistent_identity_ref",
+        "role",
+        "org",
+        "project",
+        "channel",
+        "channels",
+        "entitlement",
+        "entitlement_reason",
+        "secret",
+        "secret_ref",
+        "memory",
+        "memory_body",
+    }
+)
+
+
+def _reject_identity_fields(op: dict[str, object]) -> None:
+    present = _FORBIDDEN_IDENTITY_KEYS & op.keys()
+    if present:
+        raise MaterializationPlanError(
+            f"operation carries identity-bearing field(s) {sorted(present)}; "
+            "gr2 MaterializationPlan operations must be identity-free (config#491 §6.2)"
+        )
+
+
+def _resolve_safe_dest(workspace_root: Path, dest_path: str) -> Path:
+    """Resolve dest_path relative to workspace_root, rejecting escapes.
+
+    config#491 §3: absolute paths, .., symlink escapes, and duplicate
+    destinations are blockers. Path.resolve() normalizes .. lexically and
+    follows any existing symlinks, so a single containment check after
+    resolving catches all three escape shapes.
+    """
+    if not dest_path or dest_path.startswith("/") or dest_path.startswith("~"):
+        raise MaterializationPlanError(f"dest_path must be relative to the workspace root: {dest_path!r}")
+    workspace_resolved = workspace_root.resolve()
+    candidate = (workspace_root / dest_path).resolve()
+    if candidate != workspace_resolved and workspace_resolved not in candidate.parents:
+        raise MaterializationPlanError(f"dest_path escapes the workspace root: {dest_path!r}")
+    return workspace_root / dest_path
+
+
+def _validate_clone_isolation(repo_root: Path, *, workspace_root: Path, reference_base: str | None) -> None:
+    """gap#6 / config#491 §8.1-8.2: reject worktree-linked clones and
+    alternates pointing anywhere except the declared workspace cache."""
+    git_path = repo_root / ".git"
+    if git_path.is_file():
+        raise MaterializationPlanError(
+            f"clone at {repo_root} has a worktree-pointer .git file, not a real .git directory "
+            "(config#491 §8.1 forbids worktree-linked agent workspaces)"
+        )
+    if not git_path.is_dir():
+        raise MaterializationPlanError(f"clone at {repo_root} has no .git directory")
+
+    alternates_file = git_path / "objects" / "info" / "alternates"
+    if not alternates_file.exists():
+        return
+    approved = (workspace_root / reference_base).resolve() / "objects" if reference_base else None
+    for line in alternates_file.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if approved is None or Path(line).resolve() != approved:
+            raise MaterializationPlanError(
+                f"clone at {repo_root} has an unapproved alternate: {line} "
+                "(config#491 §8.2: alternates may only point at the declared workspace cache)"
+            )
+
+
+def _apply_clone_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
+    dest_path = str(op["dest_path"])
+    dest = _resolve_safe_dest(workspace_root, dest_path)
+    repo_url = str(op["repo_url"])
+    reference_base = op.get("reference_base")
+    reference_base = str(reference_base) if reference_base else None
+    reference_repo_root = (workspace_root / reference_base) if reference_base else None
+
+    # config#491 §8.3: an existing clone is validated, never blindly reset
+    # or replaced. Checked before attempting anything, not after -- a
+    # worktree-linked or otherwise damaged existing path must block here,
+    # not surface as a confusing "destination already exists" error from
+    # `git clone` itself.
+    if dest.exists():
+        _validate_clone_isolation(dest, workspace_root=workspace_root, reference_base=reference_base)
+        first_materialize = False
+    else:
+        first_materialize = clone_repo(repo_url, dest, reference_repo_root=reference_repo_root)
+        branch = op.get("branch")
+        if branch:
+            checkout_branch(dest, str(branch))
+        _validate_clone_isolation(dest, workspace_root=workspace_root, reference_base=reference_base)
+
+    return {
+        "kind": "clone",
+        "repo_url": repo_url,
+        "dest_path": dest_path,
+        "first_materialize": first_materialize,
+    }
+
+
+def _apply_venv_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
+    dest_path = str(op["dest_path"])
+    dest = _resolve_safe_dest(workspace_root, dest_path)
+    if dest.exists():
+        return {"kind": "venv", "dest_path": dest_path, "created": False}
+
+    python_constraint = str(op.get("python", ">=3.11"))
+    proc = subprocess.run(
+        ["uv", "venv", "--python", python_constraint, str(dest)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise MaterializationPlanError(f"uv venv failed for {dest}:\n{proc.stderr or proc.stdout}")
+    return {"kind": "venv", "dest_path": dest_path, "created": True}
+
+
+def _apply_editable_install_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
+    venv_path = _resolve_safe_dest(workspace_root, str(op["venv_path"]))
+    source_path = _resolve_safe_dest(workspace_root, str(op["source_path"]))
+    extras = [str(e) for e in op.get("extras", [])]
+    venv_python = venv_path / "bin" / "python"
+
+    target = f"{source_path}[{','.join(extras)}]" if extras else str(source_path)
+    proc = subprocess.run(
+        ["uv", "pip", "install", "--python", str(venv_python), "--editable", target],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise MaterializationPlanError(
+            f"uv pip install --editable failed for {source_path}:\n{proc.stderr or proc.stdout}"
+        )
+    return {
+        "kind": "editable_install",
+        "venv_path": str(op["venv_path"]),
+        "source_path": str(op["source_path"]),
+    }
+
+
+def _apply_project_file_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
+    source_path = Path(str(op["source_path"]))
+    dest_path = str(op["dest_path"])
+    dest = _resolve_safe_dest(workspace_root, dest_path)
+    expected_sha256 = str(op["source_sha256"])
+
+    if not source_path.exists():
+        raise MaterializationPlanError(f"project_file source does not exist: {source_path}")
+    content = source_path.read_bytes()
+    actual_sha256 = hashlib.sha256(content).hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise MaterializationPlanError(
+            f"project_file hash mismatch for {source_path}: "
+            f"expected {expected_sha256}, got {actual_sha256}"
+        )
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(content)
+    dest.chmod(0o600)
+
+    # config#491 §6.2: the staged input is a run-scoped opaque artifact,
+    # deleted after acknowledgement -- it must not linger once copied.
+    source_path.unlink()
+
+    return {"kind": "project_file", "dest_path": dest_path, "source_sha256": expected_sha256}
+
+
+_MATERIALIZATION_HANDLERS = {
+    "clone": _apply_clone_operation,
+    "venv": _apply_venv_operation,
+    "editable_install": _apply_editable_install_operation,
+    "project_file": _apply_project_file_operation,
+}
+
+
+def _materialization_receipt_path(workspace_root: Path, plan_id: str) -> Path:
+    return workspace_root / ".grip" / "state" / "materialization" / f"{plan_id}.json"
+
+
+def _write_materialization_receipt(
+    workspace_root: Path,
+    plan: dict[str, object],
+    op_results: list[dict[str, object]],
+) -> Path:
+    """gap#5: a structured, resumable per-plan receipt -- not an append-only
+    action log. config#491 §12.1: neutral receipts carry plan hash, spec
+    hash, and per-operation structural evidence; no identity, org, channel,
+    secret, or memory content."""
+    receipt = {
+        "plan_id": plan["plan_id"],
+        "schema_version": plan.get("schema_version", 1),
+        "workspace_spec_sha256": plan.get("workspace_spec_sha256"),
+        "applied_at": datetime.now(UTC).isoformat(),
+        "operations": op_results,
+    }
+    receipt_path = _materialization_receipt_path(workspace_root, str(plan["plan_id"]))
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n")
+    return receipt_path
+
+
+def apply_materialization_plan(
+    workspace_root: Path,
+    plan: dict[str, object],
+    *,
+    yes: bool = True,
+) -> dict[str, object]:
+    """Execute a neutral MaterializationPlan (config#491 §6.2).
+
+    Identity-free by construction: every operation is validated against
+    _FORBIDDEN_IDENTITY_KEYS before execution. dest_path is used explicitly
+    for every operation kind (gap#4) rather than inferred from a repo name.
+    Resumable: a rerun re-validates already-materialized state and reports
+    first_materialize/created=False rather than duplicating work or receipt
+    entries (idempotent per operation, matching clone_repo's own contract).
+    """
+    if not yes:
+        raise MaterializationPlanError("apply_materialization_plan requires yes=True (no interactive gate)")
+
+    operations = plan.get("operations", [])
+    if not isinstance(operations, list) or not operations:
+        raise MaterializationPlanError("plan.operations must be a non-empty list")
+
+    op_results: list[dict[str, object]] = []
+    for op in operations:
+        if not isinstance(op, dict):
+            raise MaterializationPlanError(f"operation must be an object, got {type(op).__name__}")
+        _reject_identity_fields(op)
+        kind = str(op.get("kind", ""))
+        handler = _MATERIALIZATION_HANDLERS.get(kind)
+        if handler is None:
+            raise MaterializationPlanError(f"unknown materialization operation kind: {kind!r}")
+        op_results.append(handler(workspace_root, op))
+
+    receipt_path = _write_materialization_receipt(workspace_root, plan, op_results)
+
+    return {
+        "workspace_root": str(workspace_root),
+        "plan_id": plan["plan_id"],
+        "operation_count": len(op_results),
+        "operations": op_results,
+        "receipt_path": str(receipt_path),
+    }

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -350,8 +350,24 @@ def _validate_clone_isolation(
             "-- an existing clone must match the declared repo_url"
         )
 
+    # config#492 §6.2.1 #5, round 4 (Atlas): "an existing destination is
+    # validated on every apply and, when reference_base is present, the
+    # resulting clone's only alternate is that cache." The round-3 form
+    # returned early here whenever the alternates file was absent, so the
+    # REQUIRED-alternate half ran only on the fresh-clone path -- an
+    # existing ordinary clone with no alternates was accepted under a plan
+    # declaring a reference_base. Checked here, in the one function BOTH
+    # the fresh-staging and existing-destination paths call, rather than
+    # at a fresh-only call site: that is what makes the two paths share a
+    # single validation contract instead of drifting apart again.
     alternates_file = git_path / "objects" / "info" / "alternates"
     if not alternates_file.exists():
+        if reference_repo_root is not None:
+            raise MaterializationPlanError(
+                f"clone at {repo_root} carries no alternate but the plan declares "
+                f"reference {reference_repo_root} -- declared object sharing was not achieved "
+                "(config#492 §6.2.1 #5)"
+            )
         return
     approved = (reference_repo_root.resolve() / "objects") if reference_repo_root else None
     for line in alternates_file.read_text().splitlines():
@@ -437,24 +453,18 @@ def _clone_isolated(
             raise
         raise MaterializationPlanError(f"clone staging failed for {repo_url} -> {dest}: {exc}") from exc
 
+    # Note: the declared-reference/no-alternate rejection now lives inside
+    # _validate_clone_isolation above, which ran against `staging` before
+    # this rename -- so a fresh clone that failed to realize its declared
+    # object sharing never reaches publication at all, and the existing-
+    # destination path gets the identical check. One contract, both paths.
     dest.parent.mkdir(parents=True, exist_ok=True)
     staging.rename(dest)
-    observed_alternate = _read_observed_alternate(dest)
-    if reference_repo_root is not None and observed_alternate is None:
-        # The cache was validated usable before cloning; a fresh clone that
-        # nonetheless carries no alternate means the declared object-sharing
-        # state was not achieved -- fail closed rather than receipt a state
-        # that differs from what the plan declared (config#492 §6.2.1 #5).
-        shutil.rmtree(dest, ignore_errors=True)
-        raise MaterializationPlanError(
-            f"clone at {dest} was created with declared reference {reference_repo_root} "
-            "but carries no alternate -- declared object sharing was not achieved"
-        )
     return CloneResult(
         first_materialize=True,
         origin_url=remote_origin_url(dest),
         head_sha=current_head_sha(dest),
-        observed_alternate=observed_alternate,
+        observed_alternate=_read_observed_alternate(dest),
     )
 
 
@@ -1148,12 +1158,41 @@ def _apply_venv_operation(workspace_root: Path, op: dict[str, object]) -> dict[s
     }
 
 
-def _find_direct_url_evidence(venv_path: Path) -> tuple[str, str] | None:
-    """Returns (relative direct_url.json path, distribution name) or None.
-    Distribution name is parsed from the *.dist-info directory name itself
-    (e.g. "product-0.1.0.dist-info" -> "product") -- config#491 §12.1 wants
-    distribution evidence, not just "the command exited 0"."""
+def _find_direct_url_evidence(venv_path: Path, source_path: Path) -> tuple[str, str] | None:
+    """Returns (relative direct_url.json path, distribution name) for the
+    editable install of THIS source, or None.
+
+    Round 4 (Atlas): the round-3 form returned the first sorted
+    direct_url.json in the venv, so a plan installing editable `alpha`
+    then editable `beta` receipted beta's operation with ALPHA's PEP 610
+    path and distribution -- a structurally complete receipt that is
+    false. Evidence must be bound to the artifact it claims to describe:
+    match the decoded PEP 610 `url` against this operation's resolved
+    source and require dir_info.editable, then derive the distribution
+    from the MATCHED row rather than from whichever row sorted first."""
+    from urllib.parse import unquote, urlparse
+
+    target = source_path.resolve()
     for candidate in sorted(venv_path.glob("lib/*/site-packages/*.dist-info/direct_url.json")):
+        try:
+            record = json.loads(candidate.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        url = record.get("url")
+        if not isinstance(url, str):
+            continue
+        parsed = urlparse(url)
+        if parsed.scheme != "file":
+            continue
+        try:
+            recorded = Path(unquote(parsed.path)).resolve()
+        except OSError:
+            continue
+        if recorded != target:
+            continue
+        dir_info = record.get("dir_info")
+        if not isinstance(dir_info, dict) or dir_info.get("editable") is not True:
+            continue
         dist_info_name = candidate.parent.name
         distribution = dist_info_name.removesuffix(".dist-info").split("-")[0]
         return str(candidate.relative_to(venv_path)), distribution
@@ -1178,11 +1217,12 @@ def _apply_editable_install_operation(workspace_root: Path, op: dict[str, object
         raise MaterializationPlanError(
             f"uv pip install --editable failed for {source_path}:\n{proc.stderr or proc.stdout}"
         )
-    evidence = _find_direct_url_evidence(venv_path)
+    evidence = _find_direct_url_evidence(venv_path, source_path)
     if evidence is None:
         raise MaterializationPlanError(
             f"uv pip install --editable reported success for {source_path}, but no PEP 610 "
-            f"direct_url.json evidence was found under {venv_path}"
+            f"direct_url.json evidence matching that source (editable, url == source) was "
+            f"found under {venv_path}"
         )
     pep610_path, distribution = evidence
     # config#491 §12.1 evidence: editable source path, extras, distribution.
@@ -1194,6 +1234,33 @@ def _apply_editable_install_operation(workspace_root: Path, op: dict[str, object
         "distribution": distribution,
         "pep610_evidence": pep610_path,
     }
+
+
+def _verify_staged_source(source_path: Path, expected_sha256: str) -> None:
+    """config#492 §6.2.1 #7: a staged input must exist, be a regular
+    non-symlink file, and its REOPENED bytes must hash to source_sha256.
+
+    Extracted in round 4 so the first-run and rerun-cleanup paths call one
+    function rather than each implementing their own subset -- the rerun
+    path previously skipped all three checks and deleted whatever it
+    found. Any future verification added here reaches both paths by
+    construction, which is the point: the recurring finding-generator has
+    been "the second path skips what the first path does"."""
+    if not source_path.exists():
+        raise MaterializationPlanError(f"project_file source does not exist: {source_path}")
+    # The symlink-free prefix (including the final component) is already
+    # enforced by _canonicalize_workspace_path's per-component walk; this
+    # rejects the remaining non-regular shapes (fifo, directory, device).
+    if not stat.S_ISREG(os.lstat(source_path).st_mode):
+        raise MaterializationPlanError(
+            f"project_file source is not a regular file: {source_path} (config#492 §6.2.1 #7)"
+        )
+    actual_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise MaterializationPlanError(
+            f"project_file hash mismatch for {source_path}: "
+            f"expected {expected_sha256}, got {actual_sha256}"
+        )
 
 
 def _apply_project_file_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
@@ -1224,26 +1291,18 @@ def _apply_project_file_operation(workspace_root: Path, op: dict[str, object]) -
                 "already_projected": True,
             }
             if source_path.exists():
+                # Round 4 (Atlas): the rerun path scheduled ANY existing
+                # staged source for deletion without verifying it -- so a
+                # source recreated with tampered bytes after the receipt
+                # was silently destroyed. Destructive cleanup must verify
+                # the artifact it is destroying, using the SAME function
+                # the first run uses, so the two paths cannot drift.
+                _verify_staged_source(source_path, expected_sha256)
                 result["_pending_unlink"] = str(source_path)
             return result
 
-    if not source_path.exists():
-        raise MaterializationPlanError(f"project_file source does not exist: {source_path}")
-    # config#492 §6.2.1 #7: a regular, non-symlink file. The symlink-free
-    # prefix (including the final component) is already enforced by
-    # _canonicalize_workspace_path's per-component walk; this rejects the
-    # remaining non-regular shapes (fifo, directory, device).
-    if not stat.S_ISREG(os.lstat(source_path).st_mode):
-        raise MaterializationPlanError(
-            f"project_file source is not a regular file: {source_path} (config#492 §6.2.1 #7)"
-        )
+    _verify_staged_source(source_path, expected_sha256)
     content = source_path.read_bytes()
-    actual_sha256 = hashlib.sha256(content).hexdigest()
-    if actual_sha256 != expected_sha256:
-        raise MaterializationPlanError(
-            f"project_file hash mismatch for {source_path}: "
-            f"expected {expected_sha256}, got {actual_sha256}"
-        )
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_bytes(content)

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -11,8 +11,274 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from .events import EventType, emit
-from .gitops import checkout_branch, clone_repo, ensure_repo_cache, is_git_dir, is_git_repo, repo_dirty
+from .gitops import (
+    checkout_branch,
+    clone_repo,
+    current_head_sha,
+    ensure_repo_cache,
+    is_git_dir,
+    is_git_repo,
+    remote_origin_url,
+    repo_dirty,
+)
 from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
+
+
+class MaterializationPlanError(Exception):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Shared containment + identity primitives (config#491 §3, §6.2)
+#
+# Used by both the legacy workspace_spec.toml path below and the neutral
+# MaterializationPlan path -- the same functions, not parallel copies.
+# ---------------------------------------------------------------------------
+
+# config#491 §6.2: "The production plan must not contain: agent display
+# name, persistent agent ID, role, org or project, channel, entitlement
+# result or reason, secret reference or value, memory body." Checked
+# recursively (Sentinel r2 P5: nested identity fields must be caught too,
+# not just top-level operation keys) as a structural safety net.
+_FORBIDDEN_IDENTITY_KEYS = frozenset(
+    {
+        "agent_name",
+        "agent_id",
+        "persistent_identity_ref",
+        "role",
+        "org",
+        "project",
+        "channel",
+        "channels",
+        "entitlement",
+        "entitlement_reason",
+        "secret",
+        "secret_ref",
+        "memory",
+        "memory_body",
+    }
+)
+
+
+def _reject_identity_fields_recursive(value: object, *, path: str) -> None:
+    if isinstance(value, dict):
+        present = _FORBIDDEN_IDENTITY_KEYS & value.keys()
+        if present:
+            raise MaterializationPlanError(
+                f"{path} carries identity-bearing field(s) {sorted(present)}; "
+                "gr2 MaterializationPlan operations must be identity-free (config#491 §6.2)"
+            )
+        for key, nested in value.items():
+            _reject_identity_fields_recursive(nested, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for i, item in enumerate(value):
+            _reject_identity_fields_recursive(item, path=f"{path}[{i}]")
+
+
+def _validate_path_safe_token(value: object, *, field_name: str) -> str:
+    """An opaque, path-safe identifier: no separators, no traversal, no
+    identity semantics interpreted -- used for plan_id and unit_key, both
+    of which end up embedded in filesystem paths (receipt filenames)."""
+    if not isinstance(value, str) or not value:
+        raise MaterializationPlanError(f"{field_name} must be a non-empty string")
+    if "/" in value or "\\" in value or value in (".", "..") or "\x00" in value:
+        raise MaterializationPlanError(f"{field_name} must be a path-safe token, got {value!r}")
+    return value
+
+
+def _resolve_contained(workspace_root: Path, relative: str, *, field_name: str) -> Path:
+    """config#491 §3: absolute paths, .., symlink escapes, and duplicate
+    destinations are blockers. Path.resolve() normalizes .. lexically and
+    follows any existing symlinks, so a single containment check after
+    resolving catches all three escape shapes. Shared by dest_path,
+    reference_base, and (via _resolve_staging_source) source_path."""
+    if not relative or relative.startswith("/") or relative.startswith("~"):
+        raise MaterializationPlanError(f"{field_name} must be relative to the workspace root: {relative!r}")
+    workspace_resolved = workspace_root.resolve()
+    candidate = (workspace_root / relative).resolve()
+    if candidate != workspace_resolved and workspace_resolved not in candidate.parents:
+        raise MaterializationPlanError(f"{field_name} escapes the workspace root: {relative!r}")
+    return workspace_root / relative
+
+
+def _resolve_safe_dest(workspace_root: Path, dest_path: str) -> Path:
+    return _resolve_contained(workspace_root, dest_path, field_name="dest_path")
+
+
+_STAGING_INPUTS_SUBPATH = Path(".grip") / "staging" / "inputs"
+
+
+def _resolve_staging_source(workspace_root: Path, source_path: str) -> Path:
+    """config#491 §6.2, Sentinel r2 P4 ruling: source_path MUST be
+    workspace-relative AND resolve beneath .grip/staging/inputs/ specifically
+    -- not just anywhere in the workspace. The normative example is
+    `.grip/staging/inputs/f_01`; S7 emits `.grip/staging/inputs/<opaque-key>`."""
+    resolved = _resolve_contained(workspace_root, source_path, field_name="source_path").resolve()
+    staging_root = (workspace_root / _STAGING_INPUTS_SUBPATH).resolve()
+    if resolved != staging_root and staging_root not in resolved.parents:
+        raise MaterializationPlanError(
+            f"source_path must resolve beneath .grip/staging/inputs/: {source_path!r}"
+        )
+    return workspace_root / source_path
+
+
+# ---------------------------------------------------------------------------
+# Shared clone executor (config#491 §7.3 "one executor", §8.1-8.3)
+#
+# The single canonical clone primitive. Used by both the legacy
+# workspace_spec.toml path and the neutral MaterializationPlan path --
+# Sentinel r2 P1: sharing only the gitops.clone_repo() leaf call does not
+# satisfy "one executor, not a second materializer." Both callers now
+# delegate the full clone-and-validate sequence here, not just the raw
+# `git clone` invocation.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class CloneResult:
+    first_materialize: bool
+    origin_url: str | None
+    head_sha: str | None
+
+
+def _validate_clone_isolation(
+    repo_root: Path,
+    *,
+    workspace_root: Path,
+    reference_repo_root: Path | None,
+    expected_origin: str,
+) -> None:
+    """config#491 §8.1-8.2: reject worktree-linked clones, clones whose
+    git-common-dir escapes their own .git, clones hosting nested linked
+    worktrees, origin mismatches, and alternates pointing anywhere except
+    the declared workspace cache. Sentinel r2 P3: "`.git` is a directory"
+    plus an alternates check alone does not prove the §8.1 common-dir,
+    origin, or no-worktrees invariants -- each is checked explicitly here."""
+    git_path = repo_root / ".git"
+    if git_path.is_file():
+        raise MaterializationPlanError(
+            f"clone at {repo_root} has a worktree-pointer .git file, not a real .git directory "
+            "(config#491 §8.1 forbids worktree-linked agent workspaces)"
+        )
+    if not git_path.is_dir():
+        raise MaterializationPlanError(f"clone at {repo_root} has no .git directory")
+
+    if (git_path / "worktrees").exists():
+        raise MaterializationPlanError(
+            f"clone at {repo_root} has .git/worktrees -- it is hosting linked worktrees, "
+            "not an isolated agent clone (config#491 §8.1)"
+        )
+
+    common_dir_proc = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if common_dir_proc.returncode == 0:
+        common_dir_raw = common_dir_proc.stdout.strip()
+        common_dir = Path(common_dir_raw)
+        if not common_dir.is_absolute():
+            common_dir = (repo_root / common_dir).resolve()
+        else:
+            common_dir = common_dir.resolve()
+        if common_dir != git_path.resolve():
+            raise MaterializationPlanError(
+                f"clone at {repo_root} has git-common-dir {common_dir} that is not its own .git "
+                "-- it shares mutable git metadata with another checkout (config#491 §8.1)"
+            )
+
+    actual_origin = remote_origin_url(repo_root)
+    if actual_origin != expected_origin:
+        raise MaterializationPlanError(
+            f"clone at {repo_root} has origin {actual_origin!r}, expected {expected_origin!r} "
+            "-- an existing clone must match the declared repo_url"
+        )
+
+    alternates_file = git_path / "objects" / "info" / "alternates"
+    if not alternates_file.exists():
+        return
+    approved = (reference_repo_root.resolve() / "objects") if reference_repo_root else None
+    for line in alternates_file.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if approved is None or Path(line).resolve() != approved:
+            raise MaterializationPlanError(
+                f"clone at {repo_root} has an unapproved alternate: {line} "
+                "(config#491 §8.2: alternates may only point at the declared workspace cache)"
+            )
+
+
+def _clone_isolated(
+    workspace_root: Path,
+    *,
+    repo_url: str,
+    dest: Path,
+    branch: str | None = None,
+    reference_repo_root: Path | None = None,
+) -> CloneResult:
+    """The one canonical clone primitive.
+
+    - An existing dest is validated, never blindly reset or replaced
+      (config#491 §8.3) -- checked before touching anything else.
+    - A fresh clone happens in a SIBLING STAGING PATH: cloned, checked out,
+      and fully validated there, then atomically renamed into dest
+      (Sentinel r2 P2). A failure at any point after the raw `git clone`
+      succeeds (bad branch, failed isolation check) must never leave a
+      partially-published dest -- the staging directory is removed and
+      dest never comes to exist.
+    """
+    if dest.exists():
+        _validate_clone_isolation(
+            dest,
+            workspace_root=workspace_root,
+            reference_repo_root=reference_repo_root,
+            expected_origin=repo_url,
+        )
+        return CloneResult(
+            first_materialize=False,
+            origin_url=remote_origin_url(dest),
+            head_sha=current_head_sha(dest),
+        )
+
+    staging = dest.parent / f".{dest.name}.staging-{os.getpid()}-{id(dest)}"
+    if staging.exists():
+        shutil.rmtree(staging, ignore_errors=True)
+    try:
+        clone_repo(repo_url, staging, reference_repo_root=reference_repo_root)
+        if branch:
+            checkout_branch(staging, branch)
+        _validate_clone_isolation(
+            staging,
+            workspace_root=workspace_root,
+            reference_repo_root=reference_repo_root,
+            expected_origin=repo_url,
+        )
+    except (SystemExit, Exception) as exc:
+        # gitops.py deliberately raises SystemExit (not Exception) on git
+        # failures -- `except Exception:` alone silently misses it and skips
+        # staging cleanup, since SystemExit is a BaseException sibling, not
+        # an Exception subclass. Caught here explicitly, verified with a
+        # test (clone + nonexistent branch) rather than assumed correct.
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+        if isinstance(exc, MaterializationPlanError):
+            raise
+        raise MaterializationPlanError(f"clone staging failed for {repo_url} -> {dest}: {exc}") from exc
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    staging.rename(dest)
+    return CloneResult(
+        first_materialize=True,
+        origin_url=remote_origin_url(dest),
+        head_sha=current_head_sha(dest),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legacy workspace_spec.toml path (repos/units declared as a TOML diff-target)
+# ---------------------------------------------------------------------------
 
 
 @dataclasses.dataclass(frozen=True)
@@ -297,7 +563,13 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
             repo_spec = _find_repo(spec, op.subject)
             repo_root = workspace_root / str(repo_spec["path"])
             cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
-            first_materialize = clone_repo(str(repo_spec["url"]), repo_root, reference_repo_root=cache_path)
+            result = _clone_isolated(
+                workspace_root,
+                repo_url=str(repo_spec["url"]),
+                dest=repo_root,
+                reference_repo_root=cache_path,
+            )
+            first_materialize = result.first_materialize
             hook_payload = _run_materialize_hooks(
                 workspace_root,
                 repo_root,
@@ -342,16 +614,27 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
         elif op.kind == "converge_unit_repos":
             unit_spec = _find_unit(spec, op.subject)
             unit_root = workspace_root / str(unit_spec["path"])
-            missing = [str(r) for r in op.details.get("missing_repos", [])]
+            # All declared repos, not just the ones build_plan flagged
+            # "missing" -- _clone_isolated handles existing-vs-missing
+            # internally (validate vs. stage-clone-rename), so this is what
+            # makes an already-present-but-corrupted or origin-mismatched
+            # unit-repo checkout actually get caught on every converge pass,
+            # not just genuinely-absent ones. Part of §7.3 "one executor":
+            # shared code with matching guarantees, not just a shared leaf
+            # git-clone call.
+            all_repos = [str(r) for r in op.details.get("all_repos", [])]
             converged: list[str] = []
-            for repo_name in missing:
+            for repo_name in all_repos:
                 repo_spec = _find_repo(spec, repo_name)
                 clone_dest = unit_root / repo_name
                 cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
-                first_materialize = clone_repo(
-                    str(repo_spec["url"]), clone_dest, reference_repo_root=cache_path,
+                result = _clone_isolated(
+                    workspace_root,
+                    repo_url=str(repo_spec["url"]),
+                    dest=clone_dest,
+                    reference_repo_root=cache_path,
                 )
-                if first_materialize:
+                if result.first_materialize:
                     converged.append(repo_name)
                     materialized_repos.append({"repo": repo_name, "first_materialize": True})
             unit_toml = unit_root / "unit.toml"
@@ -481,95 +764,12 @@ def _record_apply_state(workspace_root: Path, actions: list[str]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Neutral MaterializationPlan executor (config#491 §6.2, S4)
+# Neutral MaterializationPlan executor (config#491 §6.2, §12.1, S4)
 #
 # Consumes the plan JSON directly (clone/venv/editable_install/project_file
-# operations), rather than workspace_spec.toml's repo/unit model above. Both
-# entry points share the same clone/validation primitives -- one executor,
-# not a second materializer, per config#491 §7.3.
+# operations), rather than workspace_spec.toml's repo/unit model above.
+# Shares _clone_isolated with the legacy path (§7.3), not a parallel copy.
 # ---------------------------------------------------------------------------
-
-
-class MaterializationPlanError(Exception):
-    pass
-
-
-# config#491 §6.2: "The production plan must not contain: agent display
-# name, persistent agent ID, role, org or project, channel, entitlement
-# result or reason, secret reference or value, memory body." Checked on
-# every operation dict as a structural safety net -- gr2 must not become
-# somewhere identity data could leak through even accidentally.
-_FORBIDDEN_IDENTITY_KEYS = frozenset(
-    {
-        "agent_name",
-        "agent_id",
-        "persistent_identity_ref",
-        "role",
-        "org",
-        "project",
-        "channel",
-        "channels",
-        "entitlement",
-        "entitlement_reason",
-        "secret",
-        "secret_ref",
-        "memory",
-        "memory_body",
-    }
-)
-
-
-def _reject_identity_fields(op: dict[str, object]) -> None:
-    present = _FORBIDDEN_IDENTITY_KEYS & op.keys()
-    if present:
-        raise MaterializationPlanError(
-            f"operation carries identity-bearing field(s) {sorted(present)}; "
-            "gr2 MaterializationPlan operations must be identity-free (config#491 §6.2)"
-        )
-
-
-def _resolve_safe_dest(workspace_root: Path, dest_path: str) -> Path:
-    """Resolve dest_path relative to workspace_root, rejecting escapes.
-
-    config#491 §3: absolute paths, .., symlink escapes, and duplicate
-    destinations are blockers. Path.resolve() normalizes .. lexically and
-    follows any existing symlinks, so a single containment check after
-    resolving catches all three escape shapes.
-    """
-    if not dest_path or dest_path.startswith("/") or dest_path.startswith("~"):
-        raise MaterializationPlanError(f"dest_path must be relative to the workspace root: {dest_path!r}")
-    workspace_resolved = workspace_root.resolve()
-    candidate = (workspace_root / dest_path).resolve()
-    if candidate != workspace_resolved and workspace_resolved not in candidate.parents:
-        raise MaterializationPlanError(f"dest_path escapes the workspace root: {dest_path!r}")
-    return workspace_root / dest_path
-
-
-def _validate_clone_isolation(repo_root: Path, *, workspace_root: Path, reference_base: str | None) -> None:
-    """gap#6 / config#491 §8.1-8.2: reject worktree-linked clones and
-    alternates pointing anywhere except the declared workspace cache."""
-    git_path = repo_root / ".git"
-    if git_path.is_file():
-        raise MaterializationPlanError(
-            f"clone at {repo_root} has a worktree-pointer .git file, not a real .git directory "
-            "(config#491 §8.1 forbids worktree-linked agent workspaces)"
-        )
-    if not git_path.is_dir():
-        raise MaterializationPlanError(f"clone at {repo_root} has no .git directory")
-
-    alternates_file = git_path / "objects" / "info" / "alternates"
-    if not alternates_file.exists():
-        return
-    approved = (workspace_root / reference_base).resolve() / "objects" if reference_base else None
-    for line in alternates_file.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        if approved is None or Path(line).resolve() != approved:
-            raise MaterializationPlanError(
-                f"clone at {repo_root} has an unapproved alternate: {line} "
-                "(config#491 §8.2: alternates may only point at the declared workspace cache)"
-            )
 
 
 def _apply_clone_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
@@ -577,48 +777,68 @@ def _apply_clone_operation(workspace_root: Path, op: dict[str, object]) -> dict[
     dest = _resolve_safe_dest(workspace_root, dest_path)
     repo_url = str(op["repo_url"])
     reference_base = op.get("reference_base")
-    reference_base = str(reference_base) if reference_base else None
-    reference_repo_root = (workspace_root / reference_base) if reference_base else None
+    reference_repo_root: Path | None = None
+    if reference_base:
+        reference_repo_root = _resolve_contained(
+            workspace_root, str(reference_base), field_name="reference_base"
+        )
 
-    # config#491 §8.3: an existing clone is validated, never blindly reset
-    # or replaced. Checked before attempting anything, not after -- a
-    # worktree-linked or otherwise damaged existing path must block here,
-    # not surface as a confusing "destination already exists" error from
-    # `git clone` itself.
-    if dest.exists():
-        _validate_clone_isolation(dest, workspace_root=workspace_root, reference_base=reference_base)
-        first_materialize = False
-    else:
-        first_materialize = clone_repo(repo_url, dest, reference_repo_root=reference_repo_root)
-        branch = op.get("branch")
-        if branch:
-            checkout_branch(dest, str(branch))
-        _validate_clone_isolation(dest, workspace_root=workspace_root, reference_base=reference_base)
+    branch = op.get("branch")
+    result = _clone_isolated(
+        workspace_root,
+        repo_url=repo_url,
+        dest=dest,
+        branch=str(branch) if branch else None,
+        reference_repo_root=reference_repo_root,
+    )
 
     return {
         "kind": "clone",
         "repo_url": repo_url,
         "dest_path": dest_path,
-        "first_materialize": first_materialize,
+        "first_materialize": result.first_materialize,
+        "head_sha": result.head_sha,
     }
+
+
+def _is_real_venv(dest: Path) -> bool:
+    return (dest / "pyvenv.cfg").is_file()
 
 
 def _apply_venv_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
     dest_path = str(op["dest_path"])
     dest = _resolve_safe_dest(workspace_root, dest_path)
     if dest.exists():
+        # Sentinel r2 P5: an arbitrary existing directory must not be
+        # accepted as a valid venv just because a path exists there.
+        if not _is_real_venv(dest):
+            raise MaterializationPlanError(
+                f"venv dest {dest} exists but is not a real venv (no pyvenv.cfg)"
+            )
         return {"kind": "venv", "dest_path": dest_path, "created": False}
 
     python_constraint = str(op.get("python", ">=3.11"))
+    staging = dest.parent / f".{dest.name}.staging-{os.getpid()}-{id(dest)}"
+    if staging.exists():
+        shutil.rmtree(staging, ignore_errors=True)
+    dest.parent.mkdir(parents=True, exist_ok=True)
     proc = subprocess.run(
-        ["uv", "venv", "--python", python_constraint, str(dest)],
+        ["uv", "venv", "--python", python_constraint, str(staging)],
         capture_output=True,
         text=True,
         check=False,
     )
-    if proc.returncode != 0:
+    if proc.returncode != 0 or not _is_real_venv(staging):
+        shutil.rmtree(staging, ignore_errors=True)
         raise MaterializationPlanError(f"uv venv failed for {dest}:\n{proc.stderr or proc.stdout}")
+    staging.rename(dest)
     return {"kind": "venv", "dest_path": dest_path, "created": True}
+
+
+def _find_direct_url_evidence(venv_path: Path) -> str | None:
+    for candidate in sorted(venv_path.glob("lib/*/site-packages/*.dist-info/direct_url.json")):
+        return str(candidate.relative_to(venv_path))
+    return None
 
 
 def _apply_editable_install_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
@@ -638,21 +858,27 @@ def _apply_editable_install_operation(workspace_root: Path, op: dict[str, object
         raise MaterializationPlanError(
             f"uv pip install --editable failed for {source_path}:\n{proc.stderr or proc.stdout}"
         )
+    evidence = _find_direct_url_evidence(venv_path)
+    if evidence is None:
+        raise MaterializationPlanError(
+            f"uv pip install --editable reported success for {source_path}, but no PEP 610 "
+            f"direct_url.json evidence was found under {venv_path}"
+        )
     return {
         "kind": "editable_install",
         "venv_path": str(op["venv_path"]),
         "source_path": str(op["source_path"]),
+        "pep610_evidence": evidence,
     }
 
 
 def _apply_project_file_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
-    # source_path is workspace-relative, same as dest_path (config#491 §6.2's
-    # own example: ".grip/staging/inputs/f_01") -- resolved through the same
-    # containment guard as dest, not read+deleted as an arbitrary caller-
-    # supplied filesystem path. Stromus's r1 catch on #797: reading and then
-    # unlink()-ing an unvalidated path is a real arbitrary-file-delete gap,
-    # not just a style nit.
-    source_path = _resolve_safe_dest(workspace_root, str(op["source_path"]))
+    # source_path must resolve under .grip/staging/inputs/ specifically
+    # (Sentinel r2 P4 ruling) -- not just anywhere in the workspace. Stromus's
+    # r1 catch on #797: reading and then unlink()-ing an unvalidated path is
+    # a real arbitrary-file-delete gap, not just a style nit; the follow-up
+    # r2 tightened "anywhere in the workspace" to the actual staging contract.
+    source_path = _resolve_staging_source(workspace_root, str(op["source_path"]))
     dest_path = str(op["dest_path"])
     dest = _resolve_safe_dest(workspace_root, dest_path)
     expected_sha256 = str(op["source_sha256"])
@@ -686,6 +912,81 @@ _MATERIALIZATION_HANDLERS = {
 }
 
 
+def _require_str(op: dict[str, object], key: str, prefix: str) -> str:
+    value = op.get(key)
+    if not isinstance(value, str) or not value:
+        raise MaterializationPlanError(f"{prefix}: {key} must be a non-empty string")
+    return value
+
+
+def _validate_operation_schema(op: dict[str, object], *, idx: int, workspace_root: Path) -> None:
+    """Sentinel r2 P5: schema AND containment are validated for every
+    operation up front -- not just type-checked, and not deferred to
+    execution time. A plan whose op[2] has an unsafe dest_path must never
+    let op[0]/op[1] mutate anything first."""
+    kind = op.get("kind")
+    prefix = f"operations[{idx}] (kind={kind!r})"
+    if kind not in _MATERIALIZATION_HANDLERS:
+        raise MaterializationPlanError(f"{prefix}: unknown operation kind")
+
+    if kind == "clone":
+        _require_str(op, "repo_url", prefix)
+        dest_path = _require_str(op, "dest_path", prefix)
+        _resolve_safe_dest(workspace_root, dest_path)
+        reference_base = op.get("reference_base")
+        if reference_base:
+            _resolve_contained(workspace_root, str(reference_base), field_name=f"{prefix}.reference_base")
+    elif kind == "venv":
+        dest_path = _require_str(op, "dest_path", prefix)
+        _resolve_safe_dest(workspace_root, dest_path)
+        engine = op.get("engine", "uv")
+        if engine != "uv":
+            raise MaterializationPlanError(f"{prefix}: engine must be 'uv', got {engine!r}")
+    elif kind == "editable_install":
+        venv_path = _require_str(op, "venv_path", prefix)
+        source_path = _require_str(op, "source_path", prefix)
+        _resolve_safe_dest(workspace_root, venv_path)
+        _resolve_safe_dest(workspace_root, source_path)
+    elif kind == "project_file":
+        source_path = _require_str(op, "source_path", prefix)
+        dest_path = _require_str(op, "dest_path", prefix)
+        _require_str(op, "source_sha256", prefix)
+        _resolve_staging_source(workspace_root, source_path)
+        _resolve_safe_dest(workspace_root, dest_path)
+        mode = op.get("mode", "copy")
+        if mode != "copy":
+            raise MaterializationPlanError(f"{prefix}: mode must be 'copy' for v1, got {mode!r}")
+
+
+def _validate_plan_shape(plan: dict[str, object], *, workspace_root: Path) -> None:
+    """Sentinel r2 P5: validate the COMPLETE plan before the first
+    filesystem mutation -- not one operation validated immediately before
+    its own execution, which lets earlier operations mutate state before a
+    later operation's invalid shape is ever discovered."""
+    _validate_path_safe_token(plan.get("plan_id"), field_name="plan_id")
+    # Sentinel/Atlas r2 ruling: one MaterializationPlan is scoped to one
+    # opaque unit and carries a required top-level unit_key. gr2 validates
+    # it as a path-safe opaque token without interpreting identity.
+    _validate_path_safe_token(plan.get("unit_key"), field_name="unit_key")
+
+    operations = plan.get("operations")
+    if not isinstance(operations, list) or not operations:
+        raise MaterializationPlanError("plan.operations must be a non-empty list")
+
+    seen_dest_paths: set[str] = set()
+    for idx, op in enumerate(operations):
+        if not isinstance(op, dict):
+            raise MaterializationPlanError(f"operations[{idx}] must be an object, got {type(op).__name__}")
+        _reject_identity_fields_recursive(op, path=f"operations[{idx}]")
+        _validate_operation_schema(op, idx=idx, workspace_root=workspace_root)
+
+        dest_path = op.get("dest_path")
+        if isinstance(dest_path, str):
+            if dest_path in seen_dest_paths:
+                raise MaterializationPlanError(f"duplicate dest_path across operations: {dest_path!r}")
+            seen_dest_paths.add(dest_path)
+
+
 def _materialization_receipt_path(workspace_root: Path, plan_id: str) -> Path:
     return workspace_root / ".grip" / "state" / "materialization" / f"{plan_id}.json"
 
@@ -695,12 +996,16 @@ def _write_materialization_receipt(
     plan: dict[str, object],
     op_results: list[dict[str, object]],
 ) -> Path:
-    """gap#5: a structured, resumable per-plan receipt -- not an append-only
-    action log. config#491 §12.1: neutral receipts carry plan hash, spec
-    hash, and per-operation structural evidence; no identity, org, channel,
-    secret, or memory content."""
+    """config#491 §12.1: neutral receipts carry the plan hash, opaque unit
+    key, and per-operation structural evidence -- no identity, org, channel,
+    secret, or memory content. Written atomically (temp file + rename), not
+    directly, matching the same publish-don't-partially-write discipline as
+    _clone_isolated's staging rename."""
+    plan_hash = hashlib.sha256(json.dumps(plan, sort_keys=True).encode()).hexdigest()
     receipt = {
         "plan_id": plan["plan_id"],
+        "unit_key": plan["unit_key"],
+        "plan_hash": plan_hash,
         "schema_version": plan.get("schema_version", 1),
         "workspace_spec_sha256": plan.get("workspace_spec_sha256"),
         "applied_at": datetime.now(UTC).isoformat(),
@@ -708,7 +1013,9 @@ def _write_materialization_receipt(
     }
     receipt_path = _materialization_receipt_path(workspace_root, str(plan["plan_id"]))
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
-    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n")
+    tmp_path = receipt_path.with_name(receipt_path.name + f".tmp-{os.getpid()}")
+    tmp_path.write_text(json.dumps(receipt, indent=2) + "\n")
+    tmp_path.rename(receipt_path)
     return receipt_path
 
 
@@ -720,29 +1027,27 @@ def apply_materialization_plan(
 ) -> dict[str, object]:
     """Execute a neutral MaterializationPlan (config#491 §6.2).
 
-    Identity-free by construction: every operation is validated against
-    _FORBIDDEN_IDENTITY_KEYS before execution. dest_path is used explicitly
-    for every operation kind (gap#4) rather than inferred from a repo name.
-    Resumable: a rerun re-validates already-materialized state and reports
-    first_materialize/created=False rather than duplicating work or receipt
-    entries (idempotent per operation, matching clone_repo's own contract).
+    Validate-before-touch (Sentinel r2 P5): the entire plan is schema- and
+    containment-validated before any operation executes, so an invalid
+    operation anywhere in the plan blocks the whole apply -- not just the
+    operations that happen to come after it in list order.
+
+    Identity-free by construction: every operation (recursively, not just
+    top-level keys) is checked against _FORBIDDEN_IDENTITY_KEYS.
+
+    Resumable: a rerun re-validates already-materialized state (real clone
+    isolation, real venv) and reports first_materialize/created=False rather
+    than duplicating work or receipt entries.
     """
     if not yes:
         raise MaterializationPlanError("apply_materialization_plan requires yes=True (no interactive gate)")
 
-    operations = plan.get("operations", [])
-    if not isinstance(operations, list) or not operations:
-        raise MaterializationPlanError("plan.operations must be a non-empty list")
+    _validate_plan_shape(plan, workspace_root=workspace_root)
 
     op_results: list[dict[str, object]] = []
-    for op in operations:
-        if not isinstance(op, dict):
-            raise MaterializationPlanError(f"operation must be an object, got {type(op).__name__}")
-        _reject_identity_fields(op)
-        kind = str(op.get("kind", ""))
-        handler = _MATERIALIZATION_HANDLERS.get(kind)
-        if handler is None:
-            raise MaterializationPlanError(f"unknown materialization operation kind: {kind!r}")
+    for op in plan["operations"]:
+        kind = str(op["kind"])
+        handler = _MATERIALIZATION_HANDLERS[kind]
         op_results.append(handler(workspace_root, op))
 
     receipt_path = _write_materialization_receipt(workspace_root, plan, op_results)
@@ -750,6 +1055,7 @@ def apply_materialization_plan(
     return {
         "workspace_root": str(workspace_root),
         "plan_id": plan["plan_id"],
+        "unit_key": plan["unit_key"],
         "operation_count": len(op_results),
         "operations": op_results,
         "receipt_path": str(receipt_path),

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -2,18 +2,23 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
+import importlib.resources
 import json
 import os
 import shutil
+import stat
 import subprocess
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+
 from .events import EventType, emit
 from .gitops import (
     checkout_branch,
     clone_repo,
+    current_branch,
     current_head_sha,
     ensure_repo_cache,
     is_git_dir,
@@ -26,6 +31,49 @@ from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lif
 
 class MaterializationPlanError(Exception):
     pass
+
+
+# ---------------------------------------------------------------------------
+# Pinned MaterializationPlan v1 schema (config#492, merged 4b36896)
+#
+# The normative wire contract. Round 3 (Atlas): a hand-rolled validator is a
+# separate, looser contract by construction -- nine plans the pinned schema
+# rejects were being accepted. The packaged schema's bytes are verified
+# against the pinned SHA-256 at load; a mismatch fails closed rather than
+# validating against an unpinned document.
+# ---------------------------------------------------------------------------
+
+_PLAN_SCHEMA_SHA256 = "a5061501ba6651d7432d87d57f1c85902e5dec076f860a47faa299f5f590231c"
+_PLAN_SCHEMA_RESOURCE = "schemas/gr2-materialization-plan-v1.schema.json"
+_plan_validator: Draft202012Validator | None = None
+
+
+def _read_plan_schema_bytes() -> bytes:
+    """Load the packaged schema. importlib.resources is the real
+    (installed) path; the sibling-directory fallback covers the in-repo
+    pytest context, where conftest.py injects a bare `gr2` module without
+    a __spec__ and resources lookup cannot traverse it. Either way the
+    bytes are verified against the pinned SHA-256 before use, so WHERE
+    they load from cannot weaken WHAT gets enforced."""
+    try:
+        return (importlib.resources.files("gr2") / _PLAN_SCHEMA_RESOURCE).read_bytes()
+    except Exception:
+        return (Path(__file__).resolve().parent.parent / "gr2" / _PLAN_SCHEMA_RESOURCE).read_bytes()
+
+
+def _load_plan_validator() -> Draft202012Validator:
+    global _plan_validator
+    if _plan_validator is None:
+        raw = _read_plan_schema_bytes()
+        actual = hashlib.sha256(raw).hexdigest()
+        if actual != _PLAN_SCHEMA_SHA256:
+            raise MaterializationPlanError(
+                f"packaged MaterializationPlan v1 schema hash mismatch: expected "
+                f"{_PLAN_SCHEMA_SHA256}, got {actual} -- refusing to validate against "
+                "an unpinned schema (config#492 §6.2.1)"
+            )
+        _plan_validator = Draft202012Validator(json.loads(raw))
+    return _plan_validator
 
 
 # ---------------------------------------------------------------------------
@@ -93,21 +141,42 @@ def _validate_path_safe_token(value: object, *, field_name: str) -> str:
 
 
 def _canonicalize_workspace_path(workspace_root: Path, relative: str, *, field_name: str) -> Path:
-    """config#491 §3: absolute paths, .., symlink escapes, and duplicate/
-    case-folded-colliding destinations are blockers. Round 2 (Atlas): a
-    literal '..' segment that happens to resolve back inside the workspace
-    was being accepted -- the spec forbids '..' appearing at all, not just
-    "does it escape after resolution." Checked as a literal path-part scan
-    BEFORE resolving, in addition to the post-resolve containment check
-    (which independently catches symlink escapes resolve() reveals).
-    Returns the fully resolved (symlink-dereferenced) canonical path --
-    callers needing the original relative string for receipts/display keep
-    that separately; this return value is for filesystem operations and
-    ALL comparison (duplicate detection, cache-namespace checks)."""
+    """config#492 §6.2.1 invariant #2: reject absolute paths, `~`,
+    backslashes, empty segments, `.` or `..` segments, NUL, any existing
+    symlink in the path prefix, and any resolved escape.
+
+    Segment checks run on the RAW string split on "/" -- Path() silently
+    normalizes single-dot segments away (Path("a/./b").parts == ("a","b")),
+    so parts-based scanning cannot see them (round 3: "." segment was one
+    of the nine schema-invalid plans being accepted).
+
+    The symlink-free-prefix walk (lstat per existing component, including
+    the final one) is what a resolve()-based containment check structurally
+    cannot provide: with `.grip/staging/inputs` itself a symlink to
+    `<workspace>/rogue`, BOTH the candidate and the staging root resolve
+    through the same link, so "resolved candidate is under resolved root"
+    holds while the real bytes come from outside staging (Atlas's round-3
+    mutant, reproduced before fixing).
+
+    Returns the fully resolved canonical path -- for filesystem operations
+    and ALL comparison (duplicate detection, cache-namespace checks)."""
     if not relative or relative.startswith("/") or relative.startswith("~"):
         raise MaterializationPlanError(f"{field_name} must be relative to the workspace root: {relative!r}")
-    if ".." in Path(relative).parts:
-        raise MaterializationPlanError(f"{field_name} must not contain '..' segments: {relative!r}")
+    if "\\" in relative or "\x00" in relative:
+        raise MaterializationPlanError(f"{field_name} must not contain backslashes or NUL: {relative!r}")
+    segments = relative.split("/")
+    if any(seg in ("", ".", "..") for seg in segments):
+        raise MaterializationPlanError(
+            f"{field_name} must not contain empty, '.', or '..' segments: {relative!r}"
+        )
+    walker = workspace_root
+    for seg in segments:
+        walker = walker / seg
+        if walker.is_symlink():
+            raise MaterializationPlanError(
+                f"{field_name} passes through a symlink at {walker} -- path prefixes must be "
+                "symlink-free (config#492 §6.2.1 #2)"
+            )
     workspace_resolved = workspace_root.resolve()
     candidate = (workspace_root / relative).resolve()
     if candidate != workspace_resolved and workspace_resolved not in candidate.parents:
@@ -123,19 +192,20 @@ _STAGING_INPUTS_SUBPATH = Path(".grip") / "staging" / "inputs"
 
 
 def _resolve_staging_source(workspace_root: Path, source_path: str) -> Path:
-    """config#491 §6.2, Sentinel r2 P4 ruling: source_path MUST be
-    workspace-relative AND resolve beneath .grip/staging/inputs/ specifically
-    -- not just anywhere in the workspace. The normative example is
-    `.grip/staging/inputs/f_01`; S7 emits `.grip/staging/inputs/<opaque-key>`.
-    _canonicalize_workspace_path already follows symlinks via .resolve(), so
-    a symlink planted inside staging/inputs pointing outside it is caught by
-    the same containment check -- pinned by a real symlink test, not just
-    reasoned about."""
+    """config#492 §6.2.1 #7: source_path must be a single opaque artifact
+    DIRECTLY inside .grip/staging/inputs/ (the schema's stagedInputPath
+    pattern has no path separator in the artifact token -- nested
+    `.grip/staging/inputs/a/b` is schema-invalid and rejected here too),
+    reached through a symlink-free prefix. The per-component symlink walk
+    in _canonicalize_workspace_path covers both the prefix AND the final
+    component, so an in-staging alias symlink (inputs/alias -> inputs/real)
+    rejects as well -- Sentinel's round-3 fixture: the alias was accepted,
+    the RESOLVED target got unlinked, and the dangling alias stayed."""
     resolved = _canonicalize_workspace_path(workspace_root, source_path, field_name="source_path")
     staging_root = (workspace_root / _STAGING_INPUTS_SUBPATH).resolve()
-    if resolved != staging_root and staging_root not in resolved.parents:
+    if resolved.parent != staging_root:
         raise MaterializationPlanError(
-            f"source_path must resolve beneath .grip/staging/inputs/: {source_path!r}"
+            f"source_path must be directly inside .grip/staging/inputs/ (no nesting): {source_path!r}"
         )
     return resolved
 
@@ -144,26 +214,45 @@ _CACHE_NAMESPACE_SUBPATH = Path(".grip") / "cache" / "repos"
 
 
 def _validate_reference_base(workspace_root: Path, reference_base: str, *, repo_url: str) -> Path:
-    """config#491 §8.2, round 2 (Atlas/Sentinel): reference_base must be
-    bound to the declared cache NAMESPACE (.grip/cache/repos/*.git), not
-    just anywhere inside the workspace -- a real in-workspace mirror
-    outside that namespace was being accepted and retained as the clone's
-    alternate. Separately, if the referenced cache already exists, its own
-    canonical origin must equal repo_url -- otherwise a cache seeded from a
-    different remote could be used as if it were the right one."""
+    """config#492 §6.2.1 invariant #5: a declared reference_base must BE
+    the workspace-managed bare cache with canonical remote equal to
+    repo_url. Fail CLOSED on every unverifiable state (round 3, Atlas):
+
+    - the round-2 version accepted an existing cache whose
+      remote_origin_url returned None ("if origin is not None and differs"
+      is fail-open on absent provenance);
+    - a non-Git directory at the canonical cache path was accepted, then
+      `git clone --reference-if-able` silently skipped the unusable
+      reference and the receipt still claimed the alternate was approved;
+    - a missing cache cannot have its provenance verified at all.
+
+    All three now reject before any git command runs."""
     resolved = _canonicalize_workspace_path(workspace_root, reference_base, field_name="reference_base")
     cache_namespace = (workspace_root / _CACHE_NAMESPACE_SUBPATH).resolve()
     if resolved.parent != cache_namespace or resolved.suffix != ".git":
         raise MaterializationPlanError(
             f"reference_base must be a *.git cache directly inside .grip/cache/repos/: {reference_base!r}"
         )
-    if resolved.exists():
-        cache_origin = remote_origin_url(resolved)
-        if cache_origin is not None and cache_origin != repo_url:
-            raise MaterializationPlanError(
-                f"reference_base {reference_base!r} has canonical origin {cache_origin!r}, "
-                f"expected {repo_url!r} -- a cache seeded from a different remote cannot be reused"
-            )
+    if not resolved.exists():
+        raise MaterializationPlanError(
+            f"reference_base {reference_base!r} does not exist -- a declared cache whose "
+            "provenance cannot be verified is rejected, not silently skipped (config#492 §6.2.1 #5)"
+        )
+    if not is_git_dir(resolved):
+        raise MaterializationPlanError(
+            f"reference_base {reference_base!r} is not a bare git repository (config#492 §6.2.1 #5)"
+        )
+    cache_origin = remote_origin_url(resolved)
+    if cache_origin is None:
+        raise MaterializationPlanError(
+            f"reference_base {reference_base!r} has no canonical remote -- absent provenance "
+            "is rejected, not treated as acceptable (config#492 §6.2.1 #5)"
+        )
+    if cache_origin != repo_url:
+        raise MaterializationPlanError(
+            f"reference_base {reference_base!r} has canonical origin {cache_origin!r}, "
+            f"expected {repo_url!r} -- a cache seeded from a different remote cannot be reused"
+        )
     return resolved
 
 
@@ -184,6 +273,19 @@ class CloneResult:
     first_materialize: bool
     origin_url: str | None
     head_sha: str | None
+    # The alternate line actually OBSERVED in .git/objects/info/alternates,
+    # or None. Round 3 (Atlas): receipt evidence must be observation, not
+    # an echo of what the plan requested -- a clone that completed without
+    # any alternates file was being receipted alternate_approved=true.
+    observed_alternate: str | None
+
+
+def _read_observed_alternate(repo_root: Path) -> str | None:
+    alternates_file = repo_root / ".git" / "objects" / "info" / "alternates"
+    if not alternates_file.exists():
+        return None
+    lines = [line.strip() for line in alternates_file.read_text().splitlines() if line.strip()]
+    return lines[0] if lines else None
 
 
 def _validate_clone_isolation(
@@ -289,10 +391,25 @@ def _clone_isolated(
             reference_repo_root=reference_repo_root,
             expected_origin=repo_url,
         )
+        # config#492 §6.2.1 (round 3, Atlas): declared plan fields are
+        # DESIRED STATE, validated on every apply -- not inputs consumed
+        # only during first creation. An existing healthy clone on `main`
+        # was accepting a plan declaring `branch: feature` and silently
+        # staying on `main`. Never force-switch (prior source ruling);
+        # a mismatch blocks with a repair-is-manual message instead.
+        if branch:
+            actual_branch = current_branch(dest)
+            if actual_branch != branch:
+                raise MaterializationPlanError(
+                    f"existing clone at {dest} is on branch {actual_branch!r} but the plan "
+                    f"declares {branch!r} -- refusing to force-switch a healthy existing "
+                    "clone; reconcile manually (config#492 §6.2.1 #5, §8.3)"
+                )
         return CloneResult(
             first_materialize=False,
             origin_url=remote_origin_url(dest),
             head_sha=current_head_sha(dest),
+            observed_alternate=_read_observed_alternate(dest),
         )
 
     staging = dest.parent / f".{dest.name}.staging-{os.getpid()}-{id(dest)}"
@@ -322,10 +439,22 @@ def _clone_isolated(
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     staging.rename(dest)
+    observed_alternate = _read_observed_alternate(dest)
+    if reference_repo_root is not None and observed_alternate is None:
+        # The cache was validated usable before cloning; a fresh clone that
+        # nonetheless carries no alternate means the declared object-sharing
+        # state was not achieved -- fail closed rather than receipt a state
+        # that differs from what the plan declared (config#492 §6.2.1 #5).
+        shutil.rmtree(dest, ignore_errors=True)
+        raise MaterializationPlanError(
+            f"clone at {dest} was created with declared reference {reference_repo_root} "
+            "but carries no alternate -- declared object sharing was not achieved"
+        )
     return CloneResult(
         first_materialize=True,
         origin_url=remote_origin_url(dest),
         head_sha=current_head_sha(dest),
+        observed_alternate=observed_alternate,
     )
 
 
@@ -636,16 +765,18 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
             # dispatch the MaterializationPlan path uses, not a manually
             # invoked _clone_isolated -- "one executor" means one dispatch
             # path, not just a shared leaf clone primitive underneath two
-            # separate call sites.
-            clone_result = _apply_clone_operation(
-                workspace_root,
-                {
-                    "kind": "clone",
-                    "repo_url": str(repo_spec["url"]),
-                    "dest_path": _relative_workspace_path(workspace_root, repo_root),
-                    "reference_base": _relative_workspace_path(workspace_root, cache_path),
-                },
-            )
+            # separate call sites. reference_base is declared only when the
+            # cache actually exists: a declared-but-unverifiable cache is a
+            # hard rejection (config#492 §6.2.1 #5), while cloning
+            # self-contained without one is legitimate.
+            legacy_clone_op: dict[str, object] = {
+                "kind": "clone",
+                "repo_url": str(repo_spec["url"]),
+                "dest_path": _relative_workspace_path(workspace_root, repo_root),
+            }
+            if cache_path.exists():
+                legacy_clone_op["reference_base"] = _relative_workspace_path(workspace_root, cache_path)
+            clone_result = _apply_clone_operation(workspace_root, legacy_clone_op)
             first_materialize = bool(clone_result["first_materialize"])
             hook_payload = _run_materialize_hooks(
                 workspace_root,
@@ -705,15 +836,16 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
                 repo_spec = _find_repo(spec, repo_name)
                 clone_dest = unit_root / repo_name
                 cache_path = repo_cache_path(workspace_root, str(repo_spec["name"]))
-                clone_result = _apply_clone_operation(
-                    workspace_root,
-                    {
-                        "kind": "clone",
-                        "repo_url": str(repo_spec["url"]),
-                        "dest_path": _relative_workspace_path(workspace_root, clone_dest),
-                        "reference_base": _relative_workspace_path(workspace_root, cache_path),
-                    },
-                )
+                converge_clone_op: dict[str, object] = {
+                    "kind": "clone",
+                    "repo_url": str(repo_spec["url"]),
+                    "dest_path": _relative_workspace_path(workspace_root, clone_dest),
+                }
+                if cache_path.exists():
+                    converge_clone_op["reference_base"] = _relative_workspace_path(
+                        workspace_root, cache_path
+                    )
+                clone_result = _apply_clone_operation(workspace_root, converge_clone_op)
                 if clone_result["first_materialize"]:
                     converged.append(repo_name)
                     materialized_repos.append({"repo": repo_name, "first_materialize": True})
@@ -872,8 +1004,11 @@ def _apply_clone_operation(workspace_root: Path, op: dict[str, object]) -> dict[
         reference_repo_root=reference_repo_root,
     )
 
-    # config#491 §12.1 evidence: repo URL, destination, HEAD, and
-    # clone-state evidence; cache path and approved-alternate evidence.
+    # config#491 §12.1 evidence: repo URL, destination, HEAD, clone-state,
+    # cache path, and alternate evidence. Every field here is an
+    # OBSERVATION of resulting state, not an echo of the request -- round 3
+    # (Atlas): alternate_approved was being derived from "a reference was
+    # passed," reporting true for a clone with no alternates file at all.
     return {
         "kind": "clone",
         "repo_url": repo_url,
@@ -882,32 +1017,95 @@ def _apply_clone_operation(workspace_root: Path, op: dict[str, object]) -> dict[
         "head_sha": result.head_sha,
         "observed_origin": result.origin_url,
         "cache_path": str(reference_base) if reference_base else None,
-        "alternate_approved": reference_repo_root is not None,
+        "observed_alternate": result.observed_alternate,
+        "alternate_approved": result.observed_alternate is not None,
     }
 
 
-def _real_venv_interpreter(dest: Path) -> Path | None:
-    """Round 2 (Sentinel): a forged pyvenv.cfg with no actual interpreter
-    was being accepted as a valid existing venv. pyvenv.cfg's presence
-    alone proves nothing -- an executable interpreter binary must exist."""
-    if not (dest / "pyvenv.cfg").is_file():
+def _probe_venv_interpreter(dest: Path, *, python_constraint: str | None = None) -> Path | None:
+    """config#492 §6.2.1 invariant #6: an existing venv is valid only when
+    pyvenv.cfg is a regular file AND the interpreter is present, executable,
+    and succeeds under an isolated bounded probe reporting a resolved
+    sys.prefix equal to the declared venv path, a distinct sys.base_prefix,
+    and (when a constraint is declared) an interpreter version satisfying
+    the plan's `python` specifier.
+
+    Round 3 (Atlas + Sentinel): the round-2 check (pyvenv.cfg present +
+    executable file at bin/python*) accepted a directory holding a forged
+    pyvenv.cfg plus an executable SHELL SCRIPT named bin/python3, and a
+    real-shaped venv was accepted under python=">=99" -- an unsatisfiable
+    constraint no genuine interpreter could meet. File presence and the
+    executable bit prove nothing; only running the pinned probe does."""
+    pyvenv_cfg = dest / "pyvenv.cfg"
+    if pyvenv_cfg.is_symlink() or not pyvenv_cfg.is_file():
         return None
+    interpreter: Path | None = None
     for candidate_name in ("python3", "python"):
         candidate = dest / "bin" / candidate_name
         if candidate.is_file() and os.access(candidate, os.X_OK):
-            return candidate
-    return None
+            interpreter = candidate
+            break
+    if interpreter is None:
+        return None
+    probe_code = (
+        "import sys; print(sys.prefix); print(sys.base_prefix); "
+        "print('.'.join(map(str, sys.version_info[:3])))"
+    )
+    try:
+        proc = subprocess.run(
+            [str(interpreter), "-I", "-c", probe_code],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    lines = proc.stdout.strip().splitlines()
+    if len(lines) != 3:
+        return None
+    try:
+        reported_prefix = Path(lines[0]).resolve()
+        reported_base = Path(lines[1]).resolve()
+    except OSError:
+        return None
+    if reported_prefix != dest.resolve():
+        return None
+    if reported_prefix == reported_base:
+        return None
+    if python_constraint is not None:
+        # Deferred import: packaging is a runtime dependency, but only this
+        # probe needs it -- keep module import time flat.
+        from packaging.specifiers import InvalidSpecifier, SpecifierSet
+        from packaging.version import InvalidVersion, Version
+
+        try:
+            specifier = SpecifierSet(python_constraint)
+            version = Version(lines[2])
+        except (InvalidSpecifier, InvalidVersion):
+            return None
+        if version not in specifier:
+            return None
+    return interpreter
 
 
 def _apply_venv_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
     dest_path = str(op["dest_path"])
     dest = _resolve_safe_dest(workspace_root, dest_path)
+    # No default: the pinned v1 schema requires `python` explicitly
+    # (round 3 -- do not preserve defaulting/coercion behavior).
+    python_constraint = str(op["python"])
     if dest.exists():
-        interpreter = _real_venv_interpreter(dest)
+        interpreter = _probe_venv_interpreter(dest, python_constraint=python_constraint)
         if interpreter is None:
             raise MaterializationPlanError(
-                f"venv dest {dest} exists but is not a real venv "
-                "(no pyvenv.cfg, or no executable interpreter under bin/)"
+                f"venv dest {dest} exists but fails the isolated venv probe "
+                "(pyvenv.cfg not a regular file, no executable interpreter, probe's "
+                "sys.prefix/sys.base_prefix report does not match the declared venv, or the "
+                f"interpreter does not satisfy the declared constraint {python_constraint!r} -- "
+                "config#492 §6.2.1 #6; file presence alone is not venv evidence)"
             )
         return {
             "kind": "venv",
@@ -916,7 +1114,6 @@ def _apply_venv_operation(workspace_root: Path, op: dict[str, object]) -> dict[s
             "interpreter_path": str(interpreter.relative_to(dest)),
         }
 
-    python_constraint = str(op.get("python", ">=3.11"))
     staging = dest.parent / f".{dest.name}.staging-{os.getpid()}-{id(dest)}"
     if staging.exists():
         shutil.rmtree(staging, ignore_errors=True)
@@ -927,18 +1124,27 @@ def _apply_venv_operation(workspace_root: Path, op: dict[str, object]) -> dict[s
         text=True,
         check=False,
     )
-    interpreter = _real_venv_interpreter(staging)
-    if proc.returncode != 0 or interpreter is None:
+    if proc.returncode != 0:
         shutil.rmtree(staging, ignore_errors=True)
         raise MaterializationPlanError(f"uv venv failed for {dest}:\n{proc.stderr or proc.stdout}")
-    interpreter_relative = interpreter.relative_to(staging)
+    # Rename BEFORE probing: sys.prefix is derived at runtime from where
+    # the interpreter binary currently resides, so the probe must run at
+    # the final path -- probing at the staging path would report the
+    # staging prefix and never match the declared dest. Probe failure
+    # after rename rolls the fresh creation back entirely.
     staging.rename(dest)
+    interpreter = _probe_venv_interpreter(dest, python_constraint=python_constraint)
+    if interpreter is None:
+        shutil.rmtree(dest, ignore_errors=True)
+        raise MaterializationPlanError(
+            f"freshly created venv at {dest} fails the isolated venv probe (config#492 §6.2.1 #6)"
+        )
     # config#491 §12.1 evidence: venv interpreter.
     return {
         "kind": "venv",
         "dest_path": dest_path,
         "created": True,
-        "interpreter_path": str(interpreter_relative),
+        "interpreter_path": str(interpreter.relative_to(dest)),
     }
 
 
@@ -957,7 +1163,8 @@ def _find_direct_url_evidence(venv_path: Path) -> tuple[str, str] | None:
 def _apply_editable_install_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
     venv_path = _resolve_safe_dest(workspace_root, str(op["venv_path"]))
     source_path = _resolve_safe_dest(workspace_root, str(op["source_path"]))
-    extras = [str(e) for e in op.get("extras", [])]
+    # No default: the pinned v1 schema requires `extras` explicitly.
+    extras = [str(e) for e in op["extras"]]
     venv_python = venv_path / "bin" / "python"
 
     target = f"{source_path}[{','.join(extras)}]" if extras else str(source_path)
@@ -1000,8 +1207,36 @@ def _apply_project_file_operation(workspace_root: Path, op: dict[str, object]) -
     dest = _resolve_safe_dest(workspace_root, dest_path)
     expected_sha256 = str(op["source_sha256"])
 
+    # config#492 §6.2.1 #8: idempotent rerun. After a successful prior
+    # apply, the staged source is legitimately gone (cleaned up post-
+    # receipt) while dest carries the verified bytes -- that operation is
+    # complete, not an error. And if cleanup was interrupted AFTER receipt
+    # publication (dest correct, source still present), the rerun performs
+    # the idempotent cleanup rather than re-copying.
+    if dest.exists():
+        dest_sha256 = hashlib.sha256(dest.read_bytes()).hexdigest()
+        if dest_sha256 == expected_sha256:
+            result: dict[str, object] = {
+                "kind": "project_file",
+                "source_path": str(op["source_path"]),
+                "dest_path": dest_path,
+                "source_sha256": expected_sha256,
+                "already_projected": True,
+            }
+            if source_path.exists():
+                result["_pending_unlink"] = str(source_path)
+            return result
+
     if not source_path.exists():
         raise MaterializationPlanError(f"project_file source does not exist: {source_path}")
+    # config#492 §6.2.1 #7: a regular, non-symlink file. The symlink-free
+    # prefix (including the final component) is already enforced by
+    # _canonicalize_workspace_path's per-component walk; this rejects the
+    # remaining non-regular shapes (fifo, directory, device).
+    if not stat.S_ISREG(os.lstat(source_path).st_mode):
+        raise MaterializationPlanError(
+            f"project_file source is not a regular file: {source_path} (config#492 §6.2.1 #7)"
+        )
     content = source_path.read_bytes()
     actual_sha256 = hashlib.sha256(content).hexdigest()
     if actual_sha256 != expected_sha256:
@@ -1014,19 +1249,19 @@ def _apply_project_file_operation(workspace_root: Path, op: dict[str, object]) -
     dest.write_bytes(content)
     dest.chmod(0o600)
 
-    # config#491 §6.2: "the staging artifact is removed only after the
-    # hash-verified projection has durable acknowledgement." Round 2
-    # (Sentinel): unlinking here, immediately, meant a receipt-write
-    # failure right after this operation left the source gone with no
-    # receipt proving the projection ever happened -- deleting evidence
-    # before the transaction durably committed. _pending_unlink is an
-    # internal-only key (stripped before the result becomes receipt
+    # config#492 §6.2.1 #8: "the staging artifact is removed only after
+    # the final materialization receipt containing that operation's
+    # evidence has been atomically published and made durable." A
+    # successful destination write is NOT acknowledgement. _pending_unlink
+    # is an internal-only key (stripped before the result becomes receipt
     # content): apply_materialization_plan performs the actual unlink only
-    # after _write_materialization_receipt succeeds.
+    # after the durable (fsync'd, atomically replaced) receipt exists.
     return {
         "kind": "project_file",
+        "source_path": str(op["source_path"]),
         "dest_path": dest_path,
         "source_sha256": expected_sha256,
+        "already_projected": False,
         "_pending_unlink": str(source_path),
     }
 
@@ -1090,6 +1325,7 @@ def _validate_operation_schema(
 
     if kind == "clone":
         _require_str(op, "repo_url", prefix)
+        _require_str(op, "branch", prefix)
         dest_path = _require_str(op, "dest_path", prefix)
         canonical_dest = _resolve_safe_dest(workspace_root, dest_path)
         reference_base = op.get("reference_base")
@@ -1097,28 +1333,24 @@ def _validate_operation_schema(
             if not isinstance(reference_base, str) or not reference_base:
                 raise MaterializationPlanError(f"{prefix}: reference_base must be a non-empty string")
             _validate_reference_base(workspace_root, reference_base, repo_url=str(op["repo_url"]))
-        branch = op.get("branch")
-        if branch is not None and (not isinstance(branch, str) or not branch):
-            raise MaterializationPlanError(f"{prefix}: branch must be a non-empty string")
         return canonical_dest
     elif kind == "venv":
         dest_path = _require_str(op, "dest_path", prefix)
         canonical_dest = _resolve_safe_dest(workspace_root, dest_path)
-        engine = op.get("engine", "uv")
-        if engine != "uv":
-            raise MaterializationPlanError(f"{prefix}: engine must be 'uv', got {engine!r}")
-        python_constraint = op.get("python")
-        if python_constraint is not None and not isinstance(python_constraint, str):
-            raise MaterializationPlanError(f"{prefix}: python must be a string")
+        # No defaults anywhere (round 3): the pinned v1 schema requires
+        # engine and python explicitly; this hand layer mirrors it.
+        if op.get("engine") != "uv":
+            raise MaterializationPlanError(f"{prefix}: engine must be 'uv', got {op.get('engine')!r}")
+        _require_str(op, "python", prefix)
         return canonical_dest
     elif kind == "editable_install":
         venv_path = _require_str(op, "venv_path", prefix)
         source_path = _require_str(op, "source_path", prefix)
         _resolve_safe_dest(workspace_root, venv_path)
         _resolve_safe_dest(workspace_root, source_path)
-        extras = op.get("extras", [])
+        extras = op.get("extras")
         if not isinstance(extras, list) or not all(isinstance(e, str) for e in extras):
-            raise MaterializationPlanError(f"{prefix}: extras must be a list of strings")
+            raise MaterializationPlanError(f"{prefix}: extras must be a list of strings (required)")
         return None
     elif kind == "project_file":
         source_path = _require_str(op, "source_path", prefix)
@@ -1126,23 +1358,35 @@ def _validate_operation_schema(
         _require_str(op, "source_sha256", prefix)
         _resolve_staging_source(workspace_root, source_path)
         canonical_dest = _resolve_safe_dest(workspace_root, dest_path)
-        mode = op.get("mode", "copy")
-        if mode != "copy":
-            raise MaterializationPlanError(f"{prefix}: mode must be 'copy' for v1, got {mode!r}")
+        if op.get("mode") != "copy":
+            raise MaterializationPlanError(f"{prefix}: mode must be 'copy' for v1, got {op.get('mode')!r}")
         return canonical_dest
     return None
 
 
 def _validate_plan_shape(plan: dict[str, object], *, workspace_root: Path) -> None:
     """Round 2 (Atlas/Sentinel P5): validate the COMPLETE plan before the
-    first filesystem mutation -- not one operation validated immediately
-    before its own execution, which lets earlier operations mutate state
-    before a later operation's invalid shape is ever discovered."""
+    first filesystem mutation. Round 3: validation against the PINNED v1
+    JSON Schema comes first -- the hand-rolled layer below it is defense
+    in depth, not the contract. A hand validator is a separate, looser
+    contract by construction: nine schema-invalid plans passed it, and
+    schema_version=True passed its `!= 1` check because bool is an int
+    subclass in Python (True == 1) while JSON Schema's `const: 1`
+    correctly distinguishes the types."""
+    validator = _load_plan_validator()
+    schema_errors = sorted(validator.iter_errors(plan), key=lambda e: list(e.absolute_path))
+    if schema_errors:
+        first = schema_errors[0]
+        location = "/".join(str(p) for p in first.absolute_path) or "<root>"
+        raise MaterializationPlanError(
+            f"plan rejected by pinned MaterializationPlan v1 schema at {location}: {first.message}"
+        )
+
     unknown_top_level = plan.keys() - _PLAN_ALLOWED_TOP_LEVEL_FIELDS
     if unknown_top_level:
         raise MaterializationPlanError(f"plan: unknown top-level field(s) {sorted(unknown_top_level)}")
 
-    if plan.get("schema_version") != 1:
+    if isinstance(plan.get("schema_version"), bool) or plan.get("schema_version") != 1:
         raise MaterializationPlanError(f"plan.schema_version must be exactly 1, got {plan.get('schema_version')!r}")
 
     _validate_path_safe_token(plan.get("plan_id"), field_name="plan_id")
@@ -1151,9 +1395,24 @@ def _validate_plan_shape(plan: dict[str, object], *, workspace_root: Path) -> No
     # it as a path-safe opaque token without interpreting identity.
     _validate_path_safe_token(plan.get("unit_key"), field_name="unit_key")
 
-    workspace_spec_sha256 = plan.get("workspace_spec_sha256")
-    if not isinstance(workspace_spec_sha256, str) or not workspace_spec_sha256:
-        raise MaterializationPlanError("plan.workspace_spec_sha256 is required and must be a non-empty string")
+    # config#492 §6.2.1 invariant #1: reopen the canonical WorkspaceSpec
+    # bytes and verify their SHA-256 equals workspace_spec_sha256. Round 3
+    # (Atlas/Sentinel): the field was carried but never verified, and the
+    # executor applied with no canonical WorkspaceSpec file at all.
+    workspace_spec_sha256 = str(plan["workspace_spec_sha256"])
+    spec_file = workspace_spec_path(workspace_root)
+    if not spec_file.exists():
+        raise MaterializationPlanError(
+            "canonical WorkspaceSpec (.grip/workspace_spec.toml) not found -- "
+            "workspace_spec_sha256 cannot be verified (config#492 §6.2.1 #1)"
+        )
+    actual_spec_sha256 = hashlib.sha256(spec_file.read_bytes()).hexdigest()
+    if actual_spec_sha256 != workspace_spec_sha256:
+        raise MaterializationPlanError(
+            f"workspace_spec_sha256 mismatch: plan declares {workspace_spec_sha256}, "
+            f"canonical WorkspaceSpec bytes hash to {actual_spec_sha256} -- the plan was "
+            "compiled against a different workspace state (config#492 §6.2.1 #1)"
+        )
 
     operations = plan.get("operations")
     if not isinstance(operations, list) or not operations:
@@ -1184,35 +1443,55 @@ def _materialization_receipt_path(workspace_root: Path, plan_id: str) -> Path:
     return workspace_root / ".grip" / "state" / "materialization" / f"{plan_id}.json"
 
 
+def compute_plan_hash(plan: dict[str, object]) -> str:
+    """config#492 §6.2.1 #9, the exact pinned canonical serialization:
+    UTF-8 JSON, keys sorted, no insignificant whitespace, non-ASCII
+    unescaped. Round 3 (Atlas/Sentinel): default json.dumps separators
+    (", ", ": ") and ensure_ascii=True produce different bytes and
+    therefore a different, non-conformant hash. Public so tests recompute
+    it independently rather than trusting the receipt's own value."""
+    return hashlib.sha256(
+        json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+
+
 def _write_materialization_receipt(
     workspace_root: Path,
     plan: dict[str, object],
     op_results: list[dict[str, object]],
 ) -> Path:
-    """config#491 §12.1: neutral receipts carry the plan hash, opaque unit
-    key, and per-operation structural evidence -- no identity, org, channel,
-    secret, or memory content. Written atomically (temp file + rename), not
-    directly, matching the same publish-don't-partially-write discipline as
-    _clone_isolated's staging rename. Round 2 (Sentinel): a test asserting
-    only "no temp file left behind" doesn't distinguish this from a direct
-    write, since a direct write also trivially leaves no temp file --
-    proven instead by a test that fails the rename itself and confirms no
-    final receipt file exists."""
-    plan_hash = hashlib.sha256(json.dumps(plan, sort_keys=True).encode()).hexdigest()
+    """config#492 §6.2.1 #10: publish through a same-directory temporary
+    file, file flush and fsync, atomic replace, then parent-directory
+    fsync. Round 3 (Sentinel): write_text + rename with ZERO fsync calls
+    is not durable acknowledgement -- on power loss the rename can survive
+    while the data doesn't, yielding a receipt that "exists" with empty or
+    partial content, after the staged inputs it acknowledges were already
+    deleted. Every step here is load-bearing, in this order."""
     receipt = {
         "plan_id": plan["plan_id"],
         "unit_key": plan["unit_key"],
-        "plan_hash": plan_hash,
+        "plan_hash": compute_plan_hash(plan),
         "schema_version": plan["schema_version"],
         "workspace_spec_sha256": plan["workspace_spec_sha256"],
+        # config#491 §10 / §12.1 structural stage: MATERIALIZED is the
+        # terminal state OSS gr2 can honestly claim on its own.
+        "stage": "MATERIALIZED",
         "applied_at": datetime.now(UTC).isoformat(),
         "operations": op_results,
     }
     receipt_path = _materialization_receipt_path(workspace_root, str(plan["plan_id"]))
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = receipt_path.with_name(receipt_path.name + f".tmp-{os.getpid()}")
-    tmp_path.write_text(json.dumps(receipt, indent=2) + "\n")
-    tmp_path.rename(receipt_path)
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(receipt, indent=2) + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, receipt_path)
+    dir_fd = os.open(receipt_path.parent, os.O_RDONLY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
     return receipt_path
 
 

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -646,7 +646,13 @@ def _apply_editable_install_operation(workspace_root: Path, op: dict[str, object
 
 
 def _apply_project_file_operation(workspace_root: Path, op: dict[str, object]) -> dict[str, object]:
-    source_path = Path(str(op["source_path"]))
+    # source_path is workspace-relative, same as dest_path (config#491 §6.2's
+    # own example: ".grip/staging/inputs/f_01") -- resolved through the same
+    # containment guard as dest, not read+deleted as an arbitrary caller-
+    # supplied filesystem path. Stromus's r1 catch on #797: reading and then
+    # unlink()-ing an unvalidated path is a real arbitrary-file-delete gap,
+    # not just a style nit.
+    source_path = _resolve_safe_dest(workspace_root, str(op["source_path"]))
     dest_path = str(op["dest_path"])
     dest = _resolve_safe_dest(workspace_root, dest_path)
     expected_sha256 = str(op["source_sha256"])

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -248,19 +248,27 @@ def build_plan(workspace_root: Path) -> tuple[dict[str, object], list[PlanOperat
                 )
             )
 
-        if unit_root.exists() and unit_toml.exists():
-            declared_repos = [str(r) for r in unit.get("repos", [])]
-            missing_repos = [r for r in declared_repos if not (unit_root / r).exists()]
-            if missing_repos:
-                operations.append(
-                    PlanOperation(
-                        kind="converge_unit_repos",
-                        subject=unit_name,
-                        target_path=str(unit_root),
-                        reason=f"missing repo checkouts: {', '.join(missing_repos)}",
-                        details={"missing_repos": missing_repos, "all_repos": declared_repos},
-                    )
+        # grip#539: computed unconditionally, not gated on unit_root/unit_toml
+        # already existing. A brand-new unit's declared repos are trivially
+        # "missing" too (unit_root doesn't exist yet, so (unit_root / r).exists()
+        # is False for every r) -- the old guard meant a first apply published
+        # the unit shell without scheduling its clones, requiring a second,
+        # separate apply to notice. Ordered after create_unit_root/
+        # write_unit_metadata in this loop, so apply_plan's execution (which
+        # processes operations in list order) creates the directory before
+        # trying to clone into it.
+        declared_repos = [str(r) for r in unit.get("repos", [])]
+        missing_repos = [r for r in declared_repos if not (unit_root / r).exists()]
+        if missing_repos:
+            operations.append(
+                PlanOperation(
+                    kind="converge_unit_repos",
+                    subject=unit_name,
+                    target_path=str(unit_root),
+                    reason=f"missing repo checkouts: {', '.join(missing_repos)}",
+                    details={"missing_repos": missing_repos, "all_repos": declared_repos},
                 )
+            )
 
     return spec, operations
 

--- a/gr2/tests/test_apply_convergence.py
+++ b/gr2/tests/test_apply_convergence.py
@@ -158,8 +158,10 @@ class TestBuildPlanConvergence(ConvergenceTestBase):
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)
     @patch("gr2.python_cli.spec_apply.is_git_repo", return_value=True)
-    def test_new_unit_still_uses_create_and_write(self, _repo, _dir, _hooks):
-        """Brand-new unit (no dir, no toml) uses create_unit_root + write_unit_metadata, not converge."""
+    def test_new_unit_also_converges_repos_in_first_pass(self, _repo, _dir, _hooks):
+        """grip#539: a brand-new unit (no dir, no toml) must schedule its repo
+        checkouts in the SAME planning pass as create_unit_root/write_unit_metadata,
+        not require a second apply to notice they're missing."""
         for repo in self.repo_specs:
             self._create_workspace_repo(repo)
             self._create_repo_cache(repo["name"])
@@ -169,7 +171,10 @@ class TestBuildPlanConvergence(ConvergenceTestBase):
         kinds = [op.kind for op in operations]
         self.assertIn("create_unit_root", kinds)
         self.assertIn("write_unit_metadata", kinds)
-        self.assertNotIn("converge_unit_repos", kinds)
+        self.assertIn("converge_unit_repos", kinds)
+        converge_ops = [op for op in operations if op.kind == "converge_unit_repos"]
+        self.assertEqual(len(converge_ops), 1)
+        self.assertEqual(set(converge_ops[0].details["missing_repos"]), {"repo-a", "repo-b"})
 
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)

--- a/gr2/tests/test_apply_convergence.py
+++ b/gr2/tests/test_apply_convergence.py
@@ -26,6 +26,21 @@ from gr2.python_cli.spec_apply import (
 )
 
 
+def _fake_clone_repo(url, target_repo_root, *, reference_repo_root=None):
+    """Stand-in for gitops.clone_repo that actually creates a directory.
+
+    _clone_isolated clones into a sibling staging path and then
+    staging.rename(dest)'s it into place -- a bare `return_value=True` mock
+    leaves nothing on disk for that rename to find. This creates just
+    enough (a directory + a .git marker) for the atomic-publish step to
+    succeed; _validate_clone_isolation is mocked separately in these tests
+    since real git-state validation is covered by test_materialization_plan.py.
+    """
+    target_repo_root.mkdir(parents=True, exist_ok=True)
+    (target_repo_root / ".git").mkdir(exist_ok=True)
+    return True
+
+
 class ConvergenceTestBase(unittest.TestCase):
     """Base class that creates a minimal workspace with unit metadata."""
 
@@ -197,14 +212,22 @@ class TestBuildPlanConvergence(ConvergenceTestBase):
 class TestApplyConvergence(ConvergenceTestBase):
     """Tests that apply_plan handles converge_unit_repos correctly."""
 
+    @patch("gr2.python_cli.spec_apply._validate_clone_isolation")
     @patch("gr2.python_cli.spec_apply.run_lifecycle_stage")
     @patch("gr2.python_cli.spec_apply.apply_file_projections", return_value=[])
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)
     @patch("gr2.python_cli.spec_apply.is_git_repo", return_value=True)
-    @patch("gr2.python_cli.spec_apply.clone_repo", return_value=True)
-    def test_apply_clones_missing_repos_into_unit(self, mock_clone, _repo, _dir, _hooks, _proj, _lc):
-        """Apply should clone missing repos into the unit directory."""
+    @patch("gr2.python_cli.spec_apply.clone_repo", side_effect=_fake_clone_repo)
+    def test_apply_clones_missing_repos_into_unit(self, mock_clone, _repo, _dir, _hooks, _proj, _lc, _isolation):
+        """Apply should clone missing repos into the unit directory.
+
+        _validate_clone_isolation is mocked here (not just clone_repo):
+        this test's job is orchestration (does apply_plan call clone for the
+        right repos at the right paths), not real git state -- that's
+        covered by test_materialization_plan.py's dedicated validation
+        tests, which use real git repos throughout, not mocks.
+        """
         for repo in self.repo_specs:
             self._create_workspace_repo(repo)
             self._create_repo_cache(repo["name"])
@@ -213,22 +236,28 @@ class TestApplyConvergence(ConvergenceTestBase):
         result = apply_plan(self.workspace, yes=True)
 
         self.assertGreater(result["operation_count"], 0)
-        clone_calls = mock_clone.call_args_list
+        # _clone_isolated clones into a sibling staging path and atomically
+        # renames it into place (config#491 §8.3) -- clone_repo's own call
+        # args now legitimately show that staging path, not the final
+        # destination, so this checks the real observable outcome instead
+        # of an internal-implementation-detail mock argument.
         unit_root = self.workspace / "agents" / "test-unit"
-        expected_targets = {unit_root / "repo-a", unit_root / "repo-b"}
-        actual_targets = set()
-        for c in clone_calls:
-            args, kwargs = c
-            actual_targets.add(args[1])
-        self.assertTrue(expected_targets.issubset(actual_targets))
+        self.assertTrue((unit_root / "repo-a" / ".git").exists())
+        self.assertTrue((unit_root / "repo-b" / ".git").exists())
+        cloned_names = set()
+        for args, _kwargs in mock_clone.call_args_list:
+            basename = Path(args[1]).name
+            cloned_names.add(basename.split(".staging-")[0].lstrip("."))
+        self.assertEqual(cloned_names, {"repo-a", "repo-b"})
 
+    @patch("gr2.python_cli.spec_apply._validate_clone_isolation")
     @patch("gr2.python_cli.spec_apply.run_lifecycle_stage")
     @patch("gr2.python_cli.spec_apply.apply_file_projections", return_value=[])
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)
     @patch("gr2.python_cli.spec_apply.is_git_repo", return_value=True)
-    @patch("gr2.python_cli.spec_apply.clone_repo", return_value=True)
-    def test_apply_updates_stale_unit_toml(self, _clone, _repo, _dir, _hooks, _proj, _lc):
+    @patch("gr2.python_cli.spec_apply.clone_repo", side_effect=_fake_clone_repo)
+    def test_apply_updates_stale_unit_toml(self, _clone, _repo, _dir, _hooks, _proj, _lc, _isolation):
         """After convergence, unit.toml should reflect the full spec repo list."""
         for repo in self.repo_specs:
             self._create_workspace_repo(repo)
@@ -248,7 +277,7 @@ class TestApplyConvergence(ConvergenceTestBase):
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)
     @patch("gr2.python_cli.spec_apply.is_git_repo", return_value=True)
-    @patch("gr2.python_cli.spec_apply.clone_repo", return_value=True)
+    @patch("gr2.python_cli.spec_apply.clone_repo", side_effect=_fake_clone_repo)
     def test_convergence_is_idempotent(self, mock_clone, _repo, _dir, _hooks, _proj, _lc):
         """After apply, a second build_plan should show no converge operations."""
         self._fully_materialize()
@@ -258,13 +287,14 @@ class TestApplyConvergence(ConvergenceTestBase):
         self.assertEqual(len(operations), 0)
         mock_clone.assert_not_called()
 
+    @patch("gr2.python_cli.spec_apply._validate_clone_isolation")
     @patch("gr2.python_cli.spec_apply.run_lifecycle_stage")
     @patch("gr2.python_cli.spec_apply.apply_file_projections", return_value=[])
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)
     @patch("gr2.python_cli.spec_apply.is_git_repo", return_value=True)
-    @patch("gr2.python_cli.spec_apply.clone_repo", return_value=True)
-    def test_apply_reports_converged_repos(self, _clone, _repo, _dir, _hooks, _proj, _lc):
+    @patch("gr2.python_cli.spec_apply.clone_repo", side_effect=_fake_clone_repo)
+    def test_apply_reports_converged_repos(self, _clone, _repo, _dir, _hooks, _proj, _lc, _isolation):
         """Apply result should list what was converged."""
         for repo in self.repo_specs:
             self._create_workspace_repo(repo)

--- a/gr2/tests/test_apply_convergence.py
+++ b/gr2/tests/test_apply_convergence.py
@@ -35,9 +35,21 @@ def _fake_clone_repo(url, target_repo_root, *, reference_repo_root=None):
     enough (a directory + a .git marker) for the atomic-publish step to
     succeed; _validate_clone_isolation is mocked separately in these tests
     since real git-state validation is covered by test_materialization_plan.py.
+
+    Round 3: when a reference is supplied it also writes the alternates
+    file, because real `git clone --reference-if-able` does -- verified
+    empirically with a local bare cache, not assumed. Without this the
+    mock silently misrepresents the one thing the new declared-object-
+    sharing check inspects, which is exactly the class of unfaithful
+    fixture this whole review cycle has been about.
     """
     target_repo_root.mkdir(parents=True, exist_ok=True)
-    (target_repo_root / ".git").mkdir(exist_ok=True)
+    git_dir = target_repo_root / ".git"
+    git_dir.mkdir(exist_ok=True)
+    if reference_repo_root is not None:
+        info_dir = git_dir / "objects" / "info"
+        info_dir.mkdir(parents=True, exist_ok=True)
+        (info_dir / "alternates").write_text(f"{reference_repo_root}/objects\n")
     return True
 
 
@@ -108,9 +120,29 @@ class ConvergenceTestBase(unittest.TestCase):
         (path / ".git").mkdir()
 
     def _create_repo_cache(self, repo_name):
-        """Create a fake bare repo cache directory."""
+        """Create a REAL bare repo cache with the declared canonical origin.
+
+        Round 3 (config#492 §6.2.1 #5): cache provenance is fail-closed --
+        a bare directory that merely sits at the canonical cache path is
+        rejected, because a non-Git directory there was previously accepted,
+        silently skipped by `--reference-if-able`, and then receipted as an
+        approved alternate. Setting a remote does not require the URL to be
+        reachable, so these fixtures stay offline while being
+        production-shaped."""
+        import subprocess
+
         cache = repo_cache_path(self.workspace, repo_name)
-        cache.mkdir(parents=True, exist_ok=True)
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        repo_url = next(r["url"] for r in self.repo_specs if r["name"] == repo_name)
+        subprocess.run(
+            ["git", "init", "--bare", str(cache)], capture_output=True, text=True, check=True
+        )
+        subprocess.run(
+            ["git", "--git-dir", str(cache), "remote", "add", "origin", repo_url],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
 
     def _fully_materialize(self):
         """Set up workspace as if initial apply completed: repos, caches, unit with checkouts."""

--- a/gr2/tests/test_apply_convergence.py
+++ b/gr2/tests/test_apply_convergence.py
@@ -160,15 +160,22 @@ class TestBuildPlanConvergence(ConvergenceTestBase):
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)
     @patch("gr2.python_cli.spec_apply.is_git_repo", return_value=True)
-    def test_no_op_when_fully_materialized(self, _repo, _dir, _hooks):
-        """All repos present inside unit -> no converge operation."""
+    def test_fully_materialized_still_schedules_validation_but_nothing_missing(self, _repo, _dir, _hooks):
+        """Round 2 (Atlas/Sentinel P1): converge_unit_repos is now scheduled
+        whenever a unit has ANY declared repos, not only when build_plan's
+        cheap existence check finds something missing -- that's what makes
+        apply-time's real _clone_isolated validation (origin/isolation)
+        actually run on every pass, not just the first one. All repos
+        present still schedules the op (for validation), but its own
+        details correctly report nothing missing."""
         self._fully_materialize()
 
         _, operations = build_plan(self.workspace)
 
         converge_ops = [op for op in operations if op.kind == "converge_unit_repos"]
-        self.assertEqual(len(converge_ops), 0)
-        self.assertEqual(len(operations), 0)
+        self.assertEqual(len(converge_ops), 1)
+        self.assertEqual(converge_ops[0].details["missing_repos"], [])
+        self.assertEqual(len(operations), 1)
 
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)
@@ -279,12 +286,18 @@ class TestApplyConvergence(ConvergenceTestBase):
     @patch("gr2.python_cli.spec_apply.is_git_repo", return_value=True)
     @patch("gr2.python_cli.spec_apply.clone_repo", side_effect=_fake_clone_repo)
     def test_convergence_is_idempotent(self, mock_clone, _repo, _dir, _hooks, _proj, _lc):
-        """After apply, a second build_plan should show no converge operations."""
+        """After apply, a second build_plan schedules validation (round 2:
+        always scheduled when a unit has declared repos -- see
+        test_fully_materialized_still_schedules_validation_but_nothing_missing)
+        but performs no NEW clone work: idempotence means zero mutation on
+        a rerun, not zero operations scheduled."""
         self._fully_materialize()
 
         _, operations = build_plan(self.workspace)
 
-        self.assertEqual(len(operations), 0)
+        self.assertEqual(len(operations), 1)
+        self.assertEqual(operations[0].kind, "converge_unit_repos")
+        self.assertEqual(operations[0].details["missing_repos"], [])
         mock_clone.assert_not_called()
 
     @patch("gr2.python_cli.spec_apply._validate_clone_isolation")

--- a/gr2/tests/test_ci_gate_smoke.py
+++ b/gr2/tests/test_ci_gate_smoke.py
@@ -1,8 +1,0 @@
-"""Temporary proof-of-gate smoke test -- deliberately fails, will be reverted
-in the very next commit. Exists only to confirm the gr2_python CI job (and
-its wiring into the `ci` aggregate) actually catches a real test failure,
-not just that the job runs and exits 0 regardless of content."""
-
-
-def test_ci_gate_deliberately_fails() -> None:
-    assert False, "PROOF-OF-GATE: this is intentional, see grip PR#795"

--- a/gr2/tests/test_ci_gate_smoke.py
+++ b/gr2/tests/test_ci_gate_smoke.py
@@ -1,0 +1,8 @@
+"""Temporary proof-of-gate smoke test -- deliberately fails, will be reverted
+in the very next commit. Exists only to confirm the gr2_python CI job (and
+its wiring into the `ci` aggregate) actually catches a real test failure,
+not just that the job runs and exits 0 regardless of content."""
+
+
+def test_ci_gate_deliberately_fails() -> None:
+    assert False, "PROOF-OF-GATE: this is intentional, see grip PR#795"

--- a/gr2/tests/test_gr2_packaging.py
+++ b/gr2/tests/test_gr2_packaging.py
@@ -59,6 +59,22 @@ def test_gr2_overlay_still_imports_unprefixed(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_gr2_overlay_alias_resolves(tmp_path: Path) -> None:
+    """gr2.overlay (config#491 gap#13) must resolve, and to the same physical
+    file as gr2_overlay -- it's a compat alias, not a fork."""
+    result = _run(
+        [
+            sys.executable,
+            "-c",
+            "import gr2.overlay, gr2_overlay; "
+            "assert gr2.overlay.__file__ == gr2_overlay.__file__, "
+            "(gr2.overlay.__file__, gr2_overlay.__file__)",
+        ],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_gr2_console_script_resolves(tmp_path: Path) -> None:
     """console_scripts entry point `gr2` must be on PATH and runnable after install."""
     result = _run(["gr2", "--help"], cwd=tmp_path)

--- a/gr2/tests/test_gr2_packaging.py
+++ b/gr2/tests/test_gr2_packaging.py
@@ -1,14 +1,18 @@
 """Packaging tests: gr2 must be a real installable CLI, not a pytest-only import.
 
-Today, gr2.python_cli and gr2.prototypes only resolve inside pytest, via the
-root conftest.py's sys.modules injection (`gr2/conftest.py`). gr2/pyproject.toml
-packages only gr2_overlay. There is no console_scripts entry point.
+gr2.python_cli and gr2.prototypes are real, independently installable packages
+(grip#788 fixed the self-referential package-dir that used to drop them from
+a fresh install). The root conftest.py's sys.modules injection (`gr2/conftest.py`)
+is still present as a separate, intentional local-dev convenience -- it lets
+`pytest` run in a plain checkout without an editable install first -- but it is
+no longer load-bearing for these tests specifically.
 
 These tests deliberately run each check in a fresh subprocess with cwd pinned to
 a neutral tmp_path (never gr2/ or its parent), so a pass can only mean the
 package is genuinely installed and importable -- not that Python happened to
 find these modules via a cwd-relative accident or pytest's own sys.modules hack,
-which subprocesses don't inherit anyway.
+which subprocesses don't inherit anyway. That property is what makes them the
+regression guard for grip#788's class of bug.
 
 grip#752 slice 1 (D3): pyproject at grip/gr2/... console_scripts entry point.
 Reference path correction: the repo directory is gitgrip/gr2/, not

--- a/gr2/tests/test_grip_object_model.py
+++ b/gr2/tests/test_grip_object_model.py
@@ -96,12 +96,13 @@ def _write_workspace_spec(workspace_root: Path, repos: list[tuple[str, str]]) ->
                 """
             ).strip()
         )
+    joined_repo_blocks = "\n\n".join(repo_blocks)
     spec_path.write_text(
         textwrap.dedent(
             f"""
             workspace_name = "{workspace_root.name}"
 
-            {"\n\n".join(repo_blocks)}
+            {joined_repo_blocks}
             """
         ).strip()
         + "\n"

--- a/gr2/tests/test_materialization_plan.py
+++ b/gr2/tests/test_materialization_plan.py
@@ -20,6 +20,7 @@ import json
 import subprocess
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from gr2.python_cli.spec_apply import (
     MaterializationPlanError,
@@ -51,6 +52,7 @@ class MaterializationPlanTestBase(unittest.TestCase):
             "schema_version": 1,
             "plan_id": "mp_test",
             "unit_key": "u_test",
+            "workspace_spec_sha256": "a" * 64,
             "operations": operations,
         }
         plan.update(overrides)
@@ -108,14 +110,26 @@ class TestPathSafety(MaterializationPlanTestBase):
         """Sentinel r2 P3.1: reference_base was accepted as an absolute
         external path and passed straight to --reference-if-able, becoming
         its own 'approved' alternate. Must be containment-checked the same
-        as dest_path."""
+        as dest_path.
+
+        Round 2 catch (Sentinel, on my OWN test): this used repo_url =
+        "https://example.com/x.git" -- a fake URL. Removing the
+        reference_base containment check entirely still left this test
+        GREEN, because the clone then failed later for an unrelated reason
+        (DNS/network) and got converted to the same MaterializationPlanError
+        the test asserts on. A real, working URL is required so the test's
+        outcome is genuinely tied to the containment check, not a downstream
+        failure that happens to raise the same exception type -- the exact
+        class of mistake I'd already caught myself making once this session
+        (the dotdot source_path test) and repeated here without noticing."""
+        url = self._init_bare_remote("product")
         outside_cache = self.tmp / "outside.git"
         outside_cache.mkdir()
         plan = self._plan(
             [
                 {
                     "kind": "clone",
-                    "repo_url": "https://example.com/x.git",
+                    "repo_url": url,
                     "dest_path": "units/u1/product",
                     "reference_base": str(outside_cache),
                 }
@@ -123,6 +137,8 @@ class TestPathSafety(MaterializationPlanTestBase):
         )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
+        # If containment were broken, this would have cloned for real.
+        self.assertFalse((self.workspace_root / "units" / "u1" / "product").exists())
 
     def test_project_file_rejects_absolute_dest_path(self):
         source_rel = self._stage_source("f_01", b"hello")
@@ -215,6 +231,34 @@ class TestPathSafety(MaterializationPlanTestBase):
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
+    def test_project_file_rejects_symlink_escape_inside_staging(self):
+        """Round 2 (Sentinel): a symlink planted INSIDE .grip/staging/inputs/
+        pointing outside the workspace -- a lexical staging-prefix check on
+        the string alone would miss this; must actually resolve the
+        filesystem path (following the symlink) and check containment of
+        where it REALLY points, not just where its name lexically sits."""
+        outside_target = self.tmp / "secret.txt"
+        outside_target.write_bytes(b"secret content")
+        staging_dir = self.workspace_root / ".grip" / "staging" / "inputs"
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        symlink_path = staging_dir / "evil-link"
+        symlink_path.symlink_to(outside_target)
+
+        plan = self._plan(
+            [
+                {
+                    "kind": "project_file",
+                    "source_path": ".grip/staging/inputs/evil-link",
+                    "source_sha256": hashlib.sha256(b"secret content").hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "copy",
+                }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / "units" / "u1" / "home" / "AGENTS.md").exists())
+
 
 class TestIdentityFreedom(MaterializationPlanTestBase):
     def test_rejects_operation_with_top_level_identity_field(self):
@@ -303,6 +347,133 @@ class TestPlanShapeValidation(MaterializationPlanTestBase):
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
+    def test_rejects_unknown_top_level_field(self):
+        plan = self._plan(
+            [{"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"}],
+            org="synapt",
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_rejects_wrong_schema_version(self):
+        plan = self._plan(
+            [{"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"}],
+            schema_version=999,
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_rejects_unknown_operation_field(self):
+        """Round 2 (Atlas/Sentinel): a blacklist only catches enumerated
+        field names -- metadata.display_name="Apollo" was accepted because
+        display_name was never on the forbidden-keys list. An ALLOWLIST
+        rejects any field not explicitly permitted for that operation kind,
+        by construction, regardless of what the field is named."""
+        plan = self._plan(
+            [
+                {
+                    "kind": "venv",
+                    "dest_path": "units/u1/.venv",
+                    "engine": "uv",
+                    "python": ">=3.11",
+                    "metadata": {"display_name": "Apollo"},
+                }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / "units" / "u1" / ".venv").exists())
+
+    def test_rejects_dot_normalized_duplicate_dest_path(self):
+        """Round 2 (Sentinel): raw-string duplicate checking accepted
+        "units/u1/.venv" and "units/u1/./.venv" as different destinations,
+        even though they're the same real path -- op1 created the venv,
+        then op2 failed for an unrelated reason, violating
+        validate-before-touch in practice even though the code claims it.
+        Canonical (resolved) comparison must catch this before either runs."""
+        plan = self._plan(
+            [
+                {"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"},
+                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/./.venv"},
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / "units" / "u1" / ".venv").exists())
+
+    def test_rejects_forged_pyvenv_cfg_without_interpreter(self):
+        """Round 2 (Sentinel): a directory containing only a forged
+        pyvenv.cfg, with no actual interpreter binary, was accepted as a
+        valid existing venv under python=">=99" -- an impossible
+        constraint, which is exactly why this needed a real check rather
+        than trusting the marker file's mere presence."""
+        fake = self.workspace_root / "units" / "u1" / ".venv"
+        fake.mkdir(parents=True)
+        (fake / "pyvenv.cfg").write_text("home = /nonexistent\nversion = 3.99.0\n")
+
+        plan = self._plan([{"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=99"}])
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_clone_evidence_includes_origin_and_cache(self):
+        """config#491 §12.1: clone results must record observed origin and
+        approved-alternate/cache evidence, not just repo_url/dest_path."""
+        url = self._init_bare_remote("product")
+        cache_dir = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        cache_dir.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "clone", "--mirror", url, str(cache_dir))
+        plan = self._plan(
+            [
+                {
+                    "kind": "clone",
+                    "repo_url": url,
+                    "dest_path": "units/u1/product",
+                    "reference_base": ".grip/cache/repos/product.git",
+                }
+            ]
+        )
+        result = apply_materialization_plan(self.workspace_root, plan, yes=True)
+        op_result = result["operations"][0]
+        self.assertEqual(op_result["observed_origin"], url)
+        self.assertTrue(op_result["alternate_approved"])
+        self.assertEqual(op_result["cache_path"], ".grip/cache/repos/product.git")
+
+    def test_venv_evidence_includes_interpreter(self):
+        """config#491 §12.1: venv results must record the interpreter, not
+        just created=True/False."""
+        plan = self._plan(
+            [{"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"}]
+        )
+        result = apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("interpreter_path", result["operations"][0])
+        self.assertTrue(result["operations"][0]["interpreter_path"])
+
+    def test_receipt_publish_atomicity_proven_by_failed_rename(self):
+        """Round 2 (Sentinel): a test asserting only "no temp file left
+        behind" doesn't distinguish atomic-via-rename from a direct write --
+        a direct write also trivially leaves no temp file. This makes the
+        rename step itself fail and confirms no final receipt.json ever
+        appears, proving the publish mechanism is genuinely rename-based."""
+        url = self._init_bare_remote("product")
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            plan_id="mp_atomic_proof",
+        )
+
+        original_rename = Path.rename
+
+        def selective_fail_rename(self_path, target):
+            if "materialization" in str(self_path) and ".tmp-" in str(self_path):
+                raise OSError("simulated rename failure")
+            return original_rename(self_path, target)
+
+        with patch.object(Path, "rename", selective_fail_rename):
+            with self.assertRaises(OSError):
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+        receipt_path = self.workspace_root / ".grip" / "state" / "materialization" / "mp_atomic_proof.json"
+        self.assertFalse(receipt_path.exists())
+
 
 class TestSharedExecutor(MaterializationPlanTestBase):
     """Sentinel r2 P1: sharing only clone_repo() as a leaf primitive does
@@ -360,6 +531,47 @@ class TestSharedExecutor(MaterializationPlanTestBase):
         with self.assertRaises(MaterializationPlanError):
             apply_plan(self.workspace_root, yes=True)
 
+    def test_all_present_unit_repo_with_wrong_origin_still_caught(self):
+        """Round 2 (Atlas/Sentinel), exact reproduction: the original P1
+        fix proved "all declared repos validated" only via a scenario with
+        a second, genuinely-missing repo to trigger scheduling at all --
+        that's a scenario-specific fix, not a clause-complete one. This
+        proves the actual clause: a SINGLE declared repo, fully PRESENT,
+        with the wrong origin, must still be caught. build_plan now
+        schedules converge_unit_repos whenever a unit has ANY declared
+        repos, not only when something is missing."""
+        unit_root = self.workspace_root / "agents" / "atlas" / "home"
+        unit_root.mkdir(parents=True)
+        (unit_root / "unit.toml").write_text('name = "atlas"\nkind = "unit"\nrepos = ["app"]\n')
+
+        present_repo_root = unit_root / "app"
+        actual_origin_url = self._init_bare_remote("actual-app")
+        _git(unit_root, "clone", actual_origin_url, str(present_repo_root))
+        declared_url = self._init_bare_remote("declared-app")
+
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_path.write_text(
+            '\n'.join(
+                [
+                    'workspace_name = "test"',
+                    "",
+                    "[[repos]]",
+                    'name = "app"',
+                    'path = "repos/app"',
+                    f'url = "{declared_url}"',
+                    "",
+                    "[[units]]",
+                    'name = "atlas"',
+                    'path = "agents/atlas/home"',
+                    'repos = ["app"]',
+                    "",
+                ]
+            )
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_plan(self.workspace_root, yes=True)
+
 
 class TestCloneOperation(MaterializationPlanTestBase):
     def test_clones_to_explicit_dest_path(self):
@@ -394,6 +606,72 @@ class TestCloneOperation(MaterializationPlanTestBase):
         dest = self.workspace_root / "units" / "u1" / "product"
         alternates = dest / ".git" / "objects" / "info" / "alternates"
         self.assertTrue(alternates.exists())
+
+    def test_clone_rejects_in_workspace_cache_outside_declared_namespace(self):
+        """Sentinel r2 P3.1: a real, working in-workspace mirror was
+        accepted as reference_base and retained as the clone's alternate,
+        even though config#491 §8.2 confines this to
+        .grip/cache/repos/<declared-repo>.git specifically -- containment
+        alone (is it inside the workspace at all) isn't the actual rule."""
+        url = self._init_bare_remote("product")
+        rogue_cache = self.workspace_root / "units" / "u1" / "rogue-cache.git"
+        rogue_cache.parent.mkdir(parents=True)
+        _git(self.workspace_root, "clone", "--mirror", url, str(rogue_cache))
+
+        plan = self._plan(
+            [
+                {
+                    "kind": "clone",
+                    "repo_url": url,
+                    "dest_path": "units/u1/product",
+                    "reference_base": "units/u1/rogue-cache.git",
+                }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / "units" / "u1" / "product").exists())
+
+    def test_clone_rejects_cache_with_wrong_canonical_origin(self):
+        """Sentinel r2 P3.1: a cache backed by a DIFFERENT remote than the
+        one being cloned must not be usable as reference_base, even if it
+        sits at the canonically-correct namespace path."""
+        url_a = self._init_bare_remote("product-a")
+        url_b = self._init_bare_remote("product-b")
+        cache_dir = self.workspace_root / ".grip" / "cache" / "repos" / "product-a.git"
+        cache_dir.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "clone", "--mirror", url_b, str(cache_dir))
+
+        plan = self._plan(
+            [
+                {
+                    "kind": "clone",
+                    "repo_url": url_a,
+                    "dest_path": "units/u1/product",
+                    "reference_base": ".grip/cache/repos/product-a.git",
+                }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_clone_rejects_when_common_dir_check_cannot_run(self):
+        """Round 2 (Sentinel): fail CLOSED, not open. A .git that exists as
+        a real directory but isn't actually a valid git repository
+        internally makes `git rev-parse --git-common-dir` fail -- the prior
+        version silently skipped the whole check in that case (treated
+        "cannot verify" as "assume it's fine"). Must reject instead."""
+        dest = self.workspace_root / "units" / "u1" / "product"
+        (dest / ".git").mkdir(parents=True)
+        # .git exists as a real directory (passes the worktree-pointer-file
+        # and nested-worktrees checks) but has no actual git internals, so
+        # `git rev-parse --git-common-dir` run inside it fails for real.
+
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
 
     def test_clone_is_idempotent_for_existing_healthy_clone(self):
         url = self._init_bare_remote("product")
@@ -525,6 +803,9 @@ class TestEditableInstallOperation(MaterializationPlanTestBase):
         op_result = result["operations"][0]
         self.assertEqual(op_result["kind"], "editable_install")
         self.assertIsNotNone(op_result["pep610_evidence"])
+        # config#491 §12.1 evidence: editable source path, extras, distribution.
+        self.assertEqual(op_result["extras"], [])
+        self.assertEqual(op_result["distribution"], "product")
         check = subprocess.run(
             [str(venv_path / "bin" / "python"), "-c", "import product"],
             capture_output=True, text=True,
@@ -584,6 +865,43 @@ class TestProjectFileOperation(MaterializationPlanTestBase):
         )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         self.assertFalse((self.workspace_root / source_rel).exists())
+
+    def test_source_survives_receipt_write_failure(self):
+        """Sentinel r2 P4, exact reproduction: faulting the receipt write
+        after a valid project_file operation left source_exists=False,
+        dest_exists=True, receipt_exists=False -- the staged artifact was
+        deleted before durable acknowledgement (the receipt) existed. The
+        source must survive when the receipt write fails."""
+        content = b"important"
+        source_rel = self._stage_source("f_01", content)
+        plan = self._plan(
+            [
+                {
+                    "kind": "project_file",
+                    "source_path": source_rel,
+                    "source_sha256": hashlib.sha256(content).hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "copy",
+                }
+            ],
+            plan_id="mp_receipt_fail_test",
+        )
+
+        with patch(
+            "gr2.python_cli.spec_apply._write_materialization_receipt",
+            side_effect=OSError("simulated disk full"),
+        ):
+            with self.assertRaises(OSError):
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+        source_exists = (self.workspace_root / source_rel).exists()
+        dest_exists = (self.workspace_root / "units" / "u1" / "home" / "AGENTS.md").exists()
+        receipt_exists = (
+            self.workspace_root / ".grip" / "state" / "materialization" / "mp_receipt_fail_test.json"
+        ).exists()
+        self.assertTrue(source_exists, "source must survive an acknowledgement failure")
+        self.assertTrue(dest_exists, "the copy itself is not rolled back, only the deletion is deferred")
+        self.assertFalse(receipt_exists)
 
 
 class TestReceipts(MaterializationPlanTestBase):

--- a/gr2/tests/test_materialization_plan.py
+++ b/gr2/tests/test_materialization_plan.py
@@ -1,13 +1,17 @@
-"""Tests for apply_materialization_plan (config#491 §6.2, S4).
+"""Tests for apply_materialization_plan (config#491 §6.2, §12.1, S4).
 
 Consumes the neutral MaterializationPlan JSON schema directly (clone/venv/
 editable_install/project_file operations) rather than workspace_spec.toml's
 repo/unit model. Identity-free by construction: gr2 never reads an agent
-name, org, role, or channel out of a plan.
+name, org, role, or channel out of a plan, recursively -- not just at the
+top level of each operation.
 
-Shares clone_repo/git primitives with the existing build_plan/apply_plan
-path (config#491 §7.3: "one apply_plan executor... not a second
-materializer") -- this file tests the new entry point specifically.
+Sentinel r2 on PR#797 (2026-07-27) found five contract survivors in the
+first pass: two parallel executors instead of one shared one (P1),
+non-atomic clone publication (P2), incomplete clone/cache validation (P3),
+too-loose project_file source containment (P4, refined from Stromus's r1),
+and non-closed plan/receipt semantics (P5). Each finding gets its own test
+class below, named for what it proves, not just what it covers.
 """
 from __future__ import annotations
 
@@ -20,6 +24,8 @@ from pathlib import Path
 from gr2.python_cli.spec_apply import (
     MaterializationPlanError,
     apply_materialization_plan,
+    apply_plan,
+    workspace_spec_path,
 )
 
 
@@ -40,15 +46,25 @@ class MaterializationPlanTestBase(unittest.TestCase):
 
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def _stage_source(self, relative_path: str, content: bytes) -> str:
-        """Stage a project_file source under the workspace root, at a
-        workspace-relative path -- matching config#491 §6.2's own example
-        (`.grip/staging/inputs/f_01`), not an arbitrary absolute path.
-        Returns the relative_path for use as the plan's source_path."""
-        path = self.workspace_root / relative_path
+    def _plan(self, operations: list[dict[str, object]], **overrides: object) -> dict[str, object]:
+        plan: dict[str, object] = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "unit_key": "u_test",
+            "operations": operations,
+        }
+        plan.update(overrides)
+        return plan
+
+    def _stage_source(self, name: str, content: bytes) -> str:
+        """Stage a project_file source under .grip/staging/inputs/, matching
+        config#491 §6.2's normative contract (Sentinel r2 P4) -- not an
+        arbitrary workspace-relative path, and never outside the workspace."""
+        relative = f".grip/staging/inputs/{name}"
+        path = self.workspace_root / relative
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
-        return relative_path
+        return relative
 
     def _init_bare_remote(self, name: str) -> str:
         """Create a real local bare repo with one commit; return its URL."""
@@ -69,37 +85,49 @@ class MaterializationPlanTestBase(unittest.TestCase):
 
 class TestPathSafety(MaterializationPlanTestBase):
     def test_clone_rejects_absolute_dest_path(self):
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
-                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "/etc/passwd"}
-            ],
-        }
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "/etc/passwd"}]
+        )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
     def test_clone_rejects_dest_path_escaping_via_dotdot(self):
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        plan = self._plan(
+            [
                 {
                     "kind": "clone",
                     "repo_url": "https://example.com/x.git",
                     "dest_path": "units/u1/../../../outside",
                 }
-            ],
-        }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_clone_rejects_reference_base_escaping_workspace(self):
+        """Sentinel r2 P3.1: reference_base was accepted as an absolute
+        external path and passed straight to --reference-if-able, becoming
+        its own 'approved' alternate. Must be containment-checked the same
+        as dest_path."""
+        outside_cache = self.tmp / "outside.git"
+        outside_cache.mkdir()
+        plan = self._plan(
+            [
+                {
+                    "kind": "clone",
+                    "repo_url": "https://example.com/x.git",
+                    "dest_path": "units/u1/product",
+                    "reference_base": str(outside_cache),
+                }
+            ]
+        )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
     def test_project_file_rejects_absolute_dest_path(self):
-        source_rel = self._stage_source(".grip/staging/inputs/f_01", b"hello")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        source_rel = self._stage_source("f_01", b"hello")
+        plan = self._plan(
+            [
                 {
                     "kind": "project_file",
                     "source_path": source_rel,
@@ -107,21 +135,18 @@ class TestPathSafety(MaterializationPlanTestBase):
                     "dest_path": "/tmp/escape.md",
                     "mode": "copy",
                 }
-            ],
-        }
+            ]
+        )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
     def test_project_file_rejects_absolute_source_path(self):
-        """The finding: source_path was read+deleted with zero containment
-        check, unlike dest_path. An absolute source must be rejected the
-        same way an absolute dest is."""
+        """Original Stromus r1 finding: source_path was read+deleted with
+        zero containment check, unlike dest_path."""
         outside_source = self.tmp / "outside-workspace.md"
         outside_source.write_bytes(b"hello")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        plan = self._plan(
+            [
                 {
                     "kind": "project_file",
                     "source_path": str(outside_source),
@@ -129,21 +154,17 @@ class TestPathSafety(MaterializationPlanTestBase):
                     "dest_path": "units/u1/home/AGENTS.md",
                     "mode": "copy",
                 }
-            ],
-        }
+            ]
+        )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
-        # The whole point: an unvalidated source must never be touched, let
-        # alone deleted, before the containment check runs.
         self.assertTrue(outside_source.exists())
 
     def test_project_file_rejects_source_path_escaping_via_dotdot(self):
         outside_source = self.tmp / "outside-workspace.md"
         outside_source.write_bytes(b"hello")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        plan = self._plan(
+            [
                 {
                     "kind": "project_file",
                     "source_path": f"../{outside_source.name}",
@@ -151,43 +172,202 @@ class TestPathSafety(MaterializationPlanTestBase):
                     "dest_path": "units/u1/home/AGENTS.md",
                     "mode": "copy",
                 }
-            ],
-        }
+            ]
+        )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
         self.assertTrue(outside_source.exists())
 
+    def test_project_file_rejects_source_inside_workspace_but_outside_staging(self):
+        """Sentinel r2 P4: workspace-relative is not sufficient by itself --
+        source_path must resolve under .grip/staging/inputs/ specifically."""
+        misplaced = self.workspace_root / "units" / "u1" / "not-staged.md"
+        misplaced.parent.mkdir(parents=True)
+        misplaced.write_bytes(b"hello")
+        plan = self._plan(
+            [
+                {
+                    "kind": "project_file",
+                    "source_path": "units/u1/not-staged.md",
+                    "source_sha256": hashlib.sha256(b"hello").hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "copy",
+                }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertTrue(misplaced.exists())
+
+    def test_project_file_rejects_mode_other_than_copy(self):
+        source_rel = self._stage_source("f_01", b"hello")
+        plan = self._plan(
+            [
+                {
+                    "kind": "project_file",
+                    "source_path": source_rel,
+                    "source_sha256": hashlib.sha256(b"hello").hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "move",
+                }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
 
 class TestIdentityFreedom(MaterializationPlanTestBase):
-    def test_rejects_operation_with_identity_bearing_field(self):
-        """config#491 §6.2: the plan must not carry agent name/role/org/etc."""
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+    def test_rejects_operation_with_top_level_identity_field(self):
+        plan = self._plan(
+            [
                 {
                     "kind": "clone",
                     "repo_url": "https://example.com/x.git",
                     "dest_path": "units/u1/repo",
                     "agent_name": "apollo",
                 }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_rejects_operation_with_nested_identity_field(self):
+        """Sentinel r2 P5: nested identity smuggling (e.g. metadata.channel)
+        must be caught too -- not just a flat top-level key scan."""
+        plan = self._plan(
+            [
+                {
+                    "kind": "clone",
+                    "repo_url": "https://example.com/x.git",
+                    "dest_path": "units/u1/repo",
+                    "metadata": {"channel": "dev"},
+                }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+
+class TestPlanShapeValidation(MaterializationPlanTestBase):
+    """Sentinel r2 P5: the whole plan is validated before any operation
+    executes -- an invalid operation later in the list must not let an
+    earlier, valid-looking operation mutate anything first."""
+
+    def test_missing_unit_key_rejected(self):
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/repo"}
             ],
         }
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_unsafe_plan_id_rejected(self):
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/repo"}],
+            plan_id="../../../../escaped_receipt",
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_duplicate_dest_path_rejected(self):
+        plan = self._plan(
+            [
+                {"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"},
+                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/.venv"},
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_late_invalid_operation_leaves_earlier_operation_untouched(self):
+        """Exact Sentinel reproduction: op1 (venv) must not persist any
+        mutation when op2's dest_path is invalid -- validation covers the
+        whole plan before execution starts, not op-by-op interleaved."""
+        plan = self._plan(
+            [
+                {"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"},
+                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "/etc/passwd"},
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / "units" / "u1" / ".venv").exists())
+
+    def test_bad_engine_rejected(self):
+        plan = self._plan(
+            [{"kind": "venv", "dest_path": "units/u1/.venv", "engine": "conda", "python": ">=3.11"}]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+
+class TestSharedExecutor(MaterializationPlanTestBase):
+    """Sentinel r2 P1: sharing only clone_repo() as a leaf primitive does
+    not satisfy "one executor, not a second materializer." Proof: the
+    legacy workspace_spec.toml path must reject the exact same isolation
+    violations the MaterializationPlan path rejects, because both now
+    delegate to the same _clone_isolated function."""
+
+    def test_legacy_converge_unit_repos_rejects_existing_repo_with_mismatched_origin(self):
+        """Proof that apply_plan's converge_unit_repos now validates ALL a
+        unit's declared repos (not just build_plan's cheap "missing" list)
+        by delegating to the same _clone_isolated function the
+        MaterializationPlan path uses. A unit with two declared repos, one
+        genuinely absent (so build_plan schedules convergence at all -- its
+        own existence pre-check is deliberately unchanged, doing real git
+        validation on every plan-build would be a real cost) and one
+        present with the wrong origin, must still fail on the second."""
+        unit_root = self.workspace_root / "agents" / "atlas" / "home"
+        unit_root.mkdir(parents=True)
+        (unit_root / "unit.toml").write_text(
+            'name = "atlas"\nkind = "unit"\nrepos = ["present-app", "missing-app"]\n'
+        )
+
+        present_repo_root = unit_root / "present-app"
+        actual_origin_url = self._init_bare_remote("actual-present-app")
+        _git(unit_root, "clone", actual_origin_url, str(present_repo_root))
+        declared_url_for_present = self._init_bare_remote("declared-present-app")
+        missing_app_url = self._init_bare_remote("missing-app")
+
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_path.write_text(
+            '\n'.join(
+                [
+                    'workspace_name = "test"',
+                    "",
+                    "[[repos]]",
+                    'name = "present-app"',
+                    'path = "repos/present-app"',
+                    f'url = "{declared_url_for_present}"',
+                    "",
+                    "[[repos]]",
+                    'name = "missing-app"',
+                    'path = "repos/missing-app"',
+                    f'url = "{missing_app_url}"',
+                    "",
+                    "[[units]]",
+                    'name = "atlas"',
+                    'path = "agents/atlas/home"',
+                    'repos = ["present-app", "missing-app"]',
+                    "",
+                ]
+            )
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_plan(self.workspace_root, yes=True)
 
 
 class TestCloneOperation(MaterializationPlanTestBase):
     def test_clones_to_explicit_dest_path(self):
         """gap#4: uses the declared dest_path directly, not a repo-name-derived path."""
         url = self._init_bare_remote("product")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
-                {"kind": "clone", "repo_url": url, "dest_path": "units/u_7f3a/home/product"}
-            ],
-        }
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": url, "dest_path": "units/u_7f3a/home/product"}]
+        )
         result = apply_materialization_plan(self.workspace_root, plan, yes=True)
         dest = self.workspace_root / "units" / "u_7f3a" / "home" / "product"
         self.assertTrue((dest / "README.md").exists())
@@ -200,18 +380,16 @@ class TestCloneOperation(MaterializationPlanTestBase):
         cache_dir.parent.mkdir(parents=True, exist_ok=True)
         _git(self.workspace_root, "clone", "--mirror", url, str(cache_dir))
 
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        plan = self._plan(
+            [
                 {
                     "kind": "clone",
                     "repo_url": url,
                     "dest_path": "units/u1/product",
                     "reference_base": ".grip/cache/repos/product.git",
                 }
-            ],
-        }
+            ]
+        )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         dest = self.workspace_root / "units" / "u1" / "product"
         alternates = dest / ".git" / "objects" / "info" / "alternates"
@@ -219,56 +397,104 @@ class TestCloneOperation(MaterializationPlanTestBase):
 
     def test_clone_is_idempotent_for_existing_healthy_clone(self):
         url = self._init_bare_remote("product")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
-        }
+        plan = self._plan([{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}])
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         second = apply_materialization_plan(self.workspace_root, plan, yes=True)
         self.assertFalse(second["operations"][0]["first_materialize"])
 
     def test_clone_rejects_worktree_linked_git_dir(self):
-        """gap#6 / config#491 §8.1: .git as a worktree pointer file is forbidden."""
+        """config#491 §8.1: .git as a worktree pointer file is forbidden."""
         dest = self.workspace_root / "units" / "u1" / "product"
         dest.mkdir(parents=True)
         (dest / ".git").write_text("gitdir: /somewhere/else/.git/worktrees/product\n")
 
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
-                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}
-            ],
-        }
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}]
+        )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_clone_rejects_existing_clone_with_nested_worktrees(self):
+        """Sentinel r2 P3.3: a real .git directory that is itself hosting
+        linked worktrees (.git/worktrees present) must be rejected -- it is
+        not an isolated single clone."""
+        url = self._init_bare_remote("product")
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.parent.mkdir(parents=True)
+        _git(self.workspace_root, "clone", url, str(dest))
+        (dest / ".git" / "worktrees").mkdir()
+
+        plan = self._plan([{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}])
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_clone_rejects_existing_clone_with_mismatched_origin(self):
+        """Sentinel r2 P3.2: an existing clone whose actual origin is
+        remote A must not be silently accepted under a plan declaring
+        remote B."""
+        url_a = self._init_bare_remote("product-a")
+        url_b = self._init_bare_remote("product-b")
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.parent.mkdir(parents=True)
+        _git(self.workspace_root, "clone", url_a, str(dest))
+
+        plan = self._plan([{"kind": "clone", "repo_url": url_b, "dest_path": "units/u1/product"}])
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_clone_publication_is_atomic_on_checkout_failure(self):
+        """Sentinel r2 P2, exact reproduction: a valid remote with a
+        nonexistent branch must leave NOTHING at dest_path -- not a
+        partially-published clone on the wrong branch."""
+        url = self._init_bare_remote("product")
+        plan = self._plan(
+            [
+                {
+                    "kind": "clone",
+                    "repo_url": url,
+                    "dest_path": "units/u1/product",
+                    "branch": "does-not-exist",
+                }
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        dest = self.workspace_root / "units" / "u1" / "product"
+        self.assertFalse(dest.exists())
+        # No stray staging directory left behind either.
+        leftovers = list((self.workspace_root / "units" / "u1").glob(".product.staging-*"))
+        self.assertEqual(leftovers, [])
 
 
 class TestVenvOperation(MaterializationPlanTestBase):
     def test_creates_venv_via_uv(self):
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
-                {"kind": "venv", "dest_path": "units/u1/home/.venv", "engine": "uv", "python": ">=3.11"}
-            ],
-        }
+        plan = self._plan(
+            [{"kind": "venv", "dest_path": "units/u1/home/.venv", "engine": "uv", "python": ">=3.11"}]
+        )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         venv_path = self.workspace_root / "units" / "u1" / "home" / ".venv"
-        self.assertTrue((venv_path / "bin" / "python").exists() or (venv_path / "bin" / "python3").exists())
+        self.assertTrue((venv_path / "pyvenv.cfg").exists())
 
     def test_venv_idempotent_when_already_exists(self):
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
-                {"kind": "venv", "dest_path": "units/u1/home/.venv", "engine": "uv", "python": ">=3.11"}
-            ],
-        }
+        plan = self._plan(
+            [{"kind": "venv", "dest_path": "units/u1/home/.venv", "engine": "uv", "python": ">=3.11"}]
+        )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         second = apply_materialization_plan(self.workspace_root, plan, yes=True)
         self.assertFalse(second["operations"][0]["created"])
+
+    def test_rejects_fake_existing_venv(self):
+        """Sentinel r2 P5: an arbitrary directory at dest_path must not be
+        accepted as a valid venv just because something exists there."""
+        fake = self.workspace_root / "units" / "u1" / "home" / ".venv"
+        fake.mkdir(parents=True)
+        (fake / "not-a-real-venv.txt").write_text("nope")
+
+        plan = self._plan(
+            [{"kind": "venv", "dest_path": "units/u1/home/.venv", "engine": "uv", "python": ">=99"}]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
 
 
 class TestEditableInstallOperation(MaterializationPlanTestBase):
@@ -285,20 +511,20 @@ class TestEditableInstallOperation(MaterializationPlanTestBase):
         (source / "product").mkdir()
         (source / "product" / "__init__.py").write_text("")
 
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        plan = self._plan(
+            [
                 {
                     "kind": "editable_install",
                     "venv_path": "units/u1/home/.venv",
                     "source_path": "units/u1/home/product",
                     "extras": [],
                 }
-            ],
-        }
+            ]
+        )
         result = apply_materialization_plan(self.workspace_root, plan, yes=True)
-        self.assertEqual(result["operations"][0]["kind"], "editable_install")
+        op_result = result["operations"][0]
+        self.assertEqual(op_result["kind"], "editable_install")
+        self.assertIsNotNone(op_result["pep610_evidence"])
         check = subprocess.run(
             [str(venv_path / "bin" / "python"), "-c", "import product"],
             capture_output=True, text=True,
@@ -309,11 +535,9 @@ class TestEditableInstallOperation(MaterializationPlanTestBase):
 class TestProjectFileOperation(MaterializationPlanTestBase):
     def test_copies_and_verifies_hash(self):
         content = b"# Foundation\nRole: neutral executor.\n"
-        source_rel = self._stage_source(".grip/staging/inputs/f_01", content)
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        source_rel = self._stage_source("f_01", content)
+        plan = self._plan(
+            [
                 {
                     "kind": "project_file",
                     "source_path": source_rel,
@@ -321,18 +545,16 @@ class TestProjectFileOperation(MaterializationPlanTestBase):
                     "dest_path": "units/u1/home/AGENTS.md",
                     "mode": "copy",
                 }
-            ],
-        }
+            ]
+        )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         dest = self.workspace_root / "units" / "u1" / "home" / "AGENTS.md"
         self.assertEqual(dest.read_bytes(), content)
 
     def test_rejects_hash_mismatch(self):
-        source_rel = self._stage_source(".grip/staging/inputs/f_01", b"real content")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        source_rel = self._stage_source("f_01", b"real content")
+        plan = self._plan(
+            [
                 {
                     "kind": "project_file",
                     "source_path": source_rel,
@@ -340,19 +562,17 @@ class TestProjectFileOperation(MaterializationPlanTestBase):
                     "dest_path": "units/u1/home/AGENTS.md",
                     "mode": "copy",
                 }
-            ],
-        }
+            ]
+        )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
     def test_deletes_staging_source_after_copy(self):
         """config#491 §6.2: staging artifact is deleted after acknowledgement."""
         content = b"ephemeral"
-        source_rel = self._stage_source(".grip/staging/inputs/f_01", content)
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_test",
-            "operations": [
+        source_rel = self._stage_source("f_01", content)
+        plan = self._plan(
+            [
                 {
                     "kind": "project_file",
                     "source_path": source_rel,
@@ -360,8 +580,8 @@ class TestProjectFileOperation(MaterializationPlanTestBase):
                     "dest_path": "units/u1/home/AGENTS.md",
                     "mode": "copy",
                 }
-            ],
-        }
+            ]
+        )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         self.assertFalse((self.workspace_root / source_rel).exists())
 
@@ -369,18 +589,19 @@ class TestProjectFileOperation(MaterializationPlanTestBase):
 class TestReceipts(MaterializationPlanTestBase):
     def test_writes_structured_receipt(self):
         url = self._init_bare_remote("product")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_receipt_test",
-            "workspace_spec_sha256": "abc123",
-            "operations": [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
-        }
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            plan_id="mp_receipt_test",
+            workspace_spec_sha256="abc123",
+        )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
 
         receipt_path = self.workspace_root / ".grip" / "state" / "materialization" / "mp_receipt_test.json"
         self.assertTrue(receipt_path.exists())
         receipt = json.loads(receipt_path.read_text())
         self.assertEqual(receipt["plan_id"], "mp_receipt_test")
+        self.assertEqual(receipt["unit_key"], "u_test")
+        self.assertIn("plan_hash", receipt)
         self.assertEqual(receipt["workspace_spec_sha256"], "abc123")
         self.assertIn("operations", receipt)
         self.assertEqual(len(receipt["operations"]), 1)
@@ -388,28 +609,26 @@ class TestReceipts(MaterializationPlanTestBase):
     def test_receipt_contains_no_identity_fields(self):
         """config#491 §12.1: neutral receipts carry no identity/org/channel/secret/memory."""
         url = self._init_bare_remote("product")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_receipt_neutrality",
-            "operations": [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
-        }
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            plan_id="mp_receipt_neutrality",
+        )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
 
         receipt_path = (
             self.workspace_root / ".grip" / "state" / "materialization" / "mp_receipt_neutrality.json"
         )
         raw = receipt_path.read_text().lower()
-        for forbidden in ("agent_name", "agent_id", "role", "org", "channel", "secret", "memory"):
+        for forbidden in ("agent_name", "role", "org", "channel", "secret", "memory"):
             self.assertNotIn(forbidden, raw)
 
     def test_rerun_is_resumable_not_duplicated(self):
         """A rerun of the same plan must not re-clone or duplicate receipt entries."""
         url = self._init_bare_remote("product")
-        plan = {
-            "schema_version": 1,
-            "plan_id": "mp_resume_test",
-            "operations": [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
-        }
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            plan_id="mp_resume_test",
+        )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         second = apply_materialization_plan(self.workspace_root, plan, yes=True)
 
@@ -417,6 +636,18 @@ class TestReceipts(MaterializationPlanTestBase):
         receipt = json.loads(receipt_path.read_text())
         self.assertEqual(len(receipt["operations"]), 1)
         self.assertFalse(second["operations"][0]["first_materialize"])
+
+    def test_receipt_write_leaves_no_temp_file_behind(self):
+        """Atomic write: temp file is renamed into place, never left dangling."""
+        url = self._init_bare_remote("product")
+        plan = self._plan(
+            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            plan_id="mp_atomic_test",
+        )
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        state_dir = self.workspace_root / ".grip" / "state" / "materialization"
+        leftovers = [p for p in state_dir.glob("*.tmp-*")]
+        self.assertEqual(leftovers, [])
 
 
 if __name__ == "__main__":

--- a/gr2/tests/test_materialization_plan.py
+++ b/gr2/tests/test_materialization_plan.py
@@ -1663,6 +1663,99 @@ class TestIdempotentCleanup(MaterializationPlanTestBase):
         self.assertFalse((self.workspace_root / source_rel).exists())
 
 
+class TestPerOperationReceiptSchemas(MaterializationPlanTestBase):
+    """Sentinel round 3 asked for EXACT per-operation receipt schemas, not
+    just top-level ones: "deletion of every operation-specific evidence
+    field remains GREEN". Pinning the exact key set per kind means any
+    evidence field removed or renamed turns this RED."""
+
+    def test_clone_receipt_evidence_schema_is_exact(self):
+        url = self._init_bare_remote("product")
+        cache = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "clone", "--mirror", url, str(cache))
+        plan = self._plan(
+            [
+                self._clone_op(
+                    repo_url=url,
+                    dest_path="units/u1/product",
+                    reference_base=".grip/cache/repos/product.git",
+                )
+            ]
+        )
+        op = apply_materialization_plan(self.workspace_root, plan, yes=True)["operations"][0]
+        self.assertEqual(
+            set(op),
+            {
+                "kind",
+                "repo_url",
+                "dest_path",
+                "first_materialize",
+                "head_sha",
+                "observed_origin",
+                "cache_path",
+                "observed_alternate",
+                "alternate_approved",
+            },
+        )
+        self.assertTrue(op["head_sha"])
+        self.assertEqual(op["observed_origin"], url)
+
+    def test_venv_receipt_evidence_schema_is_exact(self):
+        plan = self._plan([self._venv_op(dest_path="units/u1/.venv")])
+        op = apply_materialization_plan(self.workspace_root, plan, yes=True)["operations"][0]
+        self.assertEqual(set(op), {"kind", "dest_path", "created", "interpreter_path"})
+
+    def test_editable_install_receipt_evidence_schema_is_exact(self):
+        venv_path = self.workspace_root / "units" / "u1" / ".venv"
+        venv_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["uv", "venv", "--python", ">=3.11", str(venv_path)], check=True, capture_output=True
+        )
+        source = self.workspace_root / "units" / "u1" / "product"
+        source.mkdir(parents=True)
+        (source / "pyproject.toml").write_text(
+            '[project]\nname = "product"\nversion = "0.1.0"\n'
+            '[build-system]\nrequires = ["setuptools>=68"]\nbuild-backend = "setuptools.build_meta"\n'
+        )
+        (source / "product").mkdir()
+        (source / "product" / "__init__.py").write_text("")
+
+        plan = self._plan(
+            [
+                {
+                    "kind": "editable_install",
+                    "venv_path": "units/u1/.venv",
+                    "source_path": "units/u1/product",
+                    "extras": [],
+                }
+            ]
+        )
+        op = apply_materialization_plan(self.workspace_root, plan, yes=True)["operations"][0]
+        self.assertEqual(
+            set(op),
+            {"kind", "venv_path", "source_path", "extras", "distribution", "pep610_evidence"},
+        )
+        self.assertEqual(op["distribution"], "product")
+
+    def test_project_file_receipt_evidence_schema_is_exact(self):
+        content = b"payload"
+        source_rel = self._stage_source("f_01", content)
+        plan = self._plan(
+            [
+                self._project_file_op(
+                    source_path=source_rel,
+                    source_sha256=hashlib.sha256(content).hexdigest(),
+                    dest_path="units/u1/AGENTS.md",
+                )
+            ]
+        )
+        op = apply_materialization_plan(self.workspace_root, plan, yes=True)["operations"][0]
+        self.assertEqual(
+            set(op), {"kind", "source_path", "dest_path", "source_sha256", "already_projected"}
+        )
+
+
 class TestProjectFileReceiptEvidence(MaterializationPlanTestBase):
     """Sentinel round 3: the observed project-file receipt had only kind,
     dest_path, and source_sha256 -- §12.1 also requires the source path."""

--- a/gr2/tests/test_materialization_plan.py
+++ b/gr2/tests/test_materialization_plan.py
@@ -1889,5 +1889,309 @@ class TestProjectFileReceiptEvidence(MaterializationPlanTestBase):
         self.assertNotIn("_pending_unlink", op, "internal orchestration key must never be receipted")
 
 
+class TestRound4Survivors(MaterializationPlanTestBase):
+    """Atlas round 4 -- three production-shaped survivors, his exact probes
+    taken verbatim as RED tests."""
+
+    def test_existing_clone_with_declared_reference_but_no_alternate_rejected(self):
+        """#1. A valid canonical mirror cache, an EXISTING ordinary clone
+        with no alternates, then a plan declaring that reference_base:
+        round 3 accepted it and receipted alternate_approved=false, because
+        the required-alternate half ran only on the fresh-clone path."""
+        url = self._init_bare_remote("product")
+        cache = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "clone", "--mirror", url, str(cache))
+
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.parent.mkdir(parents=True)
+        # An ordinary clone -- no --reference, so no alternates file.
+        _git(self.workspace_root, "clone", url, str(dest))
+        self.assertFalse((dest / ".git" / "objects" / "info" / "alternates").exists())
+
+        plan = self._plan(
+            [
+                self._clone_op(
+                    repo_url=url,
+                    dest_path="units/u1/product",
+                    reference_base=".grip/cache/repos/product.git",
+                )
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("carries no alternate", str(ctx.exception))
+
+    def test_rerun_rejects_tampered_staged_source_without_deleting_it(self):
+        """#2. Apply a project file, recreate the staged path with TAMPERED
+        bytes, rerun: round 3 succeeded and deleted the tampered source
+        without ever re-verifying it."""
+        content = b"payload"
+        source_rel = self._stage_source("f_01", content)
+        plan = self._plan(
+            [
+                self._project_file_op(
+                    source_path=source_rel,
+                    source_sha256=hashlib.sha256(content).hexdigest(),
+                    dest_path="units/u1/AGENTS.md",
+                )
+            ],
+            plan_id="mp_tamper",
+        )
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / source_rel).exists())
+
+        tampered = b"TAMPERED"
+        (self.workspace_root / source_rel).write_bytes(tampered)
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("hash mismatch", str(ctx.exception))
+        # Destructive cleanup must not have run on unverified bytes.
+        self.assertEqual((self.workspace_root / source_rel).read_bytes(), tampered)
+
+    def test_second_editable_receipts_its_own_pep610_row(self):
+        """#3. One plan installs editable alpha then editable beta; round 3
+        receipted beta's operation with ALPHA's distribution and PEP 610
+        path, because evidence selection took the first sorted row."""
+        venv_path = self.workspace_root / "units" / "u1" / ".venv"
+        venv_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["uv", "venv", "--python", ">=3.11", str(venv_path)], check=True, capture_output=True
+        )
+        for name in ("alpha", "beta"):
+            src = self.workspace_root / "units" / "u1" / name
+            src.mkdir(parents=True)
+            (src / "pyproject.toml").write_text(
+                f'[project]\nname = "{name}"\nversion = "0.1.0"\n'
+                '[build-system]\nrequires = ["setuptools>=68"]\n'
+                'build-backend = "setuptools.build_meta"\n'
+            )
+            (src / name).mkdir()
+            (src / name / "__init__.py").write_text("")
+
+        plan = self._plan(
+            [
+                {
+                    "kind": "editable_install",
+                    "venv_path": "units/u1/.venv",
+                    "source_path": "units/u1/alpha",
+                    "extras": [],
+                },
+                {
+                    "kind": "editable_install",
+                    "venv_path": "units/u1/.venv",
+                    "source_path": "units/u1/beta",
+                    "extras": [],
+                },
+            ]
+        )
+        ops = apply_materialization_plan(self.workspace_root, plan, yes=True)["operations"]
+        self.assertEqual(ops[0]["distribution"], "alpha")
+        self.assertEqual(ops[1]["distribution"], "beta")
+        self.assertIn("alpha", ops[0]["pep610_evidence"])
+        self.assertIn("beta", ops[1]["pep610_evidence"])
+        self.assertNotEqual(ops[0]["pep610_evidence"], ops[1]["pep610_evidence"])
+
+
+class TestStateMatrixParity(MaterializationPlanTestBase):
+    """THE CLASS-KILLER (Stromus round 4).
+
+    Every finding from rounds 1-4 was generated by the same untested
+    matrix: {fresh, existing-clone} x {first-run, rerun} x {single,
+    multi-unit}. Each was one code path skipping what its sibling path
+    does. Rather than testing each instance, these assert PARITY across
+    each axis: the same invariant must fire on BOTH sides.
+
+    The code-level counterpart is that the sibling paths now share one
+    function (_validate_clone_isolation for clones, _verify_staged_source
+    for staged inputs), so parity holds by construction and these tests
+    are the proof, not the mechanism."""
+
+    # --- axis 1: {fresh, existing-clone} -------------------------------
+
+    def _cache_for(self, url: str, name: str) -> str:
+        cache = self.workspace_root / ".grip" / "cache" / "repos" / f"{name}.git"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "clone", "--mirror", url, str(cache))
+        return f".grip/cache/repos/{name}.git"
+
+    def test_alternate_requirement_fires_on_fresh_clone(self):
+        url = self._init_bare_remote("product")
+        ref = self._cache_for(url, "product")
+        real_clone_repo = spec_apply.clone_repo
+
+        def clone_without_reference(repo_url, target, *, reference_repo_root=None):
+            return real_clone_repo(repo_url, target, reference_repo_root=None)
+
+        plan = self._plan(
+            [self._clone_op(repo_url=url, dest_path="units/u1/product", reference_base=ref)]
+        )
+        with patch.object(spec_apply, "clone_repo", clone_without_reference):
+            with self.assertRaises(MaterializationPlanError) as ctx:
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("carries no alternate", str(ctx.exception))
+
+    def test_alternate_requirement_fires_on_existing_clone(self):
+        """Parity partner of the test above -- same invariant, other side
+        of the fresh/existing axis."""
+        url = self._init_bare_remote("product")
+        ref = self._cache_for(url, "product")
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.parent.mkdir(parents=True)
+        _git(self.workspace_root, "clone", url, str(dest))
+
+        plan = self._plan(
+            [self._clone_op(repo_url=url, dest_path="units/u1/product", reference_base=ref)]
+        )
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("carries no alternate", str(ctx.exception))
+
+    def test_worktree_pointer_rejected_on_existing_clone(self):
+        """The .git-as-file invariant, existing side. (Fresh side cannot be
+        constructed: we create fresh clones ourselves via git.)"""
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.mkdir(parents=True)
+        (dest / ".git").write_text("gitdir: /elsewhere/.git/worktrees/product\n")
+        plan = self._plan(
+            [self._clone_op(repo_url="https://example.com/x.git", dest_path="units/u1/product")]
+        )
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("worktree-pointer", str(ctx.exception))
+
+    # --- axis 2: {first-run, rerun} ------------------------------------
+
+    def _staged_plan(self, content: bytes, *, plan_id: str) -> tuple[dict, str]:
+        source_rel = self._stage_source("f_01", content)
+        return (
+            self._plan(
+                [
+                    self._project_file_op(
+                        source_path=source_rel,
+                        source_sha256=hashlib.sha256(content).hexdigest(),
+                        dest_path="units/u1/AGENTS.md",
+                    )
+                ],
+                plan_id=plan_id,
+            ),
+            source_rel,
+        )
+
+    def test_hash_verification_fires_on_first_run(self):
+        content = b"payload"
+        plan, source_rel = self._staged_plan(content, plan_id="mp_first")
+        (self.workspace_root / source_rel).write_bytes(b"DIFFERENT")
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("hash mismatch", str(ctx.exception))
+
+    def test_hash_verification_fires_on_rerun_cleanup(self):
+        """Parity partner -- same invariant, rerun side of the axis."""
+        content = b"payload"
+        plan, source_rel = self._staged_plan(content, plan_id="mp_rerun")
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        (self.workspace_root / source_rel).write_bytes(b"DIFFERENT")
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("hash mismatch", str(ctx.exception))
+
+    def test_non_regular_source_rejected_on_first_run(self):
+        content = b"payload"
+        plan, source_rel = self._staged_plan(content, plan_id="mp_fifo_first")
+        staged = self.workspace_root / source_rel
+        staged.unlink()
+        os.mkfifo(staged)
+        try:
+            with self.assertRaises(MaterializationPlanError) as ctx:
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+            self.assertIn("not a regular file", str(ctx.exception))
+        finally:
+            staged.unlink()
+
+    def test_non_regular_source_rejected_on_rerun_cleanup(self):
+        """Parity partner -- the rerun path must apply the same
+        regular-file check, not just the hash one."""
+        content = b"payload"
+        plan, source_rel = self._staged_plan(content, plan_id="mp_fifo_rerun")
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        staged = self.workspace_root / source_rel
+        os.mkfifo(staged)
+        try:
+            with self.assertRaises(MaterializationPlanError) as ctx:
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+            self.assertIn("not a regular file", str(ctx.exception))
+        finally:
+            staged.unlink()
+
+    # --- axis 3: {single, multi-unit} ----------------------------------
+
+    def test_receipt_rows_are_scoped_per_operation_across_units(self):
+        """Two units, each with its own clone and its own staged input:
+        every receipt row must describe ITS operation, not a sibling's."""
+        url_a = self._init_bare_remote("alpha")
+        url_b = self._init_bare_remote("beta")
+        content_a = b"alpha payload"
+        content_b = b"beta payload"
+        src_a = self._stage_source("f_alpha", content_a)
+        src_b = self._stage_source("f_beta", content_b)
+
+        plan = self._plan(
+            [
+                self._clone_op(repo_url=url_a, dest_path="units/alpha/product"),
+                self._clone_op(repo_url=url_b, dest_path="units/beta/product"),
+                self._project_file_op(
+                    source_path=src_a,
+                    source_sha256=hashlib.sha256(content_a).hexdigest(),
+                    dest_path="units/alpha/AGENTS.md",
+                ),
+                self._project_file_op(
+                    source_path=src_b,
+                    source_sha256=hashlib.sha256(content_b).hexdigest(),
+                    dest_path="units/beta/AGENTS.md",
+                ),
+            ],
+            plan_id="mp_multiunit",
+        )
+        ops = apply_materialization_plan(self.workspace_root, plan, yes=True)["operations"]
+
+        self.assertEqual(ops[0]["repo_url"], url_a)
+        self.assertEqual(ops[1]["repo_url"], url_b)
+        self.assertNotEqual(ops[0]["head_sha"], ops[1]["head_sha"])
+        self.assertEqual(ops[2]["source_path"], src_a)
+        self.assertEqual(ops[3]["source_path"], src_b)
+        self.assertEqual(ops[2]["source_sha256"], hashlib.sha256(content_a).hexdigest())
+        self.assertEqual(ops[3]["source_sha256"], hashlib.sha256(content_b).hexdigest())
+        # Each unit got its OWN bytes, not the other's.
+        self.assertEqual(
+            (self.workspace_root / "units" / "alpha" / "AGENTS.md").read_bytes(), content_a
+        )
+        self.assertEqual(
+            (self.workspace_root / "units" / "beta" / "AGENTS.md").read_bytes(), content_b
+        )
+
+    def test_multi_unit_rerun_is_idempotent_per_unit(self):
+        """Multi-unit x rerun: the corner where per-unit scoping and the
+        rerun path intersect."""
+        url_a = self._init_bare_remote("alpha")
+        url_b = self._init_bare_remote("beta")
+        plan = self._plan(
+            [
+                self._clone_op(repo_url=url_a, dest_path="units/alpha/product"),
+                self._clone_op(repo_url=url_b, dest_path="units/beta/product"),
+            ],
+            plan_id="mp_multiunit_rerun",
+        )
+        first = apply_materialization_plan(self.workspace_root, plan, yes=True)["operations"]
+        self.assertTrue(all(o["first_materialize"] for o in first))
+
+        second = apply_materialization_plan(self.workspace_root, plan, yes=True)["operations"]
+        self.assertFalse(any(o["first_materialize"] for o in second))
+        self.assertEqual(second[0]["repo_url"], url_a)
+        self.assertEqual(second[1]["repo_url"], url_b)
+        self.assertEqual(first[0]["head_sha"], second[0]["head_sha"])
+        self.assertEqual(first[1]["head_sha"], second[1]["head_sha"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/gr2/tests/test_materialization_plan.py
+++ b/gr2/tests/test_materialization_plan.py
@@ -764,22 +764,38 @@ class TestCloneOperation(MaterializationPlanTestBase):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
     def test_clone_rejects_when_common_dir_check_cannot_run(self):
-        """Round 2 (Sentinel): fail CLOSED, not open. A .git that exists as
-        a real directory but isn't actually a valid git repository
-        internally makes `git rev-parse --git-common-dir` fail -- the prior
-        version silently skipped the whole check in that case (treated
-        "cannot verify" as "assume it's fine"). Must reject instead."""
-        dest = self.workspace_root / "units" / "u1" / "product"
-        (dest / ".git").mkdir(parents=True)
-        # .git exists as a real directory (passes the worktree-pointer-file
-        # and nested-worktrees checks) but has no actual git internals, so
-        # `git rev-parse --git-common-dir` run inside it fails for real.
+        """config#492 §6.2.1: fail CLOSED, not open -- if the common-dir
+        probe cannot run, that is a rejection, not "assume it's fine".
 
-        plan = self._plan(
-            [{"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}]
-        )
-        with self.assertRaises(MaterializationPlanError):
-            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        Round-3 mutation sweep caught this test itself passing for the
+        WRONG reason: its old fixture was a bare `.git` directory with no
+        git internals, which ALSO fails the origin check further down the
+        same function, so a type-only assertRaises stayed green with the
+        fail-closed branch removed entirely. Worse, I had already written
+        that exact masking into a sibling test's docstring and never came
+        back to repair this one.
+
+        Now isolated properly: a HEALTHY clone with a CORRECT origin,
+        where only the --git-common-dir probe is forced to fail, plus an
+        assertion on the specific message so no other guard can satisfy
+        it."""
+        url = self._init_bare_remote("product")
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.parent.mkdir(parents=True)
+        _git(self.workspace_root, "clone", url, str(dest))
+
+        real_run = subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "--git-common-dir" in cmd:
+                return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="simulated probe failure")
+            return real_run(cmd, *args, **kwargs)
+
+        plan = self._plan([self._clone_op(repo_url=url, dest_path="units/u1/product")])
+        with patch.object(spec_apply.subprocess, "run", fake_run):
+            with self.assertRaises(MaterializationPlanError) as ctx:
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("cannot verify isolation", str(ctx.exception))
 
     def test_clone_is_idempotent_for_existing_healthy_clone(self):
         url = self._init_bare_remote("product")
@@ -1281,6 +1297,56 @@ class TestPinnedSchemaConformance(MaterializationPlanTestBase):
         )
 
 
+class TestCanonicalizationDefenseInDepth(MaterializationPlanTestBase):
+    """Round-3 mutation sweep: deleting the raw-segment guards inside
+    _canonicalize_workspace_path left all 98 tests GREEN, because the
+    pinned schema's workspaceRelativePath pattern is a strictly stronger
+    FIRST gate -- every plan-level path test was being satisfied by the
+    schema, never reaching canonicalization. The defense-in-depth layer
+    had no independent coverage at all.
+
+    That matters precisely because it IS defense in depth: if the schema
+    is ever loosened, or a call site is added that reaches canonicalization
+    without schema validation (the legacy apply_plan adapter already does
+    exactly that), this layer is the only thing standing. So it gets tested
+    directly, at its own level, not through the schema that shadows it."""
+
+    def _reject(self, relative: str) -> None:
+        with self.assertRaises(MaterializationPlanError, msg=f"{relative!r} must be rejected"):
+            spec_apply._canonicalize_workspace_path(
+                self.workspace_root, relative, field_name="probe"
+            )
+
+    def test_rejects_single_dot_segment(self):
+        self._reject("a/./b")
+
+    def test_rejects_dotdot_segment(self):
+        self._reject("a/../b")
+
+    def test_rejects_empty_segment(self):
+        self._reject("a//b")
+
+    def test_rejects_backslash(self):
+        self._reject("a\\b")
+
+    def test_rejects_nul_byte(self):
+        """Without the raw guard this escapes as an UNCAUGHT ValueError
+        from Path.resolve() ("embedded null character"), i.e. a crash-class
+        regression rather than a clean rejection."""
+        self._reject("a/b\x00c")
+
+    def test_rejects_absolute_and_tilde(self):
+        self._reject("/etc/passwd")
+        self._reject("~/secrets")
+
+    def test_accepts_ordinary_relative_path(self):
+        """The positive face -- these guards must not reject legitimate paths."""
+        resolved = spec_apply._canonicalize_workspace_path(
+            self.workspace_root, "units/u1/product", field_name="probe"
+        )
+        self.assertEqual(resolved, (self.workspace_root / "units" / "u1" / "product").resolve())
+
+
 class TestUnicodeCollisionGuards(MaterializationPlanTestBase):
     """Sentinel round 3: removing .casefold() left all 13 plan-shape tests
     GREEN because no case-only collision fixture existed."""
@@ -1561,6 +1627,43 @@ class TestCacheProvenance(MaterializationPlanTestBase):
         self.assertIsNotNone(observed)
         self.assertEqual(Path(observed).resolve(), (cache / "objects").resolve())
         self.assertTrue(op_result["alternate_approved"])
+
+    def test_declared_reference_producing_no_alternate_is_rejected(self):
+        """Round-3 mutation sweep: the happy-path test above cannot
+        distinguish observed-from-disk evidence from evidence assumed off
+        the request, because when git DOES create the alternate both are
+        true. This forces the discriminating case -- a declared reference
+        that yields NO alternate -- by making the clone step produce a repo
+        without one. Observation-based evidence rejects; request-based
+        evidence would sail through and receipt alternate_approved=True for
+        a clone that shares no objects at all."""
+        url = self._init_bare_remote("product")
+        cache = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "clone", "--mirror", url, str(cache))
+
+        real_clone_repo = spec_apply.clone_repo
+
+        def clone_without_alternate(repo_url, target, *, reference_repo_root=None):
+            # Clone for real, but WITHOUT the reference -- simulating git
+            # declining to use a nominally-valid cache.
+            return real_clone_repo(repo_url, target, reference_repo_root=None)
+
+        plan = self._plan(
+            [
+                self._clone_op(
+                    repo_url=url,
+                    dest_path="units/u1/product",
+                    reference_base=".grip/cache/repos/product.git",
+                )
+            ]
+        )
+        with patch.object(spec_apply, "clone_repo", clone_without_alternate):
+            with self.assertRaises(MaterializationPlanError) as ctx:
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("carries no alternate", str(ctx.exception))
+        # Rolled back, not left half-published.
+        self.assertFalse((self.workspace_root / "units" / "u1" / "product").exists())
 
 
 class TestStagingSymlinkGuards(MaterializationPlanTestBase):

--- a/gr2/tests/test_materialization_plan.py
+++ b/gr2/tests/test_materialization_plan.py
@@ -17,15 +17,18 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from gr2.python_cli import spec_apply
 from gr2.python_cli.spec_apply import (
     MaterializationPlanError,
     apply_materialization_plan,
     apply_plan,
+    compute_plan_hash,
     workspace_spec_path,
 )
 
@@ -41,22 +44,49 @@ class MaterializationPlanTestBase(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         self.workspace_root = self.tmp / "workspace"
         self.workspace_root.mkdir(parents=True)
+        # config#492 §6.2.1 #1: the executor reopens the canonical
+        # WorkspaceSpec and verifies its bytes hash to the plan's
+        # workspace_spec_sha256, so every fixture needs a real one.
+        self.spec_sha256 = self._write_workspace_spec()
 
     def tearDown(self):
         import shutil
 
         shutil.rmtree(self.tmp, ignore_errors=True)
 
+    def _write_workspace_spec(self, content: str = 'workspace_name = "test"\n') -> str:
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_path.write_text(content)
+        return hashlib.sha256(spec_path.read_bytes()).hexdigest()
+
     def _plan(self, operations: list[dict[str, object]], **overrides: object) -> dict[str, object]:
         plan: dict[str, object] = {
             "schema_version": 1,
             "plan_id": "mp_test",
             "unit_key": "u_test",
-            "workspace_spec_sha256": "a" * 64,
+            "workspace_spec_sha256": self.spec_sha256,
             "operations": operations,
         }
         plan.update(overrides)
         return plan
+
+    def _clone_op(self, **fields: object) -> dict[str, object]:
+        """A schema-complete clone operation. `branch` is REQUIRED by the
+        pinned v1 schema (round 3) -- helper so every fixture carries it."""
+        op: dict[str, object] = {"kind": "clone", "branch": "main"}
+        op.update(fields)
+        return op
+
+    def _venv_op(self, **fields: object) -> dict[str, object]:
+        op: dict[str, object] = {"kind": "venv", "engine": "uv", "python": ">=3.11"}
+        op.update(fields)
+        return op
+
+    def _project_file_op(self, **fields: object) -> dict[str, object]:
+        op: dict[str, object] = {"kind": "project_file", "mode": "copy"}
+        op.update(fields)
+        return op
 
     def _stage_source(self, name: str, content: bytes) -> str:
         """Stage a project_file source under .grip/staging/inputs/, matching
@@ -88,7 +118,7 @@ class MaterializationPlanTestBase(unittest.TestCase):
 class TestPathSafety(MaterializationPlanTestBase):
     def test_clone_rejects_absolute_dest_path(self):
         plan = self._plan(
-            [{"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "/etc/passwd"}]
+            [{"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "/etc/passwd"}]
         )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
@@ -98,6 +128,7 @@ class TestPathSafety(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": "https://example.com/x.git",
                     "dest_path": "units/u1/../../../outside",
                 }
@@ -129,6 +160,7 @@ class TestPathSafety(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": url,
                     "dest_path": "units/u1/product",
                     "reference_base": str(outside_cache),
@@ -266,6 +298,7 @@ class TestIdentityFreedom(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": "https://example.com/x.git",
                     "dest_path": "units/u1/repo",
                     "agent_name": "apollo",
@@ -282,6 +315,7 @@ class TestIdentityFreedom(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": "https://example.com/x.git",
                     "dest_path": "units/u1/repo",
                     "metadata": {"channel": "dev"},
@@ -302,7 +336,7 @@ class TestPlanShapeValidation(MaterializationPlanTestBase):
             "schema_version": 1,
             "plan_id": "mp_test",
             "operations": [
-                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/repo"}
+                {"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/repo"}
             ],
         }
         with self.assertRaises(MaterializationPlanError):
@@ -310,7 +344,7 @@ class TestPlanShapeValidation(MaterializationPlanTestBase):
 
     def test_unsafe_plan_id_rejected(self):
         plan = self._plan(
-            [{"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/repo"}],
+            [{"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/repo"}],
             plan_id="../../../../escaped_receipt",
         )
         with self.assertRaises(MaterializationPlanError):
@@ -320,7 +354,7 @@ class TestPlanShapeValidation(MaterializationPlanTestBase):
         plan = self._plan(
             [
                 {"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"},
-                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/.venv"},
+                {"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/.venv"},
             ]
         )
         with self.assertRaises(MaterializationPlanError):
@@ -333,7 +367,7 @@ class TestPlanShapeValidation(MaterializationPlanTestBase):
         plan = self._plan(
             [
                 {"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"},
-                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "/etc/passwd"},
+                {"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "/etc/passwd"},
             ]
         )
         with self.assertRaises(MaterializationPlanError):
@@ -394,7 +428,7 @@ class TestPlanShapeValidation(MaterializationPlanTestBase):
         plan = self._plan(
             [
                 {"kind": "venv", "dest_path": "units/u1/.venv", "engine": "uv", "python": ">=3.11"},
-                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/./.venv"},
+                {"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/./.venv"},
             ]
         )
         with self.assertRaises(MaterializationPlanError):
@@ -426,6 +460,7 @@ class TestPlanShapeValidation(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": url,
                     "dest_path": "units/u1/product",
                     "reference_base": ".grip/cache/repos/product.git",
@@ -448,31 +483,101 @@ class TestPlanShapeValidation(MaterializationPlanTestBase):
         self.assertIn("interpreter_path", result["operations"][0])
         self.assertTrue(result["operations"][0]["interpreter_path"])
 
-    def test_receipt_publish_atomicity_proven_by_failed_rename(self):
+    def test_receipt_publish_atomicity_proven_by_failed_replace(self):
         """Round 2 (Sentinel): a test asserting only "no temp file left
-        behind" doesn't distinguish atomic-via-rename from a direct write --
+        behind" doesn't distinguish atomic-publish from a direct write --
         a direct write also trivially leaves no temp file. This makes the
-        rename step itself fail and confirms no final receipt.json ever
-        appears, proving the publish mechanism is genuinely rename-based."""
+        atomic-replace step itself fail and confirms no final receipt.json
+        ever appears, proving the publish is genuinely replace-based."""
         url = self._init_bare_remote("product")
         plan = self._plan(
-            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            [self._clone_op(repo_url=url, dest_path="units/u1/product")],
             plan_id="mp_atomic_proof",
         )
 
-        original_rename = Path.rename
+        original_replace = os.replace
 
-        def selective_fail_rename(self_path, target):
-            if "materialization" in str(self_path) and ".tmp-" in str(self_path):
-                raise OSError("simulated rename failure")
-            return original_rename(self_path, target)
+        def selective_fail_replace(src, dst, **kwargs):
+            if "materialization" in str(src):
+                raise OSError("simulated replace failure")
+            return original_replace(src, dst, **kwargs)
 
-        with patch.object(Path, "rename", selective_fail_rename):
+        with patch.object(spec_apply.os, "replace", selective_fail_replace):
             with self.assertRaises(OSError):
                 apply_materialization_plan(self.workspace_root, plan, yes=True)
 
         receipt_path = self.workspace_root / ".grip" / "state" / "materialization" / "mp_atomic_proof.json"
         self.assertFalse(receipt_path.exists())
+
+    def test_receipt_publish_fsyncs_file_and_parent_directory(self):
+        """config#492 §6.2.1 #10, Sentinel round 3: publication performed
+        write_text + rename with ZERO fsync calls. Rename success is not
+        durable acknowledgement -- on power loss the rename can survive
+        while the bytes don't, leaving a "published" receipt whose content
+        never landed, after the staged inputs it acknowledges were deleted.
+        Asserts both fsync calls happen AND that they precede the unlink."""
+        content = b"durable"
+        source_rel = self._stage_source("f_01", content)
+        plan = self._plan(
+            [
+                self._project_file_op(
+                    source_path=source_rel,
+                    source_sha256=hashlib.sha256(content).hexdigest(),
+                    dest_path="units/u1/home/AGENTS.md",
+                )
+            ],
+            plan_id="mp_fsync_proof",
+        )
+
+        events: list[str] = []
+        original_fsync = os.fsync
+        original_unlink = Path.unlink
+
+        def tracking_fsync(fd):
+            events.append("fsync")
+            return original_fsync(fd)
+
+        def tracking_unlink(self_path, **kwargs):
+            if "staging" in str(self_path):
+                events.append("unlink")
+            return original_unlink(self_path, **kwargs)
+
+        with patch.object(spec_apply.os, "fsync", tracking_fsync):
+            with patch.object(Path, "unlink", tracking_unlink):
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+        # Two fsyncs: the receipt file itself, then its parent directory.
+        self.assertEqual(events.count("fsync"), 2, events)
+        self.assertIn("unlink", events)
+        self.assertLess(
+            max(i for i, e in enumerate(events) if e == "fsync"),
+            events.index("unlink"),
+            f"both fsyncs must precede staging cleanup, got {events}",
+        )
+
+    def test_no_receipt_and_source_survives_when_fsync_fails(self):
+        """The durability guarantee's failure face: if fsync raises, there
+        must be no published receipt and the staged source must survive."""
+        content = b"durable"
+        source_rel = self._stage_source("f_01", content)
+        plan = self._plan(
+            [
+                self._project_file_op(
+                    source_path=source_rel,
+                    source_sha256=hashlib.sha256(content).hexdigest(),
+                    dest_path="units/u1/home/AGENTS.md",
+                )
+            ],
+            plan_id="mp_fsync_fail",
+        )
+
+        with patch.object(spec_apply.os, "fsync", side_effect=OSError("simulated fsync failure")):
+            with self.assertRaises(OSError):
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+        receipt_path = self.workspace_root / ".grip" / "state" / "materialization" / "mp_fsync_fail.json"
+        self.assertFalse(receipt_path.exists())
+        self.assertTrue((self.workspace_root / source_rel).exists())
 
 
 class TestSharedExecutor(MaterializationPlanTestBase):
@@ -578,7 +683,7 @@ class TestCloneOperation(MaterializationPlanTestBase):
         """gap#4: uses the declared dest_path directly, not a repo-name-derived path."""
         url = self._init_bare_remote("product")
         plan = self._plan(
-            [{"kind": "clone", "repo_url": url, "dest_path": "units/u_7f3a/home/product"}]
+            [{"kind": "clone", "branch": "main", "repo_url": url, "dest_path": "units/u_7f3a/home/product"}]
         )
         result = apply_materialization_plan(self.workspace_root, plan, yes=True)
         dest = self.workspace_root / "units" / "u_7f3a" / "home" / "product"
@@ -596,6 +701,7 @@ class TestCloneOperation(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": url,
                     "dest_path": "units/u1/product",
                     "reference_base": ".grip/cache/repos/product.git",
@@ -622,6 +728,7 @@ class TestCloneOperation(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": url,
                     "dest_path": "units/u1/product",
                     "reference_base": "units/u1/rogue-cache.git",
@@ -646,6 +753,7 @@ class TestCloneOperation(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": url_a,
                     "dest_path": "units/u1/product",
                     "reference_base": ".grip/cache/repos/product-a.git",
@@ -668,14 +776,14 @@ class TestCloneOperation(MaterializationPlanTestBase):
         # `git rev-parse --git-common-dir` run inside it fails for real.
 
         plan = self._plan(
-            [{"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}]
+            [{"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}]
         )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
     def test_clone_is_idempotent_for_existing_healthy_clone(self):
         url = self._init_bare_remote("product")
-        plan = self._plan([{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}])
+        plan = self._plan([{"kind": "clone", "branch": "main", "repo_url": url, "dest_path": "units/u1/product"}])
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         second = apply_materialization_plan(self.workspace_root, plan, yes=True)
         self.assertFalse(second["operations"][0]["first_materialize"])
@@ -687,7 +795,7 @@ class TestCloneOperation(MaterializationPlanTestBase):
         (dest / ".git").write_text("gitdir: /somewhere/else/.git/worktrees/product\n")
 
         plan = self._plan(
-            [{"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}]
+            [{"kind": "clone", "branch": "main", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}]
         )
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
@@ -702,7 +810,7 @@ class TestCloneOperation(MaterializationPlanTestBase):
         _git(self.workspace_root, "clone", url, str(dest))
         (dest / ".git" / "worktrees").mkdir()
 
-        plan = self._plan([{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}])
+        plan = self._plan([{"kind": "clone", "branch": "main", "repo_url": url, "dest_path": "units/u1/product"}])
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
@@ -716,7 +824,7 @@ class TestCloneOperation(MaterializationPlanTestBase):
         dest.parent.mkdir(parents=True)
         _git(self.workspace_root, "clone", url_a, str(dest))
 
-        plan = self._plan([{"kind": "clone", "repo_url": url_b, "dest_path": "units/u1/product"}])
+        plan = self._plan([{"kind": "clone", "branch": "main", "repo_url": url_b, "dest_path": "units/u1/product"}])
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
@@ -729,6 +837,7 @@ class TestCloneOperation(MaterializationPlanTestBase):
             [
                 {
                     "kind": "clone",
+                    "branch": "main",
                     "repo_url": url,
                     "dest_path": "units/u1/product",
                     "branch": "does-not-exist",
@@ -908,27 +1017,74 @@ class TestReceipts(MaterializationPlanTestBase):
     def test_writes_structured_receipt(self):
         url = self._init_bare_remote("product")
         plan = self._plan(
-            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            [{"kind": "clone", "branch": "main", "repo_url": url, "dest_path": "units/u1/product"}],
             plan_id="mp_receipt_test",
-            workspace_spec_sha256="abc123",
+            workspace_spec_sha256=self.spec_sha256,
         )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
 
         receipt_path = self.workspace_root / ".grip" / "state" / "materialization" / "mp_receipt_test.json"
         self.assertTrue(receipt_path.exists())
         receipt = json.loads(receipt_path.read_text())
+        # Exact receipt schema (Sentinel round 3: "checks only that broad
+        # keys exist" left field-deletion mutants green).
+        self.assertEqual(
+            set(receipt),
+            {
+                "plan_id",
+                "unit_key",
+                "plan_hash",
+                "schema_version",
+                "workspace_spec_sha256",
+                "stage",
+                "applied_at",
+                "operations",
+            },
+        )
         self.assertEqual(receipt["plan_id"], "mp_receipt_test")
         self.assertEqual(receipt["unit_key"], "u_test")
-        self.assertIn("plan_hash", receipt)
-        self.assertEqual(receipt["workspace_spec_sha256"], "abc123")
-        self.assertIn("operations", receipt)
+        self.assertEqual(receipt["stage"], "MATERIALIZED")
+        self.assertEqual(receipt["workspace_spec_sha256"], self.spec_sha256)
         self.assertEqual(len(receipt["operations"]), 1)
+        # Recompute independently from the pinned canonical serialization:
+        # a constant plan_hash mutant dies here (Sentinel: "0"*64 left all
+        # seven receipt tests green).
+        expected_hash = hashlib.sha256(
+            json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(receipt["plan_hash"], expected_hash)
+
+    def test_plan_hash_uses_pinned_canonical_serialization(self):
+        """config#492 §6.2.1 #9. Two independent proofs that this is the
+        PINNED serialization, not merely deterministic:
+        (a) equals the exact pinned recipe;
+        (b) does NOT equal the default-separators / ensure_ascii variants
+            the round-2 code actually used -- with a non-ASCII value in the
+            plan so ensure_ascii genuinely differs."""
+        plan = self._plan(
+            [self._venv_op(dest_path="units/u1/.venv")],
+            plan_id="mp_hash",
+            unit_key="u_straße",
+        )
+        pinned = hashlib.sha256(
+            json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(compute_plan_hash(plan), pinned)
+
+        default_separators = hashlib.sha256(
+            json.dumps(plan, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
+        escaped_ascii = hashlib.sha256(
+            json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        ).hexdigest()
+        self.assertNotEqual(compute_plan_hash(plan), default_separators)
+        self.assertNotEqual(compute_plan_hash(plan), escaped_ascii)
 
     def test_receipt_contains_no_identity_fields(self):
         """config#491 §12.1: neutral receipts carry no identity/org/channel/secret/memory."""
         url = self._init_bare_remote("product")
         plan = self._plan(
-            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            [{"kind": "clone", "branch": "main", "repo_url": url, "dest_path": "units/u1/product"}],
             plan_id="mp_receipt_neutrality",
         )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
@@ -944,7 +1100,7 @@ class TestReceipts(MaterializationPlanTestBase):
         """A rerun of the same plan must not re-clone or duplicate receipt entries."""
         url = self._init_bare_remote("product")
         plan = self._plan(
-            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            [{"kind": "clone", "branch": "main", "repo_url": url, "dest_path": "units/u1/product"}],
             plan_id="mp_resume_test",
         )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
@@ -959,13 +1115,582 @@ class TestReceipts(MaterializationPlanTestBase):
         """Atomic write: temp file is renamed into place, never left dangling."""
         url = self._init_bare_remote("product")
         plan = self._plan(
-            [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+            [{"kind": "clone", "branch": "main", "repo_url": url, "dest_path": "units/u1/product"}],
             plan_id="mp_atomic_test",
         )
         apply_materialization_plan(self.workspace_root, plan, yes=True)
         state_dir = self.workspace_root / ".grip" / "state" / "materialization"
         leftovers = [p for p in state_dir.glob("*.tmp-*")]
         self.assertEqual(leftovers, [])
+
+
+class TestPinnedSchemaConformance(MaterializationPlanTestBase):
+    """Round 3 (Atlas + Sentinel): a hand-rolled allowlist is a separate,
+    looser contract by construction -- config#492's malformed fixtures
+    were only 8/12 RED against it. These pin conformance to the PINNED
+    schema itself (SHA a5061501...590231c), including the exact survivors
+    both reviewers enumerated."""
+
+    def test_packaged_schema_matches_pinned_sha256(self):
+        raw = spec_apply._read_plan_schema_bytes()
+        self.assertEqual(hashlib.sha256(raw).hexdigest(), spec_apply._PLAN_SCHEMA_SHA256)
+
+    def test_schema_load_fails_closed_on_hash_mismatch(self):
+        """A tampered/unpinned schema must refuse to validate at all,
+        rather than silently enforcing a different contract."""
+        spec_apply._plan_validator = None
+        try:
+            with patch.object(spec_apply, "_read_plan_schema_bytes", return_value=b"{}"):
+                with self.assertRaises(MaterializationPlanError) as ctx:
+                    apply_materialization_plan(
+                        self.workspace_root,
+                        self._plan([self._venv_op(dest_path="units/u1/.venv")]),
+                        yes=True,
+                    )
+            self.assertIn("hash mismatch", str(ctx.exception))
+        finally:
+            spec_apply._plan_validator = None
+
+    def _assert_rejected(self, plan: dict[str, object], label: str) -> None:
+        with self.assertRaises(MaterializationPlanError, msg=f"{label} must be rejected"):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_clone_without_branch_rejected(self):
+        self._assert_rejected(
+            self._plan([{"kind": "clone", "repo_url": "https://e.com/x.git", "dest_path": "units/u1/p"}]),
+            "clone without required branch",
+        )
+
+    def test_venv_without_engine_or_python_rejected(self):
+        self._assert_rejected(
+            self._plan([{"kind": "venv", "dest_path": "units/u1/.venv"}]),
+            "venv without required engine/python",
+        )
+
+    def test_editable_install_without_extras_rejected(self):
+        self._assert_rejected(
+            self._plan(
+                [{"kind": "editable_install", "venv_path": "units/u1/.venv", "source_path": "units/u1/src"}]
+            ),
+            "editable_install without required extras",
+        )
+
+    def test_project_file_without_mode_rejected(self):
+        source_rel = self._stage_source("f_01", b"x")
+        self._assert_rejected(
+            self._plan(
+                [
+                    {
+                        "kind": "project_file",
+                        "source_path": source_rel,
+                        "source_sha256": hashlib.sha256(b"x").hexdigest(),
+                        "dest_path": "units/u1/AGENTS.md",
+                    }
+                ]
+            ),
+            "project_file without required mode",
+        )
+
+    def test_short_workspace_spec_sha_rejected(self):
+        self._assert_rejected(
+            self._plan([self._venv_op(dest_path="units/u1/.venv")], workspace_spec_sha256="abc123"),
+            "six-character workspace_spec_sha256",
+        )
+
+    def test_dot_path_segment_rejected(self):
+        self._assert_rejected(
+            self._plan([self._venv_op(dest_path="units/./u1/.venv")]),
+            "literal '.' path segment",
+        )
+
+    def test_backslash_path_rejected(self):
+        self._assert_rejected(
+            self._plan([self._venv_op(dest_path="units\\u1\\.venv")]),
+            "backslash path",
+        )
+
+    def test_duplicate_extras_rejected(self):
+        self._assert_rejected(
+            self._plan(
+                [
+                    {
+                        "kind": "editable_install",
+                        "venv_path": "units/u1/.venv",
+                        "source_path": "units/u1/src",
+                        "extras": ["dev", "dev"],
+                    }
+                ]
+            ),
+            "duplicate extras (uniqueItems)",
+        )
+
+    def test_overlong_plan_id_rejected(self):
+        self._assert_rejected(
+            self._plan([self._venv_op(dest_path="units/u1/.venv")], plan_id="p" * 129),
+            "129-character plan_id",
+        )
+
+    def test_nested_staged_input_path_rejected(self):
+        nested = self.workspace_root / ".grip" / "staging" / "inputs" / "a"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "b").write_bytes(b"x")
+        self._assert_rejected(
+            self._plan(
+                [
+                    self._project_file_op(
+                        source_path=".grip/staging/inputs/a/b",
+                        source_sha256=hashlib.sha256(b"x").hexdigest(),
+                        dest_path="units/u1/AGENTS.md",
+                    )
+                ]
+            ),
+            "nested staged input path",
+        )
+
+    def test_boolean_schema_version_rejected(self):
+        """schema_version=True passes a naive `!= 1` check because bool is
+        an int subclass in Python (True == 1); JSON Schema's const:1
+        distinguishes the types correctly."""
+        self._assert_rejected(
+            self._plan([self._venv_op(dest_path="units/u1/.venv")], schema_version=True),
+            "boolean schema_version",
+        )
+
+    def test_invalid_opaque_token_rejected(self):
+        self._assert_rejected(
+            self._plan([self._venv_op(dest_path="units/u1/.venv")], unit_key="../escape"),
+            "invalid opaque unit_key",
+        )
+
+    def test_missing_workspace_spec_file_rejected(self):
+        """config#492 §6.2.1 #1: the executor applied with no canonical
+        WorkspaceSpec at all, so the declared hash was never verified."""
+        workspace_spec_path(self.workspace_root).unlink()
+        self._assert_rejected(
+            self._plan([self._venv_op(dest_path="units/u1/.venv")]),
+            "absent canonical WorkspaceSpec",
+        )
+
+    def test_workspace_spec_hash_mismatch_rejected(self):
+        """The declared hash must equal the REOPENED bytes -- a plan
+        compiled against different workspace state must not apply."""
+        self._write_workspace_spec('workspace_name = "drifted"\n')
+        self._assert_rejected(
+            self._plan([self._venv_op(dest_path="units/u1/.venv")]),
+            "workspace_spec_sha256 vs reopened bytes mismatch",
+        )
+
+
+class TestUnicodeCollisionGuards(MaterializationPlanTestBase):
+    """Sentinel round 3: removing .casefold() left all 13 plan-shape tests
+    GREEN because no case-only collision fixture existed."""
+
+    def test_case_only_duplicate_dest_paths_rejected(self):
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(
+                self.workspace_root,
+                self._plan(
+                    [
+                        self._venv_op(dest_path="units/u1/.venv"),
+                        self._venv_op(dest_path="units/u1/.VENV"),
+                    ]
+                ),
+                yes=True,
+            )
+
+    def test_unicode_casefold_duplicate_dest_paths_rejected(self):
+        """Specifically kills a `.lower()` substitution: lower() leaves 'ß'
+        alone, only casefold() folds it to 'ss' -- so these two paths
+        collide under casefold and do not under lower."""
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(
+                self.workspace_root,
+                self._plan(
+                    [
+                        self._venv_op(dest_path="units/straße/.venv"),
+                        self._venv_op(dest_path="units/STRASSE/.venv"),
+                    ]
+                ),
+                yes=True,
+            )
+
+
+class TestCommonDirComparisonGuard(MaterializationPlanTestBase):
+    """Sentinel round 3: disabling the `common_dir != git_path` COMPARISON
+    left all 48 materialization tests GREEN. My round-2 test only exercised
+    the returncode!=0 fail-closed branch (and even that was masked, since
+    its .git-with-no-internals fixture also fails the origin check). This
+    isolates the comparison itself: a HEALTHY clone with a CORRECT origin,
+    where only the common-dir probe reports a foreign path."""
+
+    def test_rejects_common_dir_pointing_at_another_checkout(self):
+        url = self._init_bare_remote("product")
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.parent.mkdir(parents=True)
+        _git(self.workspace_root, "clone", url, str(dest))
+        foreign = self.workspace_root / "elsewhere" / ".git"
+        foreign.mkdir(parents=True)
+
+        real_run = subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list) and "--git-common-dir" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout=f"{foreign}\n", stderr="")
+            return real_run(cmd, *args, **kwargs)
+
+        plan = self._plan([self._clone_op(repo_url=url, dest_path="units/u1/product")])
+        with patch.object(spec_apply.subprocess, "run", fake_run):
+            with self.assertRaises(MaterializationPlanError) as ctx:
+                apply_materialization_plan(self.workspace_root, plan, yes=True)
+        # Match the SPECIFIC failure, not just "some error was raised" --
+        # the mistake that masked the round-2 version of this test.
+        self.assertIn("git-common-dir", str(ctx.exception))
+
+
+class TestExecutorSeamIsShared(MaterializationPlanTestBase):
+    """Sentinel round 3: replacing the legacy converge_unit_repos call to
+    _apply_clone_operation with a behavior-equivalent direct
+    _clone_isolated call left 11/11 GREEN -- behavior parity is not proof
+    of a shared seam. A spy proves the legacy adapter genuinely routes
+    through the shared operation executor; a bypass mutant makes it RED."""
+
+    def test_legacy_apply_plan_routes_clones_through_shared_operation_executor(self):
+        url = self._init_bare_remote("app")
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.write_text(
+            "\n".join(
+                [
+                    'workspace_name = "test"',
+                    "",
+                    "[[repos]]",
+                    'name = "app"',
+                    'path = "repos/app"',
+                    f'url = "{url}"',
+                    "",
+                    "[[units]]",
+                    'name = "atlas"',
+                    'path = "agents/atlas/home"',
+                    'repos = ["app"]',
+                    "",
+                ]
+            )
+        )
+
+        seen: list[dict[str, object]] = []
+        real_apply_clone = spec_apply._apply_clone_operation
+
+        def spy(workspace_root, op):
+            seen.append(op)
+            return real_apply_clone(workspace_root, op)
+
+        with patch.object(spec_apply, "_apply_clone_operation", spy):
+            apply_plan(self.workspace_root, yes=True)
+
+        # Both the workspace-level repo clone AND the unit's own checkout
+        # must have gone through the shared operation dispatch.
+        self.assertGreaterEqual(len(seen), 2, seen)
+        dests = {op["dest_path"] for op in seen}
+        self.assertIn("repos/app", dests)
+        self.assertIn("agents/atlas/home/app", dests)
+
+
+class TestVenvProbeStrength(MaterializationPlanTestBase):
+    """config#492 §6.2.1 #6 -- production-shaped mutants both reviewers
+    reported surviving the round-2 file-presence check."""
+
+    def _forge_venv(self, body: str) -> Path:
+        venv = self.workspace_root / "units" / "u1" / ".venv"
+        (venv / "bin").mkdir(parents=True)
+        (venv / "pyvenv.cfg").write_text("home = /nonexistent\nversion = 3.99.0\n")
+        interp = venv / "bin" / "python3"
+        interp.write_text(body)
+        interp.chmod(0o755)
+        return venv
+
+    def test_rejects_executable_shell_script_masquerading_as_interpreter(self):
+        """Atlas: pyvenv.cfg + an executable SHELL SCRIPT at bin/python3
+        was accepted and receipted as an existing venv."""
+        self._forge_venv("#!/bin/sh\necho fake\n")
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(
+                self.workspace_root,
+                self._plan([self._venv_op(dest_path="units/u1/.venv")]),
+                yes=True,
+            )
+
+    def test_rejects_interpreter_that_exits_nonzero(self):
+        """Sentinel: executable bin/python whose body exits 42."""
+        self._forge_venv("#!/bin/sh\nexit 42\n")
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(
+                self.workspace_root,
+                self._plan([self._venv_op(dest_path="units/u1/.venv")]),
+                yes=True,
+            )
+
+    def test_rejects_real_venv_failing_declared_python_constraint(self):
+        """Sentinel: a real-shaped venv was accepted under python=">=99",
+        an unsatisfiable constraint no genuine interpreter can meet. The
+        probe must check the DECLARED constraint, not just venv-ness."""
+        venv_path = self.workspace_root / "units" / "u1" / ".venv"
+        venv_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["uv", "venv", "--python", ">=3.11", str(venv_path)], check=True, capture_output=True
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(
+                self.workspace_root,
+                self._plan([self._venv_op(dest_path="units/u1/.venv", python=">=99")]),
+                yes=True,
+            )
+
+    def test_accepts_real_venv_satisfying_declared_constraint(self):
+        """The positive face: the probe must not reject genuine venvs."""
+        venv_path = self.workspace_root / "units" / "u1" / ".venv"
+        venv_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["uv", "venv", "--python", ">=3.11", str(venv_path)], check=True, capture_output=True
+        )
+        result = apply_materialization_plan(
+            self.workspace_root,
+            self._plan([self._venv_op(dest_path="units/u1/.venv")]),
+            yes=True,
+        )
+        self.assertFalse(result["operations"][0]["created"])
+        self.assertTrue(result["operations"][0]["interpreter_path"])
+
+
+class TestBranchDesiredState(MaterializationPlanTestBase):
+    """Atlas round 3: an existing healthy clone on `main` accepted a plan
+    declaring branch `feature` and remained on `main` -- required plan
+    fields are desired state validated on every apply, not inputs consumed
+    only during first creation."""
+
+    def test_existing_clone_on_wrong_branch_rejected(self):
+        url = self._init_bare_remote("product")
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.parent.mkdir(parents=True)
+        _git(self.workspace_root, "clone", url, str(dest))
+
+        plan = self._plan([self._clone_op(repo_url=url, dest_path="units/u1/product", branch="feature")])
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertIn("branch", str(ctx.exception))
+        # Never force-switched (prior source ruling on §8.3).
+        self.assertEqual(_git(dest, "branch", "--show-current").stdout.strip(), "main")
+
+
+class TestCacheProvenance(MaterializationPlanTestBase):
+    """config#492 §6.2.1 #5 -- fail CLOSED on unverifiable cache identity."""
+
+    def test_rejects_non_git_directory_at_canonical_cache_path(self):
+        """Atlas/Sentinel: a non-Git directory at the canonical path was
+        accepted, the clone silently proceeded WITHOUT an alternate, and
+        the receipt still claimed alternate_approved=True."""
+        url = self._init_bare_remote("product")
+        cache = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        cache.mkdir(parents=True)
+        (cache / "not-a-repo.txt").write_text("nope")
+
+        plan = self._plan(
+            [
+                self._clone_op(
+                    repo_url=url,
+                    dest_path="units/u1/product",
+                    reference_base=".grip/cache/repos/product.git",
+                )
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / "units" / "u1" / "product").exists())
+
+    def test_rejects_cache_with_no_canonical_origin(self):
+        """A bare repo with no origin remote: provenance is ABSENT, which
+        the round-2 code fail-opened on (`if origin is not None and ...`)."""
+        url = self._init_bare_remote("product")
+        cache = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "init", "--bare", str(cache))
+
+        plan = self._plan(
+            [
+                self._clone_op(
+                    repo_url=url,
+                    dest_path="units/u1/product",
+                    reference_base=".grip/cache/repos/product.git",
+                )
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_rejects_declared_cache_that_does_not_exist(self):
+        url = self._init_bare_remote("product")
+        plan = self._plan(
+            [
+                self._clone_op(
+                    repo_url=url,
+                    dest_path="units/u1/product",
+                    reference_base=".grip/cache/repos/product.git",
+                )
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_alternate_evidence_is_observed_not_assumed(self):
+        """Receipt evidence must come from the actual alternates file."""
+        url = self._init_bare_remote("product")
+        cache = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "clone", "--mirror", url, str(cache))
+
+        plan = self._plan(
+            [
+                self._clone_op(
+                    repo_url=url,
+                    dest_path="units/u1/product",
+                    reference_base=".grip/cache/repos/product.git",
+                )
+            ]
+        )
+        result = apply_materialization_plan(self.workspace_root, plan, yes=True)
+        op_result = result["operations"][0]
+        observed = op_result["observed_alternate"]
+        self.assertIsNotNone(observed)
+        self.assertEqual(Path(observed).resolve(), (cache / "objects").resolve())
+        self.assertTrue(op_result["alternate_approved"])
+
+
+class TestStagingSymlinkGuards(MaterializationPlanTestBase):
+    """config#492 §6.2.1 #2/#7 -- any EXISTING symlink in the prefix, and
+    a non-symlink regular source. Sentinel round 3's exact fixtures."""
+
+    def test_rejects_symlink_alias_inside_staging(self):
+        """`.grip/staging/inputs/alias -> .../inputs/real` was accepted;
+        the projection ran and cleanup unlinked the RESOLVED target,
+        leaving the alias dangling. Resolve-based containment can't see
+        this -- both sides are legitimately inside staging."""
+        staging = self.workspace_root / ".grip" / "staging" / "inputs"
+        staging.mkdir(parents=True, exist_ok=True)
+        real = staging / "real"
+        content = b"payload"
+        real.write_bytes(content)
+        (staging / "alias").symlink_to(real)
+
+        plan = self._plan(
+            [
+                self._project_file_op(
+                    source_path=".grip/staging/inputs/alias",
+                    source_sha256=hashlib.sha256(content).hexdigest(),
+                    dest_path="units/u1/AGENTS.md",
+                )
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertTrue(real.exists(), "the resolved target must not be unlinked")
+        self.assertFalse((self.workspace_root / "units" / "u1" / "AGENTS.md").exists())
+
+    def test_rejects_symlinked_staging_directory_prefix(self):
+        """`.grip/staging/inputs -> <workspace>/rogue`: both the candidate
+        and the staging root resolve THROUGH the same link, so a
+        resolve-only containment check holds while the bytes come from
+        outside staging entirely."""
+        rogue = self.workspace_root / "rogue"
+        rogue.mkdir()
+        content = b"rogue payload"
+        (rogue / "f_01").write_bytes(content)
+        staging_parent = self.workspace_root / ".grip" / "staging"
+        staging_parent.mkdir(parents=True, exist_ok=True)
+        (staging_parent / "inputs").symlink_to(rogue)
+
+        plan = self._plan(
+            [
+                self._project_file_op(
+                    source_path=".grip/staging/inputs/f_01",
+                    source_sha256=hashlib.sha256(content).hexdigest(),
+                    dest_path="units/u1/AGENTS.md",
+                )
+            ]
+        )
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertTrue((rogue / "f_01").exists())
+        self.assertFalse((self.workspace_root / "units" / "u1" / "AGENTS.md").exists())
+
+
+class TestIdempotentCleanup(MaterializationPlanTestBase):
+    """config#492 §6.2.1 #8: if cleanup is interrupted AFTER receipt
+    publication, a rerun performs the idempotent cleanup from the verified
+    receipt rather than failing or re-copying."""
+
+    def _project_plan(self, content: bytes, source_rel: str) -> dict[str, object]:
+        return self._plan(
+            [
+                self._project_file_op(
+                    source_path=source_rel,
+                    source_sha256=hashlib.sha256(content).hexdigest(),
+                    dest_path="units/u1/AGENTS.md",
+                )
+            ],
+            plan_id="mp_idempotent",
+        )
+
+    def test_rerun_after_successful_apply_succeeds_with_source_gone(self):
+        content = b"payload"
+        source_rel = self._stage_source("f_01", content)
+        plan = self._project_plan(content, source_rel)
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / source_rel).exists())
+
+        result = apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertTrue(result["operations"][0]["already_projected"])
+        self.assertEqual(
+            (self.workspace_root / "units" / "u1" / "AGENTS.md").read_bytes(), content
+        )
+
+    def test_rerun_cleans_up_source_left_by_interrupted_cleanup(self):
+        content = b"payload"
+        source_rel = self._stage_source("f_01", content)
+        plan = self._project_plan(content, source_rel)
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+        # Simulate cleanup interrupted after the receipt was published.
+        (self.workspace_root / source_rel).write_bytes(content)
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse((self.workspace_root / source_rel).exists())
+
+
+class TestProjectFileReceiptEvidence(MaterializationPlanTestBase):
+    """Sentinel round 3: the observed project-file receipt had only kind,
+    dest_path, and source_sha256 -- §12.1 also requires the source path."""
+
+    def test_receipt_records_project_file_source_path(self):
+        content = b"payload"
+        source_rel = self._stage_source("f_01", content)
+        plan = self._plan(
+            [
+                self._project_file_op(
+                    source_path=source_rel,
+                    source_sha256=hashlib.sha256(content).hexdigest(),
+                    dest_path="units/u1/AGENTS.md",
+                )
+            ],
+            plan_id="mp_pf_evidence",
+        )
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        receipt = json.loads(
+            (
+                self.workspace_root / ".grip" / "state" / "materialization" / "mp_pf_evidence.json"
+            ).read_text()
+        )
+        op = receipt["operations"][0]
+        self.assertEqual(op["source_path"], source_rel)
+        self.assertEqual(op["dest_path"], "units/u1/AGENTS.md")
+        self.assertEqual(op["source_sha256"], hashlib.sha256(content).hexdigest())
+        self.assertNotIn("_pending_unlink", op, "internal orchestration key must never be receipted")
 
 
 if __name__ == "__main__":

--- a/gr2/tests/test_materialization_plan.py
+++ b/gr2/tests/test_materialization_plan.py
@@ -1,0 +1,372 @@
+"""Tests for apply_materialization_plan (config#491 §6.2, S4).
+
+Consumes the neutral MaterializationPlan JSON schema directly (clone/venv/
+editable_install/project_file operations) rather than workspace_spec.toml's
+repo/unit model. Identity-free by construction: gr2 never reads an agent
+name, org, role, or channel out of a plan.
+
+Shares clone_repo/git primitives with the existing build_plan/apply_plan
+path (config#491 §7.3: "one apply_plan executor... not a second
+materializer") -- this file tests the new entry point specifically.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+from gr2.python_cli.spec_apply import (
+    MaterializationPlanError,
+    apply_materialization_plan,
+)
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=False)
+
+
+class MaterializationPlanTestBase(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self.tmp = Path(tempfile.mkdtemp())
+        self.workspace_root = self.tmp / "workspace"
+        self.workspace_root.mkdir(parents=True)
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _init_bare_remote(self, name: str) -> str:
+        """Create a real local bare repo with one commit; return its URL."""
+        bare = self.tmp / f"{name}.git"
+        _git(self.tmp, "init", "--bare", "--initial-branch=main", str(bare))
+        work = self.tmp / f"{name}-seed"
+        work.mkdir()
+        _git(work, "init", "--initial-branch=main")
+        _git(work, "config", "user.email", "test@example.com")
+        _git(work, "config", "user.name", "Test")
+        (work / "README.md").write_text(f"# {name}\n")
+        _git(work, "add", ".")
+        _git(work, "commit", "-m", "initial")
+        _git(work, "remote", "add", "origin", str(bare))
+        _git(work, "push", "origin", "main")
+        return str(bare)
+
+
+class TestPathSafety(MaterializationPlanTestBase):
+    def test_clone_rejects_absolute_dest_path(self):
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "/etc/passwd"}
+            ],
+        }
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_clone_rejects_dest_path_escaping_via_dotdot(self):
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "clone",
+                    "repo_url": "https://example.com/x.git",
+                    "dest_path": "units/u1/../../../outside",
+                }
+            ],
+        }
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_project_file_rejects_absolute_dest_path(self):
+        source = self.tmp / "staged.md"
+        source.write_text("hello")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "project_file",
+                    "source_path": str(source),
+                    "source_sha256": hashlib.sha256(b"hello").hexdigest(),
+                    "dest_path": "/tmp/escape.md",
+                    "mode": "copy",
+                }
+            ],
+        }
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+
+class TestIdentityFreedom(MaterializationPlanTestBase):
+    def test_rejects_operation_with_identity_bearing_field(self):
+        """config#491 §6.2: the plan must not carry agent name/role/org/etc."""
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "clone",
+                    "repo_url": "https://example.com/x.git",
+                    "dest_path": "units/u1/repo",
+                    "agent_name": "apollo",
+                }
+            ],
+        }
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+
+class TestCloneOperation(MaterializationPlanTestBase):
+    def test_clones_to_explicit_dest_path(self):
+        """gap#4: uses the declared dest_path directly, not a repo-name-derived path."""
+        url = self._init_bare_remote("product")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {"kind": "clone", "repo_url": url, "dest_path": "units/u_7f3a/home/product"}
+            ],
+        }
+        result = apply_materialization_plan(self.workspace_root, plan, yes=True)
+        dest = self.workspace_root / "units" / "u_7f3a" / "home" / "product"
+        self.assertTrue((dest / "README.md").exists())
+        self.assertTrue((dest / ".git").is_dir())
+        self.assertEqual(result["operation_count"], 1)
+
+    def test_clone_uses_reference_base_as_alternate(self):
+        url = self._init_bare_remote("product")
+        cache_dir = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        cache_dir.parent.mkdir(parents=True, exist_ok=True)
+        _git(self.workspace_root, "clone", "--mirror", url, str(cache_dir))
+
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "clone",
+                    "repo_url": url,
+                    "dest_path": "units/u1/product",
+                    "reference_base": ".grip/cache/repos/product.git",
+                }
+            ],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        dest = self.workspace_root / "units" / "u1" / "product"
+        alternates = dest / ".git" / "objects" / "info" / "alternates"
+        self.assertTrue(alternates.exists())
+
+    def test_clone_is_idempotent_for_existing_healthy_clone(self):
+        url = self._init_bare_remote("product")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        second = apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse(second["operations"][0]["first_materialize"])
+
+    def test_clone_rejects_worktree_linked_git_dir(self):
+        """gap#6 / config#491 §8.1: .git as a worktree pointer file is forbidden."""
+        dest = self.workspace_root / "units" / "u1" / "product"
+        dest.mkdir(parents=True)
+        (dest / ".git").write_text("gitdir: /somewhere/else/.git/worktrees/product\n")
+
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {"kind": "clone", "repo_url": "https://example.com/x.git", "dest_path": "units/u1/product"}
+            ],
+        }
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+
+class TestVenvOperation(MaterializationPlanTestBase):
+    def test_creates_venv_via_uv(self):
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {"kind": "venv", "dest_path": "units/u1/home/.venv", "engine": "uv", "python": ">=3.11"}
+            ],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        venv_path = self.workspace_root / "units" / "u1" / "home" / ".venv"
+        self.assertTrue((venv_path / "bin" / "python").exists() or (venv_path / "bin" / "python3").exists())
+
+    def test_venv_idempotent_when_already_exists(self):
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {"kind": "venv", "dest_path": "units/u1/home/.venv", "engine": "uv", "python": ">=3.11"}
+            ],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        second = apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse(second["operations"][0]["created"])
+
+
+class TestEditableInstallOperation(MaterializationPlanTestBase):
+    def test_installs_editable_source_via_uv(self):
+        venv_path = self.workspace_root / "units" / "u1" / "home" / ".venv"
+        subprocess.run(["uv", "venv", "--python", ">=3.11", str(venv_path)], check=True, capture_output=True)
+
+        source = self.workspace_root / "units" / "u1" / "home" / "product"
+        source.mkdir(parents=True)
+        (source / "pyproject.toml").write_text(
+            '[project]\nname = "product"\nversion = "0.1.0"\n'
+            '[build-system]\nrequires = ["setuptools>=68"]\nbuild-backend = "setuptools.build_meta"\n'
+        )
+        (source / "product").mkdir()
+        (source / "product" / "__init__.py").write_text("")
+
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "editable_install",
+                    "venv_path": "units/u1/home/.venv",
+                    "source_path": "units/u1/home/product",
+                    "extras": [],
+                }
+            ],
+        }
+        result = apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertEqual(result["operations"][0]["kind"], "editable_install")
+        check = subprocess.run(
+            [str(venv_path / "bin" / "python"), "-c", "import product"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(check.returncode, 0, check.stderr)
+
+
+class TestProjectFileOperation(MaterializationPlanTestBase):
+    def test_copies_and_verifies_hash(self):
+        source = self.tmp / "staged-AGENTS.md"
+        content = b"# Foundation\nRole: neutral executor.\n"
+        source.write_bytes(content)
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "project_file",
+                    "source_path": str(source),
+                    "source_sha256": hashlib.sha256(content).hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "copy",
+                }
+            ],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        dest = self.workspace_root / "units" / "u1" / "home" / "AGENTS.md"
+        self.assertEqual(dest.read_bytes(), content)
+
+    def test_rejects_hash_mismatch(self):
+        source = self.tmp / "staged.md"
+        source.write_bytes(b"real content")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "project_file",
+                    "source_path": str(source),
+                    "source_sha256": hashlib.sha256(b"different content").hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "copy",
+                }
+            ],
+        }
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_deletes_staging_source_after_copy(self):
+        """config#491 §6.2: staging artifact is deleted after acknowledgement."""
+        source = self.tmp / "staged.md"
+        content = b"ephemeral"
+        source.write_bytes(content)
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "project_file",
+                    "source_path": str(source),
+                    "source_sha256": hashlib.sha256(content).hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "copy",
+                }
+            ],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertFalse(source.exists())
+
+
+class TestReceipts(MaterializationPlanTestBase):
+    def test_writes_structured_receipt(self):
+        url = self._init_bare_remote("product")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_receipt_test",
+            "workspace_spec_sha256": "abc123",
+            "operations": [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+        receipt_path = self.workspace_root / ".grip" / "state" / "materialization" / "mp_receipt_test.json"
+        self.assertTrue(receipt_path.exists())
+        receipt = json.loads(receipt_path.read_text())
+        self.assertEqual(receipt["plan_id"], "mp_receipt_test")
+        self.assertEqual(receipt["workspace_spec_sha256"], "abc123")
+        self.assertIn("operations", receipt)
+        self.assertEqual(len(receipt["operations"]), 1)
+
+    def test_receipt_contains_no_identity_fields(self):
+        """config#491 §12.1: neutral receipts carry no identity/org/channel/secret/memory."""
+        url = self._init_bare_remote("product")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_receipt_neutrality",
+            "operations": [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+        receipt_path = (
+            self.workspace_root / ".grip" / "state" / "materialization" / "mp_receipt_neutrality.json"
+        )
+        raw = receipt_path.read_text().lower()
+        for forbidden in ("agent_name", "agent_id", "role", "org", "channel", "secret", "memory"):
+            self.assertNotIn(forbidden, raw)
+
+    def test_rerun_is_resumable_not_duplicated(self):
+        """A rerun of the same plan must not re-clone or duplicate receipt entries."""
+        url = self._init_bare_remote("product")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_resume_test",
+            "operations": [{"kind": "clone", "repo_url": url, "dest_path": "units/u1/product"}],
+        }
+        apply_materialization_plan(self.workspace_root, plan, yes=True)
+        second = apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+        receipt_path = self.workspace_root / ".grip" / "state" / "materialization" / "mp_resume_test.json"
+        receipt = json.loads(receipt_path.read_text())
+        self.assertEqual(len(receipt["operations"]), 1)
+        self.assertFalse(second["operations"][0]["first_materialize"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gr2/tests/test_materialization_plan.py
+++ b/gr2/tests/test_materialization_plan.py
@@ -40,6 +40,16 @@ class MaterializationPlanTestBase(unittest.TestCase):
 
         shutil.rmtree(self.tmp, ignore_errors=True)
 
+    def _stage_source(self, relative_path: str, content: bytes) -> str:
+        """Stage a project_file source under the workspace root, at a
+        workspace-relative path -- matching config#491 §6.2's own example
+        (`.grip/staging/inputs/f_01`), not an arbitrary absolute path.
+        Returns the relative_path for use as the plan's source_path."""
+        path = self.workspace_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        return relative_path
+
     def _init_bare_remote(self, name: str) -> str:
         """Create a real local bare repo with one commit; return its URL."""
         bare = self.tmp / f"{name}.git"
@@ -85,15 +95,14 @@ class TestPathSafety(MaterializationPlanTestBase):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
 
     def test_project_file_rejects_absolute_dest_path(self):
-        source = self.tmp / "staged.md"
-        source.write_text("hello")
+        source_rel = self._stage_source(".grip/staging/inputs/f_01", b"hello")
         plan = {
             "schema_version": 1,
             "plan_id": "mp_test",
             "operations": [
                 {
                     "kind": "project_file",
-                    "source_path": str(source),
+                    "source_path": source_rel,
                     "source_sha256": hashlib.sha256(b"hello").hexdigest(),
                     "dest_path": "/tmp/escape.md",
                     "mode": "copy",
@@ -102,6 +111,51 @@ class TestPathSafety(MaterializationPlanTestBase):
         }
         with self.assertRaises(MaterializationPlanError):
             apply_materialization_plan(self.workspace_root, plan, yes=True)
+
+    def test_project_file_rejects_absolute_source_path(self):
+        """The finding: source_path was read+deleted with zero containment
+        check, unlike dest_path. An absolute source must be rejected the
+        same way an absolute dest is."""
+        outside_source = self.tmp / "outside-workspace.md"
+        outside_source.write_bytes(b"hello")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "project_file",
+                    "source_path": str(outside_source),
+                    "source_sha256": hashlib.sha256(b"hello").hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "copy",
+                }
+            ],
+        }
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        # The whole point: an unvalidated source must never be touched, let
+        # alone deleted, before the containment check runs.
+        self.assertTrue(outside_source.exists())
+
+    def test_project_file_rejects_source_path_escaping_via_dotdot(self):
+        outside_source = self.tmp / "outside-workspace.md"
+        outside_source.write_bytes(b"hello")
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "operations": [
+                {
+                    "kind": "project_file",
+                    "source_path": f"../{outside_source.name}",
+                    "source_sha256": hashlib.sha256(b"hello").hexdigest(),
+                    "dest_path": "units/u1/home/AGENTS.md",
+                    "mode": "copy",
+                }
+            ],
+        }
+        with self.assertRaises(MaterializationPlanError):
+            apply_materialization_plan(self.workspace_root, plan, yes=True)
+        self.assertTrue(outside_source.exists())
 
 
 class TestIdentityFreedom(MaterializationPlanTestBase):
@@ -254,16 +308,15 @@ class TestEditableInstallOperation(MaterializationPlanTestBase):
 
 class TestProjectFileOperation(MaterializationPlanTestBase):
     def test_copies_and_verifies_hash(self):
-        source = self.tmp / "staged-AGENTS.md"
         content = b"# Foundation\nRole: neutral executor.\n"
-        source.write_bytes(content)
+        source_rel = self._stage_source(".grip/staging/inputs/f_01", content)
         plan = {
             "schema_version": 1,
             "plan_id": "mp_test",
             "operations": [
                 {
                     "kind": "project_file",
-                    "source_path": str(source),
+                    "source_path": source_rel,
                     "source_sha256": hashlib.sha256(content).hexdigest(),
                     "dest_path": "units/u1/home/AGENTS.md",
                     "mode": "copy",
@@ -275,15 +328,14 @@ class TestProjectFileOperation(MaterializationPlanTestBase):
         self.assertEqual(dest.read_bytes(), content)
 
     def test_rejects_hash_mismatch(self):
-        source = self.tmp / "staged.md"
-        source.write_bytes(b"real content")
+        source_rel = self._stage_source(".grip/staging/inputs/f_01", b"real content")
         plan = {
             "schema_version": 1,
             "plan_id": "mp_test",
             "operations": [
                 {
                     "kind": "project_file",
-                    "source_path": str(source),
+                    "source_path": source_rel,
                     "source_sha256": hashlib.sha256(b"different content").hexdigest(),
                     "dest_path": "units/u1/home/AGENTS.md",
                     "mode": "copy",
@@ -295,16 +347,15 @@ class TestProjectFileOperation(MaterializationPlanTestBase):
 
     def test_deletes_staging_source_after_copy(self):
         """config#491 §6.2: staging artifact is deleted after acknowledgement."""
-        source = self.tmp / "staged.md"
         content = b"ephemeral"
-        source.write_bytes(content)
+        source_rel = self._stage_source(".grip/staging/inputs/f_01", content)
         plan = {
             "schema_version": 1,
             "plan_id": "mp_test",
             "operations": [
                 {
                     "kind": "project_file",
-                    "source_path": str(source),
+                    "source_path": source_rel,
                     "source_sha256": hashlib.sha256(content).hexdigest(),
                     "dest_path": "units/u1/home/AGENTS.md",
                     "mode": "copy",
@@ -312,7 +363,7 @@ class TestProjectFileOperation(MaterializationPlanTestBase):
             ],
         }
         apply_materialization_plan(self.workspace_root, plan, yes=True)
-        self.assertFalse(source.exists())
+        self.assertFalse((self.workspace_root / source_rel).exists())
 
 
 class TestReceipts(MaterializationPlanTestBase):

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -162,17 +162,19 @@ def _write_workspace_spec_multi(workspace_root: Path, repos: list[tuple[str, str
                 """
             ).strip()
         )
+    joined_repo_blocks = "\n\n".join(repo_blocks)
+    unit_repo_names = ", ".join(f'"{name}"' for name, _ in repos)
     spec_path.write_text(
         textwrap.dedent(
             f"""
             workspace_name = "{workspace_root.name}"
 
-            {'\n\n'.join(repo_blocks)}
+            {joined_repo_blocks}
 
             [[units]]
             name = "atlas"
             path = "agents/atlas/home"
-            repos = [{", ".join(f'"{name}"' for name, _ in repos)}]
+            repos = [{unit_repo_names}]
             """
         ).strip()
         + "\n"

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -327,7 +327,16 @@ def test_workspace_materialize_emits_workspace_materialized_event(tmp_path: Path
     assert materialized["workspace"] == workspace_root.name
     assert materialized["actor"] == "system"
     assert materialized["owner_unit"] == "workspace"
-    assert materialized["repos"] == [{"repo": "app", "first_materialize": True}]
+    # _write_workspace_spec declares both a workspace-level "app" repo (repos/app)
+    # and a unit ("atlas") that references the same repo name for its own
+    # checkout (agents/atlas/home/app) -- two distinct physical clones. Pre-
+    # grip#539 fix, the unit's own checkout silently never got scheduled on a
+    # fresh workspace (the exact bug), so only the workspace-level clone showed
+    # up here. Both are expected now.
+    assert materialized["repos"] == [
+        {"repo": "app", "first_materialize": True},
+        {"repo": "app", "first_materialize": True},
+    ]
 
 
 def test_workspace_materialize_emits_file_projected_event(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

S4 — the materialize executor. Consumes config#492's pinned MaterializationPlan v1 wire schema, enforces its §6.2.1 runtime invariants, and shares one execution seam with the legacy `workspace_spec.toml` path.

## Review history

| Round | Verdict | Outcome |
|---|---|---|
| Stromus r1 | APPROVE + 1 finding | `project_file.source_path` unvalidated. Fixed. |
| Sentinel r2 | BINDING REQUEST CHANGES | 5 contract survivors (P1–P5). Stromus walked back r1. All closed. |
| Atlas + Sentinel r2 (round 2) | BINDING, convergent | Tests green *with mutants surviving*. Restructured: allowlists, canonical paths. |
| Atlas 6 + Sentinel 4 (round 3) | BINDING | Schema unwired; runtime invariants under-implemented. All closed. |
| Atlas 3 + Sentinel (round 4) | BINDING, converged | Three combination-space corners. All closed + generator killed. **This state.** |

Round 3's diagnosis was precise and correct: the round-2 restructure closed the schema/scheduling **classes**, but §6.2.1's **runtime** invariants (forged-venv, symlink, cache identity, fsync) are things "validate against a schema" structurally cannot cover. They needed per-invariant code.

## config#492's pinned schema is now wired

The schema (`4b36896`, SHA `a5061501…590231c`) is vendored in the package and validated with `Draft202012Validator` **before** any hand-rolled check. Its bytes are verified against the pinned SHA at load and **fail closed** on mismatch — refusing to validate at all rather than silently enforcing a different contract.

All 13 schema-invalid plans the reviewers passed now reject: clone without `branch`; venv without `engine`/`python`; editable_install without `extras`; project_file without `mode`; short `workspace_spec_sha256`; `.` segment; backslash path; duplicate extras; 129-char `plan_id`; nested `.grip/staging/inputs/a/b`; `schema_version=True`; invalid opaque tokens. Every default/coercion removed (`op.get(k, default)` → `op[k]`).

`schema_version=True` is worth naming: `bool` is an `int` subclass in Python, so `True == 1` and a hand `!= 1` check *accepts* it. JSON Schema's `const: 1` distinguishes the types. A concrete case where the hand validator wasn't merely looser — it was wrong.

## §6.2.1 runtime invariants

**#1 WorkspaceSpec hash** — the canonical spec is reopened and its bytes hashed against `workspace_spec_sha256`. Previously carried but never verified; the executor even applied with no spec file at all.

**#2/#7 symlink-free prefix** — a per-component `lstat` walk rejects any existing symlink in a path prefix, including the final component. `resolve()`-based containment structurally cannot catch the reviewers' fixtures: with `.grip/staging/inputs` *itself* a symlink, both candidate and staging root resolve **through the same link**, so containment holds while the bytes come from outside; and an in-staging alias got its resolved *target* unlinked, leaving the alias dangling. Raw-segment checks now scan the split string, since `Path()` normalizes `.` segments away before `.parts` can see them.

**#5 cache provenance fails closed** — absent origin (`None`) rejects; the round-2 form was fail-open. A non-Git directory at the canonical cache path rejects rather than being silently skipped by `--reference-if-able` and then receipted as approved. `alternate_approved` is **observed** from the real alternates file. `branch` is enforced as desired state on every apply (an existing clone on `main` accepted a plan declaring `feature` and stayed on `main`); never force-switched, per the standing §8.3 ruling.

**#6 isolated bounded venv probe** — runs the interpreter under `-I`, requiring resolved `sys.prefix` == declared venv, distinct `sys.base_prefix`, **and** the declared `python` constraint satisfied. Kills both production-shaped mutants: an executable *shell script* at `bin/python3`, and a real venv accepted under `python=">=99"`. File presence and the executable bit prove nothing about what a file is.

**#9/#10 canonical hash + durable publication** — `plan_hash` uses the exact pinned serialization (`sort_keys`, `separators=(",",":")`, `ensure_ascii=False`), extracted as public `compute_plan_hash` so tests recompute independently instead of trusting the receipt. Publication is same-dir temp → flush → `os.fsync(file)` → `os.replace` → parent-dir `fsync`, **then** staged cleanup. Round 2 had zero `fsync` calls; rename success is not durable acknowledgement.

**#8 idempotent cleanup** — a rerun whose dest already carries the verified bytes completes without the source, and cleans up a source left by interrupted cleanup.

## Adversarial mutation verification (the part that actually matters)

Passing tests were never the bar — Sentinel's whole point is that tests must **die under the mutant**. I ran a **20-mutant sweep** in isolated worktrees, one mutant each, with a stale-worktree sanity guard.

**First sweep: 17 killed, 3 survived.** All three survivors had the identical root cause — a type-only `assertRaises` satisfied by a *different* check than the one under test:

1. **fail-open common-dir.** The dedicated test used a bare-`.git` fixture that *also* fails the origin check further down the same function, so deleting the fail-closed branch entirely left it green. The galling part: I had already written this exact masking into a **sibling test's docstring** during round 3 and never came back to repair this one. Documenting a flaw is not fixing it.
2. **raw-segment guards.** Deleting them left all 98 tests green, because the pinned schema's `workspaceRelativePath` pattern is a strictly stronger **first** gate — every path test was satisfied by the schema and never reached canonicalization. Defense-in-depth with zero independent coverage isn't defense in depth. (The sweep also found NUL escapes as an *uncaught* `ValueError` without the guard — crash-class, not just weakened. And the legacy `apply_plan` adapter reaches canonicalization *without* schema validation, so this layer is load-bearing today, not hypothetically.)
3. **alternate evidence.** The existing test seeded a valid cache, so git created the alternate and request-derived and observation-derived evidence were **both** true — the happy path cannot discriminate them.

Each was fixed by asserting *which invariant fired*, not that *something* raised. **Re-verified: 3/3 now die. All 20 mutants killed.**

## Verification

- **20/20 mutants killed** — full sweep plus targeted re-verification, isolated worktrees, sanity-guarded against stale checkouts.
- Full suite **614 passed** on both Python 3.11.9 (declared floor) and 3.13.
- Live CI green (`gr2 Python Tests (3.11)`, `(3.13)`, aggregate `CI`).
- Real git, real `uv`, real symlinks, real `fsync`/`replace` fault injection — no shortcuts around what each test needs to prove.

## Process note, disclosed

My first mutation sweep was **invalid** and I caught it before reporting: `isolation: 'worktree'` branches from **HEAD**, so all 16 agents mutated the *round-2* committed code while my round-3 work sat uncommitted. The tell was an agent reporting "there is no function named `compute_plan_hash`" and runs collecting 57 tests where mine had 94. Those results independently corroborated Atlas's and Sentinel's round-2 findings but verified nothing about my changes. Committed first, re-ran, added an explicit stale-worktree sanity guard to every agent prompt.

## Round 4 — combination corners + the class-killer

Atlas's re-gate at `82a3a23` found three production-shaped survivors; Sentinel independently reproduced Atlas's three probes from scratch, watched them fail, and **withdrew his own approve** to converge on the identical three. Both gates agreed precisely. All three closed here.

Every one was the same shape — **a second code path skipping what the first path does** — so each is fixed by making the two paths share one function, not by patching the second one:

1. **§6.2.1 #5 — existing clone + declared `reference_base`, no alternate.** The required-alternate rejection lived at a fresh-clone-only call site while `_validate_clone_isolation` returned early whenever the alternates file was absent. An existing ordinary clone with no alternates was accepted and receipted `alternate_approved=false`. Moved the check **into** `_validate_clone_isolation` — the one function both the fresh-staging and existing-destination paths call — and deleted the fresh-only duplicate.

2. **§6.2.1 #7/#8 — rerun cleanup skipped verification.** The dest-already-correct branch scheduled *any* existing staged source for deletion without checking it was regular or re-hashing its bytes, so a source recreated with tampered bytes after receipt publication was silently destroyed. Extracted `_verify_staged_source` and called it from **both** paths. Destructive cleanup now verifies what it destroys.

3. **§9.2/§12.1 — PEP 610 evidence unbound.** `_find_direct_url_evidence` returned the first sorted `direct_url.json`, so a plan installing editable `alpha` then `beta` receipted beta's operation with **alpha's** distribution and path — a structurally complete receipt that is false. Evidence is now bound to the artifact it describes: match the decoded `file://` url against this operation's resolved source **and** require `dir_info.editable`, then derive the distribution from the matched row.

### The class-killer

Every finding across rounds 1–4 came from one untested matrix: **{fresh, existing-clone} × {first-run, rerun} × {single, multi-unit}**. `TestStateMatrixParity` asserts **parity across each axis** — the same invariant firing on *both* sides — rather than testing instances: alternate-requirement on fresh **and** existing; hash verification and regular-file checks on first-run **and** rerun; receipt rows scoped per operation across two units, including multi-unit rerun idempotence.

The code-level counterpart is that sibling paths now share one function (`_validate_clone_isolation`, `_verify_staged_source`), so parity holds **by construction** — the tests are its proof, not its mechanism.

### Round-4 verification

- **16/16 mutants killed, zero survivors.** Three round-4 fixes reverted (each RED) plus all 13 prior mutants re-run as regression (all still RED). Each round-4 mutant was caught by *both* its targeted test and its matrix-parity partner — the class-killer working as intended.
- Full suite **626 passed** on Python 3.11.9 and 3.13.
- Committed before fan-out, per the discipline learned in round 3; every agent prompt carries a stale-worktree sanity guard.

### Filed separately

grip#798 — a pre-existing Windows Rust failure (`test_update_gripspace_advances_configured_remote_branch`) Sentinel observed at this head. Outside this PR's diff, in unchanged code, on the deliberately non-blocking `test-windows` leg. Filed and boarded so it isn't lost as review noise on an unrelated PR.

## Not in this PR (disclosed)

- Migrating the 30+ existing `gr2_overlay` consumers to `gr2.overlay` — time-bounded alias per Stromus/Layne's ruling.
- `gr doctor` (config#491 §11.2) — S6.
- Dirty-clone repair beyond "don't touch it" — §8.3's fuller repair-plan semantics.

## Premium boundary

OSS (grip is MIT) — neutral materialization primitives only. No identity, org, channel, or agent semantics; enforced by the pinned schema's closed `additionalProperties: false` plus per-kind allowlists and recursive identity-key rejection, not asserted in prose.

Closes #539
