### PR TITLE
feat: S4-D venv + editable_install executors (completes the materialize path)

### DIFF
--- a/gr2/python_cli/env_exec.py
+++ b/gr2/python_cli/env_exec.py
@@ -1,0 +1,419 @@
+"""Executors for the `venv` and `editable_install` operations (S4-D).
+
+The last two materialization handlers. With these, the A -> B -> C -> D path is
+complete: contract, clones, projections, environments.
+
+Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
+      section 9.2, section 6.2.1 invariant 6, acceptance fruit 10/11/12.
+
+Working, not exhaustively hardened (Layne's 2026-07-27 prototype doctrine).
+
+INVARIANT 6 IS THE INTERESTING ONE, and it is written as a warning about
+proxies: "Treat an existing venv as valid only when pyvenv.cfg is a regular file
+AND the platform interpreter is present, executable, and succeeds under an
+isolated bounded probe. The probe must report a resolved sys.prefix equal to the
+declared venv path and a distinct sys.base_prefix. FILE PRESENCE ALONE IS NOT
+VENV EVIDENCE."
+
+That last sentence is the spec naming the mask itself. `pyvenv.cfg exists` is
+the cheap check that LOOKS like venv validation, and it stays true for a venv
+whose interpreter was deleted, whose base Python was upgraded out from under it,
+or which was copied to a new path (the config records the OLD prefix, so every
+relative path inside it is wrong). Only running the interpreter can tell.
+
+The spec's TWO PREFIX ASSERTIONS ARE KEPT BUT CANNOT FIRE on CPython 3.11+, and
+that was established by running it rather than by reading the docs:
+
+  - pyvenv.cfg next to bin/python is LITERALLY what makes a venv, so base_prefix
+    always differs from prefix -- even when the file contains garbage. A "bare
+    interpreter plus a pyvenv.cfg" is a real venv by Python's own rules.
+  - sys.prefix is derived from the directory you INVOKED THROUGH, not from
+    anything recorded inside, so it equals the declared path even when
+    bin/python symlinks to a different venv's interpreter -- and a COPIED venv
+    is self-consistent at its new location.
+
+They stay because the spec mandates them and a future Python may behave
+differently; they are defence in depth, not live guards, and saying so beats
+leaving them looking like protection. test_the_prefix_assertions_cannot_fire_on_
+current_cpython pins the empirical finding and FAILS if CPython ever changes,
+which is the signal that they have become reachable and deserve real probes.
+
+What the probe genuinely catches today is the reachable set: an interpreter that
+is missing, not executable, failing, or hanging, and a missing pyvenv.cfg. Those
+are the real content of "file presence alone is not venv evidence".
+
+FRUIT 11's `python -I` IS LOAD-BEARING, not decoration. Without isolation, an
+import can be satisfied by the current working directory or an inherited
+PYTHONPATH, so a passing import proves nothing about what the venv installed.
+`-I` ignores both, which is what makes "resolves inside that unit clone" a real
+claim.
+"""
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from .spec_apply import (
+    MaterializationPlanError,
+    ValidatedPlan,
+    _read_canonical_workspace_spec_bytes,
+    canonicalize_workspace_path,
+)
+
+# A venv probe that hangs would hang the timed path, and section 13 gives the
+# whole materialization 180s. Bounded, per invariant 6's "bounded probe".
+_PROBE_TIMEOUT_SECONDS = 30
+_INSTALL_TIMEOUT_SECONDS = 300
+
+
+class EnvExecutionError(MaterializationPlanError):
+    """A validated plan's venv or editable_install operation could not run."""
+
+
+@dataclasses.dataclass(frozen=True)
+class _VenvBinding:
+    dest_path: str
+    engine: str
+    python: str
+
+
+@dataclasses.dataclass(frozen=True)
+class _EditableBinding:
+    venv_path: str
+    source_path: str
+    extras: tuple[str, ...]
+
+
+def venv_interpreter(venv_root: Path) -> Path:
+    """Platform interpreter inside a venv. Windows puts it in Scripts/."""
+    if os.name == "nt":
+        return venv_root / "Scripts" / "python.exe"
+    return venv_root / "bin" / "python"
+
+
+def _require_workspace_binding(validated: ValidatedPlan, workspace_root: Path) -> None:
+    """Re-prove at USE what validation proved earlier -- see S4-B/S4-C. Local
+    rather than imported so the error names THIS layer; the shared executor
+    scaffolding wants extracting into one module, deferred."""
+    try:
+        spec_bytes = _read_canonical_workspace_spec_bytes(workspace_root)
+    except MaterializationPlanError as exc:
+        raise EnvExecutionError(
+            f"cannot execute against {workspace_root}: its canonical WorkspaceSpec is "
+            f"unreadable ({exc})"
+        ) from exc
+    if hashlib.sha256(spec_bytes).hexdigest() != validated.workspace_spec_sha256:
+        raise EnvExecutionError(
+            f"plan is bound to WorkspaceSpec {validated.workspace_spec_sha256} but "
+            f"{workspace_root} has a different one -- executing a plan against a "
+            "workspace it was not validated for would resolve every path elsewhere"
+        )
+
+
+def _operation_at(
+    validated: ValidatedPlan, index: int, expected_kind: str
+) -> dict[str, object]:
+    operations = validated.plan["operations"]
+    if not 0 <= index < len(operations):
+        raise EnvExecutionError(
+            f"operation index {index} is out of range for a plan with "
+            f"{len(operations)} operation(s)"
+        )
+    op = operations[index]
+    kind = op.get("kind")
+    if kind != expected_kind:
+        raise EnvExecutionError(
+            f"operations[{index}] is kind {kind!r}, not {expected_kind!r} -- evidence "
+            "must correspond to its operation, in order"
+        )
+    return op
+
+
+def probe_venv(venv_root: Path) -> dict[str, str]:
+    """Run the venv's own interpreter and ask it where it thinks it lives.
+
+    Invariant 6's bounded probe. `-I` isolates: no site-packages from the user
+    base, no inherited PYTHONPATH, no cwd on sys.path -- so the answer describes
+    the venv rather than the environment this process happens to be running in.
+
+    Raises rather than returning a sentinel: every caller treats a probe failure
+    as 'this is not a usable venv', and a sentinel invites a caller that forgets
+    to check it."""
+    interpreter = venv_interpreter(venv_root)
+    if not interpreter.exists():
+        raise EnvExecutionError(
+            f"venv at {venv_root} has no interpreter at {interpreter} -- pyvenv.cfg "
+            "presence alone is not venv evidence (invariant 6)"
+        )
+    if not os.access(interpreter, os.X_OK):
+        raise EnvExecutionError(
+            f"venv interpreter {interpreter} is not executable"
+        )
+    script = (
+        "import json,sys;"
+        "print(json.dumps({'prefix':sys.prefix,'base_prefix':sys.base_prefix,"
+        "'version':'%d.%d'%sys.version_info[:2]}))"
+    )
+    try:
+        proc = subprocess.run(
+            [str(interpreter), "-I", "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise EnvExecutionError(
+            f"venv interpreter {interpreter} did not answer within "
+            f"{_PROBE_TIMEOUT_SECONDS}s -- a hung probe would hang the timed path"
+        ) from exc
+    if proc.returncode != 0:
+        raise EnvExecutionError(
+            f"venv interpreter {interpreter} failed to run: "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise EnvExecutionError(
+            f"venv probe returned unparseable output: {proc.stdout!r}"
+        ) from exc
+
+
+def verify_venv(venv_root: Path) -> dict[str, str]:
+    """Invariant 6 in full. Returns the probe result for receipt evidence."""
+    cfg = venv_root / "pyvenv.cfg"
+    if not cfg.is_file():
+        raise EnvExecutionError(
+            f"venv at {venv_root} has no pyvenv.cfg regular file"
+        )
+    probe = probe_venv(venv_root)
+
+    # Orthogonal to the prefix check below: a bare system interpreter satisfies
+    # 'prefix == declared path' only by accident, but ALWAYS has
+    # base_prefix == prefix. This is what distinguishes a venv from a Python.
+    if probe["base_prefix"] == probe["prefix"]:
+        raise EnvExecutionError(
+            f"{venv_root} is not a virtual environment: its interpreter reports "
+            f"base_prefix == prefix ({probe['prefix']})"
+        )
+
+    # And this is what distinguishes THIS venv from one that was copied or moved
+    # here -- pyvenv.cfg would still parse, the interpreter would still run, and
+    # every relative path inside it would point at the old location.
+    if Path(probe["prefix"]).resolve() != venv_root.resolve():
+        raise EnvExecutionError(
+            f"venv at {venv_root} reports sys.prefix {probe['prefix']} -- it was "
+            "created for a different path and its internal paths are stale"
+        )
+    return probe
+
+
+def execute_venv_operation(
+    validated: ValidatedPlan, index: int, *, workspace_root: Path
+) -> dict[str, object]:
+    """Create (or accept) the unit venv at `dest_path` using `uv`."""
+    workspace_root = Path(os.fspath(workspace_root))
+    validated.verify(require_provenance=True)
+    _require_workspace_binding(validated, workspace_root)
+
+    op = _operation_at(validated, index, "venv")
+    binding = _VenvBinding(
+        dest_path=str(op["dest_path"]),
+        engine=str(op["engine"]),
+        python=str(op["python"]),
+    )
+    dest = canonicalize_workspace_path(
+        workspace_root, binding.dest_path, field_name=f"operations[{index}].dest_path"
+    )
+
+    reused = False
+    if dest.exists():
+        # Validate every time, not only on creation: invariant 5's rule for
+        # clones applies here too -- path absence must not be the condition that
+        # makes validation reachable.
+        probe = verify_venv(dest)
+        reused = True
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        proc = subprocess.run(
+            ["uv", "venv", "--python", binding.python, str(dest)],
+            capture_output=True,
+            text=True,
+            timeout=_INSTALL_TIMEOUT_SECONDS,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise EnvExecutionError(
+                f"uv venv failed for {dest} with python {binding.python!r}:\n"
+                f"{proc.stderr.strip() or proc.stdout.strip()}"
+            )
+        probe = verify_venv(dest)
+
+    return {
+        "kind": "venv",
+        "dest_path": binding.dest_path,
+        "engine": binding.engine,
+        "python": binding.python,
+        "interpreter_version": probe["version"],
+        "reused": reused,
+    }
+
+
+def _distribution_name(source: Path) -> str | None:
+    """Best-effort project name from pyproject.toml, for locating PEP 610
+    metadata. Prototype-scoped: a project whose name is set dynamically is not
+    handled, and the caller falls back to scanning."""
+    pyproject = source / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - 3.10 and older
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except Exception:
+        return None
+    name = data.get("project", {}).get("name")
+    return str(name) if name else None
+
+
+def read_direct_url(venv_root: Path, source: Path) -> dict[str, object]:
+    """PEP 610 metadata for the distribution installed from `source`.
+
+    Fruit 12 wants editable mode AND the correct source recorded. Located by
+    scanning `.dist-info/direct_url.json` and matching the recorded url back to
+    the source, rather than trusting the first one found -- a unit installs
+    several editables and 'some direct_url.json exists' proves nothing about
+    the one being asked about."""
+    probe = probe_venv(venv_root)
+    version = probe["version"]
+    site_packages = venv_root / "lib" / f"python{version}" / "site-packages"
+    if os.name == "nt":
+        site_packages = venv_root / "Lib" / "site-packages"
+    if not site_packages.is_dir():
+        raise EnvExecutionError(f"venv at {venv_root} has no site-packages directory")
+
+    wanted = source.resolve()
+    for dist_info in sorted(site_packages.glob("*.dist-info")):
+        direct_url = dist_info / "direct_url.json"
+        if not direct_url.is_file():
+            continue
+        try:
+            data = json.loads(direct_url.read_text())
+        except json.JSONDecodeError:
+            continue
+        url = str(data.get("url", ""))
+        if not url.startswith("file://"):
+            continue
+        # Percent-decoded: a source path containing a space arrives as %20, so a
+        # raw string comparison silently fails to match the very install it is
+        # looking for.
+        from urllib.parse import unquote, urlparse
+
+        recorded = Path(unquote(urlparse(url).path)).resolve()
+        if recorded == wanted:
+            return data
+    raise EnvExecutionError(
+        f"no PEP 610 direct_url.json in {venv_root} records an install from {source} "
+        "-- the editable install did not record its source (fruit 12)"
+    )
+
+
+def import_origin(venv_root: Path, module: str) -> str:
+    """Where the venv's OWN interpreter resolves `module` from, in isolation.
+
+    `-I` is the whole point (fruit 11): without it an inherited PYTHONPATH or
+    the working directory can satisfy the import, and a passing import would say
+    nothing about what this venv installed."""
+    interpreter = venv_interpreter(venv_root)
+    proc = subprocess.run(
+        [
+            str(interpreter), "-I", "-c",
+            f"import {module},os;print(os.path.realpath({module}.__file__))",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=_PROBE_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise EnvExecutionError(
+            f"module {module!r} does not import under `python -I` in {venv_root}: "
+            f"{proc.stderr.strip()}"
+        )
+    return proc.stdout.strip()
+
+
+def execute_editable_install_operation(
+    validated: ValidatedPlan, index: int, *, workspace_root: Path
+) -> dict[str, object]:
+    """Install `source_path` (with extras) as editable into `venv_path`."""
+    workspace_root = Path(os.fspath(workspace_root))
+    validated.verify(require_provenance=True)
+    _require_workspace_binding(validated, workspace_root)
+
+    op = _operation_at(validated, index, "editable_install")
+    extras = tuple(str(e) for e in op.get("extras", ()))
+    binding = _EditableBinding(
+        venv_path=str(op["venv_path"]),
+        source_path=str(op["source_path"]),
+        extras=extras,
+    )
+    venv_root = canonicalize_workspace_path(
+        workspace_root, binding.venv_path, field_name=f"operations[{index}].venv_path"
+    )
+    source = canonicalize_workspace_path(
+        workspace_root, binding.source_path, field_name=f"operations[{index}].source_path"
+    )
+
+    # The venv must be a real one BEFORE we install into it. Installing into a
+    # directory that merely looks like a venv is how the operator's own
+    # interpreter gets mutated -- section 9.2's "never mutate the operator's
+    # Python environment".
+    verify_venv(venv_root)
+    if not (source / "pyproject.toml").is_file() and not (source / "setup.py").is_file():
+        raise EnvExecutionError(
+            f"editable source {source} has no pyproject.toml or setup.py -- there is "
+            "nothing to install"
+        )
+
+    target = str(source) + (f"[{','.join(binding.extras)}]" if binding.extras else "")
+    proc = subprocess.run(
+        [
+            "uv", "pip", "install",
+            "--python", str(venv_interpreter(venv_root)),
+            "--editable", target,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=_INSTALL_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise EnvExecutionError(
+            f"uv pip install --editable {target} failed:\n"
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+
+    direct_url = read_direct_url(venv_root, source)
+    if not direct_url.get("dir_info", {}).get("editable"):
+        raise EnvExecutionError(
+            f"install from {source} is recorded in PEP 610 metadata but not as "
+            "editable (fruit 12)"
+        )
+
+    return {
+        "kind": "editable_install",
+        "venv_path": binding.venv_path,
+        "source_path": binding.source_path,
+        "extras": list(binding.extras),
+        "distribution": _distribution_name(source),
+        "editable": True,
+        "direct_url": str(direct_url.get("url", "")),
+    }

--- a/gr2/tests/test_env_materialization.py
+++ b/gr2/tests/test_env_materialization.py
@@ -1,0 +1,375 @@
+"""venv + editable_install executor tests (S4-D).
+
+The last two materialization handlers. With these the A -> B -> C -> D path is
+complete.
+
+Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
+      section 9.2, section 6.2.1 invariant 6, acceptance fruit 10/11/12.
+
+Prototype posture (Layne 2026-07-27): working end-to-end, not exhaustively
+hardened. The probes below cover the guards the spec names explicitly; broader
+adversarial coverage is filed as deferred-hardening.
+
+INVARIANT 6 NAMES ITS OWN MASK, which is unusual and worth reading closely:
+"FILE PRESENCE ALONE IS NOT VENV EVIDENCE." `pyvenv.cfg exists` is the cheap
+check that LOOKS like venv validation and stays true for a venv whose
+interpreter was deleted, whose base Python moved, or which was copied to a new
+path. Only running the interpreter can tell, which is why the spec demands a
+bounded probe rather than a stat.
+
+The probe's two assertions are orthogonal, and each is the only thing that can
+see its own failure:
+  - sys.prefix == the declared path catches a venv that RUNS BUT IS NOT THIS
+    ONE (copied or moved).
+  - sys.base_prefix != sys.prefix catches something that is NOT A VENV AT ALL;
+    a bare system interpreter passes the prefix check trivially, because for it
+    the two values are the same.
+
+FRUIT 11's `python -I` IS LOAD-BEARING. Without isolation an import can be
+satisfied by the working directory or an inherited PYTHONPATH, so a passing
+import would prove nothing about what the venv installed. There is a probe
+below that demonstrates exactly that gap rather than asserting it.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from gr2.python_cli.env_exec import (
+    EnvExecutionError,
+    execute_editable_install_operation,
+    execute_venv_operation,
+    import_origin,
+    read_direct_url,
+    venv_interpreter,
+    verify_venv,
+)
+from gr2.python_cli.spec_apply import (
+    validate_materialization_plan,
+    workspace_spec_path,
+    write_materialization_receipt,
+)
+
+UV = shutil.which("uv")
+PYVER = f"{sys.version_info[0]}.{sys.version_info[1]}"
+
+
+@unittest.skipIf(UV is None, "uv is a section 9.2 prerequisite and is not installed")
+class EnvExecTestBase(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self.tmp = Path(tempfile.mkdtemp())
+        self.workspace_root = self.tmp / "workspace"
+        self.workspace_root.mkdir(parents=True)
+        self.spec_sha256 = self._write_workspace_spec()
+
+        self.venv_rel = "units/u_test/home/.venv"
+        self.venv_path = self.workspace_root / self.venv_rel
+
+        # A real installable package inside the unit's clone.
+        self.source_rel = "units/u_test/repos/product"
+        self.source = self.workspace_root / self.source_rel
+        (self.source / "src" / "unitpkg").mkdir(parents=True)
+        (self.source / "src" / "unitpkg" / "__init__.py").write_text(
+            "VALUE = 'from the unit clone'\n"
+        )
+        (self.source / "pyproject.toml").write_text(
+            "[build-system]\n"
+            'requires = ["setuptools>=68"]\n'
+            'build-backend = "setuptools.build_meta"\n\n'
+            "[project]\n"
+            'name = "unitpkg"\n'
+            'version = "0.1.0"\n\n'
+            "[project.optional-dependencies]\n"
+            "extra = []\n\n"
+            "[tool.setuptools.packages.find]\n"
+            'where = ["src"]\n'
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_workspace_spec(self, content: str = 'workspace_name = "test"\n') -> str:
+        spec_path = workspace_spec_path(self.workspace_root)
+        spec_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_path.write_text(content)
+        return hashlib.sha256(spec_path.read_bytes()).hexdigest()
+
+    def _venv_op(self, **overrides: object) -> dict[str, object]:
+        op: dict[str, object] = {
+            "kind": "venv",
+            "dest_path": self.venv_rel,
+            "engine": "uv",
+            "python": sys.executable,
+        }
+        op.update(overrides)
+        return op
+
+    def _editable_op(self, **overrides: object) -> dict[str, object]:
+        op: dict[str, object] = {
+            "kind": "editable_install",
+            "venv_path": self.venv_rel,
+            "source_path": self.source_rel,
+            "extras": [],
+        }
+        op.update(overrides)
+        return op
+
+    def _validated(self, operations: list[dict[str, object]]):
+        return validate_materialization_plan(
+            self.workspace_root,
+            {
+                "schema_version": 1,
+                "plan_id": "mp_test",
+                "unit_key": "u_test",
+                "workspace_spec_sha256": self.spec_sha256,
+                "operations": operations,
+            },
+        )
+
+    def _make_venv(self) -> dict[str, object]:
+        return execute_venv_operation(
+            self._validated([self._venv_op()]), 0, workspace_root=self.workspace_root
+        )
+
+    def _install(self, **overrides) -> dict[str, object]:
+        validated = self._validated([self._venv_op(), self._editable_op(**overrides)])
+        execute_venv_operation(validated, 0, workspace_root=self.workspace_root)
+        return execute_editable_install_operation(
+            validated, 1, workspace_root=self.workspace_root
+        )
+
+
+class TestVenvCreation(EnvExecTestBase):
+    def test_creates_a_venv_with_the_declared_interpreter(self):
+        """Acceptance fruit 10."""
+        evidence = self._make_venv()
+
+        self.assertTrue(venv_interpreter(self.venv_path).exists())
+        self.assertEqual(evidence["kind"], "venv")
+        self.assertEqual(evidence["interpreter_version"], PYVER)
+        self.assertIs(evidence["reused"], False)
+
+    def test_an_existing_healthy_venv_is_reused_and_still_validated(self):
+        """Invariant 5's rule generalized: path ABSENCE must not be the
+        condition that makes validation reachable. The venv is re-probed on
+        every apply, not only when it is created."""
+        self._make_venv()
+        evidence = self._make_venv()
+        self.assertIs(evidence["reused"], True)
+
+    def test_evidence_is_receipt_shaped(self):
+        validated = self._validated([self._venv_op()])
+        evidence = execute_venv_operation(validated, 0, workspace_root=self.workspace_root)
+        receipt_path = write_materialization_receipt(
+            self.workspace_root, validated, [evidence]
+        )
+        receipt = json.loads(receipt_path.read_text())
+        self.assertEqual(receipt["operations"][0]["kind"], "venv")
+
+
+class TestInvariantSixProbe(EnvExecTestBase):
+    """'File presence alone is not venv evidence' -- the spec naming its own mask."""
+
+    def test_pyvenv_cfg_alone_does_not_satisfy_the_check(self):
+        """The cheap check that LOOKS like validation. pyvenv.cfg is present and
+        parseable; the interpreter is gone. A stat-based guard says healthy."""
+        self._make_venv()
+        interpreter = venv_interpreter(self.venv_path)
+        interpreter.unlink()
+
+        self.assertTrue(
+            (self.venv_path / "pyvenv.cfg").is_file(),
+            "premise: the cheap check still passes",
+        )
+        with self.assertRaises(EnvExecutionError) as ctx:
+            verify_venv(self.venv_path)
+        self.assertIn("no interpreter", str(ctx.exception))
+
+    def test_the_prefix_assertions_cannot_fire_on_current_cpython(self):
+        """PREMISE, and an honest correction to how invariant 6 reads.
+
+        The spec asks the probe to assert `sys.prefix == the declared venv path`
+        and `sys.base_prefix != sys.prefix`. Both are kept in verify_venv
+        because the spec mandates them -- but on CPython 3.11+ NEITHER CAN FAIL
+        once pyvenv.cfg exists, and that was established by running it rather
+        than by reading the docs:
+
+          - pyvenv.cfg next to bin/python is LITERALLY what makes a venv, so
+            base_prefix always differs -- even when the file contains garbage.
+          - sys.prefix is derived from the directory you INVOKED THROUGH, not
+            from anything recorded inside, so it equals the declared path even
+            when bin/python symlinks to a different venv's interpreter, and a
+            COPIED venv is self-consistent at its new location.
+
+        So the assertions are defence-in-depth against a Python that behaves
+        differently, not live guards. They are documented as such rather than
+        left looking like protection, and this test is what would notice if
+        CPython ever changed: it FAILS, and the failure says the guards became
+        reachable.
+
+        What the probe genuinely catches is the reachable set -- interpreter
+        missing, not executable, failing, or hanging -- covered above."""
+        self._make_venv()
+
+        decoy = self.workspace_root / "units" / "u_test" / "not-really-a-venv"
+        (decoy / "bin").mkdir(parents=True)
+        (decoy / "pyvenv.cfg").write_text("this is not a valid config\n")
+        os.symlink(venv_interpreter(self.venv_path), venv_interpreter(decoy))
+
+        probe = json.loads(
+            subprocess.run(
+                [str(venv_interpreter(decoy)), "-I", "-c",
+                 "import sys,json;print(json.dumps({'p':sys.prefix,'b':sys.base_prefix}))"],
+                capture_output=True, text=True, check=True,
+            ).stdout
+        )
+        self.assertNotEqual(
+            probe["b"], probe["p"],
+            "CPython no longer treats a garbage pyvenv.cfg as a venv -- the "
+            "base_prefix assertion in verify_venv is now REACHABLE and deserves "
+            "a real probe",
+        )
+        self.assertEqual(
+            Path(probe["p"]).resolve(), decoy.resolve(),
+            "CPython no longer derives sys.prefix from the invocation path -- the "
+            "prefix assertion in verify_venv is now REACHABLE and deserves a real "
+            "probe",
+        )
+        # And the consequence: verify_venv accepts it, because every guard that
+        # CAN fire passes. That is the honest state of invariant 6 today.
+        verify_venv(decoy)
+
+
+class TestEditableInstall(EnvExecTestBase):
+    def test_installs_editable_and_records_pep610_metadata(self):
+        """Acceptance fruit 12."""
+        evidence = self._install()
+
+        self.assertEqual(evidence["kind"], "editable_install")
+        self.assertIs(evidence["editable"], True)
+        self.assertEqual(evidence["distribution"], "unitpkg")
+
+        data = read_direct_url(self.venv_path, self.source)
+        self.assertTrue(data["dir_info"]["editable"])
+        self.assertTrue(str(data["url"]).startswith("file://"))
+
+    def test_import_resolves_inside_the_unit_clone(self):
+        """Acceptance fruit 11."""
+        self._install()
+        origin = import_origin(self.venv_path, "unitpkg")
+        self.assertTrue(
+            Path(origin).resolve().is_relative_to(self.source.resolve()),
+            f"unitpkg resolved to {origin}, outside the unit clone {self.source}",
+        )
+
+    def test_isolation_is_what_makes_that_claim_real(self):
+        """`python -I` is load-bearing, demonstrated rather than asserted.
+
+        Without isolation, an inherited PYTHONPATH satisfies an import that the
+        venv never installed -- so a non-isolated probe cannot distinguish
+        "this unit installed it" from "it happened to be on the path". That is
+        why fruit 11 specifies -I.
+
+        Demonstrated with a module the venv does NOT have. An earlier version of
+        this probe tried to shadow the INSTALLED package and failed: modern
+        editable installs register a MetaPathFinder, which runs ahead of sys.path
+        entirely, so PYTHONPATH loses. Shadowing proves nothing; presence does."""
+        self._install()
+        decoy = self.tmp / "decoy"
+        (decoy / "neverinstalled").mkdir(parents=True)
+        (decoy / "neverinstalled" / "__init__.py").write_text("VALUE = 'decoy'\n")
+
+        env = {**os.environ, "PYTHONPATH": str(decoy)}
+        script = "import neverinstalled,os;print(os.path.realpath(neverinstalled.__file__))"
+        interpreter = str(venv_interpreter(self.venv_path))
+
+        leaky = subprocess.run(
+            [interpreter, "-c", script], capture_output=True, text=True, env=env, check=False
+        )
+        isolated = subprocess.run(
+            [interpreter, "-I", "-c", script], capture_output=True, text=True, env=env, check=False
+        )
+
+        self.assertEqual(
+            leaky.returncode, 0,
+            "premise: without -I an inherited PYTHONPATH satisfies the import",
+        )
+        self.assertNotEqual(
+            isolated.returncode, 0,
+            "-I must ignore PYTHONPATH -- otherwise 'the import resolves' says "
+            "nothing about what this venv installed",
+        )
+        # And the real claim, on a module the unit genuinely installed.
+        self.assertTrue(
+            Path(import_origin(self.venv_path, "unitpkg")).resolve()
+            .is_relative_to(self.source.resolve())
+        )
+
+    def test_extras_are_passed_through(self):
+        evidence = self._install(extras=["extra"])
+        self.assertEqual(evidence["extras"], ["extra"])
+
+    def test_installing_into_a_directory_that_is_not_a_venv_is_refused(self):
+        """Section 9.2: never mutate the operator's Python environment.
+        Installing into something that merely looks like a venv is how that
+        happens, so the venv is verified BEFORE the install runs."""
+        validated = self._validated([self._venv_op(), self._editable_op()])
+        self.venv_path.mkdir(parents=True)
+        (self.venv_path / "pyvenv.cfg").write_text("home = /usr\n")
+
+        with self.assertRaises(EnvExecutionError) as ctx:
+            execute_editable_install_operation(
+                validated, 1, workspace_root=self.workspace_root
+            )
+        self.assertIn("no interpreter", str(ctx.exception))
+
+    def test_a_source_with_nothing_to_install_is_refused(self):
+        validated = self._validated([self._venv_op(), self._editable_op()])
+        execute_venv_operation(validated, 0, workspace_root=self.workspace_root)
+        (self.source / "pyproject.toml").unlink()
+
+        with self.assertRaises(EnvExecutionError) as ctx:
+            execute_editable_install_operation(
+                validated, 1, workspace_root=self.workspace_root
+            )
+        self.assertIn("nothing to install", str(ctx.exception))
+
+
+class TestExecutorBinding(EnvExecTestBase):
+    def test_a_tampered_capability_cannot_execute(self):
+        validated = self._validated([self._venv_op()])
+        object.__setattr__(validated, "plan_id", "mp_swapped")
+        with self.assertRaises(Exception) as ctx:
+            execute_venv_operation(validated, 0, workspace_root=self.workspace_root)
+        self.assertIn("capability is invalid", str(ctx.exception))
+
+    def test_a_wrong_kind_is_refused_by_index(self):
+        validated = self._validated([self._venv_op(), self._editable_op()])
+        with self.assertRaises(EnvExecutionError) as ctx:
+            execute_editable_install_operation(
+                validated, 0, workspace_root=self.workspace_root
+            )
+        self.assertIn("is kind 'venv'", str(ctx.exception))
+
+    def test_executing_against_a_different_workspace_root_is_rejected(self):
+        validated = self._validated([self._venv_op()])
+        other = self.tmp / "other-workspace"
+        spec = workspace_spec_path(other)
+        spec.parent.mkdir(parents=True, exist_ok=True)
+        spec.write_text('workspace_name = "other"\n')
+
+        with self.assertRaises(EnvExecutionError) as ctx:
+            execute_venv_operation(validated, 0, workspace_root=other)
+        self.assertIn("WorkspaceSpec", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

S4-D: the last two materialization handlers. **With these, the A → B → C → D path is complete on main** — contract, clones, projections, environments.

Spec §9.2 (`uv venv` + `uv pip install --editable`), §6.2.1 invariant 6, acceptance fruit 10/11/12. Ref #797.

**Premium boundary: gitgrip is OSS.** Creating environments at declared paths from declared sources. No identity read, derived, or persisted.

**Reviewers: Atlas + Sentinel.** **Prototype posture** per Layne 2026-07-27 — working end-to-end, not exhaustively hardened. Block only on demo-breaking; new hardening → `deferred-hardening` + merge.

## Invariant 6 names its own mask

> Treat an existing venv as valid only when `pyvenv.cfg` is a regular file **and** the platform interpreter is present, executable, and succeeds under an isolated bounded probe … **File presence alone is not venv evidence.**

That last sentence is the spec naming the proxy. `pyvenv.cfg exists` is the cheap check that *looks* like venv validation and stays true for a venv whose interpreter was deleted. Only running the interpreter can tell — bounded, because a hung probe would hang a 180 s timed path.

## A correction I owe the spec

Its two prefix assertions **cannot fire** on CPython 3.11+. Established by running it, not by reading docs:

- `pyvenv.cfg` next to `bin/python` is **literally what makes a venv**, so `base_prefix` always differs from `prefix` — even when that file contains garbage. A "bare interpreter plus a `pyvenv.cfg`" is a real venv by Python's own rules.
- `sys.prefix` is derived from the directory you **invoked through**, not from anything recorded inside. It equals the declared path even when `bin/python` symlinks to a *different* venv's interpreter, and a **copied** venv is self-consistent at its new location.

I wrote probes for both, watched both fail to raise, and checked *why* instead of adjusting fixtures until they passed. The assertions stay — the spec mandates them and a future Python may differ — but they are documented as defence in depth rather than left looking like live guards, and `test_the_prefix_assertions_cannot_fire_on_current_cpython` pins the finding and **fails if CPython ever changes**, which is the signal they have become reachable.

What the probe genuinely catches today: interpreter missing, not executable, failing, or hanging; `pyvenv.cfg` absent. Those are the real content of "file presence alone is not venv evidence."

## Fruit 11: `-I` is demonstrated, not asserted

My first probe tried to shadow the *installed* package via `PYTHONPATH` and failed — modern editable installs register a `MetaPathFinder`, which runs ahead of `sys.path` entirely, so the decoy loses. **Shadowing proves nothing.**

The probe now uses a module the venv does **not** have: it imports without `-I` and fails with `-I`. That is what makes "the import resolves inside the unit clone" a claim about the venv rather than about the ambient environment.

## Fruit 12: PEP 610

Metadata is located by **matching the recorded url back to the source**, not by trusting the first `direct_url.json` found — a unit installs several editables, and "some `direct_url.json` exists" proves nothing about the one being asked about. The url is **percent-decoded** before comparison, because a source path containing a space arrives as `%20` and a raw string compare silently fails to match the very install it is looking for.

## Never mutate the operator's environment

§9.2's rule is enforced by verifying the venv **before** installing into it — installing into a directory that merely *looks* like a venv is precisely how that happens.

## Carried forward from B and C without being asked twice

`workspace_root` normalised to a plain `Path` before verification; every operation field captured into one immutable binding; capability verified with provenance at use; WorkspaceSpec re-proved at execution.

## Verification

- **14 D tests**, against real `uv` venvs and a real editable install (no mocking of the thing under test).
- **697 passed** on Python 3.13.2, full gr2 suite. `ruff check` clean on both new files.
- Skips cleanly if `uv` is absent (it is a §9.2 prerequisite).

## Known deferred

`_require_workspace_binding` and the index/kind lookup are now duplicated across three executor modules. The shared scaffolding wants extracting into one `exec_common`; deferred so it does not land inside a slice PR.