### PR TITLE
feat: S5 neutral launch primitive -- the team wakes

### DIFF
--- a/gr2/python_cli/launch_exec.py
+++ b/gr2/python_cli/launch_exec.py
@@ -1,0 +1,236 @@
+"""Neutral launch primitive (S5).
+
+Executes a LaunchPlan entry: run this argv, in this working directory, with
+these environment KEY NAMES. gr2 cannot tell a synapt agent team from any other
+multi-repo workspace -- it sees an opaque `unit_key`, an argv, and a set of env
+key names whose VALUES premium supplies in memory at launch.
+
+Design: `synapt-spawn-premium-compiler-2026-07-27.md` §2 (LaunchPlan is the
+opaque tier) and §5 (cold start, no `--resume`).
+
+THE BOUNDARY CORRECTION THIS SLICE EXISTS TO MAKE
+--------------------------------------------------
+gr1's spawn builds an on-disk launch script containing `export KEY=value` lines.
+That puts identity environment VALUES on disk -- SYNAPT_AGENT_ID, org, channel
+bindings -- inside the OSS layer, in a file that outlives the launch.
+
+The neutral plan carries key NAMES; the values are injected in memory and never
+persisted. This primitive therefore has no script-writing path at all: values
+are passed straight to the child process environment and are unreachable from
+the filesystem afterwards. `test_no_environment_value_reaches_the_filesystem`
+searches the workspace for a value rather than trusting that nothing wrote one.
+
+Same rule that held through the whole materializer: no identity in any neutral
+artifact. A launch script IS a neutral artifact.
+
+WHAT "LAUNCHED" HAS TO MEAN
+---------------------------
+A spawn call returning successfully is not an agent running. A process that
+exits immediately -- a missing binary, a bad flag, an instant crash -- produces
+exactly the same "success" as one that came up healthy, and the failure surfaces
+later as an empty pane nobody notices. So launch is not acknowledged until the
+child has been observed ALIVE after a settle interval, which is the same
+distinction invariant 6 draws between a venv's files existing and its
+interpreter answering.
+"""
+from __future__ import annotations
+
+import dataclasses
+import os
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .spec_apply import MaterializationPlanError, canonicalize_workspace_path
+
+# Long enough that an immediate crash (bad binary, bad flag, instant exit) has
+# happened, short enough not to matter against §13's 180s budget.
+_LIVENESS_SETTLE_SECONDS = 0.35
+
+
+class LaunchExecutionError(MaterializationPlanError):
+    """A launch entry could not be executed safely."""
+
+
+@dataclasses.dataclass(frozen=True)
+class LaunchEntry:
+    """One unit's opaque launch declaration.
+
+    Deliberately carries no model, tool, role or agent name -- gr2 runs an argv,
+    it does not know what the argv IS."""
+
+    unit_key: str
+    workdir: str
+    argv: tuple[str, ...]
+    env_allowlist_keys: tuple[str, ...]
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> LaunchEntry:
+        allowed = {"unit_key", "workdir", "argv", "env_allowlist_keys"}
+        unknown = set(data) - allowed
+        if unknown:
+            # Closed by construction, same reason the plan schema is: a field
+            # nobody thought to reject cannot smuggle anything if it cannot
+            # exist. An unexpected key here is how identity would arrive.
+            raise LaunchExecutionError(
+                f"launch entry has unknown field(s) {sorted(unknown)} -- the opaque "
+                "tier carries exactly unit_key, workdir, argv and env_allowlist_keys"
+            )
+        for field in ("unit_key", "workdir"):
+            if not isinstance(data.get(field), str) or not data[field]:
+                raise LaunchExecutionError(f"launch entry {field!r} must be a non-empty string")
+        argv = data.get("argv")
+        if not isinstance(argv, (list, tuple)) or not argv or not all(
+            isinstance(a, str) for a in argv
+        ):
+            raise LaunchExecutionError(
+                "launch entry argv must be a non-empty list of strings -- a single "
+                "string would invite shell interpretation, and the launcher never "
+                "hands a plan's contents to a shell"
+            )
+        keys = data.get("env_allowlist_keys", [])
+        if not isinstance(keys, (list, tuple)) or not all(isinstance(k, str) for k in keys):
+            raise LaunchExecutionError("env_allowlist_keys must be a list of strings")
+        return cls(
+            unit_key=data["unit_key"],
+            workdir=data["workdir"],
+            argv=tuple(argv),
+            env_allowlist_keys=tuple(keys),
+        )
+
+
+def _require_exact_env(entry: LaunchEntry, values: Mapping[str, str]) -> dict[str, str]:
+    """The allowlist is exact in BOTH directions.
+
+    Extra: premium supplied a value for a key the plan never declared. The plan
+    is what a reviewer reads to know what a process receives, so a value outside
+    it is invisible to review.
+
+    Missing: the plan declared a key the launch has no value for. Starting the
+    process anyway hands the agent a half-built environment and the failure
+    appears later as behaviour nobody traces back to launch.
+
+    Both are refusals, and they are checked separately because a single
+    set-equality assertion would report the wrong one first and teach the
+    operator the wrong thing to fix."""
+    declared = set(entry.env_allowlist_keys)
+    supplied = set(values)
+
+    extra = sorted(supplied - declared)
+    if extra:
+        raise LaunchExecutionError(
+            f"unit {entry.unit_key}: environment value(s) supplied for undeclared "
+            f"key(s) {extra} -- the launch plan is what a reviewer reads to know what "
+            "a process receives, so anything outside it is invisible to review"
+        )
+    missing = sorted(declared - supplied)
+    if missing:
+        raise LaunchExecutionError(
+            f"unit {entry.unit_key}: no value supplied for declared key(s) {missing} -- "
+            "starting with a half-built environment defers the failure to runtime"
+        )
+    return {k: str(values[k]) for k in entry.env_allowlist_keys}
+
+
+def launch_unit(
+    entry: LaunchEntry,
+    *,
+    workspace_root: Path,
+    env_values: Mapping[str, str],
+    settle_seconds: float = _LIVENESS_SETTLE_SECONDS,
+) -> dict[str, object]:
+    """Start one unit's process and prove it is alive.
+
+    `env_values` is consumed in memory and never written anywhere. Returns
+    neutral evidence -- no argv values, no env, nothing identity-bearing."""
+    workspace_root = Path(os.fspath(workspace_root))
+    workdir = canonicalize_workspace_path(
+        workspace_root, entry.workdir, field_name=f"launch[{entry.unit_key}].workdir"
+    )
+    if not workdir.is_dir():
+        raise LaunchExecutionError(
+            f"unit {entry.unit_key}: workdir {entry.workdir} does not exist -- "
+            "materialization runs before launch, so a missing workspace means the "
+            "unit was never materialized rather than that launch should create it"
+        )
+
+    env = _require_exact_env(entry, env_values)
+
+    try:
+        # No shell. argv is a list, and a plan's contents are never handed to a
+        # shell for interpretation.
+        proc = subprocess.Popen(  # noqa: S603
+            list(entry.argv),
+            cwd=str(workdir),
+            env={**os.environ, **env},
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except FileNotFoundError as exc:
+        raise LaunchExecutionError(
+            f"unit {entry.unit_key}: {entry.argv[0]!r} not found on PATH"
+        ) from exc
+    except OSError as exc:
+        raise LaunchExecutionError(f"unit {entry.unit_key}: launch failed: {exc}") from exc
+
+    # LIVENESS, not spawn-return. A process that exits immediately produces the
+    # same successful Popen as one that came up healthy.
+    time.sleep(settle_seconds)
+    code = proc.poll()
+    if code is not None:
+        raise LaunchExecutionError(
+            f"unit {entry.unit_key}: process exited with code {code} within "
+            f"{settle_seconds}s of launch -- a spawn that returns is not an agent "
+            "that runs, and an immediately-dead process is indistinguishable from a "
+            "healthy one until someone looks"
+        )
+
+    return {
+        "kind": "launch",
+        "unit_key": entry.unit_key,
+        "workdir": entry.workdir,
+        "pid": proc.pid,
+        "env_keys": list(entry.env_allowlist_keys),  # NAMES only, never values
+        "alive": True,
+    }
+
+
+def launch_team(
+    entries: Sequence[LaunchEntry],
+    *,
+    workspace_root: Path,
+    env_values_by_unit: Mapping[str, Mapping[str, str]],
+    settle_seconds: float = _LIVENESS_SETTLE_SECONDS,
+) -> list[dict[str, object]]:
+    """Launch every unit, or none of them.
+
+    A partially launched team is the same failure shape as a partially
+    materialized one: some agents alive, some absent, presenting as a confused
+    team rather than an error. Anything already started is terminated before the
+    failure propagates, so a retry does not race a half-live team."""
+    started: list[tuple[dict[str, object], int]] = []
+    try:
+        for entry in entries:
+            values = env_values_by_unit.get(entry.unit_key)
+            if values is None:
+                raise LaunchExecutionError(
+                    f"no environment supplied for unit {entry.unit_key}"
+                )
+            evidence = launch_unit(
+                entry,
+                workspace_root=workspace_root,
+                env_values=values,
+                settle_seconds=settle_seconds,
+            )
+            started.append((evidence, int(evidence["pid"])))
+    except BaseException:
+        for _, pid in started:
+            try:
+                os.killpg(os.getpgid(pid), 15)
+            except (ProcessLookupError, PermissionError):  # pragma: no cover
+                pass
+        raise
+    return [ev for ev, _ in started]

--- a/gr2/python_cli/launch_exec.py
+++ b/gr2/python_cli/launch_exec.py
@@ -134,6 +134,44 @@ def _require_exact_env(entry: LaunchEntry, values: Mapping[str, str]) -> dict[st
     return {k: str(values[k]) for k in entry.env_allowlist_keys}
 
 
+# Launcher-owned process mechanics, supplied EXPLICITLY rather than inherited.
+# §6 classes these as launcher-owned precisely so a plan cannot declare them --
+# but the child still needs them to run at all (a binary resolved by name needs
+# PATH). Naming them here is the difference between "the launcher provides these,
+# for these reasons" and "whatever the parent happened to have".
+_LAUNCHER_OWNED_PASSTHROUGH = ("PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", "SystemRoot")
+
+
+def _child_environment(entry: LaunchEntry, values: Mapping[str, str]) -> dict[str, str]:
+    """The child's COMPLETE environment, built rather than inherited.
+
+    Sentinel, #825: passing `{**os.environ, **declared}` inherits the parent's
+    entire environment, so a child sees ambient premium variables that were
+    never declared anywhere -- reproduced on a live host, where the coordinator's
+    SYNAPT_PREMIUM_FEATURES and SYNAPT_LOOP_INTERVAL reached a spawned agent.
+
+    My allowlist check was exact in two directions and both were about the
+    SUPPLIED dict: a value for an undeclared key, and a declared key with no
+    value. Neither asks what the child ACTUALLY ENDS UP WITH. Receiving the
+    right thing and receiving ONLY that are different claims, and the test that
+    asserted the child got the declared value could not see the difference.
+
+    So the environment is CONSTRUCTED: exactly the declared keys, plus a named
+    set of launcher-owned mechanics the child cannot run without. Nothing is
+    inherited implicitly. Everything present is there because something declared
+    it or because this list names it.
+
+    That matters beyond tidiness: the demo claims identity is injected in memory
+    with nothing leaked, and inheriting os.environ leaks the COORDINATOR'S
+    premium environment into every spawned agent."""
+    child = _require_exact_env(entry, values)
+    for key in _LAUNCHER_OWNED_PASSTHROUGH:
+        ambient = os.environ.get(key)
+        if ambient is not None and key not in child:
+            child[key] = ambient
+    return child
+
+
 def launch_unit(
     entry: LaunchEntry,
     *,
@@ -156,7 +194,7 @@ def launch_unit(
             "unit was never materialized rather than that launch should create it"
         )
 
-    env = _require_exact_env(entry, env_values)
+    env = _child_environment(entry, env_values)
 
     try:
         # No shell. argv is a list, and a plan's contents are never handed to a
@@ -164,7 +202,7 @@ def launch_unit(
         proc = subprocess.Popen(  # noqa: S603
             list(entry.argv),
             cwd=str(workdir),
-            env={**os.environ, **env},
+            env=env,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,

--- a/gr2/tests/test_launch_primitive.py
+++ b/gr2/tests/test_launch_primitive.py
@@ -18,6 +18,7 @@ is the shape this sprint kept finding:
 """
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -35,6 +36,25 @@ from gr2.python_cli.launch_exec import (
 )
 
 SECRET = "SYNAPT-AGENT-ID-VALUE-THAT-MUST-NEVER-TOUCH-DISK"
+
+
+def _platform_injected_env() -> set[str]:
+    """Variables this platform adds to any child regardless of what is passed.
+
+    Measured, not listed: spawn a process with a completely empty environment
+    and see what survives. A hardcoded list would drift per-OS and, worse, would
+    silently absorb a real inheritance bug on a platform nobody measured."""
+    out = subprocess.run(
+        [sys.executable, "-c", "import os,json;print(json.dumps(dict(os.environ)))"],
+        env={},
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    try:
+        return set(json.loads(out))
+    except json.JSONDecodeError:  # pragma: no cover
+        return set()
 
 
 class LaunchTestBase(unittest.TestCase):
@@ -108,8 +128,14 @@ class TestTheBoundary(LaunchTestBase):
         for both implementations."""
         ev = self._launch()
 
+        # SCANNED FROM self.tmp, NOT self.ws (Sentinel, #825). The original
+        # scanned only workspace_root, so a value written to its PARENT left
+        # this test green -- "nothing under workspace_root" is not "nothing
+        # persisted". self.tmp is the whole region this test controls, and it
+        # contains the workspace, its parent, and anything a sibling write would
+        # land in.
         found = []
-        for path in self.ws.rglob("*"):
+        for path in self.tmp.rglob("*"):
             if not path.is_file():
                 continue
             try:
@@ -142,6 +168,61 @@ class TestTheBoundary(LaunchTestBase):
                 break
             time.sleep(0.05)
         self.assertEqual(out.read_text(), SECRET, "the child never received the value")
+
+    def test_the_child_environment_contains_no_ambient_inheritance(self):
+        """THE DIRECTION I MISSED, reproduced by Sentinel on a live host.
+
+        My allowlist was exact in two directions and both were about the
+        SUPPLIED dict -- a value for an undeclared key, and a declared key with
+        no value. Neither asks what the child ACTUALLY ENDS UP WITH. Receiving
+        the right thing and receiving ONLY that are different claims.
+
+        An ambient premium variable in the coordinator's own environment reached
+        spawned agents through `{**os.environ, **declared}` while both existing
+        directions stayed green. The environment is now CONSTRUCTED, so this
+        asserts the child's full env equals the declared set plus the named
+        launcher-owned mechanics, and nothing else."""
+        from gr2.python_cli.launch_exec import _LAUNCHER_OWNED_PASSTHROUGH
+
+        marker = "AMBIENT_PREMIUM_THAT_MUST_NOT_INHERIT"
+        os.environ[marker] = "leaked-from-the-coordinator"
+        self.addCleanup(os.environ.pop, marker, None)
+
+        out = self.unit / "env.json"
+        entry = self._entry(
+            argv=[
+                sys.executable,
+                "-c",
+                f"import os,json,time;open({str(out)!r},'w').write("
+                "json.dumps(dict(os.environ)));time.sleep(30)",
+            ]
+        )
+        self._launch(entry)
+        for _ in range(60):
+            if out.is_file() and out.read_text():
+                break
+            time.sleep(0.05)
+
+        child_env = json.loads(out.read_text())
+        self.assertNotIn(marker, child_env, "ambient parent variable was inherited")
+
+        # Platform-injected, NOT inherited -- established empirically rather
+        # than assumed: launching with a completely empty env={} on this host
+        # still yields LC_CTYPE and __CF_USER_TEXT_ENCODING, so macOS adds them
+        # regardless of what the launcher passes. Naming them without checking
+        # WHY they appeared would have quietly weakened this assertion into
+        # excusing whatever showed up.
+        platform_injected = _platform_injected_env()
+
+        expected = (
+            {"SYNAPT_AGENT_ID"}
+            | {k for k in _LAUNCHER_OWNED_PASSTHROUGH if k in os.environ}
+            | platform_injected
+        )
+        unexpected = set(child_env) - expected
+        self.assertEqual(
+            unexpected, set(), f"child received undeclared variables: {sorted(unexpected)}"
+        )
 
     def test_a_value_for_an_undeclared_key_is_refused(self):
         with self.assertRaises(LaunchExecutionError) as ctx:

--- a/gr2/tests/test_launch_primitive.py
+++ b/gr2/tests/test_launch_primitive.py
@@ -1,0 +1,277 @@
+"""Neutral launch primitive (S5) -- prove the team WAKES.
+
+Design: `synapt-spawn-premium-compiler-2026-07-27.md` §2 (LaunchPlan is the
+opaque tier) and §5 (cold start, no `--resume`).
+
+Three probes here exist because the HAPPY PATH CANNOT SEE THEIR FAILURES, which
+is the shape this sprint kept finding:
+
+  1. "Never persist env values" -- nothing writes them on the happy path, so a
+     test that merely launches passes while a launch-script implementation
+     (gr1's current one) also passes. The probe SEARCHES THE FILESYSTEM for a
+     value instead of trusting that nothing wrote it.
+  2. "Started" is not "running" -- a process that exits instantly produces the
+     same successful spawn as one that came up healthy. Same proxy invariant 6
+     names when it says file presence is not venv evidence.
+  3. The env allowlist has TWO directions -- a value for an undeclared key, and
+     a declared key with no value. Probing one leaves the other unguarded.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from gr2.python_cli.launch_exec import (
+    LaunchEntry,
+    LaunchExecutionError,
+    launch_team,
+    launch_unit,
+)
+
+SECRET = "SYNAPT-AGENT-ID-VALUE-THAT-MUST-NEVER-TOUCH-DISK"
+
+
+class LaunchTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.ws = self.tmp / "workspace"
+        self.unit = self.ws / "units" / "u_abc123" / "home"
+        self.unit.mkdir(parents=True)
+        self.pids: list[int] = []
+
+    def tearDown(self):
+        for pid in self.pids:
+            try:
+                os.killpg(os.getpgid(pid), 15)
+            except (ProcessLookupError, PermissionError):
+                pass
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _entry(self, **overrides) -> LaunchEntry:
+        data = {
+            "unit_key": "u_abc123",
+            "workdir": "units/u_abc123/home",
+            # A process that stays alive, so liveness is a real observation.
+            "argv": [sys.executable, "-c", "import time; time.sleep(30)"],
+            "env_allowlist_keys": ["SYNAPT_AGENT_ID"],
+        }
+        data.update(overrides)
+        return LaunchEntry.from_mapping(data)
+
+    def _launch(self, entry=None, env=None):
+        ev = launch_unit(
+            entry or self._entry(),
+            workspace_root=self.ws,
+            env_values=env if env is not None else {"SYNAPT_AGENT_ID": SECRET},
+        )
+        self.pids.append(int(ev["pid"]))
+        return ev
+
+
+class TestLaunchMeansAlive(LaunchTestBase):
+    def test_a_launched_unit_is_running(self):
+        ev = self._launch()
+        self.assertEqual(ev["kind"], "launch")
+        self.assertIs(ev["alive"], True)
+        os.kill(ev["pid"], 0)  # raises if not running
+
+    def test_a_process_that_exits_immediately_is_not_a_launch(self):
+        """The proxy this guard exists to reject. Popen returns successfully for
+        a process that dies on the next instruction, and the failure would
+        surface much later as an empty pane nobody notices."""
+        entry = self._entry(argv=[sys.executable, "-c", "raise SystemExit(3)"])
+        with self.assertRaises(LaunchExecutionError) as ctx:
+            self._launch(entry)
+        self.assertIn("exited with code 3", str(ctx.exception))
+
+    def test_a_missing_binary_is_named(self):
+        entry = self._entry(argv=["definitely-not-a-real-binary-xyz"])
+        with self.assertRaises(LaunchExecutionError) as ctx:
+            self._launch(entry)
+        self.assertIn("not found on PATH", str(ctx.exception))
+
+
+class TestTheBoundary(LaunchTestBase):
+    def test_no_environment_value_reaches_the_filesystem(self):
+        """The correction this slice exists to make.
+
+        gr1's spawn writes a launch script containing `export KEY=value`, which
+        puts identity values on disk inside the OSS layer, in a file that
+        outlives the launch. This SEARCHES the workspace for the value rather
+        than trusting that nothing wrote it -- a test that only launches passes
+        for both implementations."""
+        ev = self._launch()
+
+        found = []
+        for path in self.ws.rglob("*"):
+            if not path.is_file():
+                continue
+            try:
+                if SECRET in path.read_text(errors="ignore"):
+                    found.append(str(path))
+            except OSError:  # pragma: no cover
+                pass
+        self.assertEqual(found, [], f"environment value persisted to disk: {found}")
+
+        # And the evidence carries NAMES only.
+        self.assertEqual(ev["env_keys"], ["SYNAPT_AGENT_ID"])
+        self.assertNotIn(SECRET, str(ev))
+
+    def test_the_child_actually_received_the_value(self):
+        """The complement, so 'nothing on disk' is not achieved by never
+        injecting anything. The value must reach the process and only the
+        process."""
+        out = self.unit / "seen.txt"
+        entry = self._entry(
+            argv=[
+                sys.executable,
+                "-c",
+                f"import os,time;open({str(out)!r},'w').write("
+                "os.environ.get('SYNAPT_AGENT_ID','MISSING'));time.sleep(30)",
+            ]
+        )
+        self._launch(entry)
+        for _ in range(40):
+            if out.is_file() and out.read_text():
+                break
+            time.sleep(0.05)
+        self.assertEqual(out.read_text(), SECRET, "the child never received the value")
+
+    def test_a_value_for_an_undeclared_key_is_refused(self):
+        with self.assertRaises(LaunchExecutionError) as ctx:
+            self._launch(env={"SYNAPT_AGENT_ID": SECRET, "SYNAPT_ORG": "smuggled"})
+        self.assertIn("SYNAPT_ORG", str(ctx.exception))
+        self.assertIn("undeclared", str(ctx.exception))
+
+    def test_a_declared_key_with_no_value_is_refused(self):
+        """The other direction. Launching anyway hands the agent a half-built
+        environment and defers the failure to runtime."""
+        entry = self._entry(env_allowlist_keys=["SYNAPT_AGENT_ID", "SYNAPT_CHANNELS"])
+        with self.assertRaises(LaunchExecutionError) as ctx:
+            self._launch(entry, env={"SYNAPT_AGENT_ID": SECRET})
+        self.assertIn("SYNAPT_CHANNELS", str(ctx.exception))
+        self.assertIn("no value supplied", str(ctx.exception))
+
+
+class TestOpaqueEntryShape(LaunchTestBase):
+    def test_an_unknown_field_is_rejected_not_ignored(self):
+        """Closed by construction, same reason the plan schema is: a field
+        nobody thought to reject cannot smuggle anything if it cannot exist.
+        An unexpected key is exactly how identity would arrive here."""
+        with self.assertRaises(LaunchExecutionError) as ctx:
+            LaunchEntry.from_mapping(
+                {
+                    "unit_key": "u_abc123",
+                    "workdir": "units/u_abc123/home",
+                    "argv": ["true"],
+                    "env_allowlist_keys": [],
+                    "agent_name": "apollo",
+                }
+            )
+        self.assertIn("agent_name", str(ctx.exception))
+
+    def test_argv_must_be_a_list_not_a_shell_string(self):
+        """A single string invites shell interpretation. The launcher never
+        hands a plan's contents to a shell."""
+        with self.assertRaises(LaunchExecutionError) as ctx:
+            LaunchEntry.from_mapping(
+                {
+                    "unit_key": "u_abc123",
+                    "workdir": "units/u_abc123/home",
+                    "argv": "claude --model x",
+                    "env_allowlist_keys": [],
+                }
+            )
+        self.assertIn("list of strings", str(ctx.exception))
+
+    def test_a_missing_workdir_is_refused_rather_than_created(self):
+        """Materialization runs before launch, so a missing workspace means the
+        unit was never materialized -- not that launch should create it."""
+        entry = self._entry(workdir="units/u_never_materialized/home")
+        with self.assertRaises(LaunchExecutionError) as ctx:
+            self._launch(entry)
+        self.assertIn("does not exist", str(ctx.exception))
+
+
+class TestTeamLaunch(LaunchTestBase):
+    def _team_entries(self, n=3, bad_index=None):
+        entries = []
+        for i in range(n):
+            key = f"u_unit{i}"
+            (self.ws / "units" / key / "home").mkdir(parents=True, exist_ok=True)
+            argv = (
+                [sys.executable, "-c", "raise SystemExit(1)"]
+                if i == bad_index
+                else [sys.executable, "-c", "import time; time.sleep(30)"]
+            )
+            entries.append(
+                LaunchEntry.from_mapping(
+                    {
+                        "unit_key": key,
+                        "workdir": f"units/{key}/home",
+                        "argv": argv,
+                        "env_allowlist_keys": ["SYNAPT_AGENT_ID"],
+                    }
+                )
+            )
+        return entries
+
+    def test_the_whole_team_wakes(self):
+        entries = self._team_entries()
+        evidence = launch_team(
+            entries,
+            workspace_root=self.ws,
+            env_values_by_unit={e.unit_key: {"SYNAPT_AGENT_ID": SECRET} for e in entries},
+        )
+        self.assertEqual(len(evidence), 3)
+        for ev in evidence:
+            self.pids.append(int(ev["pid"]))
+            os.kill(ev["pid"], 0)
+        self.assertEqual(len({ev["pid"] for ev in evidence}), 3, "units share a process")
+
+    def test_one_failed_unit_leaves_no_half_live_team(self):
+        """Same failure shape as a partially materialized team: some agents
+        alive, some absent, presenting as a confused team rather than an error.
+        Anything already started is terminated before the failure propagates, so
+        a retry does not race a half-live team."""
+        entries = self._team_entries(bad_index=2)
+        before = _child_python_count()
+
+        with self.assertRaises(LaunchExecutionError):
+            launch_team(
+                entries,
+                workspace_root=self.ws,
+                env_values_by_unit={
+                    e.unit_key: {"SYNAPT_AGENT_ID": SECRET} for e in entries
+                },
+            )
+
+        # The two that started must have been reaped.
+        for _ in range(40):
+            if _child_python_count() <= before:
+                break
+            time.sleep(0.05)
+        self.assertLessEqual(
+            _child_python_count(), before, "survivors left behind after a failed team launch"
+        )
+
+
+def _child_python_count() -> int:
+    """Sleeping python children of this process -- the fixture's own launches."""
+    try:
+        out = subprocess.run(
+            ["pgrep", "-P", str(os.getpid())], capture_output=True, text=True, check=False
+        ).stdout
+    except OSError:  # pragma: no cover
+        return 0
+    return len([line for line in out.splitlines() if line.strip()])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gr2/tests/test_launch_primitive.py
+++ b/gr2/tests/test_launch_primitive.py
@@ -110,6 +110,25 @@ class TestLaunchMeansAlive(LaunchTestBase):
             self._launch(entry)
         self.assertIn("exited with code 3", str(ctx.exception))
 
+    def test_a_bare_binary_name_resolves_through_the_constructed_PATH(self):
+        """The demo's actual shape, and the case every other test misses.
+
+        agents.toml declares `binary = "claude"` -- a BARE NAME, resolved via
+        PATH. Every other test here uses sys.executable, an ABSOLUTE path, which
+        never consults PATH at all. Now that the environment is constructed
+        rather than inherited, PATH is something the launcher supplies
+        deliberately, so bare-name resolution is a live risk that the convenient
+        fixtures happen not to exercise.
+
+        There is a test that a bare name FAILS when missing; without this one
+        there is none that it SUCCEEDS when present, which is the happy path of
+        the thing we are actually shipping."""
+        bare = Path(sys.executable).name  # e.g. "python3.13", resolvable on PATH
+        entry = self._entry(argv=[bare, "-c", "import time; time.sleep(30)"])
+        ev = self._launch(entry)
+        self.assertIs(ev["alive"], True)
+        os.kill(ev["pid"], 0)
+
     def test_a_missing_binary_is_named(self):
         entry = self._entry(argv=["definitely-not-a-real-binary-xyz"])
         with self.assertRaises(LaunchExecutionError) as ctx:


### PR DESCRIPTION
## Summary

**S5: the neutral launch primitive.** The team wakes.

Executes a LaunchPlan entry — run this argv, in this working directory, with these environment **key names**. gr2 cannot tell a synapt agent team from any other multi-repo workspace: it sees an opaque `unit_key`, an argv, and a set of key names whose **values** premium supplies in memory.

Design: `synapt-spawn-premium-compiler-2026-07-27.md` §2 (LaunchPlan is the opaque tier) and §5 (cold start, no `--resume`).

**Premium boundary: gitgrip is OSS.** This runs an argv in a directory with a declared set of environment **key names**. Identity env **values are injected in-memory only and never persisted** — the primitive has no script-writing path at all. It reads no identity, derives none, and the evidence it returns carries key names only.

**Reviewers: Sentinel** (the identity-on-disk boundary is his QA lane) **+ Stromus.**

## The boundary correction this slice exists to make

gr1's spawn (`spawn.rs:240 build_launch_script_content`) writes an on-disk launch script containing `export KEY=value` lines. That puts identity environment **values** — `SYNAPT_AGENT_ID`, org, channel bindings — on disk inside the OSS layer, **in a file that outlives the launch**.

The neutral plan carries key names; values are injected in memory and never written. Same rule that held through the entire materializer: *no identity in any neutral artifact* — and **a launch script is a neutral artifact**.

## Why that needed a two-sided probe

On the happy path **nothing writes the value either way**, so a test that merely launches passes for the script-writing implementation *and* the correct one. `test_no_environment_value_reaches_the_filesystem` therefore **searches the workspace** for the value rather than trusting that nothing wrote it. Same move as S4-B's publication-ordering probe: when both implementations reach the same observable end state, you have to look at the thing that actually differs.

And it needs a **complement**, or "nothing on disk" is satisfied by the degenerate implementation that injects nothing at all: `test_the_child_actually_received_the_value` has the child write its received value to a file and asserts it arrived. **The value must reach the process, and only the process.** A one-sided test would have blessed an empty environment.

## What "launched" has to mean

A spawn call returning successfully is **not** an agent running. A process that exits immediately — missing binary, bad flag, instant crash — produces exactly the same successful `Popen` as one that came up healthy, and the failure surfaces later as an empty pane nobody notices.

Launch is not acknowledged until the child is observed **alive** after a settle interval. This is *existence-is-not-health* for the third time in this arc — invariant 6's `pyvenv.cfg`-isn't-a-venv, S4-B's clone-exists-isn't-isolated — and it was designed in rather than discovered.

## The env allowlist is exact in both directions

Checked **separately**, not by one set-equality assertion, because a single check reports whichever difference it finds first and teaches the operator the wrong thing to fix:

| Case | What it means |
|---|---|
| value for an **undeclared** key | premium sent something the plan never described — and the plan is what a reviewer reads to know what a process receives, so anything outside it is **invisible to review** |
| declared key with **no value** | a half-built environment; the failure is deferred to runtime as behaviour nobody traces back to launch |

## Also closed by construction

- Unknown fields on a launch entry are **rejected, not ignored** — an unexpected key is exactly how identity would arrive.
- `argv` must be a **list**; a single string invites shell interpretation, and the launcher never hands a plan's contents to a shell.
- A missing `workdir` is refused rather than created — materialization runs before launch, so a missing workspace means the unit was never materialized.

## Team launch is all-or-nothing

Same reasoning as the materializer: a partially launched team means some agents alive and some absent, presenting as a **confused team rather than an error**. Anything already started is terminated before the failure propagates, so a retry does not race a half-live team — with a probe asserting no survivors are left behind.

## Verification

**12 launch tests**, **709 gr2 tests green**, `ruff check` clean on both new files.

## Not in this PR

The premium **LaunchPlan emission** — compiling `agents.toml` into these entries, with the OperationalPlan holding the values — is the seam that joins materialize to wake. It lives in `synapt-private` and is next.