### PR TITLE
feat: S4-B clone/cache/alternates executor with its full guard set

### DIFF
--- a/gr2/python_cli/clone_exec.py
+++ b/gr2/python_cli/clone_exec.py
@@ -37,9 +37,11 @@ evidence the alternate exists.
 """
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import os
 import shutil
+import stat
 import subprocess
 import tempfile
 from pathlib import Path
@@ -54,6 +56,22 @@ from .spec_apply import (
 )
 
 
+@dataclasses.dataclass(frozen=True)
+class _CloneBinding:
+    """One immutable reading of a clone operation, taken from A's frozen plan
+    snapshot before any caller-reachable code runs.
+
+    Mirrors A's _ConsumptionBinding for the same reason: verification and use
+    must not be separated by anything that can run caller code. Holding the
+    fields instead of re-reading the capability makes a post-verification swap
+    irrelevant rather than merely detectable."""
+
+    repo_url: str
+    branch: str
+    dest_path: str
+    reference_base: str | None
+
+
 class CloneExecutionError(MaterializationPlanError):
     """A validated plan's clone operation could not be executed safely.
 
@@ -61,8 +79,119 @@ class CloneExecutionError(MaterializationPlanError):
     working, while the type still names which layer refused."""
 
 
+# Section 8.1 names these as the mutable state a clone must OWN. The
+# --git-common-dir check proves only that the .git ROOT is local; every entry
+# beneath it can be redirected individually, which is how a clone with a
+# perfectly local common dir still reads another unit's refs or object store
+# (Sentinel, #803 review at bd7afe5).
+#
+# `objects` is on this list for a reason worth stating: object sharing has TWO
+# routes, and the alternates file is only one of them. Symlinking the objects
+# directory itself shares the store with no alternates file to inspect -- so a
+# plan declaring no reference_base passes the alternates check vacuously while
+# the clone is fully joined to another unit's objects.
+_CLONE_LOCAL_GIT_ENTRIES = (
+    "objects",
+    "refs",
+    "index",
+    "HEAD",
+    "config",
+    "logs",
+    "packed-refs",
+)
+
+
 def _alternates_file(clone_root: Path) -> Path:
     return clone_root / ".git" / "objects" / "info" / "alternates"
+
+
+def _require_local_git_internals(clone_root: Path, git_dir: Path) -> None:
+    """Every entry section 8.1 requires the clone to own must be its own, not a
+    redirection. lstat, never stat: stat() follows the link and reports the
+    target, which is precisely the thing being hidden."""
+    for name in _CLONE_LOCAL_GIT_ENTRIES:
+        entry = git_dir / name
+        try:
+            mode = os.lstat(entry).st_mode
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(mode):
+            raise CloneExecutionError(
+                f"clone at {clone_root} redirects .git/{name} through a symlink to "
+                f"{os.readlink(entry)!r} -- section 8.1 requires clone-local refs, "
+                "index, locks, config and objects, and a local .git root does not "
+                "make the state beneath it local"
+            )
+
+
+def _require_complete_history(clone_root: Path, git_dir: Path) -> None:
+    """Section 8.1: the clone must hold the complete reachable history required
+    by the profile, and the v1 plan has no shallow or partial profile to opt
+    into. A depth-1 clone is otherwise indistinguishable from a healthy one --
+    correct origin, local git dir, clean tree, valid alternate -- so nothing
+    else in this verifier can see it (Sentinel, #803 review at bd7afe5)."""
+    if (git_dir / "shallow").exists():
+        raise CloneExecutionError(
+            f"clone at {clone_root} is shallow (.git/shallow present) -- section 8.1 "
+            "requires the complete reachable history and the plan declares no shallow "
+            "profile"
+        )
+    proc = gitops.git(clone_root, "rev-parse", "--is-shallow-repository")
+    if proc.returncode == 0 and proc.stdout.strip() == "true":
+        raise CloneExecutionError(
+            f"clone at {clone_root} reports itself shallow -- section 8.1 requires the "
+            "complete reachable history"
+        )
+    for key in ("remote.origin.promisor", "remote.origin.partialclonefilter"):
+        probe = gitops.git(clone_root, "config", "--get", key)
+        if probe.returncode == 0 and probe.stdout.strip():
+            raise CloneExecutionError(
+                f"clone at {clone_root} is a partial clone ({key}="
+                f"{probe.stdout.strip()!r}) -- its history is fetched lazily from the "
+                "network, which section 8.1's complete-history requirement excludes"
+            )
+
+
+def _working_tree_state(clone_root: Path) -> str:
+    """clean | dirty | unreadable.
+
+    Three outcomes, not two. gitops.repo_dirty() maps EVERY nonzero exit to
+    False, so a corrupt .git/index reads as 'clean' and a damaged clone is
+    reused as healthy (Sentinel, #803 review at bd7afe5). Collapsing the
+    unreadable case into 'clean' is a fail-open: the one state we understand
+    least becomes the one we treat most permissively.
+
+    Deliberately local rather than a fix to gitops.repo_dirty(): that helper is
+    live in app.py and syncops.py, and changing shared dirtiness semantics
+    underneath two other call paths does not belong in this PR. Filed
+    separately."""
+    proc = gitops.git(clone_root, "status", "--porcelain")
+    if proc.returncode != 0:
+        return "unreadable"
+    return "dirty" if proc.stdout.strip() else "clean"
+
+
+def _read_alternates_of(object_dir: Path) -> set[Path]:
+    """Alternate object directories declared by an arbitrary object database.
+
+    Relative entries resolve against the OBJECT DIRECTORY, which is git's rule.
+    Resolving them against the process working directory -- the obvious
+    Path(line).resolve() -- makes this verifier and git disagree about what the
+    clone is actually reading from, and a verifier that disagrees with git is
+    worse than no verifier (Atlas, #803 review at bd7afe5)."""
+    path = object_dir / "info" / "alternates"
+    if not path.exists():
+        return set()
+    entries = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        candidate = Path(line)
+        if not candidate.is_absolute():
+            candidate = object_dir / candidate
+        entries.add(candidate.resolve())
+    return entries
 
 
 def _read_alternate_entries(clone_root: Path) -> set[Path]:
@@ -81,15 +210,7 @@ def _read_alternate_entries(clone_root: Path) -> set[Path]:
     reject empty is the vacuous-truth trap: it holds for `==` and silently
     fails for the `all(entry in permitted)` spelling that any later reader may
     think is the same check."""
-    path = _alternates_file(clone_root)
-    if not path.exists():
-        return set()
-    entries = set()
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if line:
-            entries.add(Path(line).resolve())
-    return entries
+    return _read_alternates_of(clone_root / ".git" / "objects")
 
 
 def verify_cache_provenance(
@@ -134,6 +255,29 @@ def verify_cache_provenance(
             f"not from the declared upstream {repo_url!r}"
         )
 
+    # Containment is only ONE HOP without this (Atlas, #803 review at bd7afe5).
+    # A cache that sits at the right path, is bare, and carries the right origin
+    # can still reach outside the workspace two ways, and the unit clone inherits
+    # whatever it reaches: the cache's own objects dir may be a symlink, or the
+    # cache may declare its own alternate pointing at a machine-global store.
+    # Either one re-opens exactly the isolation seam section 8.2 refuses to open,
+    # one level down where the clone-side check cannot see it.
+    cache_objects = cache_resolved / "objects"
+    if stat.S_ISLNK(os.lstat(cache_objects).st_mode):
+        raise CloneExecutionError(
+            f"declared object cache {cache_root} redirects its objects directory "
+            f"through a symlink to {os.readlink(cache_objects)!r} -- the clone would "
+            "share objects with an undeclared store one hop out"
+        )
+    transitive = _read_alternates_of(cache_objects)
+    if transitive:
+        raise CloneExecutionError(
+            f"declared object cache {cache_root} declares its own alternate(s) "
+            f"{sorted(str(e) for e in transitive)} -- object sharing must terminate at "
+            "the workspace cache, and a cache that alternates onward makes every clone "
+            "reachable into an undeclared store (section 8.2)"
+        )
+
 
 def verify_clone_isolation(
     clone_root: Path,
@@ -154,11 +298,30 @@ def verify_clone_isolation(
     forbidden shape looks healthy to the obvious helper, so the checks here are
     positive statements about this clone's OWN state."""
     git_dir = clone_root / ".git"
-    if not git_dir.is_dir():
+    # lstat FIRST, and never Path.is_dir(). is_dir() follows the link, so a .git
+    # that is itself a symlink into another same-origin clone answers True --
+    # and then --git-common-dir resolves THROUGH that same link, so both sides of
+    # the common-dir comparison land on the foreign directory and agree. Two
+    # guards, one symlink, both satisfied (Atlas, #803 review at bd7afe5).
+    try:
+        git_mode = os.lstat(git_dir).st_mode
+    except FileNotFoundError:
+        raise CloneExecutionError(
+            f"clone at {clone_root} has no .git -- it is not a git repository"
+        ) from None
+    if stat.S_ISLNK(git_mode):
+        raise CloneExecutionError(
+            f"clone at {clone_root} redirects .git through a symlink to "
+            f"{os.readlink(git_dir)!r} -- .git must be a directory the clone owns "
+            "(section 8.1)"
+        )
+    if not stat.S_ISDIR(git_mode):
         raise CloneExecutionError(
             f"clone at {clone_root} is not state-isolated: .git must be a directory, "
             "not a worktree pointer file (section 8.1)"
         )
+    _require_local_git_internals(clone_root, git_dir)
+    _require_complete_history(clone_root, git_dir)
     if (git_dir / "worktrees").exists():
         raise CloneExecutionError(
             f"clone at {clone_root} hosts linked worktrees (.git/worktrees), which share "
@@ -278,10 +441,23 @@ def _reuse_existing_clone(
         repo_url=repo_url,
         reference_base=reference_base,
     )
-    if gitops.repo_dirty(dest):
+    state = _working_tree_state(dest)
+    if state == "unreadable":
+        raise CloneExecutionError(
+            f"existing clone at {dest} cannot report its working-tree state -- it is "
+            "damaged (an unreadable index or object database). Section 8.3 blocks a "
+            "damaged clone rather than repairing it, and blocking here changes none of "
+            "its bytes"
+        )
+    if state == "dirty":
         raise CloneExecutionError(
             f"existing clone at {dest} is dirty -- section 8.3 never resets or replaces "
             "a dirty clone; destructive repair requires an explicit separate command"
+        )
+    if gitops.current_head_sha(dest) is None:
+        raise CloneExecutionError(
+            f"existing clone at {dest} has no resolvable HEAD -- reuse requires a clone "
+            "that can actually be worked in, not merely one whose status command exits 0"
         )
 
 
@@ -295,6 +471,13 @@ def execute_clone_operation(
     with operation i, which is what S4-A's receipt screen requires: an executor
     that silently skipped the kinds it does not handle would shift every later
     result by one and still screen clean."""
+    # A plain Path, always. workspace_root is caller-supplied, and a Path
+    # SUBCLASS can run arbitrary code from __truediv__/resolve during the path
+    # work below -- which is the callback that reopens the window this binding
+    # exists to close. Normalising here removes the callback surface itself
+    # rather than trying to be safe around it.
+    workspace_root = Path(os.fspath(workspace_root))
+
     validated.verify(require_provenance=True)
     _require_workspace_binding(validated, workspace_root)
 
@@ -312,16 +495,31 @@ def execute_clone_operation(
             "with a later slice (venv/editable_install with S4-D, project_file with S4-C)"
         )
 
-    repo_url = str(op["repo_url"])
-    branch = str(op["branch"])
-    dest = canonicalize_workspace_path(
-        workspace_root, str(op["dest_path"]), field_name=f"operations[{index}].dest_path"
+    # ONE immutable binding taken from A's frozen snapshot, before any path work
+    # runs, and no live capability read after it (Atlas, #803 review at bd7afe5).
+    # The previous shape verified, then did callback-capable path work, then
+    # re-read validated.plan -- so a capability swapped in between was cloned
+    # from while the sealed one was never touched. This is A's own consume()
+    # lesson: the fix is not to check again, it is to stop re-reading.
+    binding = _CloneBinding(
+        repo_url=str(op["repo_url"]),
+        branch=str(op["branch"]),
+        dest_path=str(op["dest_path"]),
+        reference_base=(
+            str(op["reference_base"]) if op.get("reference_base") is not None else None
+        ),
     )
-    declared_reference = op.get("reference_base")
+
+    repo_url = binding.repo_url
+    branch = binding.branch
+    dest = canonicalize_workspace_path(
+        workspace_root, binding.dest_path, field_name=f"operations[{index}].dest_path"
+    )
+    declared_reference = binding.reference_base
     reference_base = (
         canonicalize_workspace_path(
             workspace_root,
-            str(declared_reference),
+            declared_reference,
             field_name=f"operations[{index}].reference_base",
         )
         if declared_reference is not None
@@ -352,14 +550,42 @@ def execute_clone_operation(
             reference_base=reference_base,
         )
 
+    # Section 12.1 requires repo URL, destination, HEAD, clone-state evidence,
+    # and cache path plus APPROVED-ALTERNATE evidence. The previous shape echoed
+    # the declaration back (reference_base as planned) and called it evidence --
+    # hollow-green, because a receipt that repeats the plan proves nothing about
+    # what is on disk (Atlas, #803 review at bd7afe5). What is recorded here is
+    # what was OBSERVED and proven: the alternates git will actually read, and
+    # the isolation facts the verifier established.
+    observed_alternates = sorted(
+        _relativize(entry, workspace_root) for entry in _read_alternate_entries(dest)
+    )
     return {
         "kind": "clone",
-        "dest_path": str(op["dest_path"]),
+        "repo_url": binding.repo_url,
+        "dest_path": binding.dest_path,
         "branch": gitops.current_branch(dest),
         "head_sha": gitops.current_head_sha(dest) or "",
-        "reference_base": str(declared_reference) if declared_reference is not None else None,
+        "cache_path": declared_reference,
+        "approved_alternates": observed_alternates,
+        "clone_state": {
+            "git_dir_local": True,
+            "complete_history": True,
+            "hosts_worktrees": False,
+            "working_tree": _working_tree_state(dest),
+        },
         "reused": reused,
     }
+
+
+def _relativize(path: Path, workspace_root: Path) -> str:
+    """Workspace-relative when possible. An absolute path inside a receipt is
+    not wrong, but it makes two differently-rooted clean runs produce different
+    receipts for identical work -- which acceptance fruit 16 forbids."""
+    try:
+        return str(path.relative_to(workspace_root.resolve()))
+    except ValueError:
+        return str(path)
 
 
 def _stage_and_publish(
@@ -398,7 +624,13 @@ def _stage_and_publish(
                 f"clone of {repo_url} is on branch {actual_branch!r}, not the declared "
                 f"{branch!r}"
             )
+        # Publication is INSIDE the cleanup boundary. It was outside, so an
+        # OSError from the rename kept dest correctly absent but left a fully
+        # populated staging sibling behind -- the no-residue guarantee held for
+        # every failure except the one that happens at the publication seam
+        # itself (Sentinel, #803 review at bd7afe5). Nothing follows the rename,
+        # so on success there is no staging left for the handler to remove.
+        os.replace(staging, dest)
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
         raise
-    os.replace(staging, dest)

--- a/gr2/python_cli/clone_exec.py
+++ b/gr2/python_cli/clone_exec.py
@@ -1,0 +1,404 @@
+"""Executor for the neutral MaterializationPlan `clone` operation (S4-B).
+
+S4-A landed the plan CONTRACT: validate -> un-forgeable ValidatedPlan
+capability -> durable receipt. This is the first thing that consumes it.
+
+Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
+      section 8 (full clone contract), acceptance fruit 6/7/8/9.
+
+Why this is its own module rather than more of `gitops.py`: gitops is a thin
+subprocess layer over git. The substance here is POLICY -- which object sharing
+is permitted, what makes a clone state-isolated, when an existing clone may be
+reused. Policy living in the primitive layer is policy that later callers
+bypass by reaching for the primitive directly.
+
+Design note carried from the S4-A review cycle, applied while designing rather
+than while testing: for every guard below, the question was what ELSE would
+reject this input first, and whether the guard is therefore untested at its own
+level. Five masking pairs came out of that and are recorded in the test module;
+the two that shaped this code most:
+
+  - `_read_alternate_entries` returns a SET and callers compare with `==`, never
+    `all(...)`. An empty alternates file makes "every entry is the declared
+    cache" vacuously true, which is exactly how a clone with no object sharing
+    at all passes a guard written to require object sharing.
+  - `verify_clone_isolation` re-runs `verify_cache_provenance` on the declared
+    reference instead of trusting it. Set-equality alone proves the clone points
+    where the PLAN said; it says nothing about whether the plan pointed at a
+    legitimate cache, and another unit's bare mirror of the same repository
+    satisfies every other check.
+
+And one property of git that the whole verification posture rests on:
+`--reference-if-able` SILENTLY DEGRADES. Against a missing cache it exits 0 and
+writes no alternates file at all. Section 8.2 chooses that flag deliberately so
+a cold cache cannot fail the timed path, which means a declared reference is a
+CLAIM the executor must verify positively afterwards. Passing the flag is not
+evidence the alternate exists.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from . import gitops
+from .spec_apply import (
+    MaterializationPlanError,
+    ValidatedPlan,
+    _read_canonical_workspace_spec_bytes,
+    canonicalize_workspace_path,
+    workspace_cache_root,
+)
+
+
+class CloneExecutionError(MaterializationPlanError):
+    """A validated plan's clone operation could not be executed safely.
+
+    Subclasses the contract's error so callers catching the family keep
+    working, while the type still names which layer refused."""
+
+
+def _alternates_file(clone_root: Path) -> Path:
+    return clone_root / ".git" / "objects" / "info" / "alternates"
+
+
+def _read_alternate_entries(clone_root: Path) -> set[Path]:
+    """Resolved alternate object directories declared by this clone.
+
+    Blank lines are dropped, so a whitespace-only file reads as empty rather
+    than as one weird entry pointing at the process working directory.
+
+    A SET, not a list: the same permitted cache listed twice is the same object
+    sharing, and git tolerates the duplicate. Deduplicating here means the
+    permitted-set comparison judges WHICH object stores are reachable, not how
+    many times the file happens to name them.
+
+    Emptiness is deliberately NOT encoded as "a set that fails an equality" --
+    callers claim it in an explicit branch first. Relying on the equality to
+    reject empty is the vacuous-truth trap: it holds for `==` and silently
+    fails for the `all(entry in permitted)` spelling that any later reader may
+    think is the same check."""
+    path = _alternates_file(clone_root)
+    if not path.exists():
+        return set()
+    entries = set()
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            entries.add(Path(line).resolve())
+    return entries
+
+
+def verify_cache_provenance(
+    cache_root: Path, *, workspace_root: Path, repo_url: str
+) -> None:
+    """Section 8.2: object sharing is permitted ONLY against the workspace-managed
+    cache, seeded from the declared upstream.
+
+    The three checks are orthogonal and each one is the only thing that can see
+    its own failure:
+
+      - containment rejects a bare mirror of the RIGHT repository sitting at the
+        wrong place (another unit's directory, the team clone). Provenance
+        cannot see it, because its origin matches.
+      - bare-repository rejects a working clone parked under the cache root.
+      - provenance rejects a cache under the right path, bare, seeded from a
+        different upstream.
+
+    Containment is what keeps object bytes from crossing a unit boundary, which
+    is the isolation seam the whole design refuses to open."""
+    cache_resolved = cache_root.resolve()
+    permitted_root = workspace_cache_root(workspace_root).resolve()
+    if cache_resolved == permitted_root or not cache_resolved.is_relative_to(permitted_root):
+        raise CloneExecutionError(
+            f"reference {cache_root} is not inside the workspace object cache "
+            f"({permitted_root}) -- section 8.2 permits object sharing only with the "
+            "workspace-managed cache, never with another unit or the team clone"
+        )
+    if not cache_resolved.exists():
+        raise CloneExecutionError(
+            f"declared object cache {cache_root} does not exist -- it must be seeded "
+            "before any clone references it"
+        )
+    if not gitops.is_git_dir(cache_resolved):
+        raise CloneExecutionError(
+            f"declared object cache {cache_root} is not a bare git repository"
+        )
+    actual_url = gitops.remote_origin_url(cache_resolved)
+    if actual_url != repo_url:
+        raise CloneExecutionError(
+            f"declared object cache {cache_root} was seeded from {actual_url!r}, "
+            f"not from the declared upstream {repo_url!r}"
+        )
+
+
+def verify_clone_isolation(
+    clone_root: Path,
+    *,
+    workspace_root: Path,
+    repo_url: str,
+    reference_base: Path | None,
+) -> None:
+    """Section 8.1 (independent mutable state) + 8.2 (allowed object sharing).
+
+    Runs on STAGING before publication and again on any existing clone before
+    reuse, because the two paths admit the same failures by different routes:
+    a fresh clone can silently lose its alternate, an existing directory can be
+    a worktree somebody parked there.
+
+    Deliberately does not consult `gitops.is_git_repo()`: that asks
+    "is-inside-work-tree", which answers TRUE inside a linked worktree. The
+    forbidden shape looks healthy to the obvious helper, so the checks here are
+    positive statements about this clone's OWN state."""
+    git_dir = clone_root / ".git"
+    if not git_dir.is_dir():
+        raise CloneExecutionError(
+            f"clone at {clone_root} is not state-isolated: .git must be a directory, "
+            "not a worktree pointer file (section 8.1)"
+        )
+    if (git_dir / "worktrees").exists():
+        raise CloneExecutionError(
+            f"clone at {clone_root} hosts linked worktrees (.git/worktrees), which share "
+            "its refs and locks -- section 8.1 forbids the shape in both directions"
+        )
+
+    proc = gitops.git(clone_root, "rev-parse", "--git-common-dir")
+    if proc.returncode != 0:
+        raise CloneExecutionError(
+            f"clone at {clone_root} is not a readable git repository: "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    # Relative (".git") in a normal clone, absolute inside a worktree -- so it
+    # has to be resolved against the clone root before it means anything.
+    common_dir = Path(os.path.join(clone_root, proc.stdout.strip())).resolve()
+    if common_dir != git_dir.resolve():
+        raise CloneExecutionError(
+            f"clone at {clone_root} resolves its git common directory to {common_dir}, "
+            "outside its own .git -- its refs, index, and locks are shared (section 8.1)"
+        )
+
+    actual_url = gitops.remote_origin_url(clone_root)
+    if actual_url != repo_url:
+        raise CloneExecutionError(
+            f"clone at {clone_root} has origin {actual_url!r}, not the declared "
+            f"{repo_url!r}"
+        )
+
+    entries = _read_alternate_entries(clone_root)
+    if reference_base is None:
+        if entries:
+            raise CloneExecutionError(
+                f"clone at {clone_root} declares alternate(s) "
+                f"{sorted(str(e) for e in entries)} but its plan operation declares no "
+                "reference_base -- undeclared object sharing is forbidden (section 8.2)"
+            )
+        return
+
+    verify_cache_provenance(
+        reference_base, workspace_root=workspace_root, repo_url=repo_url
+    )
+    expected = {(reference_base / "objects").resolve()}
+    if not entries:
+        raise CloneExecutionError(
+            f"clone at {clone_root} declares no alternate, but its plan operation "
+            f"declares reference_base {reference_base}. git's --reference-if-able "
+            "degrades silently, so an absent or empty alternates file is the expected "
+            "shape of a reference that never took -- not evidence that one did"
+        )
+    if entries != expected:
+        raise CloneExecutionError(
+            f"clone at {clone_root} declares alternate(s) "
+            f"{sorted(str(e) for e in entries)}, which is not exactly the declared "
+            f"workspace cache {sorted(str(e) for e in expected)} (section 8.2)"
+        )
+
+
+def _require_workspace_binding(validated: ValidatedPlan, workspace_root: Path) -> None:
+    """The plan is bound to a WorkspaceSpec at VALIDATION; the executor takes
+    workspace_root as a separate argument. Nothing structurally stops a caller
+    from validating against one workspace and executing against another, and
+    every relative path in the plan would then resolve somewhere else.
+
+    Re-checking at USE rather than trusting the capability's field is the same
+    lesson the S4-A TOCTOU round ended on: verification belongs at the moment of
+    use, not only at the moment of construction."""
+    try:
+        spec_bytes = _read_canonical_workspace_spec_bytes(workspace_root)
+    except MaterializationPlanError as exc:
+        raise CloneExecutionError(
+            f"cannot execute against {workspace_root}: its canonical WorkspaceSpec is "
+            f"unreadable ({exc})"
+        ) from exc
+    actual = hashlib.sha256(spec_bytes).hexdigest()
+    if actual != validated.workspace_spec_sha256:
+        raise CloneExecutionError(
+            f"plan is bound to WorkspaceSpec {validated.workspace_spec_sha256} but "
+            f"{workspace_root} has {actual} -- executing a plan against a workspace it "
+            "was not validated for would resolve every declared path elsewhere"
+        )
+
+
+def _git_clone(
+    repo_url: str, target: Path, *, branch: str, reference: Path | None
+) -> None:
+    command = ["git", "clone", "--quiet"]
+    if reference is not None:
+        # section 8.2: --dissociate is intentionally omitted on the timed path.
+        # State isolation, not object duplication, is the invariant.
+        command.extend(["--reference-if-able", str(reference)])
+    command.extend(["--branch", branch, repo_url, str(target)])
+    proc = subprocess.run(command, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise CloneExecutionError(
+            f"failed to clone {repo_url} at branch {branch!r}:\n"
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+
+
+def _reuse_existing_clone(
+    dest: Path, *, workspace_root: Path, repo_url: str, reference_base: Path | None
+) -> None:
+    """Section 8.3: a healthy clone is reused; a dirty one is NEVER reset or
+    replaced; a damaged or mismatched one blocks.
+
+    Isolation runs before the dirty check because "is this working tree dirty"
+    is not a meaningful question about a worktree pointer or a clone of some
+    other repository -- those are answered by refusing, not by inspecting.
+
+    The declared branch is deliberately NOT enforced on reuse. Section 8.1
+    requires a clone-local HEAD; the unit owns its branch state, and forcing it
+    back to the plan's branch would be exactly the destructive repair 8.3 puts
+    behind an explicit separate command."""
+    verify_clone_isolation(
+        dest,
+        workspace_root=workspace_root,
+        repo_url=repo_url,
+        reference_base=reference_base,
+    )
+    if gitops.repo_dirty(dest):
+        raise CloneExecutionError(
+            f"existing clone at {dest} is dirty -- section 8.3 never resets or replaces "
+            "a dirty clone; destructive repair requires an explicit separate command"
+        )
+
+
+def execute_clone_operation(
+    validated: ValidatedPlan, index: int, *, workspace_root: Path
+) -> dict[str, object]:
+    """Execute the `clone` operation at `index` of a validated plan.
+
+    Returns neutral, receipt-shaped evidence for that operation. Addressing by
+    index rather than filtering for clone operations keeps evidence[i] aligned
+    with operation i, which is what S4-A's receipt screen requires: an executor
+    that silently skipped the kinds it does not handle would shift every later
+    result by one and still screen clean."""
+    validated.verify(require_provenance=True)
+    _require_workspace_binding(validated, workspace_root)
+
+    operations = validated.plan["operations"]
+    if not 0 <= index < len(operations):
+        raise CloneExecutionError(
+            f"operation index {index} is out of range for a plan with "
+            f"{len(operations)} operation(s)"
+        )
+    op = operations[index]
+    kind = op.get("kind")
+    if kind != "clone":
+        raise CloneExecutionError(
+            f"operations[{index}] is kind {kind!r}, not 'clone' -- its handler lands "
+            "with a later slice (venv/editable_install with S4-D, project_file with S4-C)"
+        )
+
+    repo_url = str(op["repo_url"])
+    branch = str(op["branch"])
+    dest = canonicalize_workspace_path(
+        workspace_root, str(op["dest_path"]), field_name=f"operations[{index}].dest_path"
+    )
+    declared_reference = op.get("reference_base")
+    reference_base = (
+        canonicalize_workspace_path(
+            workspace_root,
+            str(declared_reference),
+            field_name=f"operations[{index}].reference_base",
+        )
+        if declared_reference is not None
+        else None
+    )
+
+    if reference_base is not None:
+        # Before any work: cloning against a cache we would refuse afterwards
+        # only wastes the timed path and leaves staging to clean up.
+        verify_cache_provenance(
+            reference_base, workspace_root=workspace_root, repo_url=repo_url
+        )
+
+    reused = dest.exists()
+    if reused:
+        _reuse_existing_clone(
+            dest,
+            workspace_root=workspace_root,
+            repo_url=repo_url,
+            reference_base=reference_base,
+        )
+    else:
+        _stage_and_publish(
+            dest,
+            workspace_root=workspace_root,
+            repo_url=repo_url,
+            branch=branch,
+            reference_base=reference_base,
+        )
+
+    return {
+        "kind": "clone",
+        "dest_path": str(op["dest_path"]),
+        "branch": gitops.current_branch(dest),
+        "head_sha": gitops.current_head_sha(dest) or "",
+        "reference_base": str(declared_reference) if declared_reference is not None else None,
+        "reused": reused,
+    }
+
+
+def _stage_and_publish(
+    dest: Path,
+    *,
+    workspace_root: Path,
+    repo_url: str,
+    branch: str,
+    reference_base: Path | None,
+) -> None:
+    """Section 8.3: create at a sibling staging path, verify, then rename.
+
+    A half-verified clone must never be visible at dest_path, because the reuse
+    path would later find it and call it healthy -- publication is the only
+    moment at which "this clone passed its guards" becomes a fact other code
+    can rely on.
+
+    Staging uses mkdtemp rather than a pid-suffixed name: two concurrent unit
+    materializations of the same repository are the normal case under section
+    9.1's parallel clone fan-out, and a name that has to be ARGUED unique is a
+    name that eventually is not. git clones happily into an existing empty
+    directory, so mkdtemp costs nothing."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(dir=dest.parent, prefix=f".{dest.name}.staging-"))
+    try:
+        _git_clone(repo_url, staging, branch=branch, reference=reference_base)
+        verify_clone_isolation(
+            staging,
+            workspace_root=workspace_root,
+            repo_url=repo_url,
+            reference_base=reference_base,
+        )
+        actual_branch = gitops.current_branch(staging)
+        if actual_branch != branch:
+            raise CloneExecutionError(
+                f"clone of {repo_url} is on branch {actual_branch!r}, not the declared "
+                f"{branch!r}"
+            )
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    os.replace(staging, dest)

--- a/gr2/tests/test_clone_materialization.py
+++ b/gr2/tests/test_clone_materialization.py
@@ -1,0 +1,677 @@
+"""Clone/cache/alternates executor tests for the neutral MaterializationPlan (S4-B).
+
+S4-A landed the plan CONTRACT (validate -> capability -> receipt) and nothing
+consumed it. This is the first operation EXECUTOR: `kind == "clone"`.
+
+Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
+      section 8 (full clone contract), acceptance fruit 6/7/8/9.
+
+Testing discipline carried forward from the S4-A review cycle, and applied at
+DESIGN time rather than at test time: for every guard, ask what ELSE would
+reject this input first, and is the guard therefore untested at its own level.
+Five masking pairs came out of that question before any implementation existed,
+and each one dictates the shape of a probe below:
+
+  1. Zero-byte alternates is masked by the entries-match-cache guard whenever
+     that guard is spelled `all(entry == declared)` -- vacuously true over zero
+     lines. Set-equality, never all().
+  2. Cache-root containment is masked by S4-A's canonicalize_workspace_path,
+     which rejects anything OUTSIDE the workspace. An out-of-workspace decoy
+     dies upstream and this guard never runs.
+  3. Cache-root containment is also masked by the origin-match guard, because
+     another unit's clone of the same repository has the SAME origin url.
+  4. Cache-root containment is also masked by a bare-repository check, because
+     another unit's clone is not bare.
+     => 2+3+4 combine: the only decoy that reaches containment is a BARE mirror
+        with the SAME origin url at an IN-workspace NON-cache path.
+  5. `.git is a directory` is masked by the existing gitops.is_git_repo(), which
+     returns True inside a linked worktree. test_is_git_repo_cannot_see_the_
+     difference pins that fact so the mask cannot silently return.
+
+Two behaviours of git itself are load-bearing here and are pinned by tests
+rather than assumed, because both were verified empirically and neither is
+obvious from the flag name:
+
+  - `--reference-if-able` SILENTLY DEGRADES: against a missing cache it exits 0
+    and writes no alternates file at all. A declared reference is therefore a
+    claim the executor must verify positively after the fact.
+  - `git rev-parse --git-common-dir` returns a RELATIVE path (".git") in a
+    normal clone and an ABSOLUTE one inside a worktree, so it must be resolved
+    against the clone root before comparison.
+"""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import unittest
+from pathlib import Path
+
+from gr2.python_cli import gitops
+from gr2.python_cli.clone_exec import (
+    CloneExecutionError,
+    execute_clone_operation,
+    verify_cache_provenance,
+    verify_clone_isolation,
+)
+from gr2.python_cli.spec_apply import (
+    validate_materialization_plan,
+    workspace_spec_path,
+    write_materialization_receipt,
+)
+
+
+def run_git(cwd: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed in {cwd}:\n{proc.stderr}")
+    return proc.stdout
+
+
+class CloneExecTestBase(unittest.TestCase):
+    """Real git repositories on local paths. No network, no fixtures-of-fixtures:
+    the guards under test read actual .git state, so simulating that state would
+    be testing the simulation."""
+
+    def setUp(self):
+        import tempfile
+
+        self.tmp = Path(tempfile.mkdtemp())
+        self.workspace_root = self.tmp / "workspace"
+        self.workspace_root.mkdir(parents=True)
+        self.spec_sha256 = self._write_workspace_spec()
+
+        # Upstream: a real repository with one commit on `main`.
+        self.origin = self.tmp / "origin"
+        self.origin.mkdir()
+        run_git(self.origin, "init", "-q", "-b", "main")
+        run_git(self.origin, "config", "user.email", "t@example.com")
+        run_git(self.origin, "config", "user.name", "T")
+        (self.origin / "README.md").write_text("hello\n")
+        run_git(self.origin, "add", ".")
+        run_git(self.origin, "commit", "-q", "-m", "init")
+        self.repo_url = str(self.origin)
+
+        # The workspace-managed object cache (section 8.2).
+        self.cache_rel = ".grip/cache/repos/product.git"
+        self.cache_path = self.workspace_root / ".grip" / "cache" / "repos" / "product.git"
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        run_git(self.tmp, "clone", "-q", "--mirror", self.repo_url, str(self.cache_path))
+
+        self.dest_rel = "units/u_test/repos/product"
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_workspace_spec(self, content: str = 'workspace_name = "test"\n') -> str:
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_path.write_text(content)
+        return hashlib.sha256(spec_path.read_bytes()).hexdigest()
+
+    def _clone_op(self, **overrides: object) -> dict[str, object]:
+        op: dict[str, object] = {
+            "kind": "clone",
+            "repo_url": self.repo_url,
+            "dest_path": self.dest_rel,
+            "branch": "main",
+            "reference_base": self.cache_rel,
+        }
+        op.update(overrides)
+        return op
+
+    def _validated(self, operations: list[dict[str, object]] | None = None):
+        plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "unit_key": "u_test",
+            "workspace_spec_sha256": self.spec_sha256,
+            "operations": operations if operations is not None else [self._clone_op()],
+        }
+        return validate_materialization_plan(self.workspace_root, plan)
+
+    def _make_clone(self, dest: Path, *, reference: Path | None = None) -> Path:
+        """A real clone, the way the executor would make one."""
+        command = ["git", "clone", "-q"]
+        if reference is not None:
+            command.extend(["--reference-if-able", str(reference)])
+        command.extend([self.repo_url, str(dest)])
+        proc = subprocess.run(command, capture_output=True, text=True, check=False)
+        if proc.returncode != 0:
+            raise AssertionError(f"fixture clone failed:\n{proc.stderr}")
+        return dest
+
+    def _healthy_clone(self) -> Path:
+        dest = self.tmp / "healthy"
+        return self._make_clone(dest, reference=self.cache_path)
+
+    def _alternates_path(self, clone_root: Path) -> Path:
+        return clone_root / ".git" / "objects" / "info" / "alternates"
+
+    def _verify(self, clone_root: Path, **overrides: object) -> None:
+        kwargs: dict[str, object] = {
+            "workspace_root": self.workspace_root,
+            "repo_url": self.repo_url,
+            "reference_base": self.cache_path,
+        }
+        kwargs.update(overrides)
+        verify_clone_isolation(clone_root, **kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# The adjacent-guard facts these probes depend on. If git or the helper ever
+# changes, these fail FIRST and name the reason, instead of quietly turning a
+# guard's probe into a test of its neighbour.
+# ---------------------------------------------------------------------------
+
+
+class TestMaskingPremises(CloneExecTestBase):
+    def test_reference_if_able_silently_degrades(self):
+        """The flag is chosen by section 8.2 so a missing cache does not fail the
+        timed path. The cost is that a declared reference can vanish with no
+        error: rc=0, and no alternates file at all. This is WHY verification
+        must be positive rather than 'we passed the flag'."""
+        dest = self.tmp / "degraded"
+        proc = subprocess.run(
+            [
+                "git", "clone", "-q",
+                "--reference-if-able", str(self.tmp / "does-not-exist.git"),
+                self.repo_url, str(dest),
+            ],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertFalse(
+            self._alternates_path(dest).exists(),
+            "git wrote an alternates file for a missing reference -- the "
+            "silent-degrade premise behind the positive-verification guards "
+            "no longer holds",
+        )
+
+    def test_is_git_repo_cannot_see_a_worktree(self):
+        """gitops.is_git_repo() answers 'is-inside-work-tree', which is TRUE
+        inside a linked worktree. Any health check gated on it reads a
+        section-8.1-forbidden worktree as a healthy clone. Pinned so the mask
+        cannot return unnoticed."""
+        host = self._healthy_clone()
+        wt = self.tmp / "linked-worktree"
+        run_git(host, "worktree", "add", "-q", str(wt), "-b", "side")
+
+        self.assertTrue(
+            gitops.is_git_repo(wt),
+            "is_git_repo no longer accepts a worktree; the .git-is-a-directory "
+            "guard may now be masked by a different neighbour -- re-run the "
+            "masking analysis",
+        )
+        self.assertTrue((wt / ".git").is_file(), "worktree .git should be a pointer file")
+
+
+# ---------------------------------------------------------------------------
+# Clone isolation (section 8.1) and alternates binding (section 8.2), each
+# guard probed at its own level on a real clone.
+# ---------------------------------------------------------------------------
+
+
+class TestCloneIsolation(CloneExecTestBase):
+    def test_healthy_clone_with_declared_reference_passes(self):
+        """The guards must not false-positive on the shape they exist to admit."""
+        self._verify(self._healthy_clone())
+
+    def test_git_dir_as_pointer_file_is_rejected(self):
+        """Acceptance fruit 8. The probe is a REAL worktree, not a hand-written
+        pointer file, because the mask being closed is that a real worktree
+        looks healthy to is_git_repo()."""
+        host = self._healthy_clone()
+        wt = self.tmp / "as-worktree"
+        run_git(host, "worktree", "add", "-q", str(wt), "-b", "side")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(wt)
+        self.assertIn(".git must be a directory", str(ctx.exception))
+
+    def test_common_dir_outside_the_clone_is_rejected(self):
+        """.git stays a real directory, so the pointer-file guard passes. Only
+        the common-dir guard can see this one."""
+        clone = self._healthy_clone()
+        foreign = self._make_clone(self.tmp / "foreign", reference=self.cache_path)
+        (clone / ".git" / "commondir").write_text(f"{foreign / '.git'}\n")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone)
+        self.assertIn("git common directory", str(ctx.exception))
+
+    def test_clone_hosting_a_worktree_is_rejected(self):
+        """This clone's OWN state is fine -- .git is a directory and the common
+        dir is its own -- so neither neighbour fires. Section 8.1 forbids
+        .git/worktrees because a host shares refs and locks with its links."""
+        clone = self._healthy_clone()
+        run_git(clone, "worktree", "add", "-q", str(self.tmp / "linked"), "-b", "side")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone)
+        self.assertIn("worktrees", str(ctx.exception))
+
+    def test_origin_url_mismatch_is_rejected(self):
+        clone = self._healthy_clone()
+        run_git(clone, "remote", "set-url", "origin", str(self.tmp / "somewhere-else"))
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone)
+        self.assertIn("origin", str(ctx.exception))
+
+
+class TestAlternatesBinding(CloneExecTestBase):
+    def test_zero_byte_alternates_does_not_satisfy_a_declared_reference(self):
+        """Sentinel's survivor. An empty file makes 'every entry is the declared
+        cache' VACUOUSLY TRUE, so an all()-shaped guard admits it while the
+        clone has no object sharing at all -- the perf lever silently absent
+        and the contract silently unmet."""
+        clone = self._healthy_clone()
+        self._alternates_path(clone).write_text("")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone)
+        self.assertIn("declares no alternate", str(ctx.exception))
+
+    def test_whitespace_only_alternates_does_not_satisfy_a_declared_reference(self):
+        """Same vacuous-truth class as zero-byte, one layer up: a guard that
+        strips blank lines before comparing sets is equally empty, and a guard
+        that only checks st_size > 0 admits this one."""
+        clone = self._healthy_clone()
+        self._alternates_path(clone).write_text("\n   \n\n")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone)
+        self.assertIn("declares no alternate", str(ctx.exception))
+
+    def test_missing_alternates_file_does_not_satisfy_a_declared_reference(self):
+        """Distinct INPUT from zero-byte, reaching a distinct code path: absent
+        raises FileNotFoundError where empty returns "". This is the state
+        --reference-if-able actually produces when the cache is missing."""
+        clone = self._healthy_clone()
+        self._alternates_path(clone).unlink()
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone)
+        self.assertIn("declares no alternate", str(ctx.exception))
+
+    def test_foreign_alternate_entry_alongside_the_cache_is_rejected(self):
+        """The declared cache IS present, so a guard asking 'is the cache in
+        there?' passes. Only set-equality sees the extra entry."""
+        clone = self._healthy_clone()
+        rogue = self.tmp / "rogue.git"
+        run_git(self.tmp, "clone", "-q", "--mirror", self.repo_url, str(rogue))
+        path = self._alternates_path(clone)
+        path.write_text(path.read_text().rstrip("\n") + f"\n{rogue / 'objects'}\n")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone)
+        self.assertIn("alternate", str(ctx.exception))
+
+    def test_alternate_to_a_non_cache_path_is_rejected(self):
+        """Acceptance fruit 9, with the decoy the masking analysis demands: a
+        BARE mirror (survives a bare-repo check) with the SAME origin url
+        (survives origin-match) at an IN-workspace path (survives S4-A's
+        canonicalizer). Only cache-root containment can reject it."""
+        decoy = self.workspace_root / "units" / "u_other" / "rogue.git"
+        decoy.parent.mkdir(parents=True, exist_ok=True)
+        run_git(self.tmp, "clone", "-q", "--mirror", self.repo_url, str(decoy))
+        self.assertTrue(gitops.is_git_dir(decoy), "decoy must be bare to reach containment")
+        self.assertEqual(
+            gitops.remote_origin_url(decoy),
+            self.repo_url,
+            "decoy must share the declared origin to reach containment",
+        )
+
+        clone = self._make_clone(self.tmp / "referencing-decoy", reference=decoy)
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone, reference_base=decoy)
+        self.assertIn("object cache", str(ctx.exception))
+
+    def test_undeclared_alternate_is_rejected(self):
+        """The inverse direction: the plan declares no reference, so there is
+        nothing to compare against -- and an unguarded 'no reference declared'
+        branch would skip the check entirely and let the clone share objects
+        with anything."""
+        rogue = self.tmp / "undeclared.git"
+        run_git(self.tmp, "clone", "-q", "--mirror", self.repo_url, str(rogue))
+        clone = self._make_clone(self.tmp / "undeclared-alt", reference=rogue)
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone, reference_base=None)
+        self.assertIn("alternate", str(ctx.exception))
+
+    def test_no_reference_declared_and_none_present_passes(self):
+        self._verify(self._make_clone(self.tmp / "standalone"), reference_base=None)
+
+
+class TestCacheProvenance(CloneExecTestBase):
+    def test_declared_cache_passes(self):
+        verify_cache_provenance(
+            self.cache_path, workspace_root=self.workspace_root, repo_url=self.repo_url
+        )
+
+    def test_cache_seeded_from_a_different_upstream_is_rejected(self):
+        """Containment passes -- it IS under the cache root. Only provenance
+        sees that its objects came from somewhere else."""
+        other = self.tmp / "other-origin"
+        other.mkdir()
+        run_git(other, "init", "-q", "-b", "main")
+        run_git(other, "config", "user.email", "t@example.com")
+        run_git(other, "config", "user.name", "T")
+        (other / "OTHER.md").write_text("other\n")
+        run_git(other, "add", ".")
+        run_git(other, "commit", "-q", "-m", "other")
+        run_git(self.cache_path, "remote", "set-url", "origin", str(other))
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            verify_cache_provenance(
+                self.cache_path, workspace_root=self.workspace_root, repo_url=self.repo_url
+            )
+        self.assertIn("seeded from", str(ctx.exception))
+
+    def test_non_bare_cache_is_rejected(self):
+        not_bare = self.workspace_root / ".grip" / "cache" / "repos" / "notbare.git"
+        self._make_clone(not_bare)
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            verify_cache_provenance(
+                not_bare, workspace_root=self.workspace_root, repo_url=self.repo_url
+            )
+        self.assertIn("bare", str(ctx.exception))
+
+    def test_cache_outside_the_cache_root_is_rejected(self):
+        """Same decoy discipline as the alternates probe: bare, same origin,
+        in-workspace. Containment is the only guard left standing."""
+        decoy = self.workspace_root / "units" / "u_other" / "rogue.git"
+        decoy.parent.mkdir(parents=True, exist_ok=True)
+        run_git(self.tmp, "clone", "-q", "--mirror", self.repo_url, str(decoy))
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            verify_cache_provenance(
+                decoy, workspace_root=self.workspace_root, repo_url=self.repo_url
+            )
+        self.assertIn("object cache", str(ctx.exception))
+
+    def test_missing_cache_is_rejected(self):
+        with self.assertRaises(CloneExecutionError) as ctx:
+            verify_cache_provenance(
+                self.workspace_root / ".grip" / "cache" / "repos" / "absent.git",
+                workspace_root=self.workspace_root,
+                repo_url=self.repo_url,
+            )
+        self.assertIn("does not exist", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Publication (section 8.3) and reuse, through the executor itself.
+# ---------------------------------------------------------------------------
+
+
+class TestClonePublication(CloneExecTestBase):
+    def test_publishes_a_referenced_clone_on_the_declared_branch(self):
+        validated = self._validated()
+        evidence = execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+
+        dest = self.workspace_root / self.dest_rel
+        self.assertTrue((dest / ".git").is_dir(), "published clone must own its git dir")
+        self.assertEqual(gitops.current_branch(dest), "main")
+        self.assertEqual(gitops.remote_origin_url(dest), self.repo_url)
+        self.assertEqual(
+            self._alternates_path(dest).read_text().split(),
+            [str((self.cache_path / "objects").resolve())],
+            "the declared cache must be the clone's only alternate",
+        )
+        self.assertEqual(evidence["kind"], "clone")
+        self.assertIs(evidence["reused"], False)
+
+    def test_no_staging_path_survives_a_successful_publish(self):
+        validated = self._validated()
+        execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+
+        dest = self.workspace_root / self.dest_rel
+        siblings = [p.name for p in dest.parent.iterdir()]
+        self.assertEqual(siblings, [dest.name], f"staging leaked: {siblings}")
+
+    def test_an_invalid_cache_is_refused_before_any_clone_runs(self):
+        """Early refusal: no work at all against a cache we would reject
+        afterwards. Note this path never reaches staging, which is precisely
+        why it cannot double as the publication-ordering probe below."""
+        self.cache_path.rename(self.tmp / "cache-moved-away")
+
+        validated = self._validated()
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+        self.assertIn("does not exist", str(ctx.exception))
+        self.assertFalse((self.workspace_root / self.dest_rel).exists())
+
+    def test_a_clone_failing_verification_is_never_published(self):
+        """Publication happens only AFTER staging verifies. A half-verified
+        clone at dest_path is worse than none, because the reuse path would
+        later find it and call it healthy.
+
+        The failure is injected rather than provoked through a bad cache: every
+        naturally-bad cache is refused earlier, so the staging path would go
+        unprobed and an executor that cloned straight to dest_path would still
+        pass. The probe has to reach the code it is named for.
+
+        The load-bearing assertion is what is true DURING the failure, not
+        after it. An executor that clones straight to dest_path and deletes it
+        on failure reaches an identical end state -- nothing at dest_path --
+        so an end-state assertion cannot tell the two apart. It is the
+        transient that differs, and the transient is what a crash freezes: an
+        unverified clone left at the canonical path, which the reuse path will
+        later find and call healthy."""
+        from unittest.mock import patch
+
+        from gr2.python_cli import clone_exec
+
+        dest = self.workspace_root / self.dest_rel
+        observed: dict[str, object] = {}
+
+        def failing_verify(clone_root, **kwargs):
+            observed["dest_existed_during_verify"] = dest.exists()
+            observed["verified_path"] = Path(clone_root)
+            raise CloneExecutionError("injected staging failure")
+
+        with patch.object(clone_exec, "verify_clone_isolation", failing_verify):
+            validated = self._validated()
+            with self.assertRaises(CloneExecutionError):
+                execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+
+        self.assertIs(
+            observed["dest_existed_during_verify"],
+            False,
+            "an unverified clone occupied dest_path while it was still being verified; "
+            "a crash at that moment leaves it there permanently",
+        )
+        self.assertNotEqual(
+            observed["verified_path"], dest, "verification ran on the published path"
+        )
+        self.assertFalse(dest.exists(), "an unverified clone was published at dest_path")
+        self.assertEqual(
+            list(dest.parent.iterdir()) if dest.parent.exists() else [],
+            [],
+            "staging survived a failed publish",
+        )
+
+    def test_the_declared_cache_listed_twice_is_still_the_declared_cache(self):
+        """Duplicate entries name the same object store, and git tolerates
+        them. Pinning this keeps the permitted-set comparison about WHICH
+        stores are reachable rather than about the file's exact bytes."""
+        clone = self._healthy_clone()
+        path = self._alternates_path(clone)
+        entry = path.read_text().strip()
+        path.write_text(f"{entry}\n{entry}\n")
+
+        self._verify(clone)
+
+    def test_evidence_is_receipt_shaped_and_identity_free(self):
+        """The evidence has to survive S4-A's receipt screen unchanged; proving
+        it here means the executor and the contract cannot drift apart
+        silently."""
+        validated = self._validated()
+        evidence = execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+
+        receipt_path = write_materialization_receipt(
+            self.workspace_root, validated, [evidence]
+        )
+        import json
+
+        receipt = json.loads(receipt_path.read_text())
+        self.assertEqual(receipt["stage"], "MATERIALIZED")
+        self.assertEqual(receipt["operations"][0]["kind"], "clone")
+
+
+class TestExistingCloneHandling(CloneExecTestBase):
+    def _publish_once(self) -> Path:
+        validated = self._validated()
+        execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+        return self.workspace_root / self.dest_rel
+
+    def test_healthy_existing_clone_is_reused(self):
+        dest = self._publish_once()
+        marker = dest / ".git" / "REUSE_MARKER"
+        marker.write_text("x")
+
+        validated = self._validated()
+        evidence = execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+
+        self.assertIs(evidence["reused"], True)
+        self.assertTrue(marker.exists(), "reuse must not re-clone over the existing git dir")
+
+    def test_dirty_existing_clone_blocks_and_is_not_reset(self):
+        """Section 8.3: a dirty clone is NEVER reset or replaced. The assertion
+        that matters is the survival of the operator's work, not the raise --
+        a guard that raises AFTER discarding is still data loss."""
+        dest = self._publish_once()
+        (dest / "UNCOMMITTED.md").write_text("work in progress\n")
+
+        validated = self._validated()
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+
+        self.assertIn("dirty", str(ctx.exception))
+        self.assertTrue(
+            (dest / "UNCOMMITTED.md").exists(),
+            "uncommitted work was destroyed by a materialization run",
+        )
+
+    def test_existing_clone_of_a_different_repo_blocks(self):
+        dest = self._publish_once()
+        run_git(dest, "remote", "set-url", "origin", str(self.tmp / "elsewhere"))
+
+        validated = self._validated()
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+        self.assertIn("origin", str(ctx.exception))
+
+    def test_existing_worktree_at_dest_blocks(self):
+        """The reuse path is exactly where the is_git_repo() mask would bite:
+        a worktree parked at dest_path answers 'yes, healthy clone here'."""
+        host = self._healthy_clone()
+        dest = self.workspace_root / self.dest_rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        run_git(host, "worktree", "add", "-q", str(dest), "-b", "side")
+
+        validated = self._validated()
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+        self.assertIn(".git must be a directory", str(ctx.exception))
+
+
+class TestExecutorBinding(CloneExecTestBase):
+    def test_executing_against_a_different_workspace_root_is_rejected(self):
+        """S4-A binds the plan to a WorkspaceSpec at validation. The executor
+        takes workspace_root as a separate argument, so nothing structurally
+        stops a caller from validating against one workspace and executing
+        against another -- every relative path in the plan would then resolve
+        somewhere else. Re-checking the spec at USE is the same lesson S4-A's
+        TOCTOU round ended on."""
+        validated = self._validated()
+
+        other_root = self.tmp / "other-workspace"
+        other_root.mkdir()
+        other_spec = workspace_spec_path(other_root)
+        other_spec.parent.mkdir(parents=True, exist_ok=True)
+        other_spec.write_text('workspace_name = "other"\n')
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(validated, 0, workspace_root=other_root)
+        self.assertIn("WorkspaceSpec", str(ctx.exception))
+
+    def test_a_tampered_capability_cannot_execute(self):
+        """frozen=True blocks __setattr__ but not object.__setattr__, so the
+        capability must be verified at USE and not trusted because it exists."""
+        validated = self._validated()
+        object.__setattr__(validated, "plan_id", "mp_swapped")
+
+        with self.assertRaises(Exception) as ctx:
+            execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+        self.assertIn("capability is invalid", str(ctx.exception))
+
+    def test_a_copied_capability_cannot_execute(self):
+        """S4-A layered content-sealing and validator-provenance separately
+        because they catch different forgeries: a faithful copy preserves every
+        field AND the seal, and only provenance can see it is not one the
+        validator minted. The executor must ask for provenance, not just a
+        valid seal -- nothing else in this module would notice if it stopped."""
+        import dataclasses
+
+        validated = self._validated()
+        copied = dataclasses.replace(validated)
+
+        with self.assertRaises(Exception) as ctx:
+            execute_clone_operation(copied, 0, workspace_root=self.workspace_root)
+        self.assertIn("capability is invalid", str(ctx.exception))
+
+    def test_out_of_range_index_is_refused(self):
+        validated = self._validated()
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(validated, 7, workspace_root=self.workspace_root)
+        self.assertIn("out of range", str(ctx.exception))
+
+    def test_declared_non_default_branch_is_honoured(self):
+        """Without this the branch field is unfalsifiable: every fixture branch
+        equals the upstream default, so an executor that ignored `branch`
+        entirely would still land on the right one."""
+        run_git(self.origin, "checkout", "-q", "-b", "side")
+        (self.origin / "SIDE.md").write_text("side\n")
+        run_git(self.origin, "add", ".")
+        run_git(self.origin, "commit", "-q", "-m", "side")
+        run_git(self.origin, "checkout", "-q", "main")
+        run_git(self.cache_path, "remote", "update")
+
+        validated = self._validated([self._clone_op(branch="side")])
+        evidence = execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+
+        dest = self.workspace_root / self.dest_rel
+        self.assertEqual(gitops.current_branch(dest), "side")
+        self.assertEqual(evidence["branch"], "side")
+        self.assertTrue((dest / "SIDE.md").exists())
+
+    def test_a_non_clone_operation_is_refused_by_index(self):
+        """Ordering is load-bearing for the receipt: evidence[i] must describe
+        operation i. An executor that silently skipped a non-clone op would
+        shift every later result."""
+        validated = self._validated(
+            [
+                {
+                    "kind": "venv",
+                    "dest_path": "units/u_test/home/.venv",
+                    "engine": "uv",
+                    "python": "3.11",
+                },
+                self._clone_op(),
+            ]
+        )
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+        self.assertIn("is kind 'venv'", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gr2/tests/test_clone_materialization.py
+++ b/gr2/tests/test_clone_materialization.py
@@ -42,11 +42,14 @@ obvious from the flag name:
 from __future__ import annotations
 
 import hashlib
+import os
+import shutil
 import subprocess
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from gr2.python_cli import gitops
+from gr2.python_cli import gitops, spec_apply
 from gr2.python_cli.clone_exec import (
     CloneExecutionError,
     execute_clone_operation,
@@ -671,6 +674,340 @@ class TestExecutorBinding(CloneExecTestBase):
         with self.assertRaises(CloneExecutionError) as ctx:
             execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
         self.assertIn("is kind 'venv'", str(ctx.exception))
+
+
+class TestIsolationCompleteness(CloneExecTestBase):
+    """Round-2 blockers from Atlas + Sentinel at bd7afe5. Every one is a real
+    git witness they built and this executor accepted; each lands here with the
+    guard that closes it, so the mutant that reopens it has a declared victim."""
+
+    def test_a_git_dir_that_is_itself_a_symlink_is_rejected(self):
+        """Atlas 1. The nastiest of the set, because it defeats TWO guards with
+        one link: Path.is_dir() FOLLOWS the symlink and answers True, and
+        `rev-parse --git-common-dir` resolves THROUGH the same link so both
+        sides of the common-dir comparison land on the foreign directory and
+        agree. Hence lstat, never is_dir()."""
+        victim = self._make_clone(self.tmp / "victim", reference=self.cache_path)
+        foreign = self._make_clone(self.tmp / "foreign", reference=self.cache_path)
+        run_git(foreign, "checkout", "-q", "-b", "foreign-only")
+
+        shutil.rmtree(victim / ".git")
+        (victim / ".git").symlink_to(foreign / ".git")
+
+        self.assertTrue((victim / ".git").is_dir(), "premise: is_dir() follows the link")
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(victim)
+        self.assertIn("redirects .git through a symlink", str(ctx.exception))
+
+    def test_symlinked_refs_are_rejected(self):
+        """Sentinel 2 / Atlas 1. .git stays a real local directory and the
+        common dir is its own, so every prior guard passes -- while the clone
+        reads another unit's refs."""
+        victim = self._make_clone(self.tmp / "victim", reference=self.cache_path)
+        foreign = self._make_clone(self.tmp / "foreign", reference=self.cache_path)
+        run_git(foreign, "checkout", "-q", "-b", "foreign-only")
+
+        shutil.rmtree(victim / ".git" / "refs")
+        (victim / ".git" / "refs").symlink_to(foreign / ".git" / "refs")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(victim)
+        self.assertIn(".git/refs", str(ctx.exception))
+
+    def test_symlinked_objects_are_rejected_when_no_reference_is_declared(self):
+        """Sentinel 2. The second route to object sharing, and the one the
+        alternates check structurally cannot see: with no reference_base
+        declared there is no alternates file to inspect, so that guard passes
+        VACUOUSLY while the objects directory itself is joined to another
+        unit's store."""
+        victim = self._make_clone(self.tmp / "victim")
+        foreign = self._make_clone(self.tmp / "foreign")
+
+        shutil.rmtree(victim / ".git" / "objects")
+        (victim / ".git" / "objects").symlink_to(foreign / ".git" / "objects")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(victim, reference_base=None)
+        self.assertIn(".git/objects", str(ctx.exception))
+
+    def test_a_shallow_clone_is_rejected(self):
+        """Sentinel 1. Correct origin, local git dir, clean tree, valid
+        alternate -- indistinguishable from healthy to every other guard.
+        Section 8.1 requires the complete reachable history and the v1 plan
+        declares no shallow profile."""
+        run_git(self.origin, "commit", "-q", "--allow-empty", "-m", "second")
+        run_git(self.cache_path, "remote", "update")
+        shallow = self.tmp / "shallow"
+        # file:// on purpose: git IGNORES --depth for a local-path clone, so a
+        # plain path silently produces a full clone and the fixture would prove
+        # nothing. Origin is then restored to the declared value, exactly as
+        # Sentinel's witness did, so the origin guard cannot be what rejects it.
+        subprocess.run(
+            ["git", "clone", "-q", "--depth", "1", "--reference-if-able",
+             str(self.cache_path), Path(self.repo_url).as_uri(), str(shallow)],
+            capture_output=True, text=True, check=False,
+        )
+        run_git(shallow, "remote", "set-url", "origin", self.repo_url)
+        self.assertTrue((shallow / ".git" / "shallow").exists(), "premise: fixture is shallow")
+        self.assertEqual(
+            run_git(shallow, "rev-list", "--count", "HEAD").strip(),
+            "1",
+            "premise: fixture holds truncated history",
+        )
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(shallow)
+        self.assertIn("shallow", str(ctx.exception))
+
+    def test_a_partial_clone_is_rejected(self):
+        """The sibling of shallow: history fetched lazily from the network
+        rather than truncated. .git/shallow is absent, so the shallow probe
+        cannot see it -- it needs its own."""
+        clone = self._healthy_clone()
+        run_git(clone, "config", "remote.origin.promisor", "true")
+        run_git(clone, "config", "remote.origin.partialclonefilter", "blob:none")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            self._verify(clone)
+        self.assertIn("partial clone", str(ctx.exception))
+
+
+class TestCacheBoundaryIsTransitive(CloneExecTestBase):
+    def test_a_cache_whose_objects_are_a_symlink_is_rejected(self):
+        """Atlas 2. Containment is only ONE HOP without this: the cache is at
+        the right path, bare, with the right origin -- and its object store
+        lives somewhere else entirely."""
+        outside = self.tmp / "global-cache.git"
+        run_git(self.tmp, "clone", "-q", "--mirror", self.repo_url, str(outside))
+        shutil.rmtree(self.cache_path / "objects")
+        (self.cache_path / "objects").symlink_to(outside / "objects")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            verify_cache_provenance(
+                self.cache_path, workspace_root=self.workspace_root, repo_url=self.repo_url
+            )
+        self.assertIn("objects directory through a symlink", str(ctx.exception))
+
+    def test_a_cache_that_alternates_onward_to_a_global_store_is_rejected(self):
+        """Atlas 2, the decisive form. The clone's own alternate correctly
+        names the workspace cache -- so the clone-side check is satisfied --
+        and the cache then alternates out to a machine-global store, which the
+        clone transitively reads. Object sharing must TERMINATE at the
+        workspace cache."""
+        global_cache = self.tmp / "global-cache.git"
+        run_git(self.tmp, "clone", "-q", "--mirror", self.repo_url, str(global_cache))
+        info = self.cache_path / "objects" / "info"
+        info.mkdir(parents=True, exist_ok=True)
+        (info / "alternates").write_text(f"{global_cache / 'objects'}\n")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            verify_cache_provenance(
+                self.cache_path, workspace_root=self.workspace_root, repo_url=self.repo_url
+            )
+        self.assertIn("must terminate at", str(ctx.exception))
+
+    def test_relative_alternate_lines_resolve_the_way_git_resolves_them(self):
+        """Atlas 2. git resolves a relative alternates entry against the OBJECT
+        DIRECTORY; resolving it against the process working directory makes the
+        verifier and git disagree about what the clone actually reads -- and a
+        verifier that disagrees with git is worse than none.
+
+        The entry below is the declared cache written relatively. It must be
+        ACCEPTED, which it can only be if resolution matches git's rule."""
+        clone = self._healthy_clone()
+        objects_dir = clone / ".git" / "objects"
+        relative = os.path.relpath(self.cache_path / "objects", objects_dir)
+        (objects_dir / "info" / "alternates").write_text(f"{relative}\n")
+
+        self._verify(clone)
+
+
+class TestDamagedCloneIsNotReused(CloneExecTestBase):
+    """Sentinel 3 AND Atlas 4 -- the one both reviewers hit independently."""
+
+    def test_a_corrupt_index_blocks_reuse_instead_of_reading_as_clean(self):
+        """gitops.repo_dirty() maps EVERY nonzero exit to False, so an
+        unreadable index reads as 'clean' and the damaged clone is reused as
+        healthy. Clean, dirty and unreadable are three outcomes; collapsing the
+        one we understand least into the most permissive one is a fail-open."""
+        validated = self._validated()
+        execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+        dest = self.workspace_root / self.dest_rel
+        index_path = dest / ".git" / "index"
+        index_path.write_bytes(b"not a git index")
+        before = index_path.read_bytes()
+
+        self.assertFalse(
+            gitops.repo_dirty(dest),
+            "premise: the shared helper reports a damaged clone as not-dirty",
+        )
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(self._validated(), 0, workspace_root=self.workspace_root)
+
+        self.assertIn("damaged", str(ctx.exception))
+        self.assertEqual(
+            index_path.read_bytes(), before, "blocking must not modify the damaged clone"
+        )
+
+    def test_a_clone_whose_head_does_not_resolve_blocks_even_though_status_is_clean(self):
+        """Atlas 4's second half: 'HEAD/reachability must succeed.'
+
+        Finding the witness for this took two tries, and the first failure is
+        worth recording. Deleting the branch ref makes git report an unborn
+        branch with every tracked file staged-new, so status reads DIRTY and the
+        dirty guard rejects it -- the HEAD check would have looked covered while
+        being untested at its own level. Adjacent-guard masking inside the very
+        guard set added to close these blockers.
+
+        The witness that actually reaches it is an unborn branch with nothing
+        tracked: status exits 0 with empty output, so the tri-state answers
+        'clean', and only HEAD resolution can see that this clone has no
+        commit to work from."""
+        validated = self._validated()
+        execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+        dest = self.workspace_root / self.dest_rel
+        run_git(dest, "checkout", "-q", "--orphan", "fresh")
+        run_git(dest, "rm", "-rq", "-f", ".")
+
+        status = gitops.git(dest, "status", "--porcelain")
+        self.assertEqual(status.returncode, 0, "premise: status still succeeds")
+        self.assertEqual(status.stdout.strip(), "", "premise: status still reads clean")
+
+        with self.assertRaises(CloneExecutionError) as ctx:
+            execute_clone_operation(self._validated(), 0, workspace_root=self.workspace_root)
+        self.assertIn("no resolvable HEAD", str(ctx.exception))
+
+
+class TestPreflightRunsBeforeAnyMutation(CloneExecTestBase):
+    def test_an_invalid_cache_is_refused_before_git_clone_runs(self):
+        """Sentinel 4, and it is the masking finding I missed: my own staging
+        verifier is a stronger neighbour that produces the SAME error and the
+        SAME end state, so removing the preflight left every test green while
+        a clone had already run.
+
+        The contract requires validation before the first filesystem mutation,
+        so the assertion has to be that no clone happened -- not that an error
+        was raised."""
+        from gr2.python_cli import clone_exec
+
+        self.cache_path.rename(self.tmp / "cache-moved-away")
+        calls: list[object] = []
+
+        def spy(*args, **kwargs):
+            calls.append(args)
+
+        with patch.object(clone_exec, "_git_clone", spy):
+            with self.assertRaises(CloneExecutionError) as ctx:
+                execute_clone_operation(
+                    self._validated(), 0, workspace_root=self.workspace_root
+                )
+
+        self.assertEqual(calls, [], "git clone ran against a cache we then refused")
+        self.assertIn("does not exist", str(ctx.exception))
+
+
+class TestPublicationResidue(CloneExecTestBase):
+    def test_a_failed_rename_leaves_no_staging_residue(self):
+        """Sentinel 5. The rename sat OUTSIDE the cleanup boundary, so the
+        no-residue guarantee held for every failure except the one occurring at
+        the publication seam itself."""
+        from gr2.python_cli import clone_exec
+
+        dest = self.workspace_root / self.dest_rel
+        real_replace = os.replace
+
+        def failing_replace(src, dst, **kwargs):
+            raise OSError("injected publication failure")
+
+        with patch.object(clone_exec.os, "replace", failing_replace):
+            with self.assertRaises(OSError):
+                execute_clone_operation(
+                    self._validated(), 0, workspace_root=self.workspace_root
+                )
+
+        self.assertIs(os.replace, real_replace, "patch leaked")
+        self.assertFalse(dest.exists())
+        self.assertEqual(
+            sorted(p.name for p in dest.parent.iterdir()) if dest.parent.exists() else [],
+            [],
+            "a populated staging sibling survived a failed publication",
+        )
+
+
+class TestCapabilityWindow(CloneExecTestBase):
+    def test_a_capability_swapped_during_path_work_cannot_redirect_the_clone(self):
+        """Atlas 3, and it is the validation-vs-use class inside B's own code.
+
+        The executor verified, then ran callback-capable path work, then re-read
+        validated.plan live -- so a caller-supplied Path subclass could swap the
+        plan after verification and have the forged destination cloned while the
+        sealed one was never created.
+
+        Closed two ways, both of which this probe exercises: workspace_root is
+        normalised to a plain Path BEFORE verification, so the callback cannot
+        run at all; and every operation field is captured into one immutable
+        binding, so a later swap is irrelevant rather than merely detectable."""
+        validated = self._validated()
+        forged_dest = "units/u_forged/repos/product"
+        forged_plan = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "unit_key": "u_test",
+            "workspace_spec_sha256": self.spec_sha256,
+            "operations": [self._clone_op(dest_path=forged_dest)],
+        }
+
+        class SwappingPath(type(Path())):
+            def __truediv__(inner, other):
+                object.__setattr__(
+                    validated, "plan", spec_apply._deep_freeze(forged_plan)
+                )
+                return super().__truediv__(other)
+
+        execute_clone_operation(
+            validated, 0, workspace_root=SwappingPath(self.workspace_root)
+        )
+
+        self.assertTrue(
+            (self.workspace_root / self.dest_rel / ".git").is_dir(),
+            "the sealed destination was never created",
+        )
+        self.assertFalse(
+            (self.workspace_root / forged_dest).exists(),
+            "the executor cloned a destination the capability never sealed",
+        )
+
+
+class TestReceiptEvidenceCompleteness(CloneExecTestBase):
+    def test_evidence_records_what_was_observed_not_what_was_declared(self):
+        """Atlas 5. Section 12.1 requires repo URL, destination, HEAD,
+        clone-state evidence, and cache path plus APPROVED-ALTERNATE evidence.
+        Echoing the plan's reference_base back is not evidence -- a receipt that
+        repeats the plan proves nothing about what is on disk. The previous
+        receipt test asserted only stage and kind, which is what let the
+        omissions read as green."""
+        validated = self._validated()
+        evidence = execute_clone_operation(validated, 0, workspace_root=self.workspace_root)
+
+        self.assertEqual(evidence["repo_url"], self.repo_url)
+        self.assertEqual(evidence["dest_path"], self.dest_rel)
+        self.assertRegex(str(evidence["head_sha"]), r"^[0-9a-f]{40}$")
+        self.assertEqual(evidence["cache_path"], self.cache_rel)
+        self.assertEqual(
+            evidence["approved_alternates"],
+            [str(Path(self.cache_rel) / "objects")],
+            "approved-alternate evidence must be the alternate git will actually "
+            "read, expressed workspace-relatively",
+        )
+        self.assertEqual(evidence["clone_state"]["working_tree"], "clean")
+
+        receipt_path = write_materialization_receipt(
+            self.workspace_root, validated, [evidence]
+        )
+        import json
+
+        receipt = json.loads(receipt_path.read_text())
+        self.assertEqual(receipt["operations"][0]["repo_url"], self.repo_url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

S4-B: the clone / cache / alternates executor. **First consumer of the S4-A plan contract** — A landed validate → un-forgeable capability → durable receipt, and nothing executed anything. This executes `kind == "clone"`.

Ref #797 (the S4 slice split). Base `main`, same as A (#799, merged at `7d840af`).

**Premium boundary: gitgrip is OSS.** This is local workspace materialization — cloning declared repositories into declared paths and proving their git state is isolated. It reads no identity, derives none, and persists none: `unit_key` stays the opaque token A defined, and the evidence it emits passes A's identity-field screen unchanged (pinned by a test). Answering *"who is this agent?"* remains premium.

**Reviewers: Atlas + Sentinel.**

## Derivation disclosure

The dispatch cited `config/design/zero-to-team-materialization-seam-2026-07-27.md` §4 ("perf levers"). **That path does not exist on `origin/main`.** Synced once, checked, and derived from the adjacent locked contract rather than inventing context: the real document is `config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md`, and the clone contract is **§8**, not §4. §8.2 *is* the perf lever the dispatch meant — alternates against a workspace-local cache.

Per `config/design/substrate-resilience-pattern-2026-05-08.md`; also posted in #dev.

## Where it lives, and why not `gitops.py`

`gitops.py` is a thin subprocess layer over git. The substance here is **policy** — which object sharing is permitted, what makes a clone state-isolated, when an existing clone may be reused. Policy living in the primitive layer is policy that later callers bypass by reaching for the primitive directly.

## The design check ran during design, not at test time

A's four review rounds shared one generator: *a guard that looks covered because a stronger neighbour keeps the probe green.* So for every guard here the question came first: **what else would reject this input first, and is this guard therefore untested at its own level?**

Five masking pairs, all found before any implementation existed. Each one dictated the shape of a probe:

| Masked guard | Masked by | Probe therefore must be |
|---|---|---|
| zero-byte alternates | entries-match-cache spelled `all(entry == declared)` — **vacuously true over zero lines** | empty file, with emptiness claimed by its own branch |
| cache-root containment | A's own `canonicalize_workspace_path` rejects any **out-of-workspace** decoy | decoy must be **in-workspace** |
| cache-root containment | origin-match passes — another unit's clone of the same repo has the **same origin url** | decoy must be **same-url** |
| cache-root containment | bare-repo check — another unit's clone **is not bare** | decoy must be a **bare mirror** |
| `.git` is a directory | existing `gitops.is_git_repo()` answers *is-inside-work-tree*, **TRUE inside a linked worktree** | probe with a **real worktree**, not a hand-written pointer file |

The three containment rows compose: the only decoy that reaches that guard is a **bare mirror with the same origin url at an in-workspace non-cache path** — which is precisely what acceptance fruit #9 ("another agent or team clone") describes. Any weaker decoy dies upstream and leaves containment untested while the suite goes green.

`TestMaskingPremises` pins the two facts these probes depend on, so if git or the helper ever changes, that fails *first* and names the reason instead of quietly turning a guard's probe into a test of its neighbour.

## Two git behaviours that are load-bearing, checked empirically

Both were verified by running git before being written down, not reasoned from the flag name.

**`--reference-if-able` silently degrades.** Against a missing cache it exits **0** and writes **no alternates file at all**, emitting only an `info:` line on stderr. §8.2 chooses that flag deliberately so a cold cache cannot fail the timed path — which means a declared reference is a **claim the executor must verify positively afterwards**. Passing the flag is not evidence the alternate exists. Absent and zero-byte are distinct inputs reaching distinct code paths; both get probes.

**`rev-parse --git-common-dir` returns a relative path** (`.git`) in a normal clone and an absolute one inside a worktree, so it means nothing until resolved against the clone root. The mutant that skips that join kills the *happy path* test — which is how it should read.

## Publication ordering, and why the assertion is about the transient

§8.3: clone at a sibling staging path → verify → atomic rename.

The first version of that test asserted the end state (nothing at `dest_path`) and **a mutant that clones straight to `dest_path` survived it** — because the failure branch deletes it, reaching an identical end state. An end-state assertion structurally cannot see an ordering property.

What differs is the transient, and the transient is what a crash freezes: an unverified clone left at the canonical path, where the reuse path later finds it and calls it healthy. The test now observes `dest.exists()` **at the moment verification fails**, and the mutant dies. Same shape as A's `os.replace` oracle, where the rename consumed the temp file so a directory listing came too late.

Staging uses `mkdtemp` rather than a pid-suffixed name: §9.1 fans clones out in parallel, and a name that has to be *argued* unique is a name that eventually is not.

## Data survival, not just refusal

§8.3 says a dirty clone is **never reset or replaced**. The test therefore asserts the operator's uncommitted work **survives**, not merely that something raised — a guard that raises *after* discarding is still data loss. One mutant (`dirty-discards-then-blocks`) does exactly that, and only the survival assertion catches it.

## WorkspaceSpec re-verified at execution

The plan is bound to a WorkspaceSpec at *validation*, but the executor takes `workspace_root` as a separate argument. Nothing structurally stopped a caller from validating against one workspace and executing against another — every declared relative path would then resolve somewhere else. Re-checking at **use** is the same lesson A's TOCTOU round ended on.

## Verification

- **34 new tests** in `gr2/tests/test_clone_materialization.py`, against real git repositories on local paths (no network). The guards read actual `.git` state, so simulating that state would be testing the simulation.
- **Mutation sweep: 24/24 killed, each by its DECLARED victim.** Harness adapted from S4-A's (not rewritten) — same declared-victim discipline, same `__pycache__` purge and `PYTHONDONTWRITEBYTECODE`, with mutants now addressed by exact string plus a uniqueness assertion so a drifted anchor fails loudly instead of mutating a neighbour.
- **2 documented equivalents**, both with proofs rather than arguments:
  - `alternates-all-instead-of-set-equality` is unkillable **precisely because the zero-byte branch holds at its own level**: `expected` always holds exactly one path, so `entries ⊆ expected` with `entries` non-empty forces equality, and the empty case is claimed earlier. Fold emptiness back into the equality and it becomes killable again — which is the whole finding.
  - `post-clone-branch-assert-removed`: `git clone --branch X` cannot land on anything but X. The flag itself *is* probed, by `clone-omits-branch-flag`.
- **Full gr2 suite: 648 passed** on Python **3.11.9** and **3.13.2**.
- `ruff check` clean. `ruff format` is not enforced in this repo (the existing S4-A files fail it too, and it is absent from CI), so formatting matches the surrounding code rather than reformatting only these files.

Two probes were added *because designing the sweep exposed them*, before it ran: nothing pinned that the executor requires capability **provenance** (a faithful copy would have executed), and nothing pinned that a declared **non-default branch** is honoured (every fixture branch equalled the upstream default, so ignoring `branch` entirely would still have landed correctly).

## Out of scope, named rather than silently skipped

- **`gitops.ensure_lane_checkout()` uses `git worktree add`**, which §8.1 explicitly forbids, and it is live at `app.py:92` and `syncops.py:622`. Not touched here: different call path, and fusing that removal in would put two unrelated changes under one review. Filing as a follow-up. This executor can neither produce nor accept a worktree, which is the part acceptance fruit #8 gates.
- **Cache dependent-recording** (§8.2, "record which units depend on each cache") is shared mutable state needing its own concurrency design (atomic append, cleanup on unit removal) and protects against a `gc`/`prune` command that does not exist yet. The clone handler is not weakened without it, so it is a separate feature rather than deferred hardening. Follow-up.
- `venv` / `editable_install` → S4-D. `project_file` → S4-C.

## Carve rule

The handler lands **with** its full guard set — alternates set-equality / non-empty / present, `.git` is a directory, common-dir inside the clone, no `.git/worktrees`, cache origin matches, reference under the cache root, existing-clone origin match, dirty blocks without reset, staging + atomic publication. No weakened path left to harden later.