### PR TITLE
feat: S4-C project_file executor (foundation projection, prototype)

### DIFF
--- a/gr2/python_cli/file_exec.py
+++ b/gr2/python_cli/file_exec.py
@@ -1,0 +1,257 @@
+"""Executor for the neutral MaterializationPlan `project_file` operation (S4-C).
+
+The foundation projection: premium compiles the foundation, stages it under an
+opaque artifact key, and gr2 projects it into the unit (for Codex, as
+`AGENTS.md`). Acceptance fruit 15 -- removing the projection makes the Codex
+startup assertion fail -- is what makes these bytes a contract rather than a
+convenience.
+
+Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
+      section 6.2.1 invariants 7 and 8, section 383, fruit 14/15/22.
+
+INVARIANT 7 IS A TRAP AS LITERALLY WORDED. It says verify the source's
+"reopened bytes match source_sha256". Read word for word -- reopen, hash, then
+copy -- that IS the read-1/read-2 TOCTOU: the bytes hashed and the bytes written
+come from two different reads and nothing binds them, so the conforming-sounding
+implementation is the vulnerable one. `verify_staged_source` therefore RETURNS
+the bytes it hashed, and the caller writes exactly those. One read. Same
+conclusion S4-A reached about consume(): the fix is not to check again, it is to
+stop re-reading.
+
+INVARIANT 8 IS SPLIT ACROSS TWO SLICES. It forbids deleting a staged input
+before the receipt carrying its evidence is durable, and names the wrong signal
+outright -- "a successful destination write or in-memory operation result is not
+acknowledgement". That is a purely NEGATIVE constraint, so this slice satisfies
+it by DELETING NOTHING. Receipt-keyed cleanup is its own later slice, because a
+delete driven by a file on disk deserves its own review surface.
+
+That carve has a consequence this module must carry: once cleanup has run there
+is no staged input left, so an executor that demanded one would fail on the
+system's own second apply. A destination already hashing to source_sha256 IS
+proof the projection is current, so that case short-circuits before the source
+is touched at all. The short-circuit only reaches reruns -- on a first apply the
+destination does not exist and every source guard runs.
+"""
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import os
+import stat
+from pathlib import Path
+
+from .spec_apply import (
+    MaterializationPlanError,
+    ValidatedPlan,
+    _read_canonical_workspace_spec_bytes,
+    canonicalize_workspace_path,
+)
+
+_STAGING_INPUTS_PARTS = (".grip", "staging", "inputs")
+
+
+class ProjectFileExecutionError(MaterializationPlanError):
+    """A validated plan's project_file operation could not be executed safely."""
+
+
+@dataclasses.dataclass(frozen=True)
+class _ProjectFileBinding:
+    """One immutable reading of the operation, taken from A's frozen snapshot
+    before any caller-reachable code runs. Same rationale as S4-B's
+    _CloneBinding: verification and use must not be separated by anything that
+    can run caller code."""
+
+    source_path: str
+    dest_path: str
+    source_sha256: str
+
+
+def staging_inputs_root(workspace_root: Path) -> Path:
+    return workspace_root.joinpath(*_STAGING_INPUTS_PARTS)
+
+
+def _require_workspace_binding(validated: ValidatedPlan, workspace_root: Path) -> None:
+    """Re-prove at USE what validation proved earlier. The plan is bound to a
+    WorkspaceSpec at validation while the executor takes workspace_root
+    separately, so nothing structurally stops executing a plan against a
+    workspace it was never validated for -- every declared relative path would
+    resolve elsewhere.
+
+    Duplicated from clone_exec rather than imported: that one raises
+    CloneExecutionError, and a project_file failure reporting a clone error is
+    worse than twelve duplicated lines. The shared executor scaffolding wants
+    extracting into one module; deferred so it does not land inside a slice PR."""
+    try:
+        spec_bytes = _read_canonical_workspace_spec_bytes(workspace_root)
+    except MaterializationPlanError as exc:
+        raise ProjectFileExecutionError(
+            f"cannot execute against {workspace_root}: its canonical WorkspaceSpec is "
+            f"unreadable ({exc})"
+        ) from exc
+    actual = hashlib.sha256(spec_bytes).hexdigest()
+    if actual != validated.workspace_spec_sha256:
+        raise ProjectFileExecutionError(
+            f"plan is bound to WorkspaceSpec {validated.workspace_spec_sha256} but "
+            f"{workspace_root} has {actual} -- executing a plan against a workspace it "
+            "was not validated for would resolve every declared path elsewhere"
+        )
+
+
+def verify_staged_source(
+    source: Path, *, workspace_root: Path, source_sha256: str
+) -> bytes:
+    """Prove the staged input, and RETURN the bytes that were proven.
+
+    Returning the buffer is the whole point. A verifier that answers True and
+    leaves the caller to reopen the file has verified one read and authorised a
+    different one; the bytes that were hashed must be the bytes that get
+    written.
+
+    Two guards this slice's design ASSUMED were its own turned out to be owned
+    upstream, and both are deliberately absent rather than duplicated here,
+    because an unreachable guard reads as protection while being untestable at
+    its own level (S4-A's round-4 conclusion):
+
+      - Section 383 staging confinement is enforced SYNTACTICALLY by the pinned
+        v1 schema at validation. The spec says "syntactically confined", and A
+        wired it, so a source_path outside .grip/staging/inputs never produces a
+        capability at all.
+      - The post-validation symlink is caught by A's canonicalize_workspace_path
+        at EXECUTION, because the executor calls it and it lstat-walks every
+        component including the last.
+
+    Both facts are pinned by premise tests, so a loosened schema or canonicalizer
+    surfaces there rather than silently opening a hole here.
+
+    What remains genuinely this guard's own is the input neither upstream check
+    sees: a path that exists, is not a symlink, and is not a regular file -- a
+    FIFO, socket, or directory sitting where the staged foundation should be."""
+    try:
+        mode = os.lstat(source).st_mode
+    except FileNotFoundError:
+        raise ProjectFileExecutionError(
+            f"staged input {source} does not exist -- premium stages the compiled "
+            "foundation before gr2 projects it"
+        ) from None
+    if not stat.S_ISREG(mode):
+        kind = "a symlink" if stat.S_ISLNK(mode) else "not a regular file"
+        raise ProjectFileExecutionError(
+            f"staged input {source} must be a regular file, but it is {kind} -- a "
+            "path validated as symlink-free at validation time is unbound at "
+            "execution time unless the executor re-proves it"
+        )
+
+    data = source.read_bytes()
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != source_sha256:
+        raise ProjectFileExecutionError(
+            f"staged input {source} hashes to {actual}, not the declared "
+            f"source_sha256 {source_sha256}"
+        )
+    return data
+
+
+def _publish_atomically(dest: Path, data: bytes) -> None:
+    """Same-directory temp -> write -> fsync -> atomic replace -> parent fsync.
+
+    A half-written AGENTS.md is worse than none: Codex reads it on startup, and
+    a truncated foundation is a silently wrong one rather than a loud failure."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.parent / f".{dest.name}.tmp-{os.getpid()}"
+    fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, 0o644)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, dest)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    dir_fd = os.open(dest.parent, os.O_RDONLY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def _destination_is_current(dest: Path, source_sha256: str) -> bool:
+    """A destination hashing to the declared value IS proof the projection is
+    current -- the hash is the contract, and satisfying it needs no source read.
+
+    This is what makes the cleanup slice safe to exist: once cleanup removes the
+    staged input, currency can still be established from the destination alone.
+    Without it, C and the cleanup slice would each be correct and together break
+    the system's own second apply."""
+    try:
+        return hashlib.sha256(dest.read_bytes()).hexdigest() == source_sha256
+    except (FileNotFoundError, IsADirectoryError, PermissionError):
+        return False
+
+
+def execute_project_file_operation(
+    validated: ValidatedPlan, index: int, *, workspace_root: Path
+) -> dict[str, object]:
+    """Execute the `project_file` operation at `index` of a validated plan.
+
+    Addressed by index rather than filtered by kind so evidence[i] stays aligned
+    with operation i, which S4-A's receipt screen requires."""
+    # Plain Path before anything else: a caller-supplied Path SUBCLASS can run
+    # arbitrary code from its dunders during path work, which is the callback
+    # that reopens the check/use window. Normalising before verification removes
+    # the surface rather than trying to be safe around it (S4-B round 2).
+    workspace_root = Path(os.fspath(workspace_root))
+
+    validated.verify(require_provenance=True)
+    _require_workspace_binding(validated, workspace_root)
+
+    operations = validated.plan["operations"]
+    if not 0 <= index < len(operations):
+        raise ProjectFileExecutionError(
+            f"operation index {index} is out of range for a plan with "
+            f"{len(operations)} operation(s)"
+        )
+    op = operations[index]
+    kind = op.get("kind")
+    if kind != "project_file":
+        raise ProjectFileExecutionError(
+            f"operations[{index}] is kind {kind!r}, not 'project_file' -- its handler "
+            "lands with a different slice (clone with S4-B, venv/editable_install "
+            "with S4-D)"
+        )
+
+    binding = _ProjectFileBinding(
+        source_path=str(op["source_path"]),
+        dest_path=str(op["dest_path"]),
+        source_sha256=str(op["source_sha256"]),
+    )
+
+    source = canonicalize_workspace_path(
+        workspace_root, binding.source_path, field_name=f"operations[{index}].source_path"
+    )
+    dest = canonicalize_workspace_path(
+        workspace_root, binding.dest_path, field_name=f"operations[{index}].dest_path"
+    )
+
+    if _destination_is_current(dest, binding.source_sha256):
+        written = False
+    else:
+        data = verify_staged_source(
+            source, workspace_root=workspace_root, source_sha256=binding.source_sha256
+        )
+        _publish_atomically(dest, data)
+        written = True
+
+    # Nothing is deleted here. Invariant 8 forbids removing a staged input
+    # before the receipt carrying this evidence is durable, and this executor
+    # cannot know when that happens -- so the staged input survives, and the
+    # cleanup slice keyed off the published receipt is the only thing entitled
+    # to remove it.
+    return {
+        "kind": "project_file",
+        "source_path": binding.source_path,
+        "dest_path": binding.dest_path,
+        "source_sha256": binding.source_sha256,
+        "mode": "copy",
+        "written": written,
+    }

--- a/gr2/tests/test_project_file_materialization.py
+++ b/gr2/tests/test_project_file_materialization.py
@@ -238,31 +238,55 @@ class TestSingleRead(ProjectFileTestBase):
 
 
 class TestSourceConfinement(ProjectFileTestBase):
-    def test_source_outside_the_staging_inputs_prefix_is_rejected(self):
-        """Section 383. The decoy is in-workspace (so A's canonicalizer admits
-        it) and hashes correctly (so the content check does not fire first).
-        Only the staging-prefix guard can reject it."""
+    def test_the_pinned_schema_owns_staging_confinement(self):
+        """PREMISE, not a guard of this slice.
+
+        The design assumed §383 confinement was C's to enforce. It is not: the
+        spec says the source is "syntactically confined", and S4-A wired that
+        into the pinned v1 schema, so a planted in-workspace file never produces
+        a capability at all. Duplicating the check in the executor would be an
+        UNREACHABLE guard -- protection-shaped and untestable at its own level.
+
+        Pinned here so a loosened schema surfaces as this test failing, rather
+        than as a silently open hole in the executor."""
         planted = self.workspace_root / "units" / "u_test" / "planted.md"
         planted.parent.mkdir(parents=True, exist_ok=True)
         planted.write_bytes(FOUNDATION)
 
-        validated = self._validated([self._op(source_path="units/u_test/planted.md")])
-        with self.assertRaises(ProjectFileExecutionError) as ctx:
-            self._execute(validated)
-        self.assertIn("staging", str(ctx.exception))
+        with self.assertRaises(Exception) as ctx:
+            self._validated([self._op(source_path="units/u_test/planted.md")])
+        self.assertIn("pinned MaterializationPlan v1 schema", str(ctx.exception))
 
-    def test_source_that_becomes_a_symlink_after_validation_is_rejected(self):
-        """A's canonicalize_workspace_path already lstat-rejects a symlinked
-        source_path -- but only at VALIDATION. A symlink planted between
-        validation and execution never meets that guard, which is exactly why
-        this one has to exist at use. Same validation-vs-use gap S4-B closed
-        for the WorkspaceSpec."""
+    def test_the_canonicalizer_owns_the_post_validation_symlink(self):
+        """PREMISE, and a correction to this slice's own design note.
+
+        The design claimed A's symlink rejection ran only at validation, leaving
+        a validation-vs-use gap for C to close. It does not: the executor calls
+        canonicalize_workspace_path itself, and that lstat-walks every component
+        including the last, so a symlink planted between validation and
+        execution IS caught -- upstream, at execution time.
+
+        The class is still real (S4-B's WorkspaceSpec re-check was a genuine
+        instance); this particular path simply is not an instance of it."""
         validated = self._validated()
 
         outside = self.tmp / "outside-the-workspace"
         outside.write_bytes(FOUNDATION)
         self.source_path.unlink()
         self.source_path.symlink_to(outside)
+
+        with self.assertRaises(Exception) as ctx:
+            self._execute(validated)
+        self.assertIn("passes through a symlink", str(ctx.exception))
+
+    def test_an_irregular_staged_input_is_rejected(self):
+        """What is genuinely this guard's own: the input neither upstream check
+        sees. The schema is satisfied (the path is syntactically a staging
+        input), the canonicalizer is satisfied (no symlink anywhere), and the
+        thing sitting there is not a file anyone can project."""
+        validated = self._validated()
+        self.source_path.unlink()
+        os.mkfifo(self.source_path)
 
         with self.assertRaises(ProjectFileExecutionError) as ctx:
             self._execute(validated)

--- a/gr2/tests/test_project_file_materialization.py
+++ b/gr2/tests/test_project_file_materialization.py
@@ -1,0 +1,441 @@
+"""Staging / project_file executor tests (S4-C).
+
+The `project_file` operation is the FOUNDATION PROJECTION: premium compiles the
+foundation, stages it under an opaque artifact key, and gr2 projects it into the
+unit (for Codex, as `AGENTS.md`). Acceptance fruit 15 -- removing the projection
+makes the Codex startup assertion fail -- is what makes these bytes a contract
+rather than a convenience.
+
+Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
+      section 6.2.1 invariants 7 and 8, section 383 (source confinement),
+      acceptance fruit 14 / 15 / 22.
+
+Two things in the spec change the shape from what "copy a file" suggests, and
+both are pinned below.
+
+INVARIANT 7 IS A TRAP AS LITERALLY WORDED. It says verify the source's
+"reopened bytes match source_sha256". Read word-for-word -- reopen, hash, then
+copy -- that IS the read-1/read-2 TOCTOU: the bytes hashed and the bytes written
+come from two different reads and nothing binds them. The invariant is satisfied
+by the broken implementation. The correct reading is that the bytes you USE must
+be the bytes you HASHED, which means exactly one read.
+
+INVARIANT 8 MAKES THIS A LIFECYCLE. A staged input may not be deleted until the
+receipt carrying its evidence is atomically published and durable, and the spec
+names the wrong signal outright: "a successful destination write or in-memory
+operation result is not acknowledgement." So the executor deletes nothing, and
+an interrupted cleanup must be recoverable from the verified receipt.
+
+Masking analysis, run before implementation (S4-A/B discipline):
+
+  1. Staging confinement is masked by A's canonicalize_workspace_path, which
+     only proves in-workspace, AND by the hash check, which kills a wrong-content
+     decoy first. The decoy must be in-workspace AND correct-hash AND outside
+     .grip/staging/inputs/.
+  2. The regular-non-symlink check is masked by A's canonicalizer ACROSS TIME:
+     A already rejects a symlinked source_path, so a symlink present at
+     validation never reaches this guard. The probe creates it BETWEEN
+     validation and execution -- the same validation-time-vs-use-time gap S4-B
+     closed for the WorkspaceSpec.
+  3. Staged-input survival is masked by success itself: an executor that copies
+     then deletes passes every content assertion while leaving the receipt with
+     no recoverable input.
+  4. The single-read probe is masked by read MECHANISM -- poisoning
+     Path.read_bytes does nothing to an implementation that copies via
+     shutil.copy(). The sweep carries a copies-via-shutil mutant to validate
+     THIS PROBE, not just the code.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gr2.python_cli.file_exec import (
+    ProjectFileExecutionError,
+    cleanup_staged_inputs,
+    execute_project_file_operation,
+)
+from gr2.python_cli.spec_apply import (
+    validate_materialization_plan,
+    workspace_spec_path,
+    write_materialization_receipt,
+)
+
+FOUNDATION = b"# Foundation\n\ncharim toward the most high.\n"
+POISON = b"# Foundation\n\nrm -rf / # injected after the hash check\n"
+
+
+class ProjectFileTestBase(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self.tmp = Path(tempfile.mkdtemp())
+        self.workspace_root = self.tmp / "workspace"
+        self.workspace_root.mkdir(parents=True)
+        self.spec_sha256 = self._write_workspace_spec()
+
+        self.artifact_key = "a_7f3a9c"
+        self.source_rel = f".grip/staging/inputs/{self.artifact_key}"
+        self.source_path = self.workspace_root / ".grip" / "staging" / "inputs" / self.artifact_key
+        self.source_path.parent.mkdir(parents=True, exist_ok=True)
+        self.source_path.write_bytes(FOUNDATION)
+        self.source_sha256 = hashlib.sha256(FOUNDATION).hexdigest()
+
+        self.dest_rel = "units/u_test/home/AGENTS.md"
+        self.dest_path = self.workspace_root / self.dest_rel
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_workspace_spec(self, content: str = 'workspace_name = "test"\n') -> str:
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_path.write_text(content)
+        return hashlib.sha256(spec_path.read_bytes()).hexdigest()
+
+    def _op(self, **overrides: object) -> dict[str, object]:
+        op: dict[str, object] = {
+            "kind": "project_file",
+            "source_path": self.source_rel,
+            "dest_path": self.dest_rel,
+            "source_sha256": self.source_sha256,
+            "mode": "copy",
+        }
+        op.update(overrides)
+        return op
+
+    def _validated(self, operations: list[dict[str, object]] | None = None, **plan_overrides):
+        plan: dict[str, object] = {
+            "schema_version": 1,
+            "plan_id": "mp_test",
+            "unit_key": "u_test",
+            "workspace_spec_sha256": self.spec_sha256,
+            "operations": operations if operations is not None else [self._op()],
+        }
+        plan.update(plan_overrides)
+        return validate_materialization_plan(self.workspace_root, plan)
+
+    def _execute(self, validated=None, index: int = 0) -> dict[str, object]:
+        return execute_project_file_operation(
+            validated if validated is not None else self._validated(),
+            index,
+            workspace_root=self.workspace_root,
+        )
+
+
+class TestProjection(ProjectFileTestBase):
+    def test_projects_the_staged_foundation_to_its_declared_destination(self):
+        evidence = self._execute()
+
+        self.assertEqual(self.dest_path.read_bytes(), FOUNDATION)
+        self.assertEqual(evidence["kind"], "project_file")
+        self.assertIs(evidence["written"], True)
+
+    def test_declared_hash_mismatch_is_rejected_and_nothing_is_written(self):
+        wrong = hashlib.sha256(b"something else").hexdigest()
+        validated = self._validated([self._op(source_sha256=wrong)])
+
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            self._execute(validated)
+        self.assertIn("source_sha256", str(ctx.exception))
+        self.assertFalse(self.dest_path.exists())
+
+    def test_unchanged_rerun_writes_nothing(self):
+        """Acceptance fruit 22. Distinct from 'the bytes are correct': a second
+        run that rewrites identical bytes is still a write, and on the timed
+        path a projection that churns every apply is a projection that cannot
+        be trusted as a no-op."""
+        self._execute()
+        first_mtime = self.dest_path.stat().st_mtime_ns
+
+        evidence = self._execute()
+
+        self.assertIs(evidence["written"], False)
+        self.assertEqual(self.dest_path.stat().st_mtime_ns, first_mtime)
+
+    def test_stale_projection_is_replaced(self):
+        """Acceptance fruit 15 requires the projection to be RE-ESTABLISHED.
+        Deliberate asymmetry with S4-B, which blocks on a dirty clone: a clone
+        holds the operator's own work, a projected file is derived output the
+        plan owns."""
+        self.dest_path.parent.mkdir(parents=True, exist_ok=True)
+        self.dest_path.write_bytes(b"stale foundation from a previous plan\n")
+
+        evidence = self._execute()
+
+        self.assertEqual(self.dest_path.read_bytes(), FOUNDATION)
+        self.assertIs(evidence["written"], True)
+
+    def test_removing_the_projection_makes_the_next_apply_restore_it(self):
+        """Acceptance fruit 15, in the direction the harness asserts it."""
+        self._execute()
+        self.dest_path.unlink()
+
+        self._execute()
+        self.assertEqual(self.dest_path.read_bytes(), FOUNDATION)
+
+
+class TestSingleRead(ProjectFileTestBase):
+    def test_bytes_written_are_the_bytes_that_were_hashed(self):
+        """Invariant 7's actual meaning, against its literal wording.
+
+        The source is swapped the instant it is first read. A single-read
+        executor already holds the verified buffer and writes it. A
+        reopen-then-copy executor -- which satisfies 'reopened bytes match
+        source_sha256' word for word -- writes the poison.
+
+        The assertion is on the DESTINATION CONTENT, not on a read count: an
+        implementation may legitimately read once and buffer, and counting
+        would pin the mechanism instead of the property."""
+        real_read_bytes = Path.read_bytes
+
+        def poisoning_read(self_path):
+            data = real_read_bytes(self_path)
+            if os.path.abspath(self_path) == os.path.abspath(self.source_path):
+                real_write = Path.write_bytes
+                real_write(self_path, POISON)
+            return data
+
+        with patch.object(Path, "read_bytes", poisoning_read):
+            self._execute()
+
+        self.assertEqual(
+            self.dest_path.read_bytes(),
+            FOUNDATION,
+            "the projection carries bytes that were never hashed -- the source "
+            "was swapped between the verification read and the copy",
+        )
+
+    def test_a_source_swapped_before_any_read_is_still_caught(self):
+        """The complement, so the single-read fix cannot be mistaken for
+        'trust the first read': if the swap happens before execution, the hash
+        check is what must fire."""
+        self.source_path.write_bytes(POISON)
+
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            self._execute()
+        self.assertIn("source_sha256", str(ctx.exception))
+        self.assertFalse(self.dest_path.exists())
+
+
+class TestSourceConfinement(ProjectFileTestBase):
+    def test_source_outside_the_staging_inputs_prefix_is_rejected(self):
+        """Section 383. The decoy is in-workspace (so A's canonicalizer admits
+        it) and hashes correctly (so the content check does not fire first).
+        Only the staging-prefix guard can reject it."""
+        planted = self.workspace_root / "units" / "u_test" / "planted.md"
+        planted.parent.mkdir(parents=True, exist_ok=True)
+        planted.write_bytes(FOUNDATION)
+
+        validated = self._validated([self._op(source_path="units/u_test/planted.md")])
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            self._execute(validated)
+        self.assertIn("staging", str(ctx.exception))
+
+    def test_source_that_becomes_a_symlink_after_validation_is_rejected(self):
+        """A's canonicalize_workspace_path already lstat-rejects a symlinked
+        source_path -- but only at VALIDATION. A symlink planted between
+        validation and execution never meets that guard, which is exactly why
+        this one has to exist at use. Same validation-vs-use gap S4-B closed
+        for the WorkspaceSpec."""
+        validated = self._validated()
+
+        outside = self.tmp / "outside-the-workspace"
+        outside.write_bytes(FOUNDATION)
+        self.source_path.unlink()
+        self.source_path.symlink_to(outside)
+
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            self._execute(validated)
+        self.assertIn("regular file", str(ctx.exception))
+
+    def test_missing_staged_input_is_rejected(self):
+        validated = self._validated()
+        self.source_path.unlink()
+
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            self._execute(validated)
+        self.assertIn("staged input", str(ctx.exception))
+
+
+class TestStagedInputLifecycle(ProjectFileTestBase):
+    def test_a_successful_projection_does_not_delete_the_staged_input(self):
+        """Invariant 8, and the spec names the proxy it is warning against: 'a
+        successful destination write or in-memory operation result is not
+        acknowledgement.' An executor that copies then deletes passes every
+        content assertion while leaving the receipt with no recoverable
+        input."""
+        self._execute()
+
+        self.assertTrue(
+            self.source_path.exists(),
+            "the staged input was deleted before any receipt was published; a "
+            "crash here loses the only recoverable copy",
+        )
+
+    def test_cleanup_removes_staged_inputs_only_after_the_receipt_is_published(self):
+        validated = self._validated()
+        evidence = self._execute(validated)
+        receipt_path = write_materialization_receipt(
+            self.workspace_root, validated, [evidence]
+        )
+
+        removed = cleanup_staged_inputs(
+            validated, workspace_root=self.workspace_root, receipt_path=receipt_path
+        )
+
+        self.assertEqual(removed, [self.source_rel])
+        self.assertFalse(self.source_path.exists())
+        self.assertEqual(self.dest_path.read_bytes(), FOUNDATION)
+
+    def test_interrupted_cleanup_is_completed_idempotently_from_the_receipt(self):
+        """Invariant 8's tail: 'if cleanup is interrupted after receipt
+        publication, rerun performs the idempotent cleanup from the verified
+        receipt.' The recovery reads the RECEIPT, not ambient filesystem
+        state -- the receipt is the only durable record of which inputs this
+        plan is entitled to remove."""
+        validated = self._validated()
+        evidence = self._execute(validated)
+        receipt_path = write_materialization_receipt(
+            self.workspace_root, validated, [evidence]
+        )
+        self.assertTrue(self.source_path.exists(), "precondition: cleanup has not run")
+
+        cleanup_staged_inputs(
+            validated, workspace_root=self.workspace_root, receipt_path=receipt_path
+        )
+        self.assertFalse(self.source_path.exists())
+
+        again = cleanup_staged_inputs(
+            validated, workspace_root=self.workspace_root, receipt_path=receipt_path
+        )
+        self.assertEqual(again, [], "a second cleanup must be a no-op, not an error")
+
+    def test_cleanup_refuses_a_receipt_belonging_to_another_plan(self):
+        """Cleanup DELETES, driven by a file on disk. Without this it is a
+        primitive that removes whatever some other plan's receipt happens to
+        name."""
+        validated = self._validated()
+        evidence = self._execute(validated)
+        receipt_path = write_materialization_receipt(
+            self.workspace_root, validated, [evidence]
+        )
+
+        other = self._validated(plan_id="mp_other")
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            cleanup_staged_inputs(
+                other, workspace_root=self.workspace_root, receipt_path=receipt_path
+            )
+        self.assertIn("does not acknowledge", str(ctx.exception))
+        self.assertTrue(self.source_path.exists())
+
+    def test_cleanup_refuses_a_receipt_that_is_not_durable(self):
+        validated = self._validated()
+        self._execute(validated)
+
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            cleanup_staged_inputs(
+                validated,
+                workspace_root=self.workspace_root,
+                receipt_path=self.workspace_root / ".grip" / "state" / "materialization" / "absent.json",
+            )
+        self.assertIn("receipt", str(ctx.exception))
+        self.assertTrue(self.source_path.exists())
+
+
+class TestPublicationOrdering(ProjectFileTestBase):
+    def test_a_projection_failing_verification_never_appears_at_dest(self):
+        """Carried directly from S4-B's survivor: an end-state assertion cannot
+        see an ordering property, because a write-then-delete-on-failure
+        implementation reaches an identical end state. What differs is the
+        transient, and the transient is what a crash freezes -- here, a
+        half-written AGENTS.md that Codex would read on startup.
+
+        So the assertion is on what was true AT the failure instant."""
+        from gr2.python_cli import file_exec
+
+        observed: dict[str, object] = {}
+        real_verify = file_exec.verify_staged_source
+
+        def failing_verify(*args, **kwargs):
+            observed["dest_existed"] = self.dest_path.exists()
+            real_verify(*args, **kwargs)
+            raise ProjectFileExecutionError("injected verification failure")
+
+        with patch.object(file_exec, "verify_staged_source", failing_verify):
+            with self.assertRaises(ProjectFileExecutionError):
+                self._execute()
+
+        self.assertIs(observed["dest_existed"], False)
+        self.assertFalse(self.dest_path.exists())
+
+    def test_no_temporary_file_survives_a_successful_projection(self):
+        self._execute()
+        siblings = sorted(p.name for p in self.dest_path.parent.iterdir())
+        self.assertEqual(siblings, ["AGENTS.md"], f"temp file leaked: {siblings}")
+
+
+class TestExecutorBinding(ProjectFileTestBase):
+    def test_evidence_is_receipt_shaped_and_identity_free(self):
+        validated = self._validated()
+        evidence = self._execute(validated)
+        receipt_path = write_materialization_receipt(
+            self.workspace_root, validated, [evidence]
+        )
+
+        receipt = json.loads(receipt_path.read_text())
+        self.assertEqual(receipt["operations"][0]["kind"], "project_file")
+        self.assertEqual(receipt["stage"], "MATERIALIZED")
+
+    def test_executing_against_a_different_workspace_root_is_rejected(self):
+        validated = self._validated()
+        other_root = self.tmp / "other-workspace"
+        other_spec = workspace_spec_path(other_root)
+        other_spec.parent.mkdir(parents=True, exist_ok=True)
+        other_spec.write_text('workspace_name = "other"\n')
+
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            execute_project_file_operation(validated, 0, workspace_root=other_root)
+        self.assertIn("WorkspaceSpec", str(ctx.exception))
+
+    def test_a_tampered_capability_cannot_execute(self):
+        validated = self._validated()
+        object.__setattr__(validated, "plan_id", "mp_swapped")
+
+        with self.assertRaises(Exception) as ctx:
+            self._execute(validated)
+        self.assertIn("capability is invalid", str(ctx.exception))
+
+    def test_a_copied_capability_cannot_execute(self):
+        import dataclasses
+
+        copied = dataclasses.replace(self._validated())
+        with self.assertRaises(Exception) as ctx:
+            self._execute(copied)
+        self.assertIn("capability is invalid", str(ctx.exception))
+
+    def test_a_non_project_file_operation_is_refused_by_index(self):
+        validated = self._validated(
+            [
+                {
+                    "kind": "venv",
+                    "dest_path": "units/u_test/home/.venv",
+                    "engine": "uv",
+                    "python": "3.11",
+                },
+                self._op(),
+            ]
+        )
+        with self.assertRaises(ProjectFileExecutionError) as ctx:
+            self._execute(validated, 0)
+        self.assertIn("is kind 'venv'", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gr2/tests/test_project_file_materialization.py
+++ b/gr2/tests/test_project_file_materialization.py
@@ -20,11 +20,25 @@ come from two different reads and nothing binds them. The invariant is satisfied
 by the broken implementation. The correct reading is that the bytes you USE must
 be the bytes you HASHED, which means exactly one read.
 
-INVARIANT 8 MAKES THIS A LIFECYCLE. A staged input may not be deleted until the
-receipt carrying its evidence is atomically published and durable, and the spec
-names the wrong signal outright: "a successful destination write or in-memory
-operation result is not acknowledgement." So the executor deletes nothing, and
-an interrupted cleanup must be recoverable from the verified receipt.
+INVARIANT 8 IS SPLIT ACROSS TWO SLICES, deliberately (Stromus 2026-07-27). The
+invariant reads: a staged input may not be deleted until the receipt carrying
+its evidence is atomically published and durable -- and it names the wrong
+signal outright, "a successful destination write or in-memory operation result
+is not acknowledgement."
+
+That is stated entirely as a NEGATIVE constraint on deletion timing, so a slice
+that never deletes satisfies it trivially. C's whole contribution to invariant 8
+is therefore that negative discipline: **C deletes nothing**, and staged inputs
+demonstrably survive a successful projection. The receipt-keyed idempotent
+cleanup is its own later slice, because a delete driven by a file on disk --
+one that must REFUSE a receipt that does not acknowledge its plan -- is a
+distinct and dangerous operation that deserves its own review surface. Never
+bundle a delete with a copy.
+
+The carve has a consequence C must carry, which is why
+test_a_rerun_after_cleanup_succeeds_from_the_destination_alone exists: once the
+cleanup slice runs, a later apply finds no staged input, so an executor that
+demanded one would break on the system's own normal sequence.
 
 Masking analysis, run before implementation (S4-A/B discipline):
 
@@ -56,7 +70,6 @@ from unittest.mock import patch
 
 from gr2.python_cli.file_exec import (
     ProjectFileExecutionError,
-    cleanup_staged_inputs,
     execute_project_file_operation,
 )
 from gr2.python_cli.spec_apply import (
@@ -255,7 +268,7 @@ class TestSourceConfinement(ProjectFileTestBase):
             self._execute(validated)
         self.assertIn("regular file", str(ctx.exception))
 
-    def test_missing_staged_input_is_rejected(self):
+    def test_missing_staged_input_with_no_current_projection_is_rejected(self):
         validated = self._validated()
         self.source_path.unlink()
 
@@ -264,7 +277,7 @@ class TestSourceConfinement(ProjectFileTestBase):
         self.assertIn("staged input", str(ctx.exception))
 
 
-class TestStagedInputLifecycle(ProjectFileTestBase):
+class TestStagedInputSurvival(ProjectFileTestBase):
     def test_a_successful_projection_does_not_delete_the_staged_input(self):
         """Invariant 8, and the spec names the proxy it is warning against: 'a
         successful destination write or in-memory operation result is not
@@ -279,74 +292,40 @@ class TestStagedInputLifecycle(ProjectFileTestBase):
             "crash here loses the only recoverable copy",
         )
 
-    def test_cleanup_removes_staged_inputs_only_after_the_receipt_is_published(self):
-        validated = self._validated()
-        evidence = self._execute(validated)
-        receipt_path = write_materialization_receipt(
-            self.workspace_root, validated, [evidence]
-        )
+    def test_a_rerun_after_cleanup_succeeds_from_the_destination_alone(self):
+        """The consequence of carving cleanup into its own slice, and the
+        reason C cannot simply require the staged input to exist.
 
-        removed = cleanup_staged_inputs(
-            validated, workspace_root=self.workspace_root, receipt_path=receipt_path
-        )
+        Run the sequence forward: C projects -> receipt publishes -> the
+        cleanup slice deletes the staged input -> someone applies again. The
+        input is gone. An executor that demands a source would make the SECOND
+        apply fail, so C and the cleanup slice together would produce a system
+        that breaks on its own normal sequence.
 
-        self.assertEqual(removed, [self.source_rel])
-        self.assertFalse(self.source_path.exists())
+        A destination already hashing to source_sha256 IS proof the projection
+        is current -- the hash is the contract, and satisfying it needs no
+        source read. Note this short-circuit only reaches a rerun: on a first
+        apply dest does not exist, so every source guard still runs."""
+        self._execute()
+        self.source_path.unlink()  # the cleanup slice, having done its job
+
+        evidence = self._execute()
+
+        self.assertIs(evidence["written"], False)
         self.assertEqual(self.dest_path.read_bytes(), FOUNDATION)
 
-    def test_interrupted_cleanup_is_completed_idempotently_from_the_receipt(self):
-        """Invariant 8's tail: 'if cleanup is interrupted after receipt
-        publication, rerun performs the idempotent cleanup from the verified
-        receipt.' The recovery reads the RECEIPT, not ambient filesystem
-        state -- the receipt is the only durable record of which inputs this
-        plan is entitled to remove."""
-        validated = self._validated()
-        evidence = self._execute(validated)
-        receipt_path = write_materialization_receipt(
-            self.workspace_root, validated, [evidence]
-        )
-        self.assertTrue(self.source_path.exists(), "precondition: cleanup has not run")
-
-        cleanup_staged_inputs(
-            validated, workspace_root=self.workspace_root, receipt_path=receipt_path
-        )
-        self.assertFalse(self.source_path.exists())
-
-        again = cleanup_staged_inputs(
-            validated, workspace_root=self.workspace_root, receipt_path=receipt_path
-        )
-        self.assertEqual(again, [], "a second cleanup must be a no-op, not an error")
-
-    def test_cleanup_refuses_a_receipt_belonging_to_another_plan(self):
-        """Cleanup DELETES, driven by a file on disk. Without this it is a
-        primitive that removes whatever some other plan's receipt happens to
-        name."""
-        validated = self._validated()
-        evidence = self._execute(validated)
-        receipt_path = write_materialization_receipt(
-            self.workspace_root, validated, [evidence]
-        )
-
-        other = self._validated(plan_id="mp_other")
-        with self.assertRaises(ProjectFileExecutionError) as ctx:
-            cleanup_staged_inputs(
-                other, workspace_root=self.workspace_root, receipt_path=receipt_path
-            )
-        self.assertIn("does not acknowledge", str(ctx.exception))
-        self.assertTrue(self.source_path.exists())
-
-    def test_cleanup_refuses_a_receipt_that_is_not_durable(self):
-        validated = self._validated()
-        self._execute(validated)
+    def test_a_stale_destination_still_demands_the_staged_input(self):
+        """The boundary of that short-circuit. If dest does NOT satisfy the
+        declared hash, the projection is not current and the source is
+        genuinely required -- otherwise 'dest exists' would quietly become
+        sufficient and a stale AGENTS.md would survive forever."""
+        self._execute()
+        self.dest_path.write_bytes(b"stale\n")
+        self.source_path.unlink()
 
         with self.assertRaises(ProjectFileExecutionError) as ctx:
-            cleanup_staged_inputs(
-                validated,
-                workspace_root=self.workspace_root,
-                receipt_path=self.workspace_root / ".grip" / "state" / "materialization" / "absent.json",
-            )
-        self.assertIn("receipt", str(ctx.exception))
-        self.assertTrue(self.source_path.exists())
+            self._execute()
+        self.assertIn("staged input", str(ctx.exception))
 
 
 class TestPublicationOrdering(ProjectFileTestBase):


### PR DESCRIPTION
## Summary

S4-C: the `project_file` executor — the **foundation projection**. Premium compiles the foundation, stages it under an opaque artifact key, and gr2 projects it into the unit (for Codex, as `AGENTS.md`). Acceptance fruit 15 — *removing the projection makes the Codex startup assertion fail* — is what makes these bytes a contract rather than a convenience.

Base `main`, rebased onto B's merge (`3310165`) so the stack is flat. Ref #797 (the S4 slice split).

**Premium boundary: gitgrip is OSS.** Projecting declared bytes to a declared path. No identity read, derived, or persisted; every evidence key is neutral and passes S4-A's recursive identity screen.

**Reviewers: Atlas + Sentinel.** **Prototype posture** per Layne 2026-07-27 — working end-to-end, not exhaustively hardened. Block only on demo-breaking; new hardening → `deferred-hardening` issue + merge.

## Invariant 7 is a trap as literally worded

> Verify `project_file.source_path` is a regular, non-symlink file … and that its **reopened bytes** match `source_sha256`.

Read word for word — reopen, hash, then copy — **that is the read-1/read-2 TOCTOU**: the bytes hashed and the bytes written come from two different reads with nothing binding them. The conforming-sounding implementation is the vulnerable one.

`verify_staged_source` therefore **returns the buffer it hashed**, and the caller writes exactly those bytes. One read. A verifier that answers `True` and leaves the caller to reopen has verified one read and authorised a different one.

Same conclusion S4-A reached about `consume()`: the fix is not *check again*, it is *stop re-reading*. (Stromus is filing the spec-wording correction separately so the next implementer cannot conform their way into the hole.)

## Invariant 8: this slice deletes nothing

Invariant 8 forbids removing a staged input before the receipt carrying its evidence is durable, and names the wrong signal outright — *"a successful destination write or in-memory operation result is not acknowledgement."*

That is a purely **negative** constraint on deletion timing, so a slice that never deletes satisfies it, and **that negative discipline is C's whole contribution to it**. Receipt-keyed cleanup is its own later slice (skeleton already written): a delete driven by a file on disk, which must *refuse* a receipt that does not acknowledge its plan, deserves its own review surface. Never bundle a delete with a copy.

### The carve's consequence, which C has to carry

Run the sequence forward: C projects → receipt publishes → the cleanup slice deletes the staged input → someone applies again. **The input is gone.** An executor that demanded a source would make the *second* apply fail — two slices, each correct alone, breaking together on the system's own normal sequence.

So a destination already hashing to `source_sha256` **is** proof the projection is current, and short-circuits before the source is touched. Two probes pin both sides: the rerun-after-cleanup path, and the boundary where a **stale** destination still demands the input, so "dest exists" cannot quietly become sufficient and leave a stale `AGENTS.md` forever.

The short-circuit only reaches reruns — on a first apply the destination does not exist and every source guard runs.

## Two guards this slice's design claimed, that are owned upstream

Both are **deliberately absent rather than duplicated**, because an unreachable guard reads as protection while being untestable at its own level (S4-A's round-4 conclusion, now applied to my own design):

| Guard | Actually owned by |
|---|---|
| §383 staging confinement | **A's pinned v1 schema**, syntactically, at validation. The spec's word is "syntactically", and A wired it — a planted in-workspace `source_path` never produces a capability at all. |
| post-validation symlink | **A's `canonicalize_workspace_path` at EXECUTION.** The executor calls it, and it lstat-walks every component including the last. |

The design note claimed the second was a validation-vs-use gap for C to close. **It is not.** The class is real — S4-B's WorkspaceSpec re-check was a genuine instance — but this path is not an instance of it, and saying so is cheaper than shipping a guard no input can reach.

Both facts are now **premise tests**, so a loosened schema or canonicalizer surfaces there rather than as a silently open hole. What remains genuinely this guard's own is the input neither upstream check sees: a path that exists, is not a symlink, and is not a regular file — probed with a **FIFO**.

## B's round-2 lessons carried forward without being asked twice

- `workspace_root` normalised to a plain `Path` **before** verification — a caller-supplied `Path` subclass can run code from its dunders during path work, which is the callback that reopens the check/use window.
- Every operation field captured into one immutable `_ProjectFileBinding`, so a post-verification swap is irrelevant rather than merely detectable.

## Publication

Same-directory temp → write → flush → `fsync` → atomic replace → parent `fsync`. A half-written `AGENTS.md` is worse than none: Codex reads it on startup, so a truncated foundation is a *silently wrong* one rather than a loud failure.

## Deliberate asymmetry with B

**B blocks on a dirty clone and never resets it; C overwrites a stale projection.**

That is a decision, not drift: a clone holds the operator's own authored work, whereas a projection is plan-owned derived output and fruit 15 requires it re-established. The invariant in one line:

> **Protect authored work, freely rebuild derived output.**

An unchanged rerun still writes nothing (fruit 22).

## Verification

- **21 C tests.** **683 passed** on Python **3.11.9** and **3.13.2** (full gr2 suite, post-rebase, with B's round-2 fixes in tree).
- `ruff check` clean on both new files.
- No mutation sweep this slice — prototype posture. The sweep harness (`sweep_s4b.py`, 41/41 with declared victims) is reusable when C is hardened.

## Known deferred

`_require_workspace_binding` is duplicated from `clone_exec` rather than imported — that one raises `CloneExecutionError`, and a `project_file` failure reporting a *clone* error is worse than twelve duplicated lines. The shared executor scaffolding wants extracting into one `exec_common` module; deferred so it does not land inside a slice PR.