### PR TITLE
release: gitgrip v1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
Version bump 1.0.1 -> 1.0.2 (Cargo.toml + Cargo.lock version lines only, zero functional change, guard-clean). Cuts the v1.0.2 release from the scrubbed main so the Homebrew delivery to the Conversa team is both guarded (scope-safety fix) and clean. Homebrew is still on v1.0.0, so this is the first delivery of the guarded binary.