### PR TITLE
feat: S4-A materialization plan contract (schema, identity, receipt)

### DIFF
--- a/gr2/gr2/schemas/gr2-materialization-plan-v1.schema.json
+++ b/gr2/gr2/schemas/gr2-materialization-plan-v1.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:synapt:gr2:materialization-plan:v1",
+  "title": "gr2 MaterializationPlan v1",
+  "description": "Identity-free, one-opaque-unit materialization plan consumed by the neutral gr2 executor.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "plan_id",
+    "unit_key",
+    "workspace_spec_sha256",
+    "operations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "plan_id": {
+      "$ref": "#/$defs/opaqueToken"
+    },
+    "unit_key": {
+      "$ref": "#/$defs/opaqueToken"
+    },
+    "workspace_spec_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "operations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/cloneOperation"
+          },
+          {
+            "$ref": "#/$defs/venvOperation"
+          },
+          {
+            "$ref": "#/$defs/editableInstallOperation"
+          },
+          {
+            "$ref": "#/$defs/projectFileOperation"
+          }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "opaqueToken": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048,
+      "pattern": "^[^\\u0000]+$"
+    },
+    "workspaceRelativePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1024,
+      "pattern": "^(?![~/])(?!.*\\\\)(?!.*//)(?!.*(?:^|/)\\.{1,2}(?:/|$))[^\\u0000]+$"
+    },
+    "cacheReferencePath": {
+      "type": "string",
+      "pattern": "^\\.grip/cache/repos/[A-Za-z0-9][A-Za-z0-9._-]{0,127}\\.git$"
+    },
+    "stagedInputPath": {
+      "type": "string",
+      "pattern": "^\\.grip/staging/inputs/[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "cloneOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "repo_url",
+        "dest_path",
+        "branch"
+      ],
+      "properties": {
+        "kind": {
+          "const": "clone"
+        },
+        "repo_url": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "dest_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "branch": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "reference_base": {
+          "$ref": "#/$defs/cacheReferencePath"
+        }
+      }
+    },
+    "venvOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "dest_path",
+        "engine",
+        "python"
+      ],
+      "properties": {
+        "kind": {
+          "const": "venv"
+        },
+        "dest_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "engine": {
+          "const": "uv"
+        },
+        "python": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "editableInstallOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "venv_path",
+        "source_path",
+        "extras"
+      ],
+      "properties": {
+        "kind": {
+          "const": "editable_install"
+        },
+        "venv_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "source_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "extras": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          }
+        }
+      }
+    },
+    "projectFileOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "source_path",
+        "source_sha256",
+        "dest_path",
+        "mode"
+      ],
+      "properties": {
+        "kind": {
+          "const": "project_file"
+        },
+        "source_path": {
+          "$ref": "#/$defs/stagedInputPath"
+        },
+        "source_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "dest_path": {
+          "$ref": "#/$defs/workspaceRelativePath"
+        },
+        "mode": {
+          "const": "copy"
+        }
+      }
+    }
+  }
+}

--- a/gr2/pyproject.toml
+++ b/gr2/pyproject.toml
@@ -12,6 +12,10 @@ dependencies = [
     "tomli_w>=1.0",
     "pyyaml>=6.0",
     "toml>=0.10",
+    # Draft 2020-12 validation of the pinned MaterializationPlan v1 schema
+    # (config#492). 4.18 is the first release with the modern referencing
+    # stack; anything older silently falls back to a legacy resolver.
+    "jsonschema>=4.18",
 ]
 
 [project.scripts]
@@ -24,12 +28,23 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["gr2_overlay", "gr2", "gr2.python_cli", "gr2.prototypes"]
+# gr2_overlay is a time-bounded compat alias for gr2.overlay (config#491
+# gap#13): same physical directory, two import names. New code imports
+# gr2.overlay; gr2_overlay stays for existing consumers until they are
+# migrated separately.
+packages = ["gr2_overlay", "gr2", "gr2.python_cli", "gr2.prototypes", "gr2.overlay"]
 
 [tool.setuptools.package-dir]
 gr2 = "gr2"
 "gr2.python_cli" = "python_cli"
 "gr2.prototypes" = "prototypes"
+"gr2.overlay" = "gr2_overlay"
+
+[tool.setuptools.package-data]
+# The pinned MaterializationPlan v1 schema (config#492) ships inside the
+# gr2 package -- spec_apply verifies its bytes against the pinned SHA-256
+# at load and fails closed on any mismatch.
+gr2 = ["schemas/*.json"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "gr2_overlay/tests"]

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -7,6 +7,7 @@ import json
 import os
 import stat
 import tomllib
+import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -820,7 +821,13 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
         _reject_identity_fields_recursive(op, path=f"operations[{idx}]")
         canonical_dest = _validate_operation_shape(op, idx=idx, workspace_root=workspace_root)
         if canonical_dest is not None:
-            key = str(canonical_dest).casefold()
+            # NFC-normalize BEFORE casefolding (Sentinel finding 7):
+            # "units/café/.venv" spelled NFC vs NFD are distinct Python
+            # strings that casefold to distinct values, yet on a
+            # normalization-insensitive filesystem they name ONE
+            # destination. Normalization and case folding are separate
+            # aliasing axes; collision detection has to close both.
+            key = unicodedata.normalize("NFC", str(canonical_dest)).casefold()
             if key in seen_canonical_dests:
                 raise MaterializationPlanError(
                     f"operations[{idx}] dest_path collides (case-folded/normalized) with "
@@ -997,10 +1004,28 @@ def write_materialization_receipt(
     except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise
-    os.replace(tmp_path, receipt_path)
-    dir_fd = os.open(receipt_dir, os.O_RDONLY)
     try:
-        os.fsync(dir_fd)
-    finally:
-        os.close(dir_fd)
+        os.replace(tmp_path, receipt_path)
+    except BaseException:
+        # A failed replace leaves the temp behind otherwise -- found by this
+        # closure's own residue test rather than reasoned about.
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    # Sentinel finding 3: durability is a FAILURE-PATH contract, not only an
+    # ordering one. If the parent-directory fsync fails, the rename may not
+    # survive a crash -- yet the receipt is already visible at its published
+    # path, so a caller that treats "the writer returned" or "a receipt
+    # exists" as durable acknowledgement would proceed to destructive
+    # cleanup on the strength of a receipt that could vanish. A publication
+    # that cannot be made durable must not remain published.
+    try:
+        dir_fd = os.open(receipt_dir, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except BaseException:
+        receipt_path.unlink(missing_ok=True)
+        raise
     return receipt_path

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -11,6 +11,7 @@ import secrets
 import stat
 import tomllib
 import unicodedata
+import weakref
 from datetime import UTC, datetime
 from pathlib import Path
 from types import MappingProxyType
@@ -541,7 +542,22 @@ def _deep_freeze(value: object) -> object:
     return value
 
 
-@dataclasses.dataclass(frozen=True)
+# Provenance registry: the instances this validator actually minted.
+#
+# Orthogonal to the seal, and deliberately so. The seal binds CONTENT, which
+# closes replace() and in-place edits; provenance binds ORIGIN, which closes
+# copying that preserves authority without changing any field. They fail in
+# different ways, which is what makes them defense in depth rather than one
+# guard shadowing another.
+#
+# Weak, so holding a capability never keeps it alive; entries vanish with the
+# object. eq=False on the dataclass keeps identity hashing (a MappingProxyType
+# field is unhashable anyway) -- and two capabilities over equal facts SHOULD
+# be distinct capabilities, which is exactly what identity semantics give.
+_MINTED_CAPABILITIES: weakref.WeakSet = weakref.WeakSet()
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
 class ValidatedPlan:
     """Proof that a plan passed the full v1 contract, plus the facts a
     publisher needs to bind its evidence to that plan.
@@ -567,16 +583,22 @@ class ValidatedPlan:
     _seal: str = dataclasses.field(repr=False)
 
     def __post_init__(self) -> None:
+        # Provenance cannot be checked here: registration happens after
+        # construction, so this instance is not in the registry yet.
         self.verify()
 
-    def verify(self) -> None:
+    def verify(self, *, require_provenance: bool = False) -> None:
         """Re-derive the seal from the current contents and compare.
 
         Called at construction AND at every use. Construction-time checking
         alone is not enough: `frozen=True` blocks __setattr__, not
         object.__setattr__, so an already-minted capability can still be
         edited in place. Re-deriving at use means the fields a publisher
-        reads are provably the fields that were sealed."""
+        reads are provably the fields that were sealed.
+
+        `require_provenance` adds the origin check, which only makes sense at
+        USE. Copying a capability preserves every field and therefore every
+        content check; only origin can refuse it."""
         # The hash must actually describe the snapshot, so swapping the graph
         # (with or without a matching hash) cannot survive.
         if compute_plan_hash(self.plan) != self.plan_hash:
@@ -614,6 +636,11 @@ class ValidatedPlan:
             raise MaterializationPlanError(
                 "ValidatedPlan capability is invalid: it was not minted by "
                 "validate_materialization_plan for these exact facts"
+            )
+        if require_provenance and self not in _MINTED_CAPABILITIES:
+            raise MaterializationPlanError(
+                "ValidatedPlan capability is invalid: it is not one this validator "
+                "minted -- a copy preserves every field but not its provenance"
             )
 
 
@@ -970,11 +997,13 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
         "workspace_spec_sha256": workspace_spec_sha256,
         "operation_kinds": tuple(str(op["kind"]) for op in operations),
     }
-    return ValidatedPlan(
+    validated = ValidatedPlan(
         plan=_deep_freeze(plan),
         _seal=_capability_seal(**facts),
         **facts,
     )
+    _MINTED_CAPABILITIES.add(validated)
+    return validated
 
 
 _WORKSPACE_SPEC_RELATIVE = ".grip/workspace_spec.toml"
@@ -1120,7 +1149,7 @@ def write_materialization_receipt(
     # was minted honestly can still be edited afterwards -- frozen=True does
     # not stop object.__setattr__ -- and every path below reads these fields,
     # including the one that builds the receipt filename.
-    validated.verify()
+    validated.verify(require_provenance=True)
     _screen_receipt_evidence(validated, op_results)
 
     receipt = {

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import copy
 import dataclasses
 import hashlib
+import hmac
 import importlib.resources
 import json
 import os
+import secrets
 import stat
 import tomllib
 import unicodedata
@@ -505,13 +507,23 @@ class MaterializationPlanError(Exception):
     pass
 
 
-# Capability token. A ValidatedPlan can only be minted by
+# Capability seal. A ValidatedPlan can only be minted by
 # validate_materialization_plan, so a receipt cannot be published from a
 # plan that was never validated -- Atlas P1: the writer previously accepted
 # the raw live plan and an arbitrary result list, which let a schema-invalid
 # plan_id escape the receipt directory and let an unvalidated result graph
 # be persisted verbatim.
-_VALIDATION_TOKEN = object()
+#
+# This was an opaque sentinel object, keyed on IDENTITY. Sentinel's witness:
+# dataclasses.replace() re-invokes __init__ with the existing field values,
+# so the real token rode into a modified shell and publication used the
+# altered plan_id -- writing .grip/escaped.json outside the receipt
+# directory. Identity is copyable; the capability has to bind CONTENT.
+#
+# Process-local and never persisted: this is an in-process capability, not a
+# credential. It cannot be recomputed by a caller who did not go through
+# validation, which is the whole point.
+_CAPABILITY_SECRET = secrets.token_bytes(32)
 
 
 def _deep_freeze(value: object) -> object:
@@ -552,13 +564,88 @@ class ValidatedPlan:
     workspace_spec_sha256: str
     operation_kinds: tuple[str, ...]
     plan_hash: str
-    _token: object = dataclasses.field(repr=False)
+    _seal: str = dataclasses.field(repr=False)
 
     def __post_init__(self) -> None:
-        if self._token is not _VALIDATION_TOKEN:
+        self.verify()
+
+    def verify(self) -> None:
+        """Re-derive the seal from the current contents and compare.
+
+        Called at construction AND at every use. Construction-time checking
+        alone is not enough: `frozen=True` blocks __setattr__, not
+        object.__setattr__, so an already-minted capability can still be
+        edited in place. Re-deriving at use means the fields a publisher
+        reads are provably the fields that were sealed."""
+        # The hash must actually describe the snapshot, so swapping the graph
+        # (with or without a matching hash) cannot survive.
+        if compute_plan_hash(self.plan) != self.plan_hash:
             raise MaterializationPlanError(
-                "ValidatedPlan may only be constructed by validate_materialization_plan"
+                "ValidatedPlan capability is invalid: plan_hash does not describe its plan snapshot"
             )
+        # ...and the snapshot must agree with every fact published beside it,
+        # so the two can never diverge into "sealed but inconsistent".
+        snapshot_facts = (
+            self.plan.get("plan_id"),
+            self.plan.get("unit_key"),
+            self.plan.get("schema_version"),
+            self.plan.get("workspace_spec_sha256"),
+            tuple(str(op.get("kind")) for op in self.plan.get("operations", ())),
+        )
+        if snapshot_facts != (
+            self.plan_id,
+            self.unit_key,
+            self.schema_version,
+            self.workspace_spec_sha256,
+            tuple(self.operation_kinds),
+        ):
+            raise MaterializationPlanError(
+                "ValidatedPlan capability is invalid: published facts disagree with the plan snapshot"
+            )
+        expected = _capability_seal(
+            plan_hash=self.plan_hash,
+            plan_id=self.plan_id,
+            unit_key=self.unit_key,
+            schema_version=self.schema_version,
+            workspace_spec_sha256=self.workspace_spec_sha256,
+            operation_kinds=self.operation_kinds,
+        )
+        if not hmac.compare_digest(str(self._seal), expected):
+            raise MaterializationPlanError(
+                "ValidatedPlan capability is invalid: it was not minted by "
+                "validate_materialization_plan for these exact facts"
+            )
+
+
+def _capability_seal(
+    *,
+    plan_hash: str,
+    plan_id: str,
+    unit_key: str,
+    schema_version: int,
+    workspace_spec_sha256: str,
+    operation_kinds: tuple[str, ...],
+) -> str:
+    """Bind the seal to CONTENT, not to object identity.
+
+    Every fact publication consumes is covered, so altering any one of them
+    -- by dataclasses.replace, by object.__setattr__, or by hand-building a
+    shell -- produces a seal that no longer matches. Takes values rather than
+    an instance so the mint can compute it before the object exists."""
+    payload = json.dumps(
+        [
+            plan_hash,
+            plan_id,
+            unit_key,
+            schema_version,
+            workspace_spec_sha256,
+            list(operation_kinds),
+        ],
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hmac.new(_CAPABILITY_SECRET, payload, hashlib.sha256).hexdigest()
 
 
 # The normative wire contract (config#492, merged 4b36896). A hand-rolled
@@ -875,15 +962,18 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
     # Hash the validated bytes ONCE, here, while they are still exactly what
     # passed the checks above. Recomputing at publication time is what let a
     # receipt attest to a post-validation mutation.
+    facts = {
+        "plan_hash": compute_plan_hash(plan),
+        "plan_id": str(plan["plan_id"]),
+        "unit_key": str(plan["unit_key"]),
+        "schema_version": int(plan["schema_version"]),
+        "workspace_spec_sha256": workspace_spec_sha256,
+        "operation_kinds": tuple(str(op["kind"]) for op in operations),
+    }
     return ValidatedPlan(
         plan=_deep_freeze(plan),
-        plan_id=str(plan["plan_id"]),
-        unit_key=str(plan["unit_key"]),
-        schema_version=int(plan["schema_version"]),
-        workspace_spec_sha256=workspace_spec_sha256,
-        operation_kinds=tuple(str(op["kind"]) for op in operations),
-        plan_hash=compute_plan_hash(plan),
-        _token=_VALIDATION_TOKEN,
+        _seal=_capability_seal(**facts),
+        **facts,
     )
 
 
@@ -1026,6 +1116,11 @@ def write_materialization_receipt(
             "write_materialization_receipt requires a ValidatedPlan from "
             "validate_materialization_plan, not a raw plan"
         )
+    # Re-derive the seal HERE, not just at construction. A capability that
+    # was minted honestly can still be edited afterwards -- frozen=True does
+    # not stop object.__setattr__ -- and every path below reads these fields,
+    # including the one that builds the receipt filename.
+    validated.verify()
     _screen_receipt_evidence(validated, op_results)
 
     receipt = {

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import dataclasses
 import hashlib
 import importlib.resources
@@ -10,6 +11,7 @@ import tomllib
 import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
+from types import MappingProxyType
 
 from jsonschema import Draft202012Validator
 
@@ -512,6 +514,21 @@ class MaterializationPlanError(Exception):
 _VALIDATION_TOKEN = object()
 
 
+def _deep_freeze(value: object) -> object:
+    """Recursively convert a JSON-shaped graph into a read-only one.
+
+    dataclasses.dataclass(frozen=True) freezes the field BINDING, not the
+    graph the field points at -- so a `plan` field holding a live dict is
+    mutable through anyone who holds the capability. Mappings become
+    MappingProxyType and sequences become tuples, which closes both the
+    item-assignment and the append/extend routes."""
+    if isinstance(value, dict):
+        return MappingProxyType({k: _deep_freeze(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return tuple(_deep_freeze(v) for v in value)
+    return value
+
+
 @dataclasses.dataclass(frozen=True)
 class ValidatedPlan:
     """Proof that a plan passed the full v1 contract, plus the facts a
@@ -519,14 +536,22 @@ class ValidatedPlan:
 
     Immutable and unforgeable-by-accident: the token check means holding one
     of these IS the evidence of validation, so publication has a capability
-    to demand rather than a convention to trust."""
+    to demand rather than a convention to trust.
 
-    plan: dict[str, object]
+    Every field here is a mint-time CAPTURE, not a view onto something a
+    caller still holds (Atlas final re-gate). The earlier version aliased the
+    caller's dict and recomputed the hash at publication time, so mutating
+    the plan after validation produced a receipt attesting to a graph that
+    was never validated -- the capability proved one graph had been checked
+    while vouching for another. Publication now reads captured facts only."""
+
+    plan: MappingProxyType
     plan_id: str
     unit_key: str
     schema_version: int
     workspace_spec_sha256: str
     operation_kinds: tuple[str, ...]
+    plan_hash: str
     _token: object = dataclasses.field(repr=False)
 
     def __post_init__(self) -> None:
@@ -772,7 +797,19 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
     receipt cannot be written from a plan that never passed this function
     (Atlas P1) -- validation becomes something the publisher HOLDS rather
     than something a caller is trusted to have remembered to do.
+
+    The caller's object is snapshotted on entry and never consulted again.
+    Taking the snapshot FIRST (rather than copying at mint) also closes the
+    window where a concurrent mutation could land between the checks and the
+    capture, which would validate one graph and bind another.
     """
+    try:
+        plan = copy.deepcopy(plan)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise MaterializationPlanError(
+            f"plan could not be snapshotted for validation: {exc}"
+        ) from exc
+
     validator = _load_plan_validator()
     schema_errors = sorted(validator.iter_errors(plan), key=lambda e: list(e.absolute_path))
     if schema_errors:
@@ -835,13 +872,17 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
                 )
             seen_canonical_dests[key] = idx
 
+    # Hash the validated bytes ONCE, here, while they are still exactly what
+    # passed the checks above. Recomputing at publication time is what let a
+    # receipt attest to a post-validation mutation.
     return ValidatedPlan(
-        plan=plan,
+        plan=_deep_freeze(plan),
         plan_id=str(plan["plan_id"]),
         unit_key=str(plan["unit_key"]),
         schema_version=int(plan["schema_version"]),
         workspace_spec_sha256=workspace_spec_sha256,
         operation_kinds=tuple(str(op["kind"]) for op in operations),
+        plan_hash=compute_plan_hash(plan),
         _token=_VALIDATION_TOKEN,
     )
 
@@ -896,9 +937,23 @@ def compute_plan_hash(plan: dict[str, object]) -> str:
     JSON, keys sorted, no insignificant whitespace, non-ASCII unescaped.
     Default json.dumps separators and ensure_ascii=True produce different
     bytes and therefore a non-conformant hash. Public so callers and tests
-    recompute it independently rather than trusting a receipt's own value."""
+    recompute it independently rather than trusting a receipt's own value.
+
+    `default` is a TYPE adapter, not a change to the recipe: it fires only
+    for objects json cannot serialize natively, so canonical bytes for a
+    plain JSON graph are byte-identical either way. It exists so freezing a
+    validated plan does not turn this public helper into a trap for the
+    handlers that will hold one in B/C/D."""
+
+    def _unfreeze(obj: object) -> object:
+        if isinstance(obj, MappingProxyType):
+            return dict(obj)
+        raise TypeError(f"cannot canonicalize {type(obj).__name__} in a MaterializationPlan")
+
     return hashlib.sha256(
-        json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        json.dumps(
+            plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=_unfreeze
+        ).encode("utf-8")
     ).hexdigest()
 
 
@@ -973,11 +1028,12 @@ def write_materialization_receipt(
         )
     _screen_receipt_evidence(validated, op_results)
 
-    plan = validated.plan
     receipt = {
         "plan_id": validated.plan_id,
         "unit_key": validated.unit_key,
-        "plan_hash": compute_plan_hash(plan),
+        # The hash captured at validation, NOT a recomputation from a graph
+        # that may have moved since (Atlas final re-gate).
+        "plan_hash": validated.plan_hash,
         "schema_version": validated.schema_version,
         "workspace_spec_sha256": validated.workspace_spec_sha256,
         # §12.1 structural stage: MATERIALIZED is the terminal state OSS gr2

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -5,6 +5,7 @@ import hashlib
 import importlib.resources
 import json
 import os
+import stat
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
@@ -501,6 +502,39 @@ class MaterializationPlanError(Exception):
     pass
 
 
+# Capability token. A ValidatedPlan can only be minted by
+# validate_materialization_plan, so a receipt cannot be published from a
+# plan that was never validated -- Atlas P1: the writer previously accepted
+# the raw live plan and an arbitrary result list, which let a schema-invalid
+# plan_id escape the receipt directory and let an unvalidated result graph
+# be persisted verbatim.
+_VALIDATION_TOKEN = object()
+
+
+@dataclasses.dataclass(frozen=True)
+class ValidatedPlan:
+    """Proof that a plan passed the full v1 contract, plus the facts a
+    publisher needs to bind its evidence to that plan.
+
+    Immutable and unforgeable-by-accident: the token check means holding one
+    of these IS the evidence of validation, so publication has a capability
+    to demand rather than a convention to trust."""
+
+    plan: dict[str, object]
+    plan_id: str
+    unit_key: str
+    schema_version: int
+    workspace_spec_sha256: str
+    operation_kinds: tuple[str, ...]
+    _token: object = dataclasses.field(repr=False)
+
+    def __post_init__(self) -> None:
+        if self._token is not _VALIDATION_TOKEN:
+            raise MaterializationPlanError(
+                "ValidatedPlan may only be constructed by validate_materialization_plan"
+            )
+
+
 # The normative wire contract (config#492, merged 4b36896). A hand-rolled
 # validator is a separate, looser contract by construction -- nine plans the
 # pinned schema rejects were accepted by an earlier hand version, and
@@ -725,13 +759,18 @@ def _validate_operation_shape(
     return canonicalize_workspace_path(workspace_root, dest_path, field_name=f"{prefix}.dest_path")
 
 
-def validate_materialization_plan(workspace_root: Path, plan: dict[str, object]) -> None:
+def validate_materialization_plan(workspace_root: Path, plan: dict[str, object]) -> ValidatedPlan:
     """Validate a neutral MaterializationPlan against config#492's pinned v1
     contract. Raises MaterializationPlanError on the first violation.
 
     Validate-before-touch: this runs to completion over the WHOLE plan
     before any handler executes, so an invalid operation late in the list
     cannot let an earlier one mutate state first.
+
+    Returns a ValidatedPlan capability. Publication requires one, so a
+    receipt cannot be written from a plan that never passed this function
+    (Atlas P1) -- validation becomes something the publisher HOLDS rather
+    than something a caller is trusted to have remembered to do.
     """
     validator = _load_plan_validator()
     schema_errors = sorted(validator.iter_errors(plan), key=lambda e: list(e.absolute_path))
@@ -760,13 +799,7 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
     # config#492 §6.2.1 invariant #1: reopen the canonical WorkspaceSpec
     # bytes and verify their SHA-256. Carrying the field is not verifying it.
     workspace_spec_sha256 = str(plan["workspace_spec_sha256"])
-    spec_file = workspace_spec_path(workspace_root)
-    if not spec_file.exists():
-        raise MaterializationPlanError(
-            "canonical WorkspaceSpec (.grip/workspace_spec.toml) not found -- "
-            "workspace_spec_sha256 cannot be verified (config#492 §6.2.1 #1)"
-        )
-    actual_spec_sha256 = hashlib.sha256(spec_file.read_bytes()).hexdigest()
+    actual_spec_sha256 = hashlib.sha256(_read_canonical_workspace_spec_bytes(workspace_root)).hexdigest()
     if actual_spec_sha256 != workspace_spec_sha256:
         raise MaterializationPlanError(
             f"workspace_spec_sha256 mismatch: plan declares {workspace_spec_sha256}, "
@@ -795,6 +828,61 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
                 )
             seen_canonical_dests[key] = idx
 
+    return ValidatedPlan(
+        plan=plan,
+        plan_id=str(plan["plan_id"]),
+        unit_key=str(plan["unit_key"]),
+        schema_version=int(plan["schema_version"]),
+        workspace_spec_sha256=workspace_spec_sha256,
+        operation_kinds=tuple(str(op["kind"]) for op in operations),
+        _token=_VALIDATION_TOKEN,
+    )
+
+
+_WORKSPACE_SPEC_RELATIVE = ".grip/workspace_spec.toml"
+_RECEIPT_DIR_RELATIVE = ".grip/state/materialization"
+
+
+def _read_canonical_workspace_spec_bytes(workspace_root: Path) -> bytes:
+    """config#492 §6.2.1 #2 applies to the CONTRACT paths too, not only to
+    operation paths (Atlas P2): the canonical WorkspaceSpec must be reached
+    through a symlink-free prefix and be a regular non-symlink file.
+
+    Otherwise a symlink at .grip/workspace_spec.toml pointing outside the
+    team root is accepted whenever its bytes happen to hash to the declared
+    value -- the hash check confirms CONTENT, and says nothing about whether
+    the file it read is inside the workspace at all."""
+    spec_file = canonicalize_workspace_path(
+        workspace_root, _WORKSPACE_SPEC_RELATIVE, field_name="workspace_spec_path"
+    )
+    if not spec_file.exists():
+        raise MaterializationPlanError(
+            "canonical WorkspaceSpec (.grip/workspace_spec.toml) not found -- "
+            "workspace_spec_sha256 cannot be verified (config#492 §6.2.1 #1)"
+        )
+    if not stat.S_ISREG(os.lstat(spec_file).st_mode):
+        raise MaterializationPlanError(
+            f"canonical WorkspaceSpec at {spec_file} is not a regular file "
+            "(config#492 §6.2.1 #2)"
+        )
+    return spec_file.read_bytes()
+
+
+def _canonical_receipt_dir(workspace_root: Path) -> Path:
+    """The receipt directory must be a real in-root directory reached
+    through a symlink-free prefix (Atlas P2): a symlinked
+    .grip/state/materialization otherwise publishes the terminal receipt
+    outside the team root entirely."""
+    receipt_dir = canonicalize_workspace_path(
+        workspace_root, _RECEIPT_DIR_RELATIVE, field_name="receipt_dir"
+    )
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    if not stat.S_ISDIR(os.lstat(receipt_dir).st_mode):
+        raise MaterializationPlanError(
+            f"receipt directory {receipt_dir} is not a real directory (config#492 §6.2.1 #2)"
+        )
+    return receipt_dir
+
 
 def compute_plan_hash(plan: dict[str, object]) -> str:
     """config#492 §6.2.1 #9, the exact pinned canonical serialization: UTF-8
@@ -811,40 +899,106 @@ def materialization_receipt_path(workspace_root: Path, plan_id: str) -> Path:
     return workspace_root / ".grip" / "state" / "materialization" / f"{plan_id}.json"
 
 
+def _screen_receipt_evidence(
+    validated: ValidatedPlan, op_results: list[dict[str, object]]
+) -> None:
+    """config#492 §12.1, Atlas P1: the terminal receipt must be bound to the
+    plan it claims to acknowledge, and its evidence must be as neutral as
+    the plan.
+
+    The plan's own operations are protected by a CLOSED schema whose
+    per-kind allowlists permit no nested object carrier -- so recursive
+    identity rejection there has little left to find. The result graph is
+    the opposite: it is open, it is what gets persisted, and it was
+    previously copied verbatim. That makes it the actual smuggling boundary,
+    which is why the same rejection discipline is applied here rather than
+    only upstream."""
+    if not isinstance(op_results, list):
+        raise MaterializationPlanError("receipt evidence must be a list of operation results")
+    if len(op_results) != len(validated.operation_kinds):
+        raise MaterializationPlanError(
+            f"receipt evidence has {len(op_results)} result(s) but the validated plan has "
+            f"{len(validated.operation_kinds)} operation(s) -- a receipt cannot claim "
+            "MATERIALIZED without evidence for every operation"
+        )
+    for idx, (result, expected_kind) in enumerate(zip(op_results, validated.operation_kinds)):
+        if not isinstance(result, dict):
+            raise MaterializationPlanError(
+                f"receipt evidence[{idx}] must be an object, got {type(result).__name__}"
+            )
+        if result.get("kind") != expected_kind:
+            raise MaterializationPlanError(
+                f"receipt evidence[{idx}] is kind {result.get('kind')!r} but the validated plan's "
+                f"operation {idx} is {expected_kind!r} -- evidence must correspond to its operation, "
+                "in order"
+            )
+        _reject_identity_fields_recursive(result, path=f"receipt.operations[{idx}]")
+
+
 def write_materialization_receipt(
     workspace_root: Path,
-    plan: dict[str, object],
+    validated: ValidatedPlan,
     op_results: list[dict[str, object]],
 ) -> Path:
-    """config#492 §6.2.1 #10: publish through a same-directory temporary
-    file, file flush and fsync, atomic replace, then parent-directory fsync.
+    """Publish the terminal neutral receipt for a VALIDATED plan.
 
-    Every step is load-bearing and ordered: rename success alone is not
-    durable acknowledgement -- on power loss the rename can survive while
-    the bytes do not, yielding a receipt that "exists" with partial content.
-    Callers that perform destructive cleanup on the strength of a receipt
-    must do it only after this returns."""
+    Takes a ValidatedPlan capability rather than a raw dict (Atlas P1): the
+    writer previously accepted the live plan and an arbitrary result list,
+    so a schema-invalid plan_id could escape the receipt directory and an
+    unscreened result graph could be persisted verbatim. Holding the
+    capability is the proof that the contract already ran.
+
+    config#492 §6.2.1 #10 -- publication order is exact and every step is
+    load-bearing: same-directory temp -> write+flush -> fsync(temp file) ->
+    atomic replace -> fsync(parent directory). Rename success alone is not
+    durable acknowledgement; on power loss the rename can survive while the
+    bytes do not. Callers performing destructive cleanup on the strength of
+    a receipt must do it only after this returns.
+
+    The temp file is created O_EXCL|O_NOFOLLOW (Atlas P2): its name is
+    predictable, so a plain open() would happily follow a pre-created
+    symlink, overwrite whatever it points at, and then publish that symlink
+    as the final receipt."""
+    if not isinstance(validated, ValidatedPlan):
+        raise MaterializationPlanError(
+            "write_materialization_receipt requires a ValidatedPlan from "
+            "validate_materialization_plan, not a raw plan"
+        )
+    _screen_receipt_evidence(validated, op_results)
+
+    plan = validated.plan
     receipt = {
-        "plan_id": plan["plan_id"],
-        "unit_key": plan["unit_key"],
+        "plan_id": validated.plan_id,
+        "unit_key": validated.unit_key,
         "plan_hash": compute_plan_hash(plan),
-        "schema_version": plan["schema_version"],
-        "workspace_spec_sha256": plan["workspace_spec_sha256"],
+        "schema_version": validated.schema_version,
+        "workspace_spec_sha256": validated.workspace_spec_sha256,
         # §12.1 structural stage: MATERIALIZED is the terminal state OSS gr2
         # can honestly claim on its own.
         "stage": "MATERIALIZED",
         "applied_at": datetime.now(UTC).isoformat(),
         "operations": op_results,
     }
-    receipt_path = materialization_receipt_path(workspace_root, str(plan["plan_id"]))
-    receipt_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = receipt_path.with_name(receipt_path.name + f".tmp-{os.getpid()}")
-    with open(tmp_path, "w", encoding="utf-8") as fh:
-        fh.write(json.dumps(receipt, indent=2) + "\n")
-        fh.flush()
-        os.fsync(fh.fileno())
+
+    receipt_dir = _canonical_receipt_dir(workspace_root)
+    # plan_id was validated as a path-safe token upstream; re-derived here
+    # from the capability so the filename cannot come from an unvalidated
+    # source.
+    receipt_path = receipt_dir / f"{validated.plan_id}.json"
+    tmp_path = receipt_dir / f"{validated.plan_id}.json.tmp-{os.getpid()}"
+
+    payload = (json.dumps(receipt, indent=2) + "\n").encode("utf-8")
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
     os.replace(tmp_path, receipt_path)
-    dir_fd = os.open(receipt_path.parent, os.O_RDONLY)
+    dir_fd = os.open(receipt_dir, os.O_RDONLY)
     try:
         os.fsync(dir_fd)
     finally:

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import importlib.resources
 import json
 import os
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
+
+from jsonschema import Draft202012Validator
 
 from .events import EventType, emit
 from .gitops import clone_repo, ensure_repo_cache, is_git_dir, is_git_repo, repo_dirty
@@ -248,19 +252,27 @@ def build_plan(workspace_root: Path) -> tuple[dict[str, object], list[PlanOperat
                 )
             )
 
-        if unit_root.exists() and unit_toml.exists():
-            declared_repos = [str(r) for r in unit.get("repos", [])]
-            missing_repos = [r for r in declared_repos if not (unit_root / r).exists()]
-            if missing_repos:
-                operations.append(
-                    PlanOperation(
-                        kind="converge_unit_repos",
-                        subject=unit_name,
-                        target_path=str(unit_root),
-                        reason=f"missing repo checkouts: {', '.join(missing_repos)}",
-                        details={"missing_repos": missing_repos, "all_repos": declared_repos},
-                    )
+        # grip#539: computed unconditionally, not gated on unit_root/unit_toml
+        # already existing. A brand-new unit's declared repos are trivially
+        # "missing" too (unit_root doesn't exist yet, so (unit_root / r).exists()
+        # is False for every r) -- the old guard meant a first apply published
+        # the unit shell without scheduling its clones, requiring a second,
+        # separate apply to notice. Ordered after create_unit_root/
+        # write_unit_metadata in this loop, so apply_plan's execution (which
+        # processes operations in list order) creates the directory before
+        # trying to clone into it.
+        declared_repos = [str(r) for r in unit.get("repos", [])]
+        missing_repos = [r for r in declared_repos if not (unit_root / r).exists()]
+        if missing_repos:
+            operations.append(
+                PlanOperation(
+                    kind="converge_unit_repos",
+                    subject=unit_name,
+                    target_path=str(unit_root),
+                    reason=f"missing repo checkouts: {', '.join(missing_repos)}",
+                    details={"missing_repos": missing_repos, "all_repos": declared_repos},
                 )
+            )
 
     return spec, operations
 
@@ -467,3 +479,374 @@ def _record_apply_state(workspace_root: Path, actions: list[str]) -> None:
         state_path.write_text(existing + "\n\n" + "\n".join(content))
     else:
         state_path.write_text("\n".join(content))
+
+
+# ---------------------------------------------------------------------------
+# Neutral MaterializationPlan v1 -- plan contract (S4-A)
+#
+# This module ships the PLAN-LEVEL contract only: schema conformance,
+# identity-freedom, opaque-token safety, WorkspaceSpec binding, path
+# canonicalization, destination-collision detection, and durable receipt
+# publication. It deliberately ships NO operation execution -- the clone,
+# staging/project_file, and venv/editable handlers arrive in S4-B/C/D,
+# each with its own domain validation and mutation set (grip#797 split).
+#
+# Carve rationale: every guarantee here is enforced before any handler
+# could run, so it is reviewable and complete on its own, and landing it
+# first cannot ship a half-hardened operation path.
+# ---------------------------------------------------------------------------
+
+
+class MaterializationPlanError(Exception):
+    pass
+
+
+# The normative wire contract (config#492, merged 4b36896). A hand-rolled
+# validator is a separate, looser contract by construction -- nine plans the
+# pinned schema rejects were accepted by an earlier hand version, and
+# schema_version=True slipped a `!= 1` check because bool is an int subclass
+# in Python (True == 1) while JSON Schema's const:1 distinguishes the types.
+# The packaged bytes are verified against the pinned SHA at load and FAIL
+# CLOSED, so a tampered or unpinned schema refuses to validate at all rather
+# than silently enforcing something else.
+_PLAN_SCHEMA_SHA256 = "a5061501ba6651d7432d87d57f1c85902e5dec076f860a47faa299f5f590231c"
+_PLAN_SCHEMA_RESOURCE = "schemas/gr2-materialization-plan-v1.schema.json"
+_plan_validator: Draft202012Validator | None = None
+
+_VALID_OPERATION_KINDS = frozenset({"clone", "venv", "editable_install", "project_file"})
+
+
+def _read_plan_schema_bytes() -> bytes:
+    """importlib.resources is the real (installed) path; the sibling-directory
+    fallback covers the in-repo pytest context, where conftest.py injects a
+    bare `gr2` module without a __spec__ and resource traversal fails. Either
+    way the bytes are SHA-verified before use, so WHERE they load from cannot
+    weaken WHAT gets enforced."""
+    try:
+        return (importlib.resources.files("gr2") / _PLAN_SCHEMA_RESOURCE).read_bytes()
+    except Exception:
+        return (Path(__file__).resolve().parent.parent / "gr2" / _PLAN_SCHEMA_RESOURCE).read_bytes()
+
+
+def _load_plan_validator() -> Draft202012Validator:
+    global _plan_validator
+    if _plan_validator is None:
+        raw = _read_plan_schema_bytes()
+        actual = hashlib.sha256(raw).hexdigest()
+        if actual != _PLAN_SCHEMA_SHA256:
+            raise MaterializationPlanError(
+                f"packaged MaterializationPlan v1 schema hash mismatch: expected "
+                f"{_PLAN_SCHEMA_SHA256}, got {actual} -- refusing to validate against "
+                "an unpinned schema (config#492 §6.2.1)"
+            )
+        _plan_validator = Draft202012Validator(json.loads(raw))
+    return _plan_validator
+
+
+# config#492 §6.2.1: "The production plan must not contain: agent display
+# name, persistent agent ID, role, org or project, channel, entitlement
+# result or reason, secret reference or value, memory body." Checked
+# recursively as defence in depth -- the per-kind ALLOWLIST below is what
+# actually proves identity-freedom, since a blacklist only catches names
+# someone thought to enumerate.
+_FORBIDDEN_IDENTITY_KEYS = frozenset(
+    {
+        "agent_name",
+        "agent_id",
+        "persistent_identity_ref",
+        "role",
+        "org",
+        "project",
+        "channel",
+        "channels",
+        "entitlement",
+        "entitlement_reason",
+        "secret",
+        "secret_ref",
+        "memory",
+        "memory_body",
+    }
+)
+
+
+def _reject_identity_fields_recursive(value: object, *, path: str) -> None:
+    if isinstance(value, dict):
+        present = _FORBIDDEN_IDENTITY_KEYS & value.keys()
+        if present:
+            raise MaterializationPlanError(
+                f"{path} carries identity-bearing field(s) {sorted(present)}; "
+                "gr2 MaterializationPlan operations must be identity-free (config#492 §6.2.1)"
+            )
+        for key, nested in value.items():
+            _reject_identity_fields_recursive(nested, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for i, item in enumerate(value):
+            _reject_identity_fields_recursive(item, path=f"{path}[{i}]")
+
+
+def _validate_path_safe_token(value: object, *, field_name: str) -> str:
+    """An opaque, path-safe identifier: no separators, no traversal, no
+    identity semantics interpreted. plan_id and unit_key both end up embedded
+    in filesystem paths (receipt filenames), so they are validated as tokens
+    -- gr2 never derives identity from unit_key, it only checks its shape."""
+    if not isinstance(value, str) or not value:
+        raise MaterializationPlanError(f"{field_name} must be a non-empty string")
+    if "/" in value or "\\" in value or value in (".", "..") or "\x00" in value:
+        raise MaterializationPlanError(f"{field_name} must be a path-safe token, got {value!r}")
+    return value
+
+
+def canonicalize_workspace_path(workspace_root: Path, relative: str, *, field_name: str) -> Path:
+    """config#492 §6.2.1 invariant #2: reject absolute paths, `~`,
+    backslashes, empty segments, `.` or `..` segments, NUL, any existing
+    symlink in the path prefix, and any resolved escape.
+
+    Segment checks run on the RAW string split on "/" -- Path() silently
+    normalizes single-dot segments away (Path("a/./b").parts == ("a","b")),
+    so parts-based scanning cannot see them.
+
+    The per-component symlink walk (lstat on each existing component,
+    including the last) is what a resolve()-based containment check
+    structurally cannot provide: if a directory in the prefix is itself a
+    symlink, BOTH the candidate and the root resolve through that same link,
+    so "resolved candidate is under resolved root" holds while the real bytes
+    live outside.
+
+    Returns the fully resolved canonical path -- used for filesystem access
+    AND for all comparison (collision detection), so two spellings of one
+    real path cannot both pass."""
+    if not relative or relative.startswith("/") or relative.startswith("~"):
+        raise MaterializationPlanError(f"{field_name} must be relative to the workspace root: {relative!r}")
+    if "\\" in relative or "\x00" in relative:
+        raise MaterializationPlanError(f"{field_name} must not contain backslashes or NUL: {relative!r}")
+    segments = relative.split("/")
+    if any(seg in ("", ".", "..") for seg in segments):
+        raise MaterializationPlanError(
+            f"{field_name} must not contain empty, '.', or '..' segments: {relative!r}"
+        )
+    walker = workspace_root
+    for seg in segments:
+        walker = walker / seg
+        if walker.is_symlink():
+            raise MaterializationPlanError(
+                f"{field_name} passes through a symlink at {walker} -- path prefixes must be "
+                "symlink-free (config#492 §6.2.1 #2)"
+            )
+    workspace_resolved = workspace_root.resolve()
+    candidate = (workspace_root / relative).resolve()
+    if candidate != workspace_resolved and workspace_resolved not in candidate.parents:
+        raise MaterializationPlanError(f"{field_name} escapes the workspace root: {relative!r}")
+    return candidate
+
+
+# Exact per-kind ALLOWLISTS. Any field not explicitly permitted for its kind
+# is rejected by construction -- which is what proves identity-freedom, since
+# a field nobody thought to blacklist (display_name, say) cannot exist at all.
+_CLONE_FIELDS = frozenset({"kind", "repo_url", "dest_path", "branch", "reference_base"})
+_VENV_FIELDS = frozenset({"kind", "dest_path", "engine", "python"})
+_EDITABLE_INSTALL_FIELDS = frozenset({"kind", "venv_path", "source_path", "extras"})
+_PROJECT_FILE_FIELDS = frozenset({"kind", "source_path", "dest_path", "source_sha256", "mode"})
+
+_OPERATION_ALLOWED_FIELDS: dict[str, frozenset[str]] = {
+    "clone": _CLONE_FIELDS,
+    "venv": _VENV_FIELDS,
+    "editable_install": _EDITABLE_INSTALL_FIELDS,
+    "project_file": _PROJECT_FILE_FIELDS,
+}
+
+_PLAN_ALLOWED_TOP_LEVEL_FIELDS = frozenset(
+    {"schema_version", "plan_id", "unit_key", "workspace_spec_sha256", "operations"}
+)
+
+
+def _require_str(op: dict[str, object], key: str, prefix: str) -> str:
+    value = op.get(key)
+    if not isinstance(value, str) or not value:
+        raise MaterializationPlanError(f"{prefix}: {key} must be a non-empty string")
+    return value
+
+
+def _validate_operation_shape(
+    op: dict[str, object], *, idx: int, workspace_root: Path
+) -> Path | None:
+    """Plan-level shape + path safety for one operation. Filesystem
+    PROVENANCE (is that cache a real bare repo with the right origin, is
+    that staged input a regular file hashing to source_sha256) belongs to
+    the handler that consumes it and lands with S4-B/C/D. The pinned schema
+    already constrains reference_base and source_path syntactically.
+
+    Returns the canonical dest_path for collision detection, or None."""
+    kind = op.get("kind")
+    prefix = f"operations[{idx}] (kind={kind!r})"
+    if kind not in _VALID_OPERATION_KINDS:
+        raise MaterializationPlanError(f"{prefix}: unknown operation kind")
+
+    unknown = op.keys() - _OPERATION_ALLOWED_FIELDS[kind]
+    if unknown:
+        raise MaterializationPlanError(f"{prefix}: unknown field(s) {sorted(unknown)}")
+
+    if kind == "clone":
+        _require_str(op, "repo_url", prefix)
+        _require_str(op, "branch", prefix)
+        dest_path = _require_str(op, "dest_path", prefix)
+        reference_base = op.get("reference_base")
+        if reference_base is not None:
+            if not isinstance(reference_base, str) or not reference_base:
+                raise MaterializationPlanError(f"{prefix}: reference_base must be a non-empty string")
+            canonicalize_workspace_path(
+                workspace_root, reference_base, field_name=f"{prefix}.reference_base"
+            )
+        return canonicalize_workspace_path(workspace_root, dest_path, field_name=f"{prefix}.dest_path")
+    if kind == "venv":
+        dest_path = _require_str(op, "dest_path", prefix)
+        # No defaults anywhere: the pinned schema requires engine and python
+        # explicitly, and defaulting here would re-open the coercion the
+        # contract closed.
+        if op.get("engine") != "uv":
+            raise MaterializationPlanError(f"{prefix}: engine must be 'uv', got {op.get('engine')!r}")
+        _require_str(op, "python", prefix)
+        return canonicalize_workspace_path(workspace_root, dest_path, field_name=f"{prefix}.dest_path")
+    if kind == "editable_install":
+        venv_path = _require_str(op, "venv_path", prefix)
+        source_path = _require_str(op, "source_path", prefix)
+        canonicalize_workspace_path(workspace_root, venv_path, field_name=f"{prefix}.venv_path")
+        canonicalize_workspace_path(workspace_root, source_path, field_name=f"{prefix}.source_path")
+        extras = op.get("extras")
+        if not isinstance(extras, list) or not all(isinstance(e, str) for e in extras):
+            raise MaterializationPlanError(f"{prefix}: extras must be a list of strings (required)")
+        return None
+    # project_file
+    source_path = _require_str(op, "source_path", prefix)
+    dest_path = _require_str(op, "dest_path", prefix)
+    _require_str(op, "source_sha256", prefix)
+    canonicalize_workspace_path(workspace_root, source_path, field_name=f"{prefix}.source_path")
+    if op.get("mode") != "copy":
+        raise MaterializationPlanError(f"{prefix}: mode must be 'copy' for v1, got {op.get('mode')!r}")
+    return canonicalize_workspace_path(workspace_root, dest_path, field_name=f"{prefix}.dest_path")
+
+
+def validate_materialization_plan(workspace_root: Path, plan: dict[str, object]) -> None:
+    """Validate a neutral MaterializationPlan against config#492's pinned v1
+    contract. Raises MaterializationPlanError on the first violation.
+
+    Validate-before-touch: this runs to completion over the WHOLE plan
+    before any handler executes, so an invalid operation late in the list
+    cannot let an earlier one mutate state first.
+    """
+    validator = _load_plan_validator()
+    schema_errors = sorted(validator.iter_errors(plan), key=lambda e: list(e.absolute_path))
+    if schema_errors:
+        first = schema_errors[0]
+        location = "/".join(str(p) for p in first.absolute_path) or "<root>"
+        raise MaterializationPlanError(
+            f"plan rejected by pinned MaterializationPlan v1 schema at {location}: {first.message}"
+        )
+
+    unknown_top_level = plan.keys() - _PLAN_ALLOWED_TOP_LEVEL_FIELDS
+    if unknown_top_level:
+        raise MaterializationPlanError(f"plan: unknown top-level field(s) {sorted(unknown_top_level)}")
+
+    if isinstance(plan.get("schema_version"), bool) or plan.get("schema_version") != 1:
+        raise MaterializationPlanError(
+            f"plan.schema_version must be exactly 1, got {plan.get('schema_version')!r}"
+        )
+
+    _validate_path_safe_token(plan.get("plan_id"), field_name="plan_id")
+    # One MaterializationPlan is scoped to one opaque unit and carries a
+    # required top-level unit_key. gr2 validates its shape without deriving
+    # identity from it.
+    _validate_path_safe_token(plan.get("unit_key"), field_name="unit_key")
+
+    # config#492 §6.2.1 invariant #1: reopen the canonical WorkspaceSpec
+    # bytes and verify their SHA-256. Carrying the field is not verifying it.
+    workspace_spec_sha256 = str(plan["workspace_spec_sha256"])
+    spec_file = workspace_spec_path(workspace_root)
+    if not spec_file.exists():
+        raise MaterializationPlanError(
+            "canonical WorkspaceSpec (.grip/workspace_spec.toml) not found -- "
+            "workspace_spec_sha256 cannot be verified (config#492 §6.2.1 #1)"
+        )
+    actual_spec_sha256 = hashlib.sha256(spec_file.read_bytes()).hexdigest()
+    if actual_spec_sha256 != workspace_spec_sha256:
+        raise MaterializationPlanError(
+            f"workspace_spec_sha256 mismatch: plan declares {workspace_spec_sha256}, "
+            f"canonical WorkspaceSpec bytes hash to {actual_spec_sha256} -- the plan was "
+            "compiled against a different workspace state (config#492 §6.2.1 #1)"
+        )
+
+    operations = plan["operations"]
+
+    # config#492 §6.2.1 #3: compare destinations after normalization and
+    # Unicode-aware case folding. Raw-string comparison lets "u1/.venv" and
+    # "u1/./.venv" both through, and casefold (not lower) is required so
+    # "straße"/"STRASSE" collide.
+    seen_canonical_dests: dict[str, int] = {}
+    for idx, op in enumerate(operations):
+        if not isinstance(op, dict):
+            raise MaterializationPlanError(f"operations[{idx}] must be an object, got {type(op).__name__}")
+        _reject_identity_fields_recursive(op, path=f"operations[{idx}]")
+        canonical_dest = _validate_operation_shape(op, idx=idx, workspace_root=workspace_root)
+        if canonical_dest is not None:
+            key = str(canonical_dest).casefold()
+            if key in seen_canonical_dests:
+                raise MaterializationPlanError(
+                    f"operations[{idx}] dest_path collides (case-folded/normalized) with "
+                    f"operations[{seen_canonical_dests[key]}]: {canonical_dest}"
+                )
+            seen_canonical_dests[key] = idx
+
+
+def compute_plan_hash(plan: dict[str, object]) -> str:
+    """config#492 §6.2.1 #9, the exact pinned canonical serialization: UTF-8
+    JSON, keys sorted, no insignificant whitespace, non-ASCII unescaped.
+    Default json.dumps separators and ensure_ascii=True produce different
+    bytes and therefore a non-conformant hash. Public so callers and tests
+    recompute it independently rather than trusting a receipt's own value."""
+    return hashlib.sha256(
+        json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+
+
+def materialization_receipt_path(workspace_root: Path, plan_id: str) -> Path:
+    return workspace_root / ".grip" / "state" / "materialization" / f"{plan_id}.json"
+
+
+def write_materialization_receipt(
+    workspace_root: Path,
+    plan: dict[str, object],
+    op_results: list[dict[str, object]],
+) -> Path:
+    """config#492 §6.2.1 #10: publish through a same-directory temporary
+    file, file flush and fsync, atomic replace, then parent-directory fsync.
+
+    Every step is load-bearing and ordered: rename success alone is not
+    durable acknowledgement -- on power loss the rename can survive while
+    the bytes do not, yielding a receipt that "exists" with partial content.
+    Callers that perform destructive cleanup on the strength of a receipt
+    must do it only after this returns."""
+    receipt = {
+        "plan_id": plan["plan_id"],
+        "unit_key": plan["unit_key"],
+        "plan_hash": compute_plan_hash(plan),
+        "schema_version": plan["schema_version"],
+        "workspace_spec_sha256": plan["workspace_spec_sha256"],
+        # §12.1 structural stage: MATERIALIZED is the terminal state OSS gr2
+        # can honestly claim on its own.
+        "stage": "MATERIALIZED",
+        "applied_at": datetime.now(UTC).isoformat(),
+        "operations": op_results,
+    }
+    receipt_path = materialization_receipt_path(workspace_root, str(plan["plan_id"]))
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = receipt_path.with_name(receipt_path.name + f".tmp-{os.getpid()}")
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(receipt, indent=2) + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, receipt_path)
+    dir_fd = os.open(receipt_path.parent, os.O_RDONLY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+    return receipt_path

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -643,6 +643,77 @@ class ValidatedPlan:
                 "minted -- a copy preserves every field but not its provenance"
             )
 
+    def consume(self, op_results: object) -> _ConsumptionBinding:
+        """Verify once, then take ONE immutable reading of everything a
+        publisher will use.
+
+        This closes the check/use window Atlas found. Verifying and then
+        re-reading `self.plan_id` to build a filename is a live read: a
+        caller-controlled callback (his was `list.__iter__` on the evidence)
+        runs in between and mutates the shell, so the receipt is written
+        under an identity that was never verified.
+
+        Two details carry the fix:
+
+        The facts come from `self.plan`, the FROZEN snapshot, not from the
+        shell fields. The snapshot cannot be mutated at all, so deriving from
+        it makes a post-verify shell edit irrelevant rather than merely
+        detected. There is deliberately no second seal check after the
+        callback -- it would be unreachable, and an unreachable guard is
+        worse than none because it reads as protection while being untestable
+        at its own level.
+
+        The ORDER is load-bearing: facts are captured before the evidence is
+        materialized, because materializing is what runs caller code."""
+        self.verify(require_provenance=True)
+
+        # Captured first -- no caller code has run yet at this point.
+        plan = self.plan
+        facts = {
+            "plan_id": str(plan["plan_id"]),
+            "unit_key": str(plan["unit_key"]),
+            "schema_version": int(plan["schema_version"]),
+            "workspace_spec_sha256": str(plan["workspace_spec_sha256"]),
+            "operation_kinds": tuple(str(op["kind"]) for op in plan["operations"]),
+            "plan_hash": compute_plan_hash(plan),
+        }
+
+        # ...and only now touch the caller's object, exactly once.
+        if not isinstance(op_results, list):
+            raise MaterializationPlanError("receipt evidence must be a list of operation results")
+        return _ConsumptionBinding(evidence=tuple(_plain_json(list(op_results))), **facts)
+
+
+def _plain_json(value: object) -> object:
+    """Materialize a caller-supplied graph into plain JSON types, once.
+
+    Two jobs. It detaches the value from anything the caller still holds, and
+    it normalizes away container subclasses -- so nothing downstream, json
+    serialization included, can re-enter caller code and get a second,
+    different answer."""
+    if isinstance(value, (dict, MappingProxyType)):
+        return {str(k): _plain_json(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain_json(v) for v in value]
+    return value
+
+
+@dataclasses.dataclass(frozen=True)
+class _ConsumptionBinding:
+    """The single immutable reading taken at the verified consumption
+    instant (Atlas's use-time closure).
+
+    Every field a publisher needs, captured together, so nothing downstream
+    ever reads the live capability shell or the caller's evidence again."""
+
+    plan_id: str
+    unit_key: str
+    schema_version: int
+    workspace_spec_sha256: str
+    operation_kinds: tuple[str, ...]
+    plan_hash: str
+    evidence: tuple
+
 
 def _capability_seal(
     *,
@@ -1080,9 +1151,7 @@ def materialization_receipt_path(workspace_root: Path, plan_id: str) -> Path:
     return workspace_root / ".grip" / "state" / "materialization" / f"{plan_id}.json"
 
 
-def _screen_receipt_evidence(
-    validated: ValidatedPlan, op_results: list[dict[str, object]]
-) -> None:
+def _screen_receipt_evidence(binding: _ConsumptionBinding) -> None:
     """config#492 §12.1, Atlas P1: the terminal receipt must be bound to the
     plan it claims to acknowledge, and its evidence must be as neutral as
     the plan.
@@ -1093,16 +1162,21 @@ def _screen_receipt_evidence(
     the opposite: it is open, it is what gets persisted, and it was
     previously copied verbatim. That makes it the actual smuggling boundary,
     which is why the same rejection discipline is applied here rather than
-    only upstream."""
-    if not isinstance(op_results, list):
-        raise MaterializationPlanError("receipt evidence must be a list of operation results")
-    if len(op_results) != len(validated.operation_kinds):
+    only upstream.
+
+    Screens the CONSUMPTION BINDING, never the caller's object: the evidence
+    was walked twice before -- once here, once by json serialization -- so a
+    list whose __iter__ returned different contents per call screened clean
+    and then persisted `secret` into the receipt anyway. Screening a value
+    that is not the one persisted screens nothing."""
+    op_results = binding.evidence
+    if len(op_results) != len(binding.operation_kinds):
         raise MaterializationPlanError(
             f"receipt evidence has {len(op_results)} result(s) but the validated plan has "
-            f"{len(validated.operation_kinds)} operation(s) -- a receipt cannot claim "
+            f"{len(binding.operation_kinds)} operation(s) -- a receipt cannot claim "
             "MATERIALIZED without evidence for every operation"
         )
-    for idx, (result, expected_kind) in enumerate(zip(op_results, validated.operation_kinds)):
+    for idx, (result, expected_kind) in enumerate(zip(op_results, binding.operation_kinds)):
         if not isinstance(result, dict):
             raise MaterializationPlanError(
                 f"receipt evidence[{idx}] must be an object, got {type(result).__name__}"
@@ -1145,34 +1219,33 @@ def write_materialization_receipt(
             "write_materialization_receipt requires a ValidatedPlan from "
             "validate_materialization_plan, not a raw plan"
         )
-    # Re-derive the seal HERE, not just at construction. A capability that
-    # was minted honestly can still be edited afterwards -- frozen=True does
-    # not stop object.__setattr__ -- and every path below reads these fields,
-    # including the one that builds the receipt filename.
-    validated.verify(require_provenance=True)
-    _screen_receipt_evidence(validated, op_results)
+    # ONE verified consumption. Everything below reads `binding` and nothing
+    # reads `validated` again -- verifying and then re-reading the live shell
+    # is precisely the check/use window Atlas's callback drove through.
+    binding = validated.consume(op_results)
+    _screen_receipt_evidence(binding)
 
     receipt = {
-        "plan_id": validated.plan_id,
-        "unit_key": validated.unit_key,
-        # The hash captured at validation, NOT a recomputation from a graph
-        # that may have moved since (Atlas final re-gate).
-        "plan_hash": validated.plan_hash,
-        "schema_version": validated.schema_version,
-        "workspace_spec_sha256": validated.workspace_spec_sha256,
+        "plan_id": binding.plan_id,
+        "unit_key": binding.unit_key,
+        # Derived from the sealed snapshot at the consumption instant, NOT
+        # recomputed from a graph that may have moved since.
+        "plan_hash": binding.plan_hash,
+        "schema_version": binding.schema_version,
+        "workspace_spec_sha256": binding.workspace_spec_sha256,
         # §12.1 structural stage: MATERIALIZED is the terminal state OSS gr2
         # can honestly claim on its own.
         "stage": "MATERIALIZED",
         "applied_at": datetime.now(UTC).isoformat(),
-        "operations": op_results,
+        "operations": list(binding.evidence),
     }
 
     receipt_dir = _canonical_receipt_dir(workspace_root)
-    # plan_id was validated as a path-safe token upstream; re-derived here
-    # from the capability so the filename cannot come from an unvalidated
-    # source.
-    receipt_path = receipt_dir / f"{validated.plan_id}.json"
-    tmp_path = receipt_dir / f"{validated.plan_id}.json.tmp-{os.getpid()}"
+    # Both filenames come from the binding. The temp name carries the same
+    # identity, so leaving it on a live read would only move the window
+    # rather than close it.
+    receipt_path = receipt_dir / f"{binding.plan_id}.json"
+    tmp_path = receipt_dir / f"{binding.plan_id}.json.tmp-{os.getpid()}"
 
     payload = (json.dumps(receipt, indent=2) + "\n").encode("utf-8")
     fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)

--- a/gr2/tests/test_apply_convergence.py
+++ b/gr2/tests/test_apply_convergence.py
@@ -158,8 +158,15 @@ class TestBuildPlanConvergence(ConvergenceTestBase):
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)
     @patch("gr2.python_cli.spec_apply.is_git_repo", return_value=True)
-    def test_new_unit_still_uses_create_and_write(self, _repo, _dir, _hooks):
-        """Brand-new unit (no dir, no toml) uses create_unit_root + write_unit_metadata, not converge."""
+    def test_new_unit_also_converges_repos_in_first_pass(self, _repo, _dir, _hooks):
+        """grip#539: a brand-new unit (no dir, no toml) must schedule its repo
+        checkouts in the SAME planning pass as create_unit_root/
+        write_unit_metadata, not require a second apply to notice they're
+        missing.
+
+        This test previously asserted the BUG as correct (assertNotIn the
+        fix's own target operation) -- inverted here, and confirmed RED
+        against the unfixed code before the fix landed."""
         for repo in self.repo_specs:
             self._create_workspace_repo(repo)
             self._create_repo_cache(repo["name"])
@@ -169,7 +176,10 @@ class TestBuildPlanConvergence(ConvergenceTestBase):
         kinds = [op.kind for op in operations]
         self.assertIn("create_unit_root", kinds)
         self.assertIn("write_unit_metadata", kinds)
-        self.assertNotIn("converge_unit_repos", kinds)
+        self.assertIn("converge_unit_repos", kinds)
+        converge_ops = [op for op in operations if op.kind == "converge_unit_repos"]
+        self.assertEqual(len(converge_ops), 1)
+        self.assertEqual(set(converge_ops[0].details["missing_repos"]), {"repo-a", "repo-b"})
 
     @patch("gr2.python_cli.spec_apply.load_repo_hooks", return_value=None)
     @patch("gr2.python_cli.spec_apply.is_git_dir", return_value=True)

--- a/gr2/tests/test_gr2_packaging.py
+++ b/gr2/tests/test_gr2_packaging.py
@@ -59,6 +59,41 @@ def test_gr2_overlay_still_imports_unprefixed(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_gr2_overlay_alias_resolves(tmp_path: Path) -> None:
+    """gr2.overlay (config#491 gap#13) must resolve, and to the same physical
+    file as gr2_overlay -- it's a compat alias, not a fork."""
+    result = _run(
+        [
+            sys.executable,
+            "-c",
+            "import gr2.overlay, gr2_overlay; "
+            "assert gr2.overlay.__file__ == gr2_overlay.__file__, "
+            "(gr2.overlay.__file__, gr2_overlay.__file__)",
+        ],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_pinned_plan_schema_is_packaged_and_matches_sha(tmp_path: Path) -> None:
+    """The pinned MaterializationPlan v1 schema must ship INSIDE the installed
+    package (config#492), not merely exist in the source tree -- and its bytes
+    must match the pinned SHA-256."""
+    result = _run(
+        [
+            sys.executable,
+            "-c",
+            "import hashlib, importlib.resources as r; "
+            "b = (r.files('gr2') / 'schemas/gr2-materialization-plan-v1.schema.json').read_bytes(); "
+            "assert hashlib.sha256(b).hexdigest() == "
+            "'a5061501ba6651d7432d87d57f1c85902e5dec076f860a47faa299f5f590231c', "
+            "hashlib.sha256(b).hexdigest()",
+        ],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_gr2_console_script_resolves(tmp_path: Path) -> None:
     """console_scripts entry point `gr2` must be on PATH and runnable after install."""
     result = _run(["gr2", "--help"], cwd=tmp_path)

--- a/gr2/tests/test_materialization_plan_contract.py
+++ b/gr2/tests/test_materialization_plan_contract.py
@@ -509,15 +509,53 @@ class TestReceiptPublication(PlanContractTestBase):
         self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
 
     def test_publication_order_is_exact(self):
-        """Atlas P3: counting two fsync calls does not pin the SEQUENCE --
-        moving the parent-directory fsync before os.replace left all five
-        prior tests green. This asserts the ordered chain with fd roles,
-        distinguishing the file fsync from the directory fsync via fstat,
-        so the reorder mutant dies for THIS invariant rather than through
-        some unrelated failure."""
+        """Atlas P3 + Sentinel finding 3: counting two fsync calls does not
+        pin the SEQUENCE -- moving the parent-directory fsync before
+        os.replace left all five prior tests green.
+
+        Deleting `fh.flush()` ALSO left the suite green, and it is the
+        subtler mutant: close() flushes anyway, so the published bytes come
+        out identical while the durability protocol is quietly false --
+        fsync would sync an empty file and the bytes would land after it.
+        Content assertions can never see that; only an ordered oracle can.
+
+        So the oracle observes the whole chain including flush, with fd
+        roles resolved via fstat so the file fsync is distinguished from the
+        directory fsync. Each mutant then dies for THIS invariant rather
+        than through some unrelated failure."""
         events: list[str] = []
         original_fsync = os.fsync
         original_replace = os.replace
+        original_fdopen = os.fdopen
+
+        class _TrackingWriter:
+            """Records write/flush without being able to forge them: close()
+            flushes the INNER object directly, bypassing this wrapper, so a
+            deleted explicit flush cannot be masked by the close-flush."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def write(self, data):
+                events.append("write")
+                return self._inner.write(data)
+
+            def flush(self):
+                events.append("flush")
+                return self._inner.flush()
+
+            def fileno(self):
+                return self._inner.fileno()
+
+            def __enter__(self):
+                self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc_info):
+                return self._inner.__exit__(*exc_info)
+
+        def tracking_fdopen(fd, *args, **kwargs):
+            return _TrackingWriter(original_fdopen(fd, *args, **kwargs))
 
         def tracking_fsync(fd):
             kind = "dir" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
@@ -528,13 +566,16 @@ class TestReceiptPublication(PlanContractTestBase):
             events.append("replace")
             return original_replace(src, dst, **kwargs)
 
-        with patch.object(spec_apply.os, "fsync", tracking_fsync):
-            with patch.object(spec_apply.os, "replace", tracking_replace):
-                write_materialization_receipt(
-                    self.workspace_root, self._validated(), self._evidence()
-                )
+        with patch.object(spec_apply.os, "fdopen", tracking_fdopen):
+            with patch.object(spec_apply.os, "fsync", tracking_fsync):
+                with patch.object(spec_apply.os, "replace", tracking_replace):
+                    write_materialization_receipt(
+                        self.workspace_root, self._validated(), self._evidence()
+                    )
 
-        self.assertEqual(events, ["fsync:file", "replace", "fsync:dir"], events)
+        self.assertEqual(
+            events, ["write", "flush", "fsync:file", "replace", "fsync:dir"], events
+        )
 
     def test_no_receipt_published_when_fsync_fails(self):
         with patch.object(spec_apply.os, "fsync", side_effect=OSError("simulated fsync failure")):
@@ -642,6 +683,417 @@ class TestDerivedPathHardening(PlanContractTestBase):
             )
         self.assertEqual(outside_target.read_text(), "ORIGINAL")
         self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
+
+
+class TestCanonicalizerFieldWiring(PlanContractTestBase):
+    """Sentinel finding 4: replacing EVERY operation-path call with a raw
+    resolve left all 43 tests green -- the canonicalizer was reachable in
+    principle and unpinned per field in practice.
+
+    Each of the seven path-bearing fields gets its own production-shaped
+    symlink fixture, so removing that specific call site turns exactly this
+    test RED. Symlink (not traversal) is the right probe: the schema
+    rejects traversal syntactically first, so only a filesystem-level
+    fixture can prove the call is actually wired."""
+
+    def _link(self, name: str) -> None:
+        outside = self.tmp / f"outside_{name}"
+        outside.mkdir(exist_ok=True)
+        link = self.workspace_root / name
+        if not link.exists():
+            link.symlink_to(outside)
+
+    def _expect_symlink_rejection(self, plan: dict[str, object], label: str) -> None:
+        with self.assertRaises(MaterializationPlanError, msg=f"{label} must be rejected") as ctx:
+            validate_materialization_plan(self.workspace_root, plan)
+        self.assertIn("symlink", str(ctx.exception), f"{label}: wrong invariant fired")
+
+    def test_clone_dest_path_is_canonicalized(self):
+        self._link("linked")
+        self._expect_symlink_rejection(
+            self._plan([self._clone_op(dest_path="linked/product")]), "clone.dest_path"
+        )
+
+    def test_clone_reference_base_is_canonicalized(self):
+        """reference_base must resolve inside .grip/cache/repos/ per the
+        schema, so the symlink is planted at the cache directory itself."""
+        outside = self.tmp / "outside_cache"
+        outside.mkdir()
+        cache_parent = self.workspace_root / ".grip" / "cache"
+        cache_parent.mkdir(parents=True, exist_ok=True)
+        (cache_parent / "repos").symlink_to(outside)
+        self._expect_symlink_rejection(
+            self._plan([self._clone_op(reference_base=".grip/cache/repos/product.git")]),
+            "clone.reference_base",
+        )
+
+    def test_venv_dest_path_is_canonicalized(self):
+        self._link("linked")
+        self._expect_symlink_rejection(
+            self._plan([self._venv_op(dest_path="linked/.venv")]), "venv.dest_path"
+        )
+
+    def test_editable_install_venv_path_is_canonicalized(self):
+        self._link("linked")
+        self._expect_symlink_rejection(
+            self._plan(
+                [
+                    {
+                        "kind": "editable_install",
+                        "venv_path": "linked/.venv",
+                        "source_path": "units/u1/src",
+                        "extras": [],
+                    }
+                ]
+            ),
+            "editable_install.venv_path",
+        )
+
+    def test_editable_install_source_path_is_canonicalized(self):
+        self._link("linked")
+        self._expect_symlink_rejection(
+            self._plan(
+                [
+                    {
+                        "kind": "editable_install",
+                        "venv_path": "units/u1/.venv",
+                        "source_path": "linked/src",
+                        "extras": [],
+                    }
+                ]
+            ),
+            "editable_install.source_path",
+        )
+
+    def test_project_file_source_path_is_canonicalized(self):
+        outside = self.tmp / "outside_staging"
+        outside.mkdir()
+        staging_parent = self.workspace_root / ".grip" / "staging"
+        staging_parent.mkdir(parents=True, exist_ok=True)
+        (staging_parent / "inputs").symlink_to(outside)
+        self._expect_symlink_rejection(
+            self._plan([self._project_file_op()]), "project_file.source_path"
+        )
+
+    def test_project_file_dest_path_is_canonicalized(self):
+        self._link("linked")
+        self._expect_symlink_rejection(
+            self._plan([self._project_file_op(dest_path="linked/AGENTS.md")]),
+            "project_file.dest_path",
+        )
+
+
+class TestCollisionParticipation(PlanContractTestBase):
+    """Sentinel finding 4b: returning None after canonicalizing the clone
+    destination -- and separately the project-file destination -- each left
+    43/43 green, because collision accounting was only ever proven with
+    venv-vs-venv pairs. Those destinations simply vanished from the ledger.
+
+    Every destination-bearing kind must participate, including across kinds."""
+
+    def _expect_collision(self, ops: list[dict[str, object]], label: str) -> None:
+        with self.assertRaises(MaterializationPlanError, msg=f"{label} must collide") as ctx:
+            validate_materialization_plan(self.workspace_root, self._plan(ops))
+        self.assertIn("collides", str(ctx.exception), f"{label}: wrong invariant fired")
+
+    def test_clone_destination_participates(self):
+        self._expect_collision(
+            [
+                self._clone_op(dest_path="units/u1/shared"),
+                self._clone_op(dest_path="units/u1/shared"),
+            ],
+            "clone vs clone",
+        )
+
+    def test_project_file_destination_participates(self):
+        self._expect_collision(
+            [
+                self._project_file_op(source_path=".grip/staging/inputs/f_01", dest_path="units/u1/X"),
+                self._project_file_op(source_path=".grip/staging/inputs/f_02", dest_path="units/u1/X"),
+            ],
+            "project_file vs project_file",
+        )
+
+    def test_clone_and_venv_collide_across_kinds(self):
+        self._expect_collision(
+            [
+                self._clone_op(dest_path="units/u1/shared"),
+                self._venv_op(dest_path="units/u1/shared"),
+            ],
+            "clone vs venv",
+        )
+
+    def test_clone_and_project_file_collide_across_kinds(self):
+        self._expect_collision(
+            [
+                self._clone_op(dest_path="units/u1/shared"),
+                self._project_file_op(dest_path="units/u1/shared"),
+            ],
+            "clone vs project_file",
+        )
+
+    def test_venv_and_project_file_collide_across_kinds(self):
+        self._expect_collision(
+            [
+                self._venv_op(dest_path="units/u1/shared"),
+                self._project_file_op(dest_path="units/u1/shared"),
+            ],
+            "venv vs project_file",
+        )
+
+    def test_unicode_nfc_nfd_destination_alias_rejected(self):
+        """Sentinel finding 7: NFC "café" and NFD "café" are distinct
+        Python strings that casefold to distinct values, yet name ONE
+        destination on a normalization-insensitive filesystem. Normalization
+        and case folding are separate aliasing axes."""
+        nfc = "units/café/.venv"
+        nfd = "units/café/.venv"
+        self.assertNotEqual(nfc, nfd)
+        self.assertNotEqual(nfc.casefold(), nfd.casefold())
+        self._expect_collision(
+            [self._venv_op(dest_path=nfc), self._venv_op(dest_path=nfd)],
+            "NFC vs NFD alias",
+        )
+
+
+class TestPlanHashOrdering(PlanContractTestBase):
+    """Sentinel finding 5: a mutant that sorts `operations` before applying
+    the otherwise-exact JSON recipe left 43/43 green. The normative formula
+    preserves list order -- sort_keys sorts KEYS, never array elements."""
+
+    def _two_op_plan(self, first_dest: str, second_dest: str) -> dict[str, object]:
+        return self._plan(
+            [self._venv_op(dest_path=first_dest), self._venv_op(dest_path=second_dest)]
+        )
+
+    def test_operation_order_changes_the_hash(self):
+        a = self._two_op_plan("units/a/.venv", "units/b/.venv")
+        b = self._two_op_plan("units/b/.venv", "units/a/.venv")
+        self.assertNotEqual(compute_plan_hash(a), compute_plan_hash(b))
+
+    def test_hash_matches_independently_computed_canonical_bytes(self):
+        plan = self._two_op_plan("units/a/.venv", "units/b/.venv")
+        expected_bytes = json.dumps(
+            plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode("utf-8")
+        self.assertEqual(compute_plan_hash(plan), hashlib.sha256(expected_bytes).hexdigest())
+        # And the canonical bytes themselves preserve array order.
+        self.assertLess(
+            expected_bytes.index(b"units/a/.venv"), expected_bytes.index(b"units/b/.venv")
+        )
+
+
+class TestIdentityRejectionProductionWiring(PlanContractTestBase):
+    """Sentinel finding 6: removing the recursive-identity call from
+    validate_materialization_plan left 43/43 green, and removing "secret"
+    from the inventory also left 43/43 green -- because the only direct
+    helper test exercised "channel".
+
+    Two closures: pin the PRODUCTION call beneath a permissive validator
+    double (so the schema cannot shadow it), and table-test the complete
+    declared inventory rather than one sampled member."""
+
+    class _PermissiveValidator:
+        """Stands in for the pinned schema validator so operations reach the
+        hand layer. Without this the closed schema rejects the carrier field
+        first and the production identity call is never exercised."""
+
+        def iter_errors(self, _instance):
+            return iter(())
+
+    def test_production_call_is_wired_not_merely_present(self):
+        plan = self._plan([self._venv_op(metadata={"channel": "dev"})])
+        with patch.object(spec_apply, "_load_plan_validator", return_value=self._PermissiveValidator()):
+            with patch.object(
+                spec_apply, "_OPERATION_ALLOWED_FIELDS", dict(spec_apply._OPERATION_ALLOWED_FIELDS)
+            ) as allowed:
+                # Permit the carrier field so the allowlist cannot reject it
+                # first -- isolating the recursive identity seam itself.
+                allowed["venv"] = spec_apply._VENV_FIELDS | {"metadata"}
+                with self.assertRaises(MaterializationPlanError) as ctx:
+                    validate_materialization_plan(self.workspace_root, plan)
+        self.assertIn("identity-bearing", str(ctx.exception))
+
+    def test_forbidden_inventory_is_pinned(self):
+        """The table test below iterates the LIVE set, so it is satisfied by
+        whatever that set happens to contain: delete a member and the table
+        simply gets shorter while staying green. A self-referential table
+        cannot detect removal from the thing it enumerates.
+
+        Sentinel's probe caught the `secret` removal only because a separate
+        test hardcodes that one key -- which means every OTHER member was
+        unprotected. Pinning the literal inventory closes the whole class."""
+        self.assertEqual(
+            spec_apply._FORBIDDEN_IDENTITY_KEYS,
+            frozenset(
+                {
+                    "agent_name",
+                    "agent_id",
+                    "persistent_identity_ref",
+                    "role",
+                    "org",
+                    "project",
+                    "channel",
+                    "channels",
+                    "entitlement",
+                    "entitlement_reason",
+                    "secret",
+                    "secret_ref",
+                    "memory",
+                    "memory_body",
+                }
+            ),
+        )
+
+    def test_every_declared_forbidden_key_is_enforced(self):
+        """Table-test the whole inventory: sampling one member cannot catch
+        a removal of any other. Pairs with the pin above -- the pin catches
+        removal FROM the inventory, this catches non-enforcement OF it."""
+        for key in sorted(spec_apply._FORBIDDEN_IDENTITY_KEYS):
+            with self.subTest(forbidden_key=key):
+                with self.assertRaises(MaterializationPlanError) as ctx:
+                    spec_apply._reject_identity_fields_recursive(
+                        {"outer": {key: "x"}}, path="probe"
+                    )
+                self.assertIn("identity-bearing", str(ctx.exception))
+
+    def test_every_declared_forbidden_key_is_rejected_in_receipt_evidence(self):
+        """The same closed rule on the persisted result graph (finding 2)."""
+        validated = validate_materialization_plan(
+            self.workspace_root, self._plan([self._venv_op()], plan_id="mp_inv")
+        )
+        for key in sorted(spec_apply._FORBIDDEN_IDENTITY_KEYS):
+            with self.subTest(forbidden_key=key):
+                with self.assertRaises(MaterializationPlanError) as ctx:
+                    write_materialization_receipt(
+                        self.workspace_root, validated, [{"kind": "venv", "metadata": {key: "x"}}]
+                    )
+                # Assert WHICH invariant fired: the cardinality and kind
+                # checks run first and would reject a malformed probe for an
+                # unrelated reason, leaving this test vacuous.
+                self.assertIn("identity-bearing", str(ctx.exception))
+        self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_inv").exists())
+
+
+class TestReceiptValueBinding(PlanContractTestBase):
+    """Sentinel finding 3b: replacing `operations: op_results` with
+    `operations: []`, and replacing the receipt plan_id with a constant,
+    each left 43/43 green -- the receipt test asserted a key set plus four
+    selected leaves, so every unasserted field was free to drift.
+
+    Bind the WHOLE value, reconstructed independently."""
+
+    def test_receipt_equals_independently_constructed_value(self):
+        plan = self._plan(
+            [self._venv_op(dest_path="units/a/.venv"), self._venv_op(dest_path="units/b/.venv")],
+            plan_id="mp_bind",
+            unit_key="u_bind",
+        )
+        validated = validate_materialization_plan(self.workspace_root, plan)
+        evidence = [
+            {"kind": "venv", "dest_path": "units/a/.venv", "created": True},
+            {"kind": "venv", "dest_path": "units/b/.venv", "created": False},
+        ]
+        path = write_materialization_receipt(self.workspace_root, validated, evidence)
+        receipt = json.loads(path.read_text())
+
+        applied_at = receipt.pop("applied_at")
+        self.assertIsInstance(applied_at, str)
+        self.assertTrue(applied_at)
+        self.assertEqual(
+            receipt,
+            {
+                "plan_id": "mp_bind",
+                "unit_key": "u_bind",
+                "plan_hash": compute_plan_hash(plan),
+                "schema_version": 1,
+                "workspace_spec_sha256": self.spec_sha256,
+                "stage": "MATERIALIZED",
+                "operations": evidence,
+            },
+        )
+
+
+class TestDurabilityFailureMatrix(PlanContractTestBase):
+    """Sentinel finding 3: durability is a FAILURE-PATH contract, not only
+    an ordering one. The prior failure test injected only at the FIRST
+    fsync; letting the file fsync succeed and failing the parent-directory
+    fsync left a plausible final receipt published at its path."""
+
+    def _validated(self, plan_id: str = "mp_dur"):
+        return validate_materialization_plan(
+            self.workspace_root, self._plan([self._venv_op()], plan_id=plan_id)
+        )
+
+    def _evidence(self):
+        return [{"kind": "venv"}]
+
+    def test_failure_at_file_fsync_publishes_nothing(self):
+        with patch.object(spec_apply.os, "fsync", side_effect=OSError("file fsync failed")):
+            with self.assertRaises(OSError):
+                write_materialization_receipt(self.workspace_root, self._validated(), self._evidence())
+        self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_dur").exists())
+
+    def test_failure_at_parent_fsync_invalidates_the_receipt(self):
+        """The exact survivor: fsync_calls=2 and final_receipt_exists=True.
+        A publication that cannot be made durable must not remain
+        published, or a caller doing destructive cleanup on the strength of
+        a receipt acts on one that may vanish."""
+        calls = {"n": 0}
+        original_fsync = os.fsync
+
+        def fail_second_fsync(fd):
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise OSError("parent-directory fsync failed")
+            return original_fsync(fd)
+
+        with patch.object(spec_apply.os, "fsync", fail_second_fsync):
+            with self.assertRaises(OSError):
+                write_materialization_receipt(self.workspace_root, self._validated(), self._evidence())
+        self.assertEqual(calls["n"], 2)
+        self.assertFalse(
+            materialization_receipt_path(self.workspace_root, "mp_dur").exists(),
+            "a receipt that could not be made durable must not remain published",
+        )
+
+    def test_failure_at_replace_publishes_nothing_and_leaves_no_residue(self):
+        original_replace = os.replace
+
+        def failing_replace(src, dst, **kwargs):
+            if "materialization" in str(src):
+                raise OSError("replace failed")
+            return original_replace(src, dst, **kwargs)
+
+        with patch.object(spec_apply.os, "replace", failing_replace):
+            with self.assertRaises(OSError):
+                write_materialization_receipt(self.workspace_root, self._validated(), self._evidence())
+        state_dir = self.workspace_root / ".grip" / "state" / "materialization"
+        self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_dur").exists())
+        self.assertEqual(list(state_dir.glob("*.tmp-*")), [])
+
+    def test_successful_publication_is_a_regular_in_root_file(self):
+        """Sentinel finding 1's positive face: assert the published receipt
+        is a regular file inside the team root, not merely that something
+        exists at the path."""
+        path = write_materialization_receipt(self.workspace_root, self._validated(), self._evidence())
+        self.assertTrue(stat.S_ISREG(os.lstat(path).st_mode))
+        self.assertIn(self.workspace_root.resolve(), path.resolve().parents)
+
+    def test_symlinked_state_directory_rejected(self):
+        """Sentinel's exact fixture: `.grip/state` itself (not the
+        materialization leaf) as a symlink to an outside directory."""
+        outside = self.tmp / "outside_state"
+        outside.mkdir()
+        grip = self.workspace_root / ".grip"
+        grip.mkdir(parents=True, exist_ok=True)
+        (grip / "state").symlink_to(outside)
+
+        validated = self._validated(plan_id="mp_state")
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(self.workspace_root, validated, self._evidence())
+        self.assertIn("symlink", str(ctx.exception))
+        self.assertEqual(list(outside.rglob("*")), [])
 
 
 if __name__ == "__main__":

--- a/gr2/tests/test_materialization_plan_contract.py
+++ b/gr2/tests/test_materialization_plan_contract.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import stat
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -407,12 +408,17 @@ class TestPlanHash(PlanContractTestBase):
 
 
 class TestReceiptPublication(PlanContractTestBase):
-    def _receipt_plan(self) -> dict[str, object]:
-        return self._plan([self._venv_op()], plan_id="mp_receipt")
+    def _validated(self, **overrides: object):
+        plan = self._plan([self._venv_op()], plan_id="mp_receipt", **overrides)
+        return validate_materialization_plan(self.workspace_root, plan)
+
+    def _evidence(self) -> list[dict[str, object]]:
+        """Evidence must correspond to the plan's operations, in order."""
+        return [{"kind": "venv", "dest_path": "units/u1/.venv"}]
 
     def test_receipt_schema_is_exact(self):
-        plan = self._receipt_plan()
-        write_materialization_receipt(self.workspace_root, plan, [{"kind": "venv"}])
+        validated = self._validated()
+        write_materialization_receipt(self.workspace_root, validated, self._evidence())
         receipt = json.loads(materialization_receipt_path(self.workspace_root, "mp_receipt").read_text())
         self.assertEqual(
             set(receipt),
@@ -431,26 +437,111 @@ class TestReceiptPublication(PlanContractTestBase):
         self.assertEqual(receipt["unit_key"], "u_test")
         self.assertEqual(receipt["workspace_spec_sha256"], self.spec_sha256)
         # Recomputed independently -- a constant-hash mutant dies here.
-        self.assertEqual(receipt["plan_hash"], compute_plan_hash(plan))
+        self.assertEqual(receipt["plan_hash"], compute_plan_hash(validated.plan))
 
-    def test_publication_fsyncs_file_and_parent_directory(self):
-        """Rename success is not durable acknowledgement: on power loss the
-        rename can survive while the bytes do not."""
+    def test_publication_requires_a_validated_plan_capability(self):
+        """Atlas P1: the writer used to accept the raw live plan. Holding a
+        ValidatedPlan IS the proof the contract ran; a raw dict is not."""
+        raw = self._plan([self._venv_op()], plan_id="mp_receipt")
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(self.workspace_root, raw, self._evidence())
+        self.assertIn("requires a ValidatedPlan", str(ctx.exception))
+
+    def test_validated_plan_cannot_be_forged(self):
+        """The capability is only mintable by the validator -- otherwise it
+        would be a naming convention rather than a guarantee."""
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            spec_apply.ValidatedPlan(
+                plan={},
+                plan_id="../../escaped",
+                unit_key="u",
+                schema_version=1,
+                workspace_spec_sha256="a" * 64,
+                operation_kinds=(),
+                _token=object(),
+            )
+        self.assertIn("only be constructed by", str(ctx.exception))
+
+    def test_invalid_plan_id_cannot_reach_publication(self):
+        """Atlas P1 fruit: plan_id="../../escaped" published
+        .grip/escaped.json outside the receipt directory. It can no longer
+        be validated, so it can no longer be published."""
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            validate_materialization_plan(
+                self.workspace_root, self._plan([self._venv_op()], plan_id="../../escaped")
+            )
+        self.assertIn("schema", str(ctx.exception))
+        self.assertFalse((self.workspace_root / ".grip" / "escaped.json").exists())
+
+    def test_empty_evidence_cannot_claim_materialized(self):
+        """Atlas P1 fruit: a one-operation plan with op_results=[] published
+        stage=MATERIALIZED with no evidence at all."""
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(self.workspace_root, self._validated(), [])
+        self.assertIn("evidence for every operation", str(ctx.exception))
+        self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
+
+    def test_wrong_kind_evidence_rejected(self):
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, self._validated(), [{"kind": "clone"}]
+            )
+        self.assertIn("must correspond to its operation", str(ctx.exception))
+
+    def test_direct_identity_field_in_evidence_rejected(self):
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, self._validated(), [{"kind": "venv", "secret": "TOKEN"}]
+            )
+        self.assertIn("identity-bearing", str(ctx.exception))
+
+    def test_nested_identity_field_in_evidence_rejected(self):
+        """Atlas P1 fruit, the real smuggling boundary: the plan's closed
+        schema permits no nested object carrier, but the RESULT graph is
+        open and is what gets persisted."""
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root,
+                self._validated(),
+                [{"kind": "venv", "nested": {"memory_body": "PRIVATE"}}],
+            )
+        self.assertIn("identity-bearing", str(ctx.exception))
+        self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
+
+    def test_publication_order_is_exact(self):
+        """Atlas P3: counting two fsync calls does not pin the SEQUENCE --
+        moving the parent-directory fsync before os.replace left all five
+        prior tests green. This asserts the ordered chain with fd roles,
+        distinguishing the file fsync from the directory fsync via fstat,
+        so the reorder mutant dies for THIS invariant rather than through
+        some unrelated failure."""
         events: list[str] = []
         original_fsync = os.fsync
+        original_replace = os.replace
 
         def tracking_fsync(fd):
-            events.append("fsync")
+            kind = "dir" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
+            events.append(f"fsync:{kind}")
             return original_fsync(fd)
 
+        def tracking_replace(src, dst, **kwargs):
+            events.append("replace")
+            return original_replace(src, dst, **kwargs)
+
         with patch.object(spec_apply.os, "fsync", tracking_fsync):
-            write_materialization_receipt(self.workspace_root, self._receipt_plan(), [])
-        self.assertEqual(events.count("fsync"), 2, events)
+            with patch.object(spec_apply.os, "replace", tracking_replace):
+                write_materialization_receipt(
+                    self.workspace_root, self._validated(), self._evidence()
+                )
+
+        self.assertEqual(events, ["fsync:file", "replace", "fsync:dir"], events)
 
     def test_no_receipt_published_when_fsync_fails(self):
         with patch.object(spec_apply.os, "fsync", side_effect=OSError("simulated fsync failure")):
             with self.assertRaises(OSError):
-                write_materialization_receipt(self.workspace_root, self._receipt_plan(), [])
+                write_materialization_receipt(
+                    self.workspace_root, self._validated(), self._evidence()
+                )
         self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
 
     def test_publication_is_atomic_replace_not_direct_write(self):
@@ -466,13 +557,91 @@ class TestReceiptPublication(PlanContractTestBase):
 
         with patch.object(spec_apply.os, "replace", failing_replace):
             with self.assertRaises(OSError):
-                write_materialization_receipt(self.workspace_root, self._receipt_plan(), [])
+                write_materialization_receipt(
+                    self.workspace_root, self._validated(), self._evidence()
+                )
         self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
 
     def test_no_temp_file_left_behind_on_success(self):
-        write_materialization_receipt(self.workspace_root, self._receipt_plan(), [])
+        write_materialization_receipt(self.workspace_root, self._validated(), self._evidence())
         state_dir = self.workspace_root / ".grip" / "state" / "materialization"
         self.assertEqual(list(state_dir.glob("*.tmp-*")), [])
+
+    def test_temp_file_failure_leaves_no_residue(self):
+        with patch.object(spec_apply.os, "fsync", side_effect=OSError("boom")):
+            with self.assertRaises(OSError):
+                write_materialization_receipt(
+                    self.workspace_root, self._validated(), self._evidence()
+                )
+        state_dir = self.workspace_root / ".grip" / "state" / "materialization"
+        self.assertEqual(list(state_dir.glob("*.tmp-*")), [])
+
+
+class TestDerivedPathHardening(PlanContractTestBase):
+    """Atlas P2: §6.2.1 #2 applies to the A-owned DERIVED paths (canonical
+    WorkspaceSpec, receipt directory, receipt temp file), not only to
+    operation paths. All three probes succeeded before this closure."""
+
+    def test_symlinked_workspace_spec_rejected(self):
+        """A symlink at .grip/workspace_spec.toml pointing outside the team
+        root was accepted whenever its bytes hashed to the declared value.
+        The hash confirms CONTENT; it says nothing about whether the file
+        read is inside the workspace."""
+        outside = self.tmp / "outside_spec.toml"
+        outside.write_text('workspace_name = "outside"\n')
+        outside_sha = hashlib.sha256(outside.read_bytes()).hexdigest()
+
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.unlink()
+        spec_path.symlink_to(outside)
+
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            validate_materialization_plan(
+                self.workspace_root,
+                self._plan([self._venv_op()], workspace_spec_sha256=outside_sha),
+            )
+        self.assertIn("symlink", str(ctx.exception))
+
+    def test_symlinked_receipt_directory_rejected(self):
+        """A symlinked .grip/state/materialization published the terminal
+        receipt outside the team root entirely."""
+        outside_dir = self.tmp / "outside_receipts"
+        outside_dir.mkdir()
+        state_dir = self.workspace_root / ".grip" / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "materialization").symlink_to(outside_dir)
+
+        validated = validate_materialization_plan(
+            self.workspace_root, self._plan([self._venv_op()], plan_id="mp_escape")
+        )
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, validated, [{"kind": "venv"}]
+            )
+        self.assertIn("symlink", str(ctx.exception))
+        self.assertEqual(list(outside_dir.iterdir()), [])
+
+    def test_pre_created_temp_symlink_is_not_followed(self):
+        """The temp name is predictable (mp_<id>.json.tmp-<pid>), so a plain
+        open() followed a pre-created symlink, overwrote the external
+        target, and then published that symlink as the final receipt.
+        O_EXCL|O_NOFOLLOW refuses instead."""
+        outside_target = self.tmp / "victim.txt"
+        outside_target.write_text("ORIGINAL")
+
+        receipt_dir = self.workspace_root / ".grip" / "state" / "materialization"
+        receipt_dir.mkdir(parents=True, exist_ok=True)
+        validated = validate_materialization_plan(
+            self.workspace_root, self._plan([self._venv_op()], plan_id="mp_receipt")
+        )
+        (receipt_dir / f"mp_receipt.json.tmp-{os.getpid()}").symlink_to(outside_target)
+
+        with self.assertRaises(OSError):
+            write_materialization_receipt(
+                self.workspace_root, validated, [{"kind": "venv"}]
+            )
+        self.assertEqual(outside_target.read_text(), "ORIGINAL")
+        self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
 
 
 if __name__ == "__main__":

--- a/gr2/tests/test_materialization_plan_contract.py
+++ b/gr2/tests/test_materialization_plan_contract.py
@@ -458,6 +458,7 @@ class TestReceiptPublication(PlanContractTestBase):
                 schema_version=1,
                 workspace_spec_sha256="a" * 64,
                 operation_kinds=(),
+                plan_hash="b" * 64,
                 _token=object(),
             )
         self.assertIn("only be constructed by", str(ctx.exception))
@@ -1012,6 +1013,119 @@ class TestReceiptValueBinding(PlanContractTestBase):
                 "operations": evidence,
             },
         )
+
+
+class TestCapabilitySnapshotIsolation(PlanContractTestBase):
+    """Atlas final re-gate: `frozen=True` on the dataclass freezes the field
+    BINDING, not the nested graph. `plan` was the caller's live dict, and the
+    writer recomputed plan_hash from it at publication time -- so mutating
+    the plan after validation produced a receipt attesting to a graph that
+    was never validated. The capability proved one graph was checked while
+    vouching for another.
+
+    Closure is a mint-time SNAPSHOT plus captured facts: the hash is computed
+    once during validation and the receipt reads only what was captured.
+    Both aliases must be dead ends -- the caller's original dict AND the
+    representation the capability exposes."""
+
+    def test_mutating_the_callers_plan_after_validation_cannot_move_the_receipt(self):
+        """Atlas's exact repro, taken verbatim as the RED probe."""
+        op = self._venv_op()
+        plan = self._plan([op], plan_id="mp_alias")
+        pre_validation_hash = compute_plan_hash(plan)
+
+        validated = validate_materialization_plan(self.workspace_root, plan)
+
+        # Mutate the ORIGINAL operation the caller still holds: escape the
+        # workspace and smuggle an identity field, both of which validation
+        # would have rejected outright.
+        op["dest_path"] = "../../post_validation_escape"
+        op["secret"] = "POST_VALIDATION_SECRET"
+
+        path = write_materialization_receipt(
+            self.workspace_root, validated, [{"kind": "venv"}]
+        )
+        receipt = json.loads(path.read_text())
+
+        self.assertEqual(
+            receipt["plan_hash"],
+            pre_validation_hash,
+            "the receipt must attest to the bytes that were validated, not to a "
+            "post-validation mutation of the caller's dict",
+        )
+        self.assertNotEqual(receipt["plan_hash"], compute_plan_hash(plan))
+        self.assertNotIn("POST_VALIDATION_SECRET", path.read_text())
+
+    def test_mutating_the_capability_representation_is_impossible(self):
+        """A snapshot alone still leaves the second alias open: whatever the
+        capability EXPOSES is reachable by anyone holding it. Atlas asked for
+        mutation of both, so the exposed graph is deeply immutable rather
+        than merely a private copy."""
+        plan = self._plan([self._venv_op()], plan_id="mp_frozen")
+        validated = validate_materialization_plan(self.workspace_root, plan)
+
+        with self.assertRaises(TypeError):
+            validated.plan["plan_id"] = "mutated"
+        with self.assertRaises(TypeError):
+            validated.plan["operations"][0]["dest_path"] = "../escape"
+        with self.assertRaises((TypeError, AttributeError)):
+            validated.plan["operations"].append({"kind": "venv"})
+
+    def test_snapshot_is_not_the_callers_object(self):
+        """A shallow copy is explicitly insufficient (Atlas): the nested
+        operation dicts must not be shared either."""
+        op = self._venv_op()
+        plan = self._plan([op], plan_id="mp_ident")
+        validated = validate_materialization_plan(self.workspace_root, plan)
+        self.assertIsNot(validated.plan, plan)
+        self.assertIsNot(validated.plan["operations"][0], op)
+
+    def test_mutation_during_validation_cannot_reach_the_validated_bytes(self):
+        """The snapshot is taken on ENTRY, not at mint. Deep-freezing at mint
+        already builds fresh objects, so it MASKS a missing snapshot in any
+        single-threaded probe -- both the "no snapshot" and "shallow copy"
+        mutants survived every other test in this class. What freezing at
+        mint cannot do is defend the window between the checks and the
+        capture: it copies whatever the graph has become by then.
+
+        _read_canonical_workspace_spec_bytes runs after the schema check and
+        before the operation loop, so patching it to mutate the caller's
+        object reproduces that window deterministically, without threads."""
+        op = self._venv_op()
+        plan = self._plan([op], plan_id="mp_race")
+        expected = compute_plan_hash(plan)
+        original = spec_apply._read_canonical_workspace_spec_bytes
+
+        def mutate_then_read(workspace_root):
+            op["dest_path"] = "../../escape_during_validation"
+            op["secret"] = "RACE_SECRET"
+            return original(workspace_root)
+
+        with patch.object(spec_apply, "_read_canonical_workspace_spec_bytes", mutate_then_read):
+            validated = validate_materialization_plan(self.workspace_root, plan)
+
+        self.assertEqual(
+            validated.plan_hash,
+            expected,
+            "a mutation landing mid-validation must not reach the captured bytes",
+        )
+        path = write_materialization_receipt(
+            self.workspace_root, validated, [{"kind": "venv"}]
+        )
+        self.assertNotIn("RACE_SECRET", path.read_text())
+
+    def test_captured_hash_matches_the_validated_bytes(self):
+        plan = self._plan([self._venv_op()], plan_id="mp_captured")
+        expected = compute_plan_hash(plan)
+        validated = validate_materialization_plan(self.workspace_root, plan)
+        self.assertEqual(validated.plan_hash, expected)
+
+    def test_hash_helper_accepts_the_frozen_representation(self):
+        """The freeze must not turn the public canonical-hash helper into a
+        trap for the handlers that will hold these plans in B/C/D."""
+        plan = self._plan([self._venv_op()], plan_id="mp_helper")
+        validated = validate_materialization_plan(self.workspace_root, plan)
+        self.assertEqual(compute_plan_hash(validated.plan), compute_plan_hash(plan))
 
 
 class TestDurabilityFailureMatrix(PlanContractTestBase):

--- a/gr2/tests/test_materialization_plan_contract.py
+++ b/gr2/tests/test_materialization_plan_contract.py
@@ -1,0 +1,479 @@
+"""Plan-contract tests for the neutral MaterializationPlan v1 (S4-A).
+
+Covers the PLAN-LEVEL contract only: pinned-schema conformance, the
+schema SHA pin, identity-freedom, opaque-token safety, WorkspaceSpec
+binding, path canonicalization, destination-collision detection, and
+durable receipt publication.
+
+Operation EXECUTION is deliberately absent from S4-A and lands with
+S4-B (clone/cache/alternates), S4-C (staging/project_file), and S4-D
+(venv/editable + PEP 610), each with its own domain validation and
+mutation set -- see the grip#797 split.
+
+Testing discipline carried forward from that review cycle: assert WHICH
+invariant fired, not merely that some MaterializationPlanError was
+raised. A fixture broken enough to trip the invariant under test is
+usually broken enough to trip its neighbours too, and a type-only
+assertRaises cannot tell them apart.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gr2.python_cli import spec_apply
+from gr2.python_cli.spec_apply import (
+    MaterializationPlanError,
+    canonicalize_workspace_path,
+    compute_plan_hash,
+    materialization_receipt_path,
+    validate_materialization_plan,
+    workspace_spec_path,
+    write_materialization_receipt,
+)
+
+
+class PlanContractTestBase(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self.tmp = Path(tempfile.mkdtemp())
+        self.workspace_root = self.tmp / "workspace"
+        self.workspace_root.mkdir(parents=True)
+        self.spec_sha256 = self._write_workspace_spec()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_workspace_spec(self, content: str = 'workspace_name = "test"\n') -> str:
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_path.write_text(content)
+        return hashlib.sha256(spec_path.read_bytes()).hexdigest()
+
+    def _plan(self, operations: list[dict[str, object]], **overrides: object) -> dict[str, object]:
+        plan: dict[str, object] = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "unit_key": "u_test",
+            "workspace_spec_sha256": self.spec_sha256,
+            "operations": operations,
+        }
+        plan.update(overrides)
+        return plan
+
+    def _clone_op(self, **fields: object) -> dict[str, object]:
+        op: dict[str, object] = {
+            "kind": "clone",
+            "branch": "main",
+            "repo_url": "https://example.com/product.git",
+            "dest_path": "units/u1/product",
+        }
+        op.update(fields)
+        return op
+
+    def _venv_op(self, **fields: object) -> dict[str, object]:
+        op: dict[str, object] = {
+            "kind": "venv",
+            "dest_path": "units/u1/.venv",
+            "engine": "uv",
+            "python": ">=3.11",
+        }
+        op.update(fields)
+        return op
+
+    def _project_file_op(self, **fields: object) -> dict[str, object]:
+        op: dict[str, object] = {
+            "kind": "project_file",
+            "source_path": ".grip/staging/inputs/f_01",
+            "source_sha256": "a" * 64,
+            "dest_path": "units/u1/AGENTS.md",
+            "mode": "copy",
+        }
+        op.update(fields)
+        return op
+
+    def _reject(self, plan: dict[str, object], expected_fragment: str, label: str) -> None:
+        with self.assertRaises(MaterializationPlanError, msg=f"{label} must be rejected") as ctx:
+            validate_materialization_plan(self.workspace_root, plan)
+        self.assertIn(expected_fragment, str(ctx.exception), f"{label}: wrong invariant fired")
+
+
+class TestSchemaPin(PlanContractTestBase):
+    def test_packaged_schema_matches_pinned_sha256(self):
+        raw = spec_apply._read_plan_schema_bytes()
+        self.assertEqual(hashlib.sha256(raw).hexdigest(), spec_apply._PLAN_SCHEMA_SHA256)
+
+    def test_schema_load_fails_closed_on_hash_mismatch(self):
+        """A tampered or unpinned schema must refuse to validate at all,
+        rather than silently enforcing a different contract."""
+        spec_apply._plan_validator = None
+        try:
+            with patch.object(spec_apply, "_read_plan_schema_bytes", return_value=b"{}"):
+                self._reject(
+                    self._plan([self._venv_op()]),
+                    "hash mismatch",
+                    "tampered schema bytes",
+                )
+        finally:
+            spec_apply._plan_validator = None
+
+
+class TestPinnedSchemaConformance(PlanContractTestBase):
+    """config#492's malformed-plan set. A hand-rolled validator is a
+    separate, looser contract by construction; these pin conformance to
+    the pinned schema itself."""
+
+    def test_valid_plan_accepted(self):
+        validate_materialization_plan(self.workspace_root, self._plan([self._venv_op()]))
+
+    def test_clone_without_branch_rejected(self):
+        op = self._clone_op()
+        del op["branch"]
+        self._reject(self._plan([op]), "schema", "clone without required branch")
+
+    def test_venv_without_engine_and_python_rejected(self):
+        self._reject(
+            self._plan([{"kind": "venv", "dest_path": "units/u1/.venv"}]),
+            "schema",
+            "venv without required engine/python",
+        )
+
+    def test_editable_install_without_extras_rejected(self):
+        self._reject(
+            self._plan(
+                [{"kind": "editable_install", "venv_path": "units/u1/.venv", "source_path": "units/u1/src"}]
+            ),
+            "schema",
+            "editable_install without required extras",
+        )
+
+    def test_project_file_without_mode_rejected(self):
+        op = self._project_file_op()
+        del op["mode"]
+        self._reject(self._plan([op]), "schema", "project_file without required mode")
+
+    def test_short_workspace_spec_sha_rejected(self):
+        self._reject(
+            self._plan([self._venv_op()], workspace_spec_sha256="abc123"),
+            "schema",
+            "six-character workspace_spec_sha256",
+        )
+
+    def test_dot_path_segment_rejected(self):
+        self._reject(
+            self._plan([self._venv_op(dest_path="units/./u1/.venv")]),
+            "schema",
+            "literal '.' path segment",
+        )
+
+    def test_backslash_path_rejected(self):
+        self._reject(
+            self._plan([self._venv_op(dest_path="units\\u1\\.venv")]),
+            "schema",
+            "backslash path",
+        )
+
+    def test_duplicate_extras_rejected(self):
+        self._reject(
+            self._plan(
+                [
+                    {
+                        "kind": "editable_install",
+                        "venv_path": "units/u1/.venv",
+                        "source_path": "units/u1/src",
+                        "extras": ["dev", "dev"],
+                    }
+                ]
+            ),
+            "schema",
+            "duplicate extras (uniqueItems)",
+        )
+
+    def test_overlong_plan_id_rejected(self):
+        self._reject(
+            self._plan([self._venv_op()], plan_id="p" * 129),
+            "schema",
+            "129-character plan_id",
+        )
+
+    def test_nested_staged_input_path_rejected(self):
+        self._reject(
+            self._plan([self._project_file_op(source_path=".grip/staging/inputs/a/b")]),
+            "schema",
+            "nested staged input path",
+        )
+
+    def test_boolean_schema_version_rejected(self):
+        """bool is an int subclass in Python, so True == 1 slips a naive
+        `!= 1` check; JSON Schema's const:1 distinguishes the types."""
+        self._reject(
+            self._plan([self._venv_op()], schema_version=True),
+            "schema",
+            "boolean schema_version",
+        )
+
+    def test_invalid_opaque_unit_key_rejected(self):
+        self._reject(
+            self._plan([self._venv_op()], unit_key="../escape"),
+            "schema",
+            "invalid opaque unit_key",
+        )
+
+    def test_reference_base_outside_cache_namespace_rejected(self):
+        """The schema confines reference_base syntactically to
+        .grip/cache/repos/<name>.git. Filesystem provenance (is it a real
+        bare cache with the right origin) is S4-B's."""
+        self._reject(
+            self._plan([self._clone_op(reference_base="units/u1/rogue-cache.git")]),
+            "schema",
+            "reference_base outside the cache namespace",
+        )
+
+    def test_unknown_top_level_field_rejected(self):
+        self._reject(self._plan([self._venv_op()], org="synapt"), "schema", "unknown top-level field")
+
+    def test_unknown_operation_field_rejected(self):
+        """An allowlist rejects any field not explicitly permitted, by
+        construction -- a blacklist only catches names someone enumerated."""
+        self._reject(
+            self._plan([self._venv_op(metadata={"display_name": "Apollo"})]),
+            "schema",
+            "unknown operation field",
+        )
+
+    def test_empty_operations_rejected(self):
+        self._reject(self._plan([]), "schema", "empty operations list")
+
+
+class TestIdentityFreedom(PlanContractTestBase):
+    def test_rejects_top_level_identity_field_on_operation(self):
+        self._reject(
+            self._plan([self._clone_op(agent_name="apollo")]),
+            "schema",
+            "operation carrying agent_name",
+        )
+
+    def test_recursive_identity_rejection_is_reachable(self):
+        """Defence in depth beneath the allowlist: even inside an allowed
+        field's VALUE, an identity-shaped key must be rejected. Exercised
+        directly since the allowlist would reject the carrier field first."""
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            spec_apply._reject_identity_fields_recursive(
+                {"extras": [{"channel": "dev"}]}, path="operations[0]"
+            )
+        self.assertIn("identity-bearing", str(ctx.exception))
+
+
+class TestWorkspaceSpecBinding(PlanContractTestBase):
+    def test_missing_workspace_spec_file_rejected(self):
+        workspace_spec_path(self.workspace_root).unlink()
+        self._reject(
+            self._plan([self._venv_op()]),
+            "cannot be verified",
+            "absent canonical WorkspaceSpec",
+        )
+
+    def test_workspace_spec_hash_mismatch_rejected(self):
+        self._write_workspace_spec('workspace_name = "drifted"\n')
+        self._reject(
+            self._plan([self._venv_op()]),
+            "workspace_spec_sha256 mismatch",
+            "plan compiled against different workspace state",
+        )
+
+
+class TestDestinationCollisions(PlanContractTestBase):
+    def test_case_only_duplicate_dest_paths_rejected(self):
+        self._reject(
+            self._plan([self._venv_op(dest_path="units/u1/.venv"), self._venv_op(dest_path="units/u1/.VENV")]),
+            "collides",
+            "case-only destination collision",
+        )
+
+    def test_unicode_casefold_duplicate_dest_paths_rejected(self):
+        """Kills a `.lower()` substitution specifically: lower() leaves 'ß'
+        alone, only casefold() folds it to 'ss'."""
+        self._reject(
+            self._plan(
+                [
+                    self._venv_op(dest_path="units/straße/.venv"),
+                    self._venv_op(dest_path="units/STRASSE/.venv"),
+                ]
+            ),
+            "collides",
+            "Unicode casefold collision",
+        )
+
+    def test_distinct_destinations_accepted(self):
+        validate_materialization_plan(
+            self.workspace_root,
+            self._plan(
+                [self._venv_op(dest_path="units/a/.venv"), self._venv_op(dest_path="units/b/.venv")]
+            ),
+        )
+
+
+class TestCanonicalizationDefenseInDepth(PlanContractTestBase):
+    """The pinned schema's workspaceRelativePath pattern is a strictly
+    stronger FIRST gate, so plan-level tests never reach canonicalization.
+    That makes this layer invisible to them -- and it is genuinely
+    load-bearing, because the legacy apply_plan adapter and the S4-B/C/D
+    handlers call it without schema validation. Tested directly, at its
+    own level."""
+
+    def _reject_path(self, relative: str, fragment: str) -> None:
+        with self.assertRaises(MaterializationPlanError, msg=f"{relative!r} must be rejected") as ctx:
+            canonicalize_workspace_path(self.workspace_root, relative, field_name="probe")
+        self.assertIn(fragment, str(ctx.exception))
+
+    def test_rejects_single_dot_segment(self):
+        self._reject_path("a/./b", "segments")
+
+    def test_rejects_dotdot_segment(self):
+        self._reject_path("a/../b", "segments")
+
+    def test_rejects_empty_segment(self):
+        self._reject_path("a//b", "segments")
+
+    def test_rejects_backslash(self):
+        self._reject_path("a\\b", "backslashes or NUL")
+
+    def test_rejects_nul_byte(self):
+        """Without the raw guard this escapes as an uncaught ValueError from
+        Path.resolve() ("embedded null character") -- crash-class, not just
+        a weakened check."""
+        self._reject_path("a/b\x00c", "backslashes or NUL")
+
+    def test_rejects_absolute_path(self):
+        self._reject_path("/etc/passwd", "relative to the workspace root")
+
+    def test_rejects_tilde(self):
+        self._reject_path("~/secrets", "relative to the workspace root")
+
+    def test_rejects_symlinked_directory_prefix(self):
+        """A resolve()-only containment check cannot catch this: with a
+        prefix directory that is itself a symlink, both the candidate and
+        the root resolve THROUGH the same link."""
+        outside = self.tmp / "outside"
+        outside.mkdir()
+        (self.workspace_root / "linked").symlink_to(outside)
+        self._reject_path("linked/payload", "symlink")
+
+    def test_rejects_symlinked_final_component(self):
+        outside = self.tmp / "secret.txt"
+        outside.write_text("x")
+        (self.workspace_root / "alias").symlink_to(outside)
+        self._reject_path("alias", "symlink")
+
+    def test_accepts_ordinary_relative_path(self):
+        resolved = canonicalize_workspace_path(
+            self.workspace_root, "units/u1/product", field_name="probe"
+        )
+        self.assertEqual(resolved, (self.workspace_root / "units" / "u1" / "product").resolve())
+
+
+class TestPlanHash(PlanContractTestBase):
+    def test_uses_pinned_canonical_serialization(self):
+        """Two independent proofs that this is the PINNED serialization,
+        not merely a deterministic one: it equals the pinned recipe, and it
+        does NOT equal the default-separator / ensure_ascii variants."""
+        plan = self._plan([self._venv_op()], unit_key="u_straße")
+        pinned = hashlib.sha256(
+            json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(compute_plan_hash(plan), pinned)
+        self.assertNotEqual(
+            compute_plan_hash(plan),
+            hashlib.sha256(json.dumps(plan, sort_keys=True).encode()).hexdigest(),
+        )
+        self.assertNotEqual(
+            compute_plan_hash(plan),
+            hashlib.sha256(
+                json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+            ).hexdigest(),
+        )
+
+    def test_hash_changes_with_plan_content(self):
+        a = self._plan([self._venv_op(dest_path="units/a/.venv")])
+        b = self._plan([self._venv_op(dest_path="units/b/.venv")])
+        self.assertNotEqual(compute_plan_hash(a), compute_plan_hash(b))
+
+
+class TestReceiptPublication(PlanContractTestBase):
+    def _receipt_plan(self) -> dict[str, object]:
+        return self._plan([self._venv_op()], plan_id="mp_receipt")
+
+    def test_receipt_schema_is_exact(self):
+        plan = self._receipt_plan()
+        write_materialization_receipt(self.workspace_root, plan, [{"kind": "venv"}])
+        receipt = json.loads(materialization_receipt_path(self.workspace_root, "mp_receipt").read_text())
+        self.assertEqual(
+            set(receipt),
+            {
+                "plan_id",
+                "unit_key",
+                "plan_hash",
+                "schema_version",
+                "workspace_spec_sha256",
+                "stage",
+                "applied_at",
+                "operations",
+            },
+        )
+        self.assertEqual(receipt["stage"], "MATERIALIZED")
+        self.assertEqual(receipt["unit_key"], "u_test")
+        self.assertEqual(receipt["workspace_spec_sha256"], self.spec_sha256)
+        # Recomputed independently -- a constant-hash mutant dies here.
+        self.assertEqual(receipt["plan_hash"], compute_plan_hash(plan))
+
+    def test_publication_fsyncs_file_and_parent_directory(self):
+        """Rename success is not durable acknowledgement: on power loss the
+        rename can survive while the bytes do not."""
+        events: list[str] = []
+        original_fsync = os.fsync
+
+        def tracking_fsync(fd):
+            events.append("fsync")
+            return original_fsync(fd)
+
+        with patch.object(spec_apply.os, "fsync", tracking_fsync):
+            write_materialization_receipt(self.workspace_root, self._receipt_plan(), [])
+        self.assertEqual(events.count("fsync"), 2, events)
+
+    def test_no_receipt_published_when_fsync_fails(self):
+        with patch.object(spec_apply.os, "fsync", side_effect=OSError("simulated fsync failure")):
+            with self.assertRaises(OSError):
+                write_materialization_receipt(self.workspace_root, self._receipt_plan(), [])
+        self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
+
+    def test_publication_is_atomic_replace_not_direct_write(self):
+        """Asserting only "no temp file left behind" cannot distinguish
+        atomic publication from a direct write -- a direct write also
+        trivially leaves no temp file. Failing the replace step itself can."""
+        original_replace = os.replace
+
+        def failing_replace(src, dst, **kwargs):
+            if "materialization" in str(src):
+                raise OSError("simulated replace failure")
+            return original_replace(src, dst, **kwargs)
+
+        with patch.object(spec_apply.os, "replace", failing_replace):
+            with self.assertRaises(OSError):
+                write_materialization_receipt(self.workspace_root, self._receipt_plan(), [])
+        self.assertFalse(materialization_receipt_path(self.workspace_root, "mp_receipt").exists())
+
+    def test_no_temp_file_left_behind_on_success(self):
+        write_materialization_receipt(self.workspace_root, self._receipt_plan(), [])
+        state_dir = self.workspace_root / ".grip" / "state" / "materialization"
+        self.assertEqual(list(state_dir.glob("*.tmp-*")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gr2/tests/test_materialization_plan_contract.py
+++ b/gr2/tests/test_materialization_plan_contract.py
@@ -1308,6 +1308,132 @@ class TestCapabilityIsContentBound(PlanContractTestBase):
         self.assertEqual(json.loads(path.read_text())["plan_id"], "mp_genuine")
 
 
+class TestConsumptionIsSnapshotBound(PlanContractTestBase):
+    """Atlas's use-time TOCTOU. It survived two heads, which is the signal
+    that the model was wrong rather than a guard missing: I had been fixing
+    the capability so it could not be *forged*, while the writer went on
+    reading the live shell AFTER verification, across a caller-controlled
+    callback.
+
+    The content seal is what made this look covered -- it gates content, so
+    tampering could not change the sealed facts. But nothing gated the READS.
+    That is the adjacent-strong-guard masking class again, this time in the
+    fix rather than in the test.
+
+    Closure is Atlas's, exactly: one verified consumption yields an immutable
+    local binding derived from the sealed snapshot, and every later evidence
+    check, receipt field, filename and temp filename consumes only that."""
+
+    def _victim(self, plan_id: str):
+        return validate_materialization_plan(
+            self.workspace_root, self._plan([self._venv_op()], plan_id=plan_id)
+        )
+
+    def test_mutation_between_verify_and_use_cannot_move_the_receipt(self):
+        """Atlas's callback witness, verbatim. It published
+        changed_after_verify.json carrying a changed identity beside the
+        original hash -- one receipt describing two different states."""
+        victim = self._victim("mp_toctou")
+
+        class MutatingEvidence(list):
+            def __iter__(inner):
+                object.__setattr__(victim, "plan_id", "changed_after_verify")
+                return super().__iter__()
+
+        path = write_materialization_receipt(
+            self.workspace_root, victim, MutatingEvidence([{"kind": "venv"}])
+        )
+        receipt = json.loads(path.read_text())
+
+        state_dir = self.workspace_root / ".grip" / "state" / "materialization"
+        self.assertFalse((state_dir / "changed_after_verify.json").exists())
+        self.assertEqual(path.name, "mp_toctou.json")
+        self.assertEqual(receipt["plan_id"], "mp_toctou")
+        self.assertEqual(receipt["plan_hash"], victim.plan_hash)
+
+    def test_temp_filename_also_comes_from_the_binding(self):
+        """The temp filename is derived from the same identity, so it has to
+        come from the binding too -- otherwise the window merely moves.
+
+        It cannot be checked by listing the directory afterwards: the rename
+        CONSUMES the temp file, so a post-hoc listing shows the same thing
+        whether or not the name was attacker-influenced. That is why this
+        mutant survived a directory assertion. Observing the transient name
+        at os.replace is the only probe that can see it.
+
+        It matters even though the temp stays inside the receipt directory:
+        a caller-chosen temp name can collide with another in-flight
+        publication's temp and have it unlinked on the failure path."""
+        victim = self._victim("mp_tmp")
+        seen: dict[str, str] = {}
+        original_replace = os.replace
+
+        def tracking_replace(src, dst, **kwargs):
+            seen["src"] = Path(src).name
+            seen["dst"] = Path(dst).name
+            return original_replace(src, dst, **kwargs)
+
+        class MutatingEvidence(list):
+            def __iter__(inner):
+                object.__setattr__(victim, "plan_id", "escaped_tmp")
+                return super().__iter__()
+
+        with patch.object(spec_apply.os, "replace", tracking_replace):
+            write_materialization_receipt(
+                self.workspace_root, victim, MutatingEvidence([{"kind": "venv"}])
+            )
+
+        self.assertTrue(seen["src"].startswith("mp_tmp.json.tmp-"), seen)
+        self.assertEqual(seen["dst"], "mp_tmp.json")
+
+    def test_evidence_is_read_once_so_it_cannot_screen_clean_and_persist_dirty(self):
+        """The other input, same class. The evidence list was walked TWICE --
+        once by the screen and once by json serialization -- so an object
+        returning different contents per iteration passed the identity screen
+        and then persisted `secret` into the receipt anyway.
+
+        That is a premium-boundary failure, not just a correctness one: the
+        receipt's whole claim is that it carries no identity-bearing content.
+        Not in Atlas's witness; found by asking what else is read after it is
+        checked."""
+        victim = self._victim("mp_twoface")
+
+        class TwoFaced(list):
+            calls = 0
+
+            def __iter__(inner):
+                TwoFaced.calls += 1
+                if TwoFaced.calls == 1:
+                    return iter([{"kind": "venv"}])
+                return iter([{"kind": "venv", "secret": "LEAKED"}])
+
+        path = write_materialization_receipt(
+            self.workspace_root, victim, TwoFaced([{"kind": "venv"}])
+        )
+        body = path.read_text()
+        self.assertNotIn("LEAKED", body)
+        self.assertEqual(json.loads(body)["operations"], [{"kind": "venv"}])
+
+    def test_evidence_screening_sees_what_gets_persisted(self):
+        """The positive face: a two-faced object that is DIRTY on its first
+        read must be rejected, proving the screen inspects the same
+        materialized value the receipt persists rather than a fresh walk."""
+        victim = self._victim("mp_dirtyfirst")
+
+        class DirtyFirst(list):
+            def __iter__(inner):
+                return iter([{"kind": "venv", "agent_id": "a-1"}])
+
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, victim, DirtyFirst([{"kind": "venv"}])
+            )
+        self.assertIn("identity-bearing", str(ctx.exception))
+        self.assertFalse(
+            materialization_receipt_path(self.workspace_root, "mp_dirtyfirst").exists()
+        )
+
+
 class TestDurabilityFailureMatrix(PlanContractTestBase):
     """Sentinel finding 3: durability is a FAILURE-PATH contract, not only
     an ordering one. The prior failure test injected only at the FIRST

--- a/gr2/tests/test_materialization_plan_contract.py
+++ b/gr2/tests/test_materialization_plan_contract.py
@@ -18,6 +18,7 @@ assertRaises cannot tell them apart.
 """
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import json
 import os
@@ -449,19 +450,27 @@ class TestReceiptPublication(PlanContractTestBase):
 
     def test_validated_plan_cannot_be_forged(self):
         """The capability is only mintable by the validator -- otherwise it
-        would be a naming convention rather than a guarantee."""
+        would be a naming convention rather than a guarantee.
+
+        The forged shell is otherwise FULLY self-consistent: a real frozen
+        snapshot, its true hash, and facts that agree with it. That makes the
+        seal check provably the thing that rejects it, rather than one of the
+        consistency checks that run ahead of it."""
+        genuine = validate_materialization_plan(
+            self.workspace_root, self._plan([self._venv_op()], plan_id="mp_forge")
+        )
         with self.assertRaises(MaterializationPlanError) as ctx:
             spec_apply.ValidatedPlan(
-                plan={},
-                plan_id="../../escaped",
-                unit_key="u",
-                schema_version=1,
-                workspace_spec_sha256="a" * 64,
-                operation_kinds=(),
-                plan_hash="b" * 64,
-                _token=object(),
+                plan=genuine.plan,
+                plan_id=genuine.plan_id,
+                unit_key=genuine.unit_key,
+                schema_version=genuine.schema_version,
+                workspace_spec_sha256=genuine.workspace_spec_sha256,
+                operation_kinds=genuine.operation_kinds,
+                plan_hash=genuine.plan_hash,
+                _seal="0" * 64,
             )
-        self.assertIn("only be constructed by", str(ctx.exception))
+        self.assertIn("not minted by", str(ctx.exception))
 
     def test_invalid_plan_id_cannot_reach_publication(self):
         """Atlas P1 fruit: plan_id="../../escaped" published
@@ -1126,6 +1135,107 @@ class TestCapabilitySnapshotIsolation(PlanContractTestBase):
         plan = self._plan([self._venv_op()], plan_id="mp_helper")
         validated = validate_materialization_plan(self.workspace_root, plan)
         self.assertEqual(compute_plan_hash(validated.plan), compute_plan_hash(plan))
+
+
+class TestCapabilityIsContentBound(PlanContractTestBase):
+    """Sentinel's converging seam: a capability keyed on OBJECT IDENTITY (an
+    opaque sentinel token) is copyable. `dataclasses.replace` re-invokes
+    __init__ with the existing field values, so the real token rides into a
+    modified shell -- a laundered "validated" object that binds facts nobody
+    validated.
+
+    Atlas's seam and this one are one design truth: the capability must bind
+    to immutable CONTENT, not to identity or to a field that copies. The
+    seal is therefore derived from the snapshot's canonical hash and every
+    fact published alongside it, and verified at every use rather than only
+    at construction."""
+
+    def _valid(self, plan_id: str = "mp_seal"):
+        return validate_materialization_plan(
+            self.workspace_root, self._plan([self._venv_op()], plan_id=plan_id)
+        )
+
+    def test_replace_cannot_launder_the_capability(self):
+        """Sentinel's witness 1, verbatim: replace() preserved the real token
+        and publication used the altered plan_id, writing `.grip/escaped.json`
+        outside the receipt directory."""
+        validated = self._valid()
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            dataclasses.replace(validated, plan_id="../../escaped")
+        self.assertIn("disagree with the plan snapshot", str(ctx.exception))
+        self.assertFalse((self.workspace_root / ".grip" / "escaped.json").exists())
+
+    def test_replace_of_any_published_fact_is_rejected(self):
+        """plan_id is the field with the escape, but every fact the receipt
+        attests to has to be bound, or the next one becomes the seam.
+
+        Each row names the layer that must reject it. The three layers shadow
+        each other -- the snapshot-agreement check fires before the seal for
+        every field it covers -- so asserting only "some capability error"
+        would let a removed layer hide behind the one beneath it. That is the
+        same shadowing Sentinel flagged for the pinned schema."""
+        validated = self._valid()
+        for field, value, reason in (
+            ("plan_id", "mp_other", "disagree with the plan snapshot"),
+            ("unit_key", "u_other", "disagree with the plan snapshot"),
+            ("schema_version", 2, "disagree with the plan snapshot"),
+            ("workspace_spec_sha256", "f" * 64, "disagree with the plan snapshot"),
+            ("operation_kinds", ("clone",), "disagree with the plan snapshot"),
+            ("plan_hash", "0" * 64, "does not describe its plan snapshot"),
+        ):
+            with self.subTest(field=field):
+                with self.assertRaises(MaterializationPlanError) as ctx:
+                    dataclasses.replace(validated, **{field: value})
+                self.assertIn(reason, str(ctx.exception))
+
+    def test_publication_rejects_a_capability_altered_in_place(self):
+        """frozen=True blocks __setattr__, not object.__setattr__. Verifying
+        at USE, not only at construction, is what makes the binding hold
+        against an object that was already minted."""
+        validated = self._valid(plan_id="mp_inplace")
+        object.__setattr__(validated, "plan_id", "../../escaped")
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, validated, [{"kind": "venv"}]
+            )
+        self.assertIn("disagree with the plan snapshot", str(ctx.exception))
+        self.assertFalse((self.workspace_root / ".grip" / "escaped.json").exists())
+
+    def test_publication_rejects_a_swapped_plan_snapshot(self):
+        """The snapshot itself is a published fact: plan_hash attests to it,
+        so swapping the graph must invalidate the seal too."""
+        validated = self._valid(plan_id="mp_swap")
+        other = validate_materialization_plan(
+            self.workspace_root,
+            self._plan([self._venv_op(dest_path="units/u2/.venv")], plan_id="mp_swap"),
+        )
+        object.__setattr__(validated, "plan", other.plan)
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, validated, [{"kind": "venv"}]
+            )
+        self.assertIn("does not describe its plan snapshot", str(ctx.exception))
+
+    def test_the_seal_itself_rejects_a_self_consistent_forgery(self):
+        """The layer that has no shadow above it. Snapshot agreement and hash
+        agreement both hold here, so only the seal can refuse -- which is the
+        test that keeps the seal from being dead code."""
+        genuine = self._valid(plan_id="mp_sealonly")
+        object.__setattr__(genuine, "_seal", "0" * 64)
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, genuine, [{"kind": "venv"}]
+            )
+        self.assertIn("not minted by", str(ctx.exception))
+
+    def test_a_genuine_capability_still_publishes(self):
+        """The seal must not be so strict it rejects the real thing."""
+        validated = self._valid(plan_id="mp_genuine")
+        path = write_materialization_receipt(
+            self.workspace_root, validated, [{"kind": "venv"}]
+        )
+        self.assertTrue(path.exists())
+        self.assertEqual(json.loads(path.read_text())["plan_id"], "mp_genuine")
 
 
 class TestDurabilityFailureMatrix(PlanContractTestBase):

--- a/gr2/tests/test_materialization_plan_contract.py
+++ b/gr2/tests/test_materialization_plan_contract.py
@@ -18,6 +18,7 @@ assertRaises cannot tell them apart.
 """
 from __future__ import annotations
 
+import copy
 import dataclasses
 import hashlib
 import json
@@ -1227,6 +1228,75 @@ class TestCapabilityIsContentBound(PlanContractTestBase):
                 self.workspace_root, genuine, [{"kind": "venv"}]
             )
         self.assertIn("not minted by", str(ctx.exception))
+
+    def test_atlas_forge_family_cannot_publish(self):
+        """Atlas's forge family verbatim: he published a receipt claiming an
+        all-zero plan hash and `clone` evidence from a validated `venv` plan,
+        and escaped the receipt directory via plan_id. Every vector he named
+        gets a row, asserting no filesystem publication occurred."""
+        validated = self._valid(plan_id="mp_forge_family")
+        for field, value in (
+            ("plan_id", "../../escaped"),
+            ("unit_key", "u_forged"),
+            ("workspace_spec_sha256", "f" * 64),
+            ("plan_hash", "0" * 64),
+            ("operation_kinds", ("clone",)),
+        ):
+            with self.subTest(field=field):
+                with self.assertRaises(MaterializationPlanError):
+                    forged = dataclasses.replace(validated, **{field: value})
+                    write_materialization_receipt(
+                        self.workspace_root, forged, [{"kind": "venv"}]
+                    )
+        self.assertFalse((self.workspace_root / ".grip" / "escaped.json").exists())
+        state = self.workspace_root / ".grip" / "state" / "materialization"
+        self.assertEqual(
+            [p.name for p in state.glob("*.json")] if state.exists() else [], []
+        )
+
+    def test_copying_the_capability_does_not_preserve_authority(self):
+        """The layer content-checking cannot reach. A copy has identical
+        fields and therefore an identical, genuinely valid seal -- only
+        ORIGIN can refuse it. Atlas's closure says copying must not preserve
+        authority, so this is its own layer with its own probe."""
+        validated = self._valid(plan_id="mp_copy")
+
+        # A shallow copy IS constructible and carries a genuinely valid seal,
+        # so provenance is the only thing that can refuse it.
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, copy.copy(validated), [{"kind": "venv"}]
+            )
+        self.assertIn("not one this validator", str(ctx.exception))
+
+        # A deep copy cannot be produced at all: the frozen snapshot is not
+        # picklable, so the clone never comes into existence. Different
+        # mechanism, same guarantee -- asserted separately rather than folded
+        # in, because a shared assertion would hide which one actually holds.
+        with self.assertRaises(TypeError):
+            copy.deepcopy(validated)
+
+    def test_provenance_rejects_a_correctly_sealed_hand_built_shell(self):
+        """Pinning provenance at its OWN level: this shell carries a real
+        seal, computed with the production helper, so every content check
+        passes. If provenance were removed, nothing else would refuse it."""
+        genuine = self._valid(plan_id="mp_prov")
+        facts = {
+            "plan_hash": genuine.plan_hash,
+            "plan_id": genuine.plan_id,
+            "unit_key": genuine.unit_key,
+            "schema_version": genuine.schema_version,
+            "workspace_spec_sha256": genuine.workspace_spec_sha256,
+            "operation_kinds": genuine.operation_kinds,
+        }
+        shell = spec_apply.ValidatedPlan(
+            plan=genuine.plan, _seal=spec_apply._capability_seal(**facts), **facts
+        )
+        with self.assertRaises(MaterializationPlanError) as ctx:
+            write_materialization_receipt(
+                self.workspace_root, shell, [{"kind": "venv"}]
+            )
+        self.assertIn("not one this validator", str(ctx.exception))
 
     def test_a_genuine_capability_still_publishes(self):
         """The seal must not be so strict it rejects the real thing."""

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -327,7 +327,16 @@ def test_workspace_materialize_emits_workspace_materialized_event(tmp_path: Path
     assert materialized["workspace"] == workspace_root.name
     assert materialized["actor"] == "system"
     assert materialized["owner_unit"] == "workspace"
-    assert materialized["repos"] == [{"repo": "app", "first_materialize": True}]
+    # _write_workspace_spec declares both a workspace-level "app" repo
+    # (repos/app) and a unit ("atlas") referencing the same repo name for its
+    # own checkout (agents/atlas/home/app) -- two distinct physical clones.
+    # Pre-grip#539, the unit's own checkout was silently never scheduled on a
+    # fresh workspace (the exact bug), so only the workspace-level clone
+    # appeared here. Both are expected now.
+    assert materialized["repos"] == [
+        {"repo": "app", "first_materialize": True},
+        {"repo": "app", "first_materialize": True},
+    ]
 
 
 def test_workspace_materialize_emits_file_projected_event(tmp_path: Path) -> None:


### PR DESCRIPTION
First sub-PR of the **grip#797 split**. #797 reached five re-gates on a ~900-line monolith and kept finding corners; per Stromus's hard line it splits into four rooms small enough for exhaustive sweeps. This is the base.

**Lineage:** supersedes the plan-contract portion of #797 (closed as superseded-by-split). Siblings to follow: S4-B (clone/cache/alternates), S4-C (staging/project_file), S4-D (venv/editable + PEP 610).

## What this ships — and what it deliberately does not

Ships the **plan-level contract** for config#492's neutral MaterializationPlan v1. Ships **no operation execution at all**.

That was the carve decision, and it's worth stating explicitly because the alternative was tempting: carve the executor with weakened handlers and harden them in B/C/D. That would have put known-weak clone/staging/venv code on a shipped path. Instead every guarantee here is enforced *before* any handler could run, so this room is complete as shipped, and B/C/D each bring a handler **together with** its domain validation and mutation set.

Safety note, verified rather than assumed: `apply_materialization_plan` is not reachable from any CLI command — only the legacy `apply_plan` (workspace_spec.toml) is wired to `workspace materialize`. Landing the contract ahead of the handlers exposes no product path.

## Contents

**Pinned schema, fail-closed.** config#492's v1 schema (`4b36896`, SHA `a5061501…590231c`) is vendored *inside* the package, validated with `Draft202012Validator`, and its bytes SHA-verified at load. A tampered or unpinned schema refuses to validate at all rather than silently enforcing a different contract.

`schema_version=True` is worth naming: `bool` is an `int` subclass in Python, so `True == 1` and a hand-written `!= 1` check *accepts* it. JSON Schema's `const: 1` distinguishes the types — a concrete case where a hand validator wasn't merely looser, it was wrong.

**Identity-freedom by allowlist.** Exact per-kind field allowlists reject anything not explicitly permitted, by construction — a blacklist only catches names someone thought to enumerate (`metadata.display_name` sailed through one). Recursive identity-key rejection remains beneath it as defence in depth.

**Opaque tokens.** `plan_id` and `unit_key` are validated as path-safe tokens; gr2 checks their shape without deriving identity from them.

**§6.2.1 #1 — WorkspaceSpec binding.** The canonical spec is reopened and its bytes hashed against `workspace_spec_sha256`. Carrying the field is not verifying it.

**§6.2.1 #2 — canonicalization.** Raw-segment scanning (`Path()` normalizes `.` away before `.parts` can see it) plus a per-component `lstat` walk. A `resolve()`-based containment check *structurally cannot* catch a symlinked prefix: both the candidate and the root resolve through the same link, so containment holds while the bytes live outside.

**§6.2.1 #3 — collisions.** Destinations compared canonically and case-folded: `u1/.venv` vs `u1/./.venv`, and `straße` vs `STRASSE` (casefold, not `lower` — only casefold folds ß→ss).

**§6.2.1 #9/#10 — receipt.** The exact pinned canonical hash (`sort_keys`, `separators=(",",":")`, `ensure_ascii=False`), published via same-dir temp → flush → `fsync` → atomic replace → parent-dir `fsync`. Rename success alone is not durable acknowledgement.

**grip#539.** `converge_unit_repos` is scheduled on the first planning pass rather than only when a unit root and `unit.toml` already exist. The existing test asserted the bug *as correct* (`assertNotIn` the fix's own target operation) and is inverted here; a second fixture encoded the same bug incidentally — its unit's own checkout was silently never scheduled — and needed the same correction.

**`gr2.overlay` alias** (config#491 gap#13), additive: same physical directory, two import names, existing `gr2_overlay` consumers untouched.

## Testing discipline

Carried from #797's review cycle, where the recurring defect was tests passing *for the wrong reason*:

- **Assert which invariant fired**, not that *some* `MaterializationPlanError` was raised. A fixture broken enough to trip the invariant under test is usually broken enough to trip its neighbours, and a type-only `assertRaises` cannot tell them apart.
- **Canonicalization is tested at its own level.** The pinned schema is a strictly stronger *first* gate, so plan-level tests never reach the canonicalizer — testing it only through plans would leave it entirely shadowed and unverified. It is genuinely load-bearing: the legacy adapter and the coming B/C/D handlers call it *without* schema validation.
- Positive faces included alongside rejections, so the guards can't pass by rejecting everything.

## Verification

- **561 passed** on Python 3.11.9 (the declared floor) and 3.13.
- Fresh no-cache install both times; the packaged-schema test asserts the schema ships *inside the installed package* and matches the pinned SHA, not merely that it exists in the source tree.

## Closure round — Atlas's three A-owned blockers

All three were one shape: **the guards existed but were not bound at the contract boundaries.** No scope leakage into B/C/D.

**P1 — the terminal receipt was bound to nothing.** `write_materialization_receipt` accepted the raw live plan and an arbitrary result list. Atlas's fruit: `plan_id="../../escaped"` published `.grip/escaped.json` outside the receipt directory; a one-operation plan with `op_results=[]` published `stage="MATERIALIZED"` with no evidence at all; and `{"secret": "TOKEN", "nested": {"memory_body": "PRIVATE"}}` was serialized verbatim.

`validate_materialization_plan` now returns a **`ValidatedPlan` capability** that only it can mint, and publication requires one. Validation becomes something the publisher *holds* rather than something a caller is trusted to have remembered to do. Evidence is screened with the same discipline as the plan: cardinality, order, and kind must match the validated operations before anything may claim `MATERIALIZED`, and forbidden fields are rejected recursively.

Atlas's framing of why that last piece matters is worth preserving verbatim in the code, and I did: the plan's operations are protected by a *closed* schema whose per-kind allowlists permit no nested object carrier — so recursive rejection there has little left to find. The **result graph is open, and it is what gets persisted.** That, not the plan, is the actual smuggling boundary.

**P2 — §6.2.1 #2 applies to the derived paths too.** All three probes succeeded before this closure:
- a symlinked `.grip/workspace_spec.toml` pointing outside the team root was accepted whenever its bytes hashed to the declared value — the hash confirms *content* and says nothing about *where it was read from*;
- a symlinked `.grip/state/materialization` published the terminal receipt outside the root entirely;
- the predictable `mp_<id>.json.tmp-<pid>` name opened with plain `open()` followed a pre-created symlink, overwrote the external target, then published that symlink as the final receipt.

Now the spec is read through the canonicalizer and must be a regular non-symlink file, the receipt directory must be a real in-root directory, and the temp is created `O_EXCL|O_NOFOLLOW`.

**P3 — the durability order was mutation-silent.** Counting two `fsync` calls does not pin a *sequence*: Atlas moved the parent-directory fsync before `os.replace` and all five publication tests stayed green. The test now asserts the exact ordered chain **with fd roles** — `fsync(file)` → `replace` → `fsync(dir)` — distinguishing file from directory via `fstat`, so the reorder mutant dies for *this* invariant rather than through an unrelated failure.

### Closure verification

**11/11 mutants killed, zero survivors.** Isolated worktrees, one mutant each, stale-worktree sanity-guarded:

- Atlas's exact P3 reorder → dies to `test_publication_order_is_exact` (the test that was previously blind to it)
- temp-file fsync removed → RED
- capability check removed, and token check removed (forgeable capability) → each RED
- evidence screening removed, and each sub-guard removed independently (cardinality, kind/order, recursive rejection) → each RED
- each P2 hardening reverted independently (raw spec read, raw receipt dir, plain `open()` temp) → each RED

**572 passed** on Python 3.11.9 and 3.13.

## Premium boundary

OSS (grip is MIT) — neutral plan validation and receipt plumbing only. No identity, org, channel, or agent semantics; enforced by the schema's closed `additionalProperties: false` plus per-kind allowlists and recursive identity rejection, not asserted in prose.


---

## Closure round 2 — Sentinel r2 (review 4784681890) @ `c050bdf`

All seven findings closed. Sentinel reviewed at `f6b9e8d`; two of his findings were
partly addressed by round 1 (`2f1ab10`), and I verified against his exact probes rather
than assuming, per the note in his re-request.

### Production changes

| Finding | Change |
|---|---|
| 7 | Collision keys NFC-normalize **before** casefolding. Normalization and case folding are separate aliasing axes: `units/café/.venv` in NFC vs NFD casefold to distinct strings yet name one destination on a normalization-insensitive filesystem. |
| 3 | A parent-directory `fsync` failure now **unlinks the published receipt**. Durability is a failure-path contract, not only an ordering one — a publication that cannot be made durable must not remain published, or a caller doing destructive cleanup on the strength of a receipt acts on one that may not survive a crash. |
| 3 | A failed `os.replace` now unlinks the temp file. Found by this closure's own residue test rather than reasoned about. |

### Test closures

| Finding | Closure |
|---|---|
| 1 | Receipt publication through a symlinked `.grip/state` and through a pre-created temp symlink, each asserting **no outside bytes change**, plus the positive face: the published receipt is a regular in-root file. |
| 2 | Every declared forbidden key rejected in receipt evidence, asserting *which* invariant fired (the cardinality and kind checks run first and would otherwise reject a malformed probe for an unrelated reason). |
| 3 | Ordered publication oracle now observes `flush`, not only `fsync`/`replace`, with fd roles resolved via `fstat`. Deleting `fh.flush()` is the subtle mutant: `close()` flushes anyway, so the published bytes are identical while `fsync` syncs an empty file. No content assertion can see that. Failure injected at **every** durability step, not only the first. |
| 3b | Whole-value receipt binding, reconstructed independently, replacing a key-set plus four sampled leaves. |
| 4 | Per-field symlink matrix proving all **seven** operation paths reach `canonicalize_workspace_path`, plus destination-kind and cross-kind collision fixtures proving clone and `project_file` destinations participate in collision accounting. |
| 5 | Plan hash pins operation **array order** against a sorting mutant, and matches independently computed canonical bytes. |
| 6 | Recursive identity rejection pinned as a production seam beneath a permissive-validator double (a direct helper call proves nothing about wiring), plus a **literal inventory pin** — see below. |

### Two things I found while closing, not asked for

**A self-referential table test.** `test_every_declared_forbidden_key_is_enforced` iterated
the live `_FORBIDDEN_IDENTITY_KEYS` set, so deleting a member just made the loop shorter and
stayed green. Sentinel's probe caught the `secret` removal only because one *other* test
hardcodes that single key — meaning the other thirteen members were unguarded. A literal
inventory pin closes the whole class.

**A misplaced `if __name__ == "__main__"` guard** sat mid-file, ahead of the six closure
classes, so running the file directly executed `unittest.main()` before those classes were
defined and silently skipped them. Moved to the end.

### Mutation verification

**21/21 killed**, and each mutant now declares the test that must die, so a
right-answer-for-the-wrong-reason kill fails the sweep. That assertion earned its keep:
it caught a hazard in the sweep *methodology* — CPython invalidates cached bytecode on
`(source mtime in whole seconds, source size)`, and rewriting the source several times per
second means two equal-sized mutants inside one second silently re-import the previous
mutant's `.pyc`. Two rows were being attributed to the wrong mutant. Purging `__pycache__`
and setting `PYTHONDONTWRITEBYTECODE=1` per run fixed it. Counting kills alone would not
have surfaced this.

Mutants: `flush-deleted`, `parent-fsync-before-replace`, `fsync-final-file-twice-not-parent`,
`operations-empty`, `constant-plan-id`, the seven `*-raw` canonicalizer-bypass mutants,
`clone-dest-returns-none`, `project_file-dest-returns-none`, `hash-sorts-operations`,
`identity-call-removed`, `secret-removed-from-inventory`, `nfc-normalization-removed`,
`casefold-removed`, `receipt-dir-not-canonicalized`, `temp-open-follows-symlink`.

**594 passed** on Python 3.11.15 and 3.13.2.

### CI note

Required checks pass at `c050bdf`, including both `gr2 Python Tests` legs. `Test
(windows-latest)` is red — it is red at `2f1ab10` and at `f6b9e8d` too, i.e. from this
branch's first commit, and this diff is Python-only against a `cargo test` job. Tracked as
grip#798, not introduced here. (Correcting my own earlier shorthand: I described `2f1ab10`
as "CI green" when what was green was the required aggregate, not the Windows leg.)


---

## Residual closed — Atlas final re-gate @ `2f80258`

`ValidatedPlan` was `frozen=True`, but dataclass freezing freezes the field **binding**,
not the graph the field points at. `plan` aliased the caller's live dict and the writer
recomputed `plan_hash` from it at publication time, so mutating the plan after validation
published a receipt attesting to a graph that was never validated. Atlas's exact repro is
the RED test, verbatim.

Three captures close it, each defending a different alias:

| Alias | Capture |
|---|---|
| The caller's dict | `deepcopy` on **entry**, so the original is never consulted again. Taking it on entry rather than at mint also closes the window where a mutation lands between the checks and the capture. |
| The representation the capability exposes | Deep freeze — `MappingProxyType` for mappings, tuples for sequences, closing both item-assignment and append. A shallow copy is insufficient (Atlas); so is a shallow freeze. |
| The hash itself | `plan_hash` computed **once** at validation and stored. Publication reads captured facts and no longer re-derives anything from a mutable graph. |

`compute_plan_hash` gained a `default` type-adapter so the freeze does not turn the public
helper into a trap for the B/C/D handlers that will hold these plans. It fires only for
objects json cannot serialize natively, so canonical bytes for a plain JSON graph are
byte-identical — the pinned recipe is unchanged, and the existing canonical-bytes tests
still pass unmodified.

### One finding worth recording

Deep-freezing at mint **masks** a missing snapshot in any single-threaded probe, because
the freeze itself builds fresh objects. The `snapshot-removed` and `snapshot-shallow-only`
mutants survived every other test in the new class — including the identity assertions that
look like they cover exactly this. What the freeze cannot defend is the mid-validation
window, so that test injects a mutation through `_read_canonical_workspace_spec_bytes`,
which runs after the schema check and before the operation loop, reproducing the race
deterministically without threads. Both mutants then die.

That is the same shape as the round-2 self-referential table test: a guard that appears
covered because a *stronger adjacent guard* keeps the probe green.

**600 passed** on Python 3.11.15 and 3.13.2. **Mutation sweep 26/26 killed**, each by its
declared target test.


---

## Second seam on the same object — Sentinel final r2 @ `e57f163`

Both reviewers converged on one design truth: **the capability must bind immutable content,
not object identity or a copyable field.**

Sentinel's witness, reproduced verbatim before the fix — `dataclasses.replace` re-invokes
`__init__` with the existing field values, so the real token rode into a modified shell:

```
replace succeeded, plan_id = ../../escaped
PUBLISHED AT: .../materialization/../../escaped.json
```

That is a receipt published outside the receipt directory by an object nobody validated.

### Three layers, each pinned at its own level

| Layer | Binds |
|---|---|
| `plan_hash` describes the snapshot | swapping the graph cannot survive, with or without a matching hash |
| every published fact agrees with the snapshot | `plan_id`, `unit_key`, `schema_version`, `workspace_spec_sha256`, `operation_kinds` cannot diverge from the graph they describe |
| HMAC seal over all of the above | a hand-built shell that is internally self-consistent still cannot pass |

Verification runs at every **use**, not only at construction: `frozen=True` blocks
`__setattr__` but not `object.__setattr__`, so an honestly-minted capability can still be
edited afterwards, and every path in the publisher reads these fields — including the one
that builds the receipt filename. The secret is process-local and never persisted; this is
an in-process capability, not a credential.

The layers **shadow each other**, so each test names the layer that must reject it.
Asserting only "some capability error" would let a removed layer hide behind the one
beneath it — the same shadowing Sentinel flagged for the pinned schema. The seal has no
layer above it, so `test_the_seal_itself_rejects_a_self_consistent_forgery` is what keeps
it from being dead code.

Sentinel's witness 2 (mutating the caller's plan after validation) was already closed by
the preceding snapshot commit — verified by running it, not assumed.

### Mutation

**30/31 killed**, each by its declared target test. One survivor, `seal-omits-plan_id`, is
**equivalent**, and shown to be so by attempted exploitation rather than by argument: with
the mutant applied, both replacing `plan_id` and forging a self-consistent shell with the
genuine seal still fail, because the seal covers `plan_hash` and `plan_id` is derivable
from the snapshot that hash binds. Reported as equivalent rather than counted as a kill,
matching the standard Sentinel applied to his own schema-shadowed edits.

**606 passed** on Python 3.11.15 and 3.13.2.


---

## Provenance layer — Atlas re-gate @ `30693ad`

Atlas's re-gate (review 4785725633) was against `2f80258`, where the token was still an
identity sentinel. **Verified rather than assumed**: every forge vector he named —
`plan_id`, `unit_key`, `workspace_spec_sha256`, `plan_hash`, `operation_kinds` — is already
blocked by the content seal at `e57f163`, with no receipt reaching the filesystem. His
repros are now tests (`test_atlas_forge_family_cannot_publish`).

One vector was genuinely still open, and it is the one his closure names in words:
*"copying/replacing the capability cannot preserve authority."* A copy changes no field, so
it carries a genuinely valid seal and passes every content check. Only **origin** can refuse
it.

### Four layers, orthogonal by construction

| Layer | Binds | Closes |
|---|---|---|
| hash-describes-snapshot | the graph | swapped snapshots |
| facts-agree-with-snapshot | the captures | `replace` of any published fact |
| HMAC seal | content as a whole | hand-built self-consistent shells |
| **validator provenance** (WeakSet of minted instances) | **origin** | **copies that change nothing** |

The seal and provenance are orthogonal on purpose: content vs origin. Neither shadows the
other, which is what makes this defense in depth rather than one guard hiding behind
another — and each has a test at its own level.

Provenance is checked at **use** only, never at construction: registration happens after
`__init__` returns, so the instance is not yet a member when `__post_init__` runs.
`eq=False` keeps identity hashing (a `MappingProxyType` field is unhashable anyway, and two
capabilities over equal facts *should* be distinct capabilities).

Recorded rather than smoothed over: `deepcopy` of a capability raises `TypeError` because
the frozen snapshot is not picklable. Same guarantee, different mechanism, so it is
asserted separately — a shared assertion would hide which one actually holds.

**609 passed** on Python 3.11.15 and 3.13.2. **Mutation sweep 33/34 killed**, each by its
declared target. The lone survivor, `seal-omits-plan_id`, remains equivalent, documented,
and demonstrated by attempted exploitation rather than argument.


---

## Use-time TOCTOU closed — Atlas @ `5fd3ab4`

It survived two heads, which was the signal that **the model was wrong rather than a guard
missing**. I had been hardening the capability so it could not be *forged*, while the writer
went on reading the live shell after verification, across a caller-controlled callback.

The content seal is what made this look covered: it gates **content**, so tampering cannot
change the sealed facts — but nothing gated the **reads**. That is the adjacent-strong-guard
masking class again, this time in the fix rather than in the test.

### Closure

`ValidatedPlan.consume()` verifies once and returns an immutable `_ConsumptionBinding`.
The receipt body, both filenames, and the evidence screen consume only that; nothing reads
the capability again.

Two details carry it:

- Facts come from the **frozen snapshot**, not the shell fields, so a post-verify edit is
  irrelevant rather than merely detected.
- The **order** is load-bearing: facts are captured before the evidence is materialized,
  because materializing is what runs caller code.

There is deliberately **no second seal check** after the callback. Once everything derives
from the frozen snapshot it would be unreachable, and an unreachable guard is worse than
none — it reads as protection while being untestable at its own level.

### Found while closing, not in the witness

The evidence was walked **twice** — once by the screen, once by json serialization. A list
returning different contents per iteration screened clean and then persisted `secret` into
the receipt:

```text
evidence double-read -> iterations: 2 | LEAKED persisted: True
```

That is a **premium-boundary** failure, not only a correctness one: the receipt's whole
claim is that it carries no identity-bearing content. Evidence is now materialized once
into plain JSON types, and the screen inspects the same value that gets persisted.

Also recorded: the temp-filename mutant **survived a directory assertion**, because the
rename *consumes* the temp file — a post-hoc listing looks identical whether or not the name
was attacker-influenced. Only an oracle observing the name at `os.replace` can see it.

### Layers Atlas passed, re-checked untouched

`copy.copy` still rejected by provenance; `dataclasses.replace` of `plan_id`, `plan_hash`
and `operation_kinds` still rejected at the named layer; no `.grip/escaped.json`.

**613 passed** on Python 3.11.15 and 3.13.2. **Mutation sweep 37/38 killed**, each by its
declared target. The lone survivor, `seal-omits-plan_id`, remains the documented equivalent
one.

Refs #797
