### PR TITLE
ci: bound the Windows leg and split compile from run (grip#821)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,13 @@ jobs:
   test-windows:
     name: Test (windows-latest)
     runs-on: windows-latest
+    # Bounded so a hang reports as a FAILURE WITH A LOG rather than running to
+    # the 6-hour default. This leg hung three times on 2026-07-27 (91 min, then
+    # 26, then 26 again) and every diagnosis was blocked on never seeing where it
+    # stopped -- a hang is worse than a failure precisely because it is
+    # indistinguishable from "still running". 15 against a ~8 min baseline is
+    # generous enough not to fire on a cold cache. See grip#821.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -141,6 +148,19 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+
+      # Compilation is split out from execution ON PURPOSE. `cargo test` does
+      # both, so a single step sitting "in_progress" cannot tell a slow Windows
+      # compile apart from a hung test -- which is the exact question three
+      # investigations could not answer. With the split, the step breakdown
+      # alone discriminates: if "Build tests" completes and "Run tests" hangs,
+      # it is a test; if "Build tests" hangs, it is the toolchain.
+      # The second invocation reuses the first's artifacts, so this costs a
+      # dependency check, not a rebuild.
+      - name: Build tests
+        run: cargo test --all-features --no-run
+        env:
+          RUSTFLAGS: '-C link-arg=advapi32.lib -C link-arg=/STACK:8388608'
 
       - name: Run tests
         run: cargo test --all-features


### PR DESCRIPTION
## Summary

Bounds the Windows CI leg and makes the next hang produce **evidence instead of silence**.

Ratified by Stromus 2026-07-27 off the corrected diagnosis in **grip#821**.

**Premium boundary: gitgrip is OSS.** CI configuration only.

**Reviewers: Atlas + Sentinel.**

## Why

The Windows job hung three times on 2026-07-27 — **91 minutes**, then **26** after a cancel-and-rerun, then **26 again** with the suspected test ignored. Every diagnosis was blocked on the same thing: never seeing where it stops.

## Two changes, each answering a question the last three investigations could not

**`timeout-minutes: 15`.** A hang is worse than a failure. A failing test costs eight minutes and names itself; a hang runs to the six-hour default and is **indistinguishable from "still running"** — which is how the first instance sat 91 minutes before anyone measured elapsed against a baseline. Bounding it converts the hang into a **failure with a log**. 15 against a ~8 min baseline is generous enough not to fire on a cold cache.

**Splitting `cargo test --no-run` from `cargo test`.** This is the discriminator. `cargo test` compiles *and* runs, so a single step sitting `in_progress` cannot tell a slow Windows compile from a hung test — the exact question I could not answer while looking at a live job (setup/checkout/toolchain/cache all complete, `Run tests` in progress, no way to know which half). With the split, the step breakdown alone discriminates:

| Observation | Conclusion |
|---|---|
| `Build tests` completes, `Run tests` hangs | a **test** hangs |
| `Build tests` hangs | the **toolchain/compile** hangs |

The second invocation reuses the first's artifacts, so the cost is a dependency check rather than a rebuild.

`RUSTFLAGS` is carried on **both** steps deliberately — the link-arg settings affect compilation, so omitting them from the build step would compile something other than what runs.

## Scope

Only the `test-windows` job. ubuntu and macos are untouched and both finish this step in under four minutes. Verified by parsing the YAML: `timeout-minutes: 15`, steps `[checkout, Install Rust toolchain, Cache cargo, Build tests, Run tests]`, `RUSTFLAGS` present on both, all other jobs unchanged.

## What this does NOT do

**It does not fix the hang, and does not pretend to.** grip#821 carries the corrected diagnosis: my first hypothesis — the `file://` push/fetch inside `test_update_gripspace_advances_configured_remote_branch` — was **disproven** when the leg hung again with that test ignored. I corrected the issue in place rather than leave a confident-but-wrong pointer, since an issue aiming someone at the wrong file is worse than one that says "unknown."

Related: whether the Windows check should be non-blocking until post-demo is a separate decision currently with Layne. This PR does not touch branch protection.