### PR TITLE
scrub(privacy): remove residual public-repo disclosures from grip (2026-07-29)

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -604,10 +604,10 @@ Closes #130
 ```
 Griptrees
 
-  feat-auth -> /Users/layne/Development/feat-auth
+  feat-auth -> /Users/example/Development/feat-auth
 
 ⚠ Found unregistered griptrees:
-  codi-dev -> /Users/layne/Development/codi-dev (unregistered)
+  codi-dev -> /Users/example/Development/codi-dev (unregistered)
 
 These griptrees point to this workspace but are not in griptrees.json.
 You can manually add them to griptrees.json if needed.
@@ -626,7 +626,7 @@ You can manually add them to griptrees.json if needed.
 
 **Problem**: When a branch is checked out in another worktree, git gives a cryptic error:
 ```
-fatal: 'main' is already used by worktree at '/Users/layne/Development/codi-workspace/gitgrip'
+fatal: 'main' is already used by worktree at '/Users/example/Development/codi-workspace/gitgrip'
 ```
 
 **Solution**: Enhanced error handling in `checkout_branch()` and `create_and_checkout_branch()` to detect worktree conflicts and provide actionable guidance:
@@ -763,7 +763,7 @@ gh pr merge 16 --repo laynepenney/codi-strategy --squash --delete-branch
 
 **Raw commands used**:
 ```bash
-cd /Users/layne/Development/codi-gripspace/.gitgrip/manifests
+cd /Users/example/Development/codi-gripspace/.gitgrip/manifests
 git push -u origin codi-gripspace
 gh pr create --title "..." --body "..." --repo laynepenney/codi-workspace
 ```

--- a/gr2/pyproject.toml
+++ b/gr2/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "tomli_w>=1.0",
     "pyyaml>=6.0",
     "toml>=0.10",
-    # Draft 2020-12 validation of the pinned MaterializationPlan v1 schema
-    # (config#492). 4.18 is the first release with the modern referencing
+    # Draft 2020-12 validation of the pinned MaterializationPlan v1 schema.
+    # 4.18 is the first release with the modern referencing
     # stack; anything older silently falls back to a legacy resolver.
     "jsonschema>=4.18",
 ]
@@ -28,8 +28,8 @@ dev = [
 ]
 
 [tool.setuptools]
-# gr2_overlay is a time-bounded compat alias for gr2.overlay (config#491
-# gap#13): same physical directory, two import names. New code imports
+# gr2_overlay is a time-bounded compatibility alias for gr2.overlay:
+# same physical directory, two import names. New code imports
 # gr2.overlay; gr2_overlay stays for existing consumers until they are
 # migrated separately.
 packages = ["gr2_overlay", "gr2", "gr2.python_cli", "gr2.prototypes", "gr2.overlay"]
@@ -41,7 +41,7 @@ gr2 = "gr2"
 "gr2.overlay" = "gr2_overlay"
 
 [tool.setuptools.package-data]
-# The pinned MaterializationPlan v1 schema (config#492) ships inside the
+# The pinned MaterializationPlan v1 schema ships inside the
 # gr2 package -- spec_apply verifies its bytes against the pinned SHA-256
 # at load and fails closed on any mismatch.
 gr2 = ["schemas/*.json"]

--- a/gr2/python_cli/clone_exec.py
+++ b/gr2/python_cli/clone_exec.py
@@ -3,8 +3,7 @@
 S4-A landed the plan CONTRACT: validate -> un-forgeable ValidatedPlan
 capability -> durable receipt. This is the first thing that consumes it.
 
-Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
-      section 8 (full clone contract), acceptance fruit 6/7/8/9.
+Contract: MaterializationPlan v1 clone contract and acceptance fruit 6/7/8/9.
 
 Why this is its own module rather than more of `gitops.py`: gitops is a thin
 subprocess layer over git. The substance here is POLICY -- which object sharing

--- a/gr2/python_cli/env_exec.py
+++ b/gr2/python_cli/env_exec.py
@@ -3,8 +3,8 @@
 The last two materialization handlers. With these, the A -> B -> C -> D path is
 complete: contract, clones, projections, environments.
 
-Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
-      section 9.2, section 6.2.1 invariant 6, acceptance fruit 10/11/12.
+Contract: MaterializationPlan v1 environment invariant 6 and
+          acceptance fruit 10/11/12.
 
 Working, not exhaustively hardened (Layne's 2026-07-27 prototype doctrine).
 

--- a/gr2/python_cli/file_exec.py
+++ b/gr2/python_cli/file_exec.py
@@ -5,8 +5,8 @@ inside the unit, and refuses unless the bytes hash to the `source_sha256` the
 plan declares. gr2 reads only the plan: it does not know what the file is for,
 and nothing here depends on its contents.
 
-Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
-      section 6.2.1 invariants 7 and 8, section 383, fruit 14/15/22.
+Contract: MaterializationPlan v1 project-file invariants 7 and 8,
+          including source confinement and acceptance fruit 14/15/22.
 
 INVARIANT 7 IS A TRAP AS LITERALLY WORDED. It says verify the source's
 "reopened bytes match source_sha256". Read word for word -- reopen, hash, then

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -746,7 +746,7 @@ def _capability_seal(
     return hmac.new(_CAPABILITY_SECRET, payload, hashlib.sha256).hexdigest()
 
 
-# The normative wire contract (config#492, merged 4b36896). A hand-rolled
+# The normative MaterializationPlan v1 wire contract. A hand-rolled
 # validator is a separate, looser contract by construction -- nine plans the
 # pinned schema rejects were accepted by an earlier hand version, and
 # schema_version=True slipped a `!= 1` check because bool is an int subclass
@@ -782,13 +782,13 @@ def _load_plan_validator() -> Draft202012Validator:
             raise MaterializationPlanError(
                 f"packaged MaterializationPlan v1 schema hash mismatch: expected "
                 f"{_PLAN_SCHEMA_SHA256}, got {actual} -- refusing to validate against "
-                "an unpinned schema (config#492 §6.2.1)"
+                "an unpinned schema"
             )
         _plan_validator = Draft202012Validator(json.loads(raw))
     return _plan_validator
 
 
-# config#492 §6.2.1: "The production plan must not contain: agent display
+# MaterializationPlan v1: "The production plan must not contain: agent display
 # name, persistent agent ID, role, org or project, channel, entitlement
 # result or reason, secret reference or value, memory body." Checked
 # recursively as defence in depth -- the per-kind ALLOWLIST below is what
@@ -820,7 +820,7 @@ def _reject_identity_fields_recursive(value: object, *, path: str) -> None:
         if present:
             raise MaterializationPlanError(
                 f"{path} carries identity-bearing field(s) {sorted(present)}; "
-                "gr2 MaterializationPlan operations must be identity-free (config#492 §6.2.1)"
+                "gr2 MaterializationPlan operations must be identity-free"
             )
         for key, nested in value.items():
             _reject_identity_fields_recursive(nested, path=f"{path}.{key}")
@@ -842,7 +842,7 @@ def _validate_path_safe_token(value: object, *, field_name: str) -> str:
 
 
 def canonicalize_workspace_path(workspace_root: Path, relative: str, *, field_name: str) -> Path:
-    """config#492 §6.2.1 invariant #2: reject absolute paths, `~`,
+    """MaterializationPlan v1 invariant #2: reject absolute paths, `~`,
     backslashes, empty segments, `.` or `..` segments, NUL, any existing
     symlink in the path prefix, and any resolved escape.
 
@@ -875,7 +875,7 @@ def canonicalize_workspace_path(workspace_root: Path, relative: str, *, field_na
         if walker.is_symlink():
             raise MaterializationPlanError(
                 f"{field_name} passes through a symlink at {walker} -- path prefixes must be "
-                "symlink-free (config#492 §6.2.1 #2)"
+                "symlink-free (MaterializationPlan v1 invariant #2)"
             )
     workspace_resolved = workspace_root.resolve()
     candidate = (workspace_root / relative).resolve()
@@ -971,7 +971,7 @@ def _validate_operation_shape(
 
 
 def validate_materialization_plan(workspace_root: Path, plan: dict[str, object]) -> ValidatedPlan:
-    """Validate a neutral MaterializationPlan against config#492's pinned v1
+    """Validate a neutral MaterializationPlan against its pinned v1
     contract. Raises MaterializationPlanError on the first violation.
 
     Validate-before-touch: this runs to completion over the WHOLE plan
@@ -1019,7 +1019,7 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
     # identity from it.
     _validate_path_safe_token(plan.get("unit_key"), field_name="unit_key")
 
-    # config#492 §6.2.1 invariant #1: reopen the canonical WorkspaceSpec
+    # MaterializationPlan v1 invariant #1: reopen the canonical WorkspaceSpec
     # bytes and verify their SHA-256. Carrying the field is not verifying it.
     workspace_spec_sha256 = str(plan["workspace_spec_sha256"])
     actual_spec_sha256 = hashlib.sha256(_read_canonical_workspace_spec_bytes(workspace_root)).hexdigest()
@@ -1027,12 +1027,12 @@ def validate_materialization_plan(workspace_root: Path, plan: dict[str, object])
         raise MaterializationPlanError(
             f"workspace_spec_sha256 mismatch: plan declares {workspace_spec_sha256}, "
             f"canonical WorkspaceSpec bytes hash to {actual_spec_sha256} -- the plan was "
-            "compiled against a different workspace state (config#492 §6.2.1 #1)"
+            "compiled against a different workspace state (MaterializationPlan v1 invariant #1)"
         )
 
     operations = plan["operations"]
 
-    # config#492 §6.2.1 #3: compare destinations after normalization and
+    # MaterializationPlan v1 invariant #3: compare destinations after normalization and
     # Unicode-aware case folding. Raw-string comparison lets "u1/.venv" and
     # "u1/./.venv" both through, and casefold (not lower) is required so
     # "straße"/"STRASSE" collide.
@@ -1082,7 +1082,7 @@ _RECEIPT_DIR_RELATIVE = ".grip/state/materialization"
 
 
 def _read_canonical_workspace_spec_bytes(workspace_root: Path) -> bytes:
-    """config#492 §6.2.1 #2 applies to the CONTRACT paths too, not only to
+    """MaterializationPlan v1 invariant #2 applies to contract paths too, not only to
     operation paths (Atlas P2): the canonical WorkspaceSpec must be reached
     through a symlink-free prefix and be a regular non-symlink file.
 
@@ -1096,12 +1096,12 @@ def _read_canonical_workspace_spec_bytes(workspace_root: Path) -> bytes:
     if not spec_file.exists():
         raise MaterializationPlanError(
             "canonical WorkspaceSpec (.grip/workspace_spec.toml) not found -- "
-            "workspace_spec_sha256 cannot be verified (config#492 §6.2.1 #1)"
+            "workspace_spec_sha256 cannot be verified (MaterializationPlan v1 invariant #1)"
         )
     if not stat.S_ISREG(os.lstat(spec_file).st_mode):
         raise MaterializationPlanError(
             f"canonical WorkspaceSpec at {spec_file} is not a regular file "
-            "(config#492 §6.2.1 #2)"
+            "(MaterializationPlan v1 invariant #2)"
         )
     return spec_file.read_bytes()
 
@@ -1117,13 +1117,14 @@ def _canonical_receipt_dir(workspace_root: Path) -> Path:
     receipt_dir.mkdir(parents=True, exist_ok=True)
     if not stat.S_ISDIR(os.lstat(receipt_dir).st_mode):
         raise MaterializationPlanError(
-            f"receipt directory {receipt_dir} is not a real directory (config#492 §6.2.1 #2)"
+            f"receipt directory {receipt_dir} is not a real directory "
+            "(MaterializationPlan v1 invariant #2)"
         )
     return receipt_dir
 
 
 def compute_plan_hash(plan: dict[str, object]) -> str:
-    """config#492 §6.2.1 #9, the exact pinned canonical serialization: UTF-8
+    """MaterializationPlan v1 invariant #9, the exact pinned canonical serialization: UTF-8
     JSON, keys sorted, no insignificant whitespace, non-ASCII unescaped.
     Default json.dumps separators and ensure_ascii=True produce different
     bytes and therefore a non-conformant hash. Public so callers and tests
@@ -1152,7 +1153,7 @@ def materialization_receipt_path(workspace_root: Path, plan_id: str) -> Path:
 
 
 def _screen_receipt_evidence(binding: _ConsumptionBinding) -> None:
-    """config#492 §12.1, Atlas P1: the terminal receipt must be bound to the
+    """The terminal receipt must be bound to the
     plan it claims to acknowledge, and its evidence must be as neutral as
     the plan.
 
@@ -1203,7 +1204,7 @@ def write_materialization_receipt(
     unscreened result graph could be persisted verbatim. Holding the
     capability is the proof that the contract already ran.
 
-    config#492 §6.2.1 #10 -- publication order is exact and every step is
+    MaterializationPlan v1 invariant #10 -- publication order is exact and every step is
     load-bearing: same-directory temp -> write+flush -> fsync(temp file) ->
     atomic replace -> fsync(parent directory). Rename success alone is not
     durable acknowledgement; on power loss the rename can survive while the

--- a/gr2/python_cli/staging_cleanup.py
+++ b/gr2/python_cli/staging_cleanup.py
@@ -4,8 +4,7 @@ Carved out of S4-C so a DELETE never shares a review surface with a copy. C
 stages, projects, and publishes a receipt, and deletes nothing. This module is
 the only thing in the system permitted to remove a staged input.
 
-Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
-      section 6.2.1 invariant 8.
+Contract: MaterializationPlan v1 staged-input durability invariant 8.
 
     "Do not delete a staged project-file input until the final materialization
     receipt containing that operation's evidence has been atomically published

--- a/gr2/tests/test_clone_materialization.py
+++ b/gr2/tests/test_clone_materialization.py
@@ -3,8 +3,7 @@
 S4-A landed the plan CONTRACT (validate -> capability -> receipt) and nothing
 consumed it. This is the first operation EXECUTOR: `kind == "clone"`.
 
-Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
-      section 8 (full clone contract), acceptance fruit 6/7/8/9.
+Contract: MaterializationPlan v1 clone contract and acceptance fruit 6/7/8/9.
 
 Testing discipline carried forward from the S4-A review cycle, and applied at
 DESIGN time rather than at test time: for every guard, ask what ELSE would

--- a/gr2/tests/test_env_materialization.py
+++ b/gr2/tests/test_env_materialization.py
@@ -3,8 +3,8 @@
 The last two materialization handlers. With these the A -> B -> C -> D path is
 complete.
 
-Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
-      section 9.2, section 6.2.1 invariant 6, acceptance fruit 10/11/12.
+Contract: MaterializationPlan v1 environment invariant 6 and
+          acceptance fruit 10/11/12.
 
 Prototype posture (Layne 2026-07-27): working end-to-end, not exhaustively
 hardened. The probes below cover the guards the spec names explicitly; broader

--- a/gr2/tests/test_gr2_packaging.py
+++ b/gr2/tests/test_gr2_packaging.py
@@ -60,7 +60,7 @@ def test_gr2_overlay_still_imports_unprefixed(tmp_path: Path) -> None:
 
 
 def test_gr2_overlay_alias_resolves(tmp_path: Path) -> None:
-    """gr2.overlay (config#491 gap#13) must resolve, and to the same physical
+    """gr2.overlay must resolve to the same physical
     file as gr2_overlay -- it's a compat alias, not a fork."""
     result = _run(
         [
@@ -77,7 +77,7 @@ def test_gr2_overlay_alias_resolves(tmp_path: Path) -> None:
 
 def test_pinned_plan_schema_is_packaged_and_matches_sha(tmp_path: Path) -> None:
     """The pinned MaterializationPlan v1 schema must ship INSIDE the installed
-    package (config#492), not merely exist in the source tree -- and its bytes
+    package, not merely exist in the source tree -- and its bytes
     must match the pinned SHA-256."""
     result = _run(
         [

--- a/gr2/tests/test_grip_hardening.py
+++ b/gr2/tests/test_grip_hardening.py
@@ -51,7 +51,7 @@ def workspace(tmp_path: Path) -> Path:
     _init_repo(ws / "recall", name="recall")
     git(ws / "recall", "remote", "add", "origin", "https://github.com/synapt-dev/recall")
     _init_repo(ws / "config", name="config")
-    git(ws / "config", "remote", "add", "origin", "https://github.com/synapt-dev/config")
+    git(ws / "config", "remote", "add", "origin", "https://github.com/example-org/config")
     return ws
 
 

--- a/gr2/tests/test_grip_snapshot.py
+++ b/gr2/tests/test_grip_snapshot.py
@@ -55,7 +55,7 @@ def workspace(tmp_path: Path) -> Path:
     git(ws / "recall", "remote", "add", "origin", "https://github.com/synapt-dev/recall")
 
     _init_repo(ws / "config", name="config")
-    git(ws / "config", "remote", "add", "origin", "https://github.com/synapt-dev/config")
+    git(ws / "config", "remote", "add", "origin", "https://github.com/example-org/config")
 
     return ws
 

--- a/gr2/tests/test_materialization_plan_contract.py
+++ b/gr2/tests/test_materialization_plan_contract.py
@@ -129,7 +129,7 @@ class TestSchemaPin(PlanContractTestBase):
 
 
 class TestPinnedSchemaConformance(PlanContractTestBase):
-    """config#492's malformed-plan set. A hand-rolled validator is a
+    """The MaterializationPlan v1 malformed-plan set. A hand-rolled validator is a
     separate, looser contract by construction; these pin conformance to
     the pinned schema itself."""
 

--- a/gr2/tests/test_project_file_materialization.py
+++ b/gr2/tests/test_project_file_materialization.py
@@ -5,9 +5,8 @@ destination inside the unit, refusing unless the bytes hash to the declared
 `source_sha256`. These tests pin the copy, the hash gate, and the refusals --
 nothing about what the file is for, because the executor does not know.
 
-Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
-      section 6.2.1 invariants 7 and 8, section 383 (source confinement),
-      acceptance fruit 14 / 15 / 22.
+Contract: MaterializationPlan v1 project-file invariants 7 and 8,
+          including source confinement and acceptance fruit 14 / 15 / 22.
 
 Two things in the spec change the shape from what "copy a file" suggests, and
 both are pinned below.
@@ -77,7 +76,7 @@ from gr2.python_cli.spec_apply import (
     write_materialization_receipt,
 )
 
-FOUNDATION = b"# Foundation\n\ncharim toward the most high.\n"
+FOUNDATION = b"# Runtime Guide\n\nFollow the declared workspace plan.\n"
 POISON = b"# Foundation\n\nrm -rf / # injected after the hash check\n"
 
 

--- a/gr2/tests/test_staging_cleanup.py
+++ b/gr2/tests/test_staging_cleanup.py
@@ -5,8 +5,7 @@ surface with a copy. C stages, projects, and publishes a receipt, and deletes
 nothing. This slice is the only thing in the system permitted to remove a
 staged input.
 
-Spec: config/design/zero-to-team-gr2-materialization-spec-2026-07-26.md
-      section 6.2.1 invariant 8.
+Contract: MaterializationPlan v1 staged-input durability invariant 8.
 
     "Do not delete a staged project-file input until the final materialization
     receipt containing that operation's evidence has been atomically published
@@ -93,7 +92,7 @@ from gr2.python_cli.staging_cleanup import (
     cleanup_staged_inputs,
 )
 
-FOUNDATION = b"# Foundation\n\ncharim toward the most high.\n"
+FOUNDATION = b"# Runtime Guide\n\nFollow the declared workspace plan.\n"
 
 
 class StagingCleanupTestBase(unittest.TestCase):

--- a/src/cli/commands/migrate.rs
+++ b/src/cli/commands/migrate.rs
@@ -66,7 +66,7 @@ pub async fn run_migrate_from_repos(
         let parts: Vec<&str> = spec.splitn(2, '/').collect();
         if parts.len() != 2 {
             anyhow::bail!(
-                "Invalid repo format '{}': expected owner/repo (e.g. GetConversa/conversa-app)",
+                "Invalid repo format '{}': expected owner/repo (e.g. example-org/example-app)",
                 spec
             );
         }
@@ -925,7 +925,7 @@ fn worktree_repair_must_succeed(repair: &ProcessOutput) -> anyhow::Result<()> {
 }
 
 /// Derive the repo name from `git remote get-url origin`, falling back to dir name.
-/// "git@github.com:GetConversa/conversa-app.git" → "conversa-app"
+/// "git@github.com:example-org/example-app.git" → "example-app"
 fn derive_repo_name_from_remote(repo: &Path) -> String {
     let result = std::process::Command::new("git")
         .args(["remote", "get-url", "origin"])
@@ -1021,15 +1021,15 @@ mod tests {
     #[test]
     fn test_generate_manifest_yaml() {
         let repos = vec![
-            ("GetConversa".to_string(), "conversa-app".to_string()),
-            ("GetConversa".to_string(), "blessed-sound".to_string()),
+            ("example-org".to_string(), "example-app".to_string()),
+            ("example-org".to_string(), "example-api".to_string()),
         ];
-        let yaml = generate_manifest_yaml(&repos, "synapt-dev", "consult-conversa");
+        let yaml = generate_manifest_yaml(&repos, "example-org", "example-workspace");
         assert!(yaml.contains("version: 2"));
-        assert!(yaml.contains("conversa-app:"));
-        assert!(yaml.contains("blessed-sound:"));
-        assert!(yaml.contains("GetConversa/conversa-app.git"));
-        assert!(yaml.contains("consult-conversa-config:"));
+        assert!(yaml.contains("example-app:"));
+        assert!(yaml.contains("example-api:"));
+        assert!(yaml.contains("example-org/example-app.git"));
+        assert!(yaml.contains("example-workspace-config:"));
         assert!(yaml.contains("clone_strategy: clone"));
     }
 
@@ -1092,15 +1092,15 @@ mod tests {
 
     #[test]
     fn test_parse_worktree_list_marks_main_and_branch_names() {
-        let main = PathBuf::from("/tmp/conversa")
+        let main = PathBuf::from("/tmp/example-workspace")
             .canonicalize()
-            .unwrap_or_else(|_| PathBuf::from("/tmp/conversa"));
+            .unwrap_or_else(|_| PathBuf::from("/tmp/example-workspace"));
         let porcelain = "\
-worktree /tmp/conversa
+worktree /tmp/example-workspace
 HEAD deadbeef
 branch refs/heads/main
 
-worktree /tmp/conversa-dev
+worktree /tmp/example-workspace-dev
 HEAD feedface
 branch refs/heads/feat/dev
 ";
@@ -1116,8 +1116,8 @@ branch refs/heads/feat/dev
     #[tokio::test]
     async fn test_migrate_in_place_converts_linked_worktrees_into_griptrees() {
         let temp = TempDir::new().unwrap();
-        let main_root = temp.path().join("conversa");
-        let linked_root = temp.path().join("conversa-dev");
+        let main_root = temp.path().join("example-workspace");
+        let linked_root = temp.path().join("example-workspace-dev");
         std::fs::create_dir_all(&main_root).unwrap();
 
         assert_git_ok(&main_root, &["init", "-b", "main"]);
@@ -1133,7 +1133,7 @@ branch refs/heads/feat/dev
                 "remote",
                 "add",
                 "origin",
-                "git@github.com:GetConversa/conversa-app.git",
+                "git@github.com:example-org/example-app.git",
             ],
         );
 
@@ -1153,7 +1153,7 @@ branch refs/heads/feat/dev
             .await
             .unwrap();
 
-        let repo_name = "conversa-app";
+        let repo_name = "example-app";
         let main_child = main_root.join(repo_name);
         let linked_child = linked_root.join(repo_name);
 
@@ -1194,7 +1194,7 @@ branch refs/heads/feat/dev
         assert_eq!(repo.revision.as_deref(), Some("main"));
         assert_eq!(
             repo.url.as_deref(),
-            Some("git@github.com:GetConversa/conversa-app.git")
+            Some("git@github.com:example-org/example-app.git")
         );
 
         let pointer = GriptreePointer::load(&linked_root.join(".griptree")).unwrap();

--- a/src/core/agent_registry.rs
+++ b/src/core/agent_registry.rs
@@ -4,7 +4,7 @@
 //! in `~/.synapt/orgs/<org_id>/team.db` and passed to agent sessions via
 //! the `SYNAPT_AGENT_ID` environment variable.
 //!
-//! Phase 0 of the channel scoping design (config/design/channel-scoping.md).
+//! Phase 0 of the channel-scoped agent registry.
 
 use std::path::{Path, PathBuf};
 

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -922,7 +922,7 @@ mod tests {
     /// fail the `[a-zA-Z0-9._-]` name allowlist.
     ///
     /// A Windows file URL needs forward slashes and an extra leading slash
-    /// before the drive: `file:///C:/Users/.../base.git`, from which
+    /// before the drive: `file:///C:/Users/example/base.git`, from which
     /// `gripspace_name` correctly reads `base`.
     fn file_url(path: &std::path::Path) -> String {
         let s = path.display().to_string().replace('\\', "/");

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -1643,7 +1643,7 @@ workspace:
     post-checkout:
       - command: "echo ok"
   env:
-    HOME_DIR: "/Users/layne/Development"
+    HOME_DIR: "/Users/example/Development"
 "#;
         let manifest: Manifest = serde_yaml::from_str(yaml).unwrap();
         let warnings = manifest.lint_absolute_paths();

--- a/tests/integration_agent_id.rs
+++ b/tests/integration_agent_id.rs
@@ -2,8 +2,8 @@
 //!
 //! Verifies that gr spawn creates registry entries in team.db and
 //! that the generated agent_id follows the name-NNN format.
-//! The full end-to-end (Rust → Python channel) is tested via the
-//! Conversa migration test in CI.
+//! The full end-to-end (Rust → Python channel) is covered by the
+//! migration test in CI.
 
 use std::fs;
 use tempfile::TempDir;
@@ -13,48 +13,48 @@ use gitgrip::core::agent_registry::{
     get_agent, get_agent_by_name, list_agents, register_agent, rename_agent,
 };
 
-/// Integration test: register 4 agents (matching Conversa team),
+/// Integration test: register a four-agent synthetic team,
 /// verify all get unique stable IDs, then simulate a restart
 /// (re-lookup) and confirm IDs are preserved.
 #[test]
 fn test_full_agent_lifecycle() {
     let tmp = TempDir::new().unwrap();
-    let org_dir = tmp.path().join("conversa");
+    let org_dir = tmp.path().join("example-team");
     fs::create_dir_all(&org_dir).unwrap();
 
-    let org_id = "conversa";
+    let org_id = "example-team";
 
     // Phase 1: Register 4 agents (simulates gr spawn up)
-    let anchor_id = register_agent(&org_dir, org_id, "anchor", Some("CEO — coordination")).unwrap();
-    let opus_id = register_agent(&org_dir, org_id, "opus", Some("CTO — data backbone")).unwrap();
-    let atlas_id = register_agent(&org_dir, org_id, "atlas", Some("CXO — UI, design")).unwrap();
-    let forge_id = register_agent(&org_dir, org_id, "forge", Some("Chief Architect")).unwrap();
+    let alpha_id = register_agent(&org_dir, org_id, "alpha", Some("team lead")).unwrap();
+    let beta_id = register_agent(&org_dir, org_id, "beta", Some("implementation")).unwrap();
+    let gamma_id = register_agent(&org_dir, org_id, "gamma", Some("design")).unwrap();
+    let delta_id = register_agent(&org_dir, org_id, "delta", Some("architecture")).unwrap();
 
     // Verify format: name-NNN
-    assert_eq!(anchor_id, "anchor-001");
-    assert_eq!(opus_id, "opus-001");
-    assert_eq!(atlas_id, "atlas-001");
-    assert_eq!(forge_id, "forge-001");
+    assert_eq!(alpha_id, "alpha-001");
+    assert_eq!(beta_id, "beta-001");
+    assert_eq!(gamma_id, "gamma-001");
+    assert_eq!(delta_id, "delta-001");
 
     // Phase 2: Simulate restart — lookup by name (same as spawn up does)
-    let anchor_lookup = get_agent_by_name(&org_dir, org_id, "anchor")
+    let alpha_lookup = get_agent_by_name(&org_dir, org_id, "alpha")
         .unwrap()
         .unwrap();
-    assert_eq!(anchor_lookup.agent_id, "anchor-001");
-    assert_eq!(anchor_lookup.role, Some("CEO — coordination".to_string()));
+    assert_eq!(alpha_lookup.agent_id, "alpha-001");
+    assert_eq!(alpha_lookup.role, Some("team lead".to_string()));
 
     // Phase 3: List all agents
     let all = list_agents(&org_dir, org_id).unwrap();
     assert_eq!(all.len(), 4);
 
     // Phase 4: Rename doesn't change ID
-    rename_agent(&org_dir, "opus-001", "Opus Prime").unwrap();
-    let renamed = get_agent(&org_dir, "opus-001").unwrap().unwrap();
-    assert_eq!(renamed.agent_id, "opus-001"); // ID unchanged
-    assert_eq!(renamed.display_name, "Opus Prime"); // Name updated
+    rename_agent(&org_dir, "beta-001", "Beta Prime").unwrap();
+    let renamed = get_agent(&org_dir, "beta-001").unwrap().unwrap();
+    assert_eq!(renamed.agent_id, "beta-001"); // ID unchanged
+    assert_eq!(renamed.display_name, "Beta Prime"); // Name updated
 
     // Phase 5: Duplicate registration fails
-    let dup = register_agent(&org_dir, org_id, "anchor", None);
+    let dup = register_agent(&org_dir, org_id, "alpha", None);
     assert!(dup.is_err(), "Duplicate display_name should be rejected");
 
     // Phase 6: IDs are unique
@@ -68,28 +68,26 @@ fn test_full_agent_lifecycle() {
 #[test]
 fn test_cross_org_isolation() {
     let tmp = TempDir::new().unwrap();
-    let synapt_dir = tmp.path().join("synapt-dev");
-    let conversa_dir = tmp.path().join("conversa");
-    fs::create_dir_all(&synapt_dir).unwrap();
-    fs::create_dir_all(&conversa_dir).unwrap();
+    let org_a_dir = tmp.path().join("org-a");
+    let org_b_dir = tmp.path().join("org-b");
+    fs::create_dir_all(&org_a_dir).unwrap();
+    fs::create_dir_all(&org_b_dir).unwrap();
 
     // Same display name, different orgs
-    let synapt_atlas =
-        register_agent(&synapt_dir, "synapt-dev", "Atlas", Some("research")).unwrap();
-    let conversa_atlas =
-        register_agent(&conversa_dir, "conversa", "Atlas", Some("design")).unwrap();
+    let org_a_casey = register_agent(&org_a_dir, "org-a", "Casey", Some("research")).unwrap();
+    let org_b_casey = register_agent(&org_b_dir, "org-b", "Casey", Some("design")).unwrap();
 
     // Both succeed — no cross-org collision
-    assert_eq!(synapt_atlas, "atlas-001");
-    assert_eq!(conversa_atlas, "atlas-001");
+    assert_eq!(org_a_casey, "casey-001");
+    assert_eq!(org_b_casey, "casey-001");
 
     // Each org has only 1 agent
-    assert_eq!(list_agents(&synapt_dir, "synapt-dev").unwrap().len(), 1);
-    assert_eq!(list_agents(&conversa_dir, "conversa").unwrap().len(), 1);
+    assert_eq!(list_agents(&org_a_dir, "org-a").unwrap().len(), 1);
+    assert_eq!(list_agents(&org_b_dir, "org-b").unwrap().len(), 1);
 
     // Roles are org-specific
-    let s = get_agent(&synapt_dir, "atlas-001").unwrap().unwrap();
-    let c = get_agent(&conversa_dir, "atlas-001").unwrap().unwrap();
-    assert_eq!(s.role, Some("research".to_string()));
-    assert_eq!(c.role, Some("design".to_string()));
+    let a = get_agent(&org_a_dir, "casey-001").unwrap().unwrap();
+    let b = get_agent(&org_b_dir, "casey-001").unwrap().unwrap();
+    assert_eq!(a.role, Some("research".to_string()));
+    assert_eq!(b.role, Some("design".to_string()));
 }


### PR DESCRIPTION
Privacy/hygiene scrub of grip — removes residual internal-detail disclosures (real local paths, private design-doc references, and an internal fixture string), genericized in place. Guard clean (0/0) with a live negative control; Python + cargo all-features + fmt all green. Two-agent gate satisfied (author + independent second-stance + guard backstop). Merge-commit per policy. Premium boundary: OSS.