### PR TITLE
feat(gr2): add socket-isolated tmux launch runtime

### DIFF
--- a/gr2/python_cli/launch_exec.py
+++ b/gr2/python_cli/launch_exec.py
@@ -1,9 +1,9 @@
 """Neutral launch primitive (S5).
 
 Executes a LaunchPlan entry: run this argv, in this working directory, with
-these environment KEY NAMES. gr2 cannot tell one caller's workspace from another -- it sees an opaque
-`unit_key`, an argv, and a set of env key names whose VALUES the caller supplies
-in memory at launch.
+these environment KEY NAMES. gr2 cannot tell one caller's workspace from
+another -- it sees an opaque `unit_key`, an argv, and a set of env key names
+whose VALUES the caller supplies in memory at launch.
 
 Design: the spawn launch contract, §2 (LaunchPlan is the
 opaque tier) and §5 (cold start, no `--resume`).
@@ -33,21 +33,36 @@ child has been observed ALIVE after a settle interval, which is the same
 distinction invariant 6 draws between a venv's files existing and its
 interpreter answering.
 """
+
 from __future__ import annotations
 
 import dataclasses
 import os
+import re
+import socket
+import stat
 import subprocess
+import sys
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from .spec_apply import MaterializationPlanError, canonicalize_workspace_path
 
 # Long enough that an immediate crash (bad binary, bad flag, instant exit) has
 # happened, short enough not to matter against §13's 180s budget.
 _LIVENESS_SETTLE_SECONDS = 0.35
+
+# macOS exposes 104 bytes for sockaddr_un.sun_path including the terminating
+# NUL, so 103 encoded path bytes is the portable ceiling this runtime accepts.
+# Linux permits a few more; using the smaller measured limit makes the same
+# explicit socket viable on every supported POSIX host instead of branching on
+# whichever generated workspace path or kernel happens to be present.
+_AF_UNIX_SOCKET_PATH_MAX_BYTES = 103
+_MINIMUM_TMUX_VERSION = (3, 2)
+_TMUX_ROLLBACK_SETTLE_SECONDS = 2.0
+_TMUX_ROLLBACK_POLL_SECONDS = 0.02
 
 
 class LaunchExecutionError(MaterializationPlanError):
@@ -82,8 +97,10 @@ class LaunchEntry:
             if not isinstance(data.get(field), str) or not data[field]:
                 raise LaunchExecutionError(f"launch entry {field!r} must be a non-empty string")
         argv = data.get("argv")
-        if not isinstance(argv, (list, tuple)) or not argv or not all(
-            isinstance(a, str) for a in argv
+        if (
+            not isinstance(argv, (list, tuple))
+            or not argv
+            or not all(isinstance(a, str) for a in argv)
         ):
             raise LaunchExecutionError(
                 "launch entry argv must be a non-empty list of strings -- a single "
@@ -172,6 +189,480 @@ def _child_environment(entry: LaunchEntry, values: Mapping[str, str]) -> dict[st
     return child
 
 
+@dataclasses.dataclass(frozen=True)
+class TmuxPaneHandle:
+    """A handle returned by the runtime, never a name to resolve later.
+
+    ``alive_at_launch`` is deliberately a momentary observation.  A field named
+    ``alive`` would read as current truth even though the process can exit the
+    instant after this value is returned.
+    """
+
+    kind: str
+    unit_key: str
+    socket_path: Path
+    session_id: str
+    server_pid: int
+    pane_id: str
+    pid: int
+    workdir: Path
+    env_keys: tuple[str, ...]
+    alive_at_launch: bool
+
+
+class LaunchRuntime(Protocol):
+    """Common interface implemented by the available launch modes."""
+
+    def launch_team(
+        self,
+        entries: Sequence[LaunchEntry],
+        *,
+        workspace_root: Path,
+        env_values_by_unit: Mapping[str, Mapping[str, str]],
+        settle_seconds: float,
+    ) -> list[dict[str, object]] | list[TmuxPaneHandle]: ...
+
+
+@dataclasses.dataclass(frozen=True)
+class DirectProcessRuntime:
+    """Today's headless process runtime, retained as the default behavior."""
+
+    def launch_team(
+        self,
+        entries: Sequence[LaunchEntry],
+        *,
+        workspace_root: Path,
+        env_values_by_unit: Mapping[str, Mapping[str, str]],
+        settle_seconds: float,
+    ) -> list[dict[str, object]]:
+        return _launch_team_direct(
+            entries,
+            workspace_root=workspace_root,
+            env_values_by_unit=env_values_by_unit,
+            settle_seconds=settle_seconds,
+        )
+
+
+def _tmux_client_environment() -> dict[str, str]:
+    """Build the tmux client's complete environment from a closed allowlist.
+
+    The server inherits the environment of the client that creates it.  An
+    inherited ``TMUX`` can also redirect a bare client to an ambient server.
+    Building rather than filtering makes both properties closed by
+    construction: unknown selector variables and unrelated ambient values do
+    not cross merely because nobody remembered to add them to a denylist.
+    """
+
+    allowed = ("PATH", "HOME", "LANG", "LC_ALL", "TMPDIR")
+    env = {key: os.environ[key] for key in allowed if key in os.environ}
+    env.pop("TMUX", None)
+    env.pop("TMUX_PANE", None)
+    return env
+
+
+def _parse_tmux_version(output: str) -> tuple[int, int] | None:
+    match = re.fullmatch(r"tmux\s+(\d+)\.(\d+)[a-z]?", output.strip())
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _process_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@dataclasses.dataclass(frozen=True)
+class _PreparedTmuxEntry:
+    entry: LaunchEntry
+    workdir: Path
+    env: Mapping[str, str]
+
+
+@dataclasses.dataclass(frozen=True)
+class _ObservedPane:
+    pane_id: str
+    pid: int
+    workdir: Path
+    dead: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class TmuxPaneRuntime:
+    """Launch one unit per pane on an explicit, create-only tmux server.
+
+    The socket and session are caller inputs. The runtime never derives either
+    coordinate, uses tmux's default server, attaches, or reuses a socket. Every
+    invocation is structurally prefixed by ``-S``. After session creation, the
+    runtime addresses only tmux IDs.
+    """
+
+    socket_path: Path | str
+    session_name: str
+    tmux_binary: str = "tmux"
+
+    def __post_init__(self) -> None:
+        raw_socket = os.fspath(self.socket_path)
+        if not raw_socket or not isinstance(self.session_name, str) or not self.session_name:
+            raise LaunchExecutionError(
+                "tmux socket path and session name are required explicit inputs"
+            )
+        if not isinstance(self.tmux_binary, str) or not self.tmux_binary:
+            raise LaunchExecutionError("tmux binary is required")
+
+        socket_path = Path(raw_socket)
+        object.__setattr__(self, "socket_path", socket_path)
+        self._validate_socket_coordinate()
+
+    def _validate_socket_coordinate(self) -> None:
+        socket_path = Path(self.socket_path)
+        measured = len(os.fsencode(socket_path))
+        if measured > _AF_UNIX_SOCKET_PATH_MAX_BYTES:
+            raise LaunchExecutionError(
+                f"tmux socket path is {measured} encoded bytes, exceeding the "
+                f"portable AF_UNIX limit of {_AF_UNIX_SOCKET_PATH_MAX_BYTES}"
+            )
+        if not socket_path.is_absolute():
+            raise LaunchExecutionError("tmux socket path must be absolute")
+
+        parent = socket_path.parent
+        if parent.is_symlink():
+            raise LaunchExecutionError("tmux socket parent must not be a symlink")
+        try:
+            parent_stat = parent.stat()
+        except OSError as exc:
+            raise LaunchExecutionError(
+                f"tmux socket parent must already exist as a private 0700 directory: {exc}"
+            ) from exc
+        if not stat.S_ISDIR(parent_stat.st_mode):
+            raise LaunchExecutionError("tmux socket parent must be a directory")
+        mode = stat.S_IMODE(parent_stat.st_mode)
+        if mode != 0o700:
+            raise LaunchExecutionError(f"tmux socket parent must have mode 0700, found {mode:04o}")
+        if hasattr(os, "getuid") and parent_stat.st_uid != os.getuid():
+            raise LaunchExecutionError("tmux socket parent must be owned by the current user")
+
+    def _invoke(self, *args: str, operation: str) -> subprocess.CompletedProcess[str]:
+        command = [self.tmux_binary, "-S", str(self.socket_path), *args]
+        try:
+            return subprocess.run(  # noqa: S603
+                command,
+                env=_tmux_client_environment(),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise LaunchExecutionError(
+                f"tmux executable {self.tmux_binary!r} was not found"
+            ) from exc
+        except OSError as exc:
+            raise LaunchExecutionError(f"tmux {operation} could not run: {exc}") from exc
+
+    def _require_success(self, result: subprocess.CompletedProcess[str], *, operation: str) -> str:
+        if result.returncode != 0:
+            raise LaunchExecutionError(
+                f"tmux {operation} failed with exit code {result.returncode}"
+            )
+        return result.stdout.strip()
+
+    def _require_supported_version(self) -> None:
+        result = self._invoke("-V", operation="version check")
+        reported = (result.stdout or result.stderr).strip()
+        version = _parse_tmux_version(reported) if result.returncode == 0 else None
+        if version is None or version < _MINIMUM_TMUX_VERSION:
+            shown = reported or f"exit code {result.returncode}"
+            raise LaunchExecutionError(
+                f"tmux {shown!r} is unsupported; tmux 3.2 or newer is required "
+                "for per-pane -e environment isolation"
+            )
+
+    def _prepare(
+        self,
+        entries: Sequence[LaunchEntry],
+        *,
+        workspace_root: Path,
+        env_values_by_unit: Mapping[str, Mapping[str, str]],
+    ) -> list[_PreparedTmuxEntry]:
+        prepared = []
+        for entry in entries:
+            values = env_values_by_unit.get(entry.unit_key)
+            if values is None:
+                raise LaunchExecutionError(f"no environment supplied for unit {entry.unit_key}")
+            workdir = canonicalize_workspace_path(
+                workspace_root,
+                entry.workdir,
+                field_name=f"launch[{entry.unit_key}].workdir",
+            )
+            if not workdir.is_dir():
+                raise LaunchExecutionError(
+                    f"unit {entry.unit_key}: workdir {entry.workdir} does not exist -- "
+                    "materialization runs before launch"
+                )
+            prepared.append(
+                _PreparedTmuxEntry(
+                    entry=entry,
+                    workdir=workdir,
+                    env=_child_environment(entry, values),
+                )
+            )
+        return prepared
+
+    def _create_session(self, workspace_root: Path) -> str:
+        result = self._invoke(
+            "new-session",
+            "-d",
+            "-P",
+            "-F",
+            "#{pid}\t#{session_id}\t#{pane_id}",
+            "-s",
+            self.session_name,
+            "-c",
+            str(workspace_root),
+            "--",
+            sys.executable,
+            "-c",
+            "import time; time.sleep(86400)",
+            operation="session creation",
+        )
+        return self._require_success(result, operation="session creation")
+
+    def _parse_session_handles(self, output: str) -> tuple[int, str, str]:
+        fields = output.split("\t")
+        if len(fields) != 3 or not fields[1].startswith("$") or not fields[2].startswith("%"):
+            raise LaunchExecutionError("tmux session creation returned malformed handle evidence")
+        try:
+            server_pid = int(fields[0])
+        except ValueError as exc:
+            raise LaunchExecutionError(
+                "tmux session creation returned a non-numeric server PID"
+            ) from exc
+        if server_pid <= 0:
+            raise LaunchExecutionError("tmux session creation returned an invalid server PID")
+        return server_pid, fields[1], fields[2]
+
+    def _create_unit_pane(self, prepared: _PreparedTmuxEntry, *, session_id: str) -> str:
+        environment_args: list[str] = []
+        for key, value in prepared.env.items():
+            environment_args.extend(("-e", f"{key}={value}"))
+        result = self._invoke(
+            "new-window",
+            "-d",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "-t",
+            session_id,
+            "-c",
+            str(prepared.workdir),
+            *environment_args,
+            "--",
+            *prepared.entry.argv,
+            operation=f"unit {prepared.entry.unit_key} pane creation",
+        )
+        pane_id = self._require_success(
+            result, operation=f"unit {prepared.entry.unit_key} pane creation"
+        )
+        if not pane_id.startswith("%") or "\n" in pane_id:
+            raise LaunchExecutionError(
+                f"unit {prepared.entry.unit_key}: tmux returned malformed pane handle evidence"
+            )
+        return pane_id
+
+    def _observe_panes(self) -> dict[str, _ObservedPane]:
+        result = self._invoke(
+            "list-panes",
+            "-a",
+            "-F",
+            "#{pane_id}\t#{pane_pid}\t#{pane_current_path}\t#{pane_dead}",
+            operation="pane observation",
+        )
+        output = self._require_success(result, operation="pane observation")
+        observed: dict[str, _ObservedPane] = {}
+        for line in output.splitlines():
+            fields = line.split("\t")
+            if len(fields) != 4:
+                raise LaunchExecutionError("tmux returned malformed pane observation evidence")
+            pane_id, pid_text, workdir_text, dead_text = fields
+            try:
+                pid = int(pid_text)
+            except ValueError as exc:
+                raise LaunchExecutionError("tmux returned a non-numeric pane PID") from exc
+            observed[pane_id] = _ObservedPane(
+                pane_id=pane_id,
+                pid=pid,
+                workdir=Path(workdir_text),
+                dead=dead_text != "0",
+            )
+        return observed
+
+    def _require_live_units(
+        self,
+        pane_ids: Mapping[str, str],
+        prepared_by_unit: Mapping[str, _PreparedTmuxEntry],
+    ) -> dict[str, _ObservedPane]:
+        observed = self._observe_panes()
+        live: dict[str, _ObservedPane] = {}
+        for unit_key, pane_id in pane_ids.items():
+            pane = observed.get(pane_id)
+            if pane is None or pane.dead:
+                raise LaunchExecutionError(
+                    f"unit {unit_key}: pane was not alive at launch observation"
+                )
+            expected_workdir = prepared_by_unit[unit_key].workdir.resolve()
+            if pane.workdir.resolve() != expected_workdir:
+                raise LaunchExecutionError(
+                    f"unit {unit_key}: pane started in an unexpected working directory"
+                )
+            live[unit_key] = pane
+        return live
+
+    def _socket_listener_is_reachable(self) -> bool:
+        probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            probe.connect(os.fspath(self.socket_path))
+        except (FileNotFoundError, ConnectionRefusedError):
+            return False
+        except OSError as exc:
+            raise LaunchExecutionError(
+                f"tmux rollback termination could not be observed safely: {exc}"
+            ) from exc
+        else:
+            return True
+        finally:
+            probe.close()
+
+    def _kill_created_server(
+        self,
+        socket_identity: tuple[int, int] | None,
+        server_pid: int | None,
+    ) -> None:
+        result = self._invoke("kill-server", operation="rollback")
+        self._require_success(result, operation="rollback")
+        if server_pid is None:
+            raise LaunchExecutionError(
+                "tmux rollback cannot verify server-process death without captured PID evidence"
+            )
+
+        # Verify both fruits independently of the tmux client whose
+        # acknowledgement is under test. Calling that same executable a second
+        # time would be one stance twice: a wrapper could falsely report both
+        # successful termination and failed lookup. Listener death and process
+        # death are separate too: an orphan can close or lose its socket while
+        # remaining alive.
+        deadline = time.monotonic() + _TMUX_ROLLBACK_SETTLE_SECONDS
+        while True:
+            listener_reachable = self._socket_listener_is_reachable()
+            process_alive = _process_is_alive(server_pid)
+            if not listener_reachable and not process_alive:
+                break
+
+            if time.monotonic() >= deadline:
+                survivors = []
+                if listener_reachable:
+                    survivors.append("socket listener is still reachable")
+                if process_alive:
+                    survivors.append(f"server process {server_pid} is still alive")
+                raise LaunchExecutionError(
+                    "tmux rollback was acknowledged but " + " and ".join(survivors)
+                )
+            time.sleep(_TMUX_ROLLBACK_POLL_SECONDS)
+
+        # tmux can leave the AF_UNIX node behind after the server has exited.
+        # Remove only the exact socket this call observed creating.  If another
+        # process replaced the path, inode identity no longer matches and this
+        # rollback must not spend ownership it does not have.
+        if socket_identity is None:
+            return
+        try:
+            current = Path(self.socket_path).lstat()
+        except FileNotFoundError:
+            return
+        if stat.S_ISSOCK(current.st_mode) and (current.st_dev, current.st_ino) == socket_identity:
+            Path(self.socket_path).unlink()
+
+    def launch_team(
+        self,
+        entries: Sequence[LaunchEntry],
+        *,
+        workspace_root: Path,
+        env_values_by_unit: Mapping[str, Mapping[str, str]],
+        settle_seconds: float,
+    ) -> list[TmuxPaneHandle]:
+        entries = tuple(entries)
+        if not entries:
+            return []
+
+        workspace_root = Path(os.fspath(workspace_root))
+        prepared = self._prepare(
+            entries,
+            workspace_root=workspace_root,
+            env_values_by_unit=env_values_by_unit,
+        )
+        prepared_by_unit = {item.entry.unit_key: item for item in prepared}
+        self._validate_socket_coordinate()
+        self._require_supported_version()
+        if os.path.lexists(self.socket_path):
+            raise LaunchExecutionError(
+                f"tmux socket {self.socket_path} already exists; launch is create-only"
+            )
+
+        server_created = False
+        created_socket_identity: tuple[int, int] | None = None
+        server_pid: int | None = None
+        try:
+            session_output = self._create_session(workspace_root)
+            server_created = True
+            server_pid, session_id, bootstrap_pane = self._parse_session_handles(session_output)
+
+            socket_stat = Path(self.socket_path).lstat()
+            if not stat.S_ISSOCK(socket_stat.st_mode):
+                raise LaunchExecutionError(
+                    "tmux did not create a Unix socket at the requested path"
+                )
+            created_socket_identity = (socket_stat.st_dev, socket_stat.st_ino)
+            Path(self.socket_path).chmod(0o600)
+
+            pane_ids = {
+                item.entry.unit_key: self._create_unit_pane(item, session_id=session_id)
+                for item in prepared
+            }
+            time.sleep(settle_seconds)
+            self._require_live_units(pane_ids, prepared_by_unit)
+
+            # The bootstrap is removed only while unit panes exist.  Then every
+            # unit is observed again, because the first observation is stale the
+            # instant cleanup begins and a dead unit must not return success.
+            cleanup = self._invoke("kill-pane", "-t", bootstrap_pane, operation="bootstrap removal")
+            self._require_success(cleanup, operation="bootstrap removal")
+            live = self._require_live_units(pane_ids, prepared_by_unit)
+
+            return [
+                TmuxPaneHandle(
+                    kind="tmux-pane",
+                    unit_key=item.entry.unit_key,
+                    socket_path=Path(self.socket_path),
+                    session_id=session_id,
+                    server_pid=server_pid,
+                    pane_id=pane_ids[item.entry.unit_key],
+                    pid=live[item.entry.unit_key].pid,
+                    workdir=live[item.entry.unit_key].workdir,
+                    env_keys=item.entry.env_allowlist_keys,
+                    alive_at_launch=True,
+                )
+                for item in prepared
+            ]
+        except BaseException:
+            if server_created:
+                self._kill_created_server(created_socket_identity, server_pid)
+            raise
+
+
 def launch_unit(
     entry: LaunchEntry,
     *,
@@ -236,7 +727,7 @@ def launch_unit(
     }
 
 
-def launch_team(
+def _launch_team_direct(
     entries: Sequence[LaunchEntry],
     *,
     workspace_root: Path,
@@ -254,9 +745,7 @@ def launch_team(
         for entry in entries:
             values = env_values_by_unit.get(entry.unit_key)
             if values is None:
-                raise LaunchExecutionError(
-                    f"no environment supplied for unit {entry.unit_key}"
-                )
+                raise LaunchExecutionError(f"no environment supplied for unit {entry.unit_key}")
             evidence = launch_unit(
                 entry,
                 workspace_root=workspace_root,
@@ -272,3 +761,26 @@ def launch_team(
                 pass
         raise
     return [ev for ev, _ in started]
+
+
+def launch_team(
+    entries: Sequence[LaunchEntry],
+    *,
+    workspace_root: Path,
+    env_values_by_unit: Mapping[str, Mapping[str, str]],
+    settle_seconds: float = _LIVENESS_SETTLE_SECONDS,
+    runtime: LaunchRuntime | None = None,
+) -> list[dict[str, object]] | list[TmuxPaneHandle]:
+    """Launch a team through the caller-selected runtime.
+
+    Direct processes remain the default for compatibility. An alternate
+    runtime is an explicit strategy input rather than an ambient choice.
+    """
+
+    selected: LaunchRuntime = runtime if runtime is not None else DirectProcessRuntime()
+    return selected.launch_team(
+        entries,
+        workspace_root=Path(os.fspath(workspace_root)),
+        env_values_by_unit=env_values_by_unit,
+        settle_seconds=settle_seconds,
+    )

--- a/gr2/tests/test_tmux_launch_runtime.py
+++ b/gr2/tests/test_tmux_launch_runtime.py
@@ -1,0 +1,764 @@
+"""Executable contract for the socket-isolated tmux launch runtime.
+
+This file names a runtime interface rather than making tmux itself the calling
+seam:
+
+    launch_team(..., runtime=TmuxPaneRuntime(socket_path=..., session_name=...))
+
+The load-bearing claims are proved from the other side of the process boundary.
+A successful tmux command is not launch evidence.  The tests query the pane that
+actually exists, compare its cwd and PID with the returned handle, and prove a
+client on another socket cannot resolve the launched session.
+
+The command recorder is also deliberate.  ``-S`` is a property of EVERY tmux
+operation, not a guard a caller may remember on most paths.  The rollback test
+records the failure path separately so deleting socket threading from cleanup
+cannot hide behind a green happy path.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from gr2.python_cli import launch_exec
+
+TMUX = shutil.which("tmux")
+DECLARED_VALUE = "TMUX-DECLARED-VALUE-NOT-FOR-DISK"
+AMBIENT_KEY = "SYNAPT_TMUX_AMBIENT_MUST_NOT_INHERIT"
+DECLARED_KEY = "DECLARED_RUNTIME_VALUE"
+
+
+def _pid_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # pragma: no cover - same-user tmux should be inspectable
+        return True
+    return True
+
+
+def _terminate_process(pid: int) -> None:
+    if _pid_is_alive(pid):
+        os.kill(pid, signal.SIGTERM)
+    for _ in range(100):
+        if not _pid_is_alive(pid):
+            return
+        time.sleep(0.02)
+
+
+def _test_client_env() -> dict[str, str]:
+    """A tmux client environment that cannot fall back through $TMUX."""
+    keys = ("PATH", "HOME", "LANG", "LC_ALL", "TMPDIR")
+    env = {key: os.environ[key] for key in keys if key in os.environ}
+    env.pop("TMUX", None)
+    env.pop("TMUX_PANE", None)
+    return env
+
+
+def _tmux(*args: str, check: bool = False) -> subprocess.CompletedProcess[str]:
+    assert TMUX is not None
+    return subprocess.run(
+        [TMUX, *args],
+        env=_test_client_env(),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _write_tmux_proxy(
+    path: Path,
+    *,
+    real_tmux: str,
+    log_path: Path,
+    sabotage_marker: Path | None = None,
+    fail_kill_server: bool = False,
+    acknowledge_kill_without_stopping: bool = False,
+    unlink_socket_without_stopping: bool = False,
+    pre_kill_evidence_path: Path | None = None,
+) -> None:
+    """Record every argv then exec real tmux.
+
+    When ``sabotage_marker`` exists, the proxy kills one unit pane immediately
+    before the runtime removes its bootstrap pane.  That creates the exact
+    between-observations race the success path must close: a unit was alive at
+    the first observation and is gone after bootstrap removal.
+    """
+    sabotage = repr(str(sabotage_marker)) if sabotage_marker is not None else "None"
+    evidence = repr(str(pre_kill_evidence_path)) if pre_kill_evidence_path else "None"
+    path.write_text(
+        f"""#!{sys.executable}
+import json
+import os
+import subprocess
+import sys
+
+REAL_TMUX = {real_tmux!r}
+LOG_PATH = {str(log_path)!r}
+SABOTAGE_MARKER = {sabotage}
+FAIL_KILL_SERVER = {fail_kill_server!r}
+ACKNOWLEDGE_KILL_WITHOUT_STOPPING = {acknowledge_kill_without_stopping!r}
+UNLINK_SOCKET_WITHOUT_STOPPING = {unlink_socket_without_stopping!r}
+PRE_KILL_EVIDENCE = {evidence}
+args = sys.argv[1:]
+with open(LOG_PATH, "a", encoding="utf-8") as stream:
+    stream.write(json.dumps(args) + "\\n")
+
+if PRE_KILL_EVIDENCE and "kill-server" in args:
+    socket_path = args[args.index("-S") + 1]
+    client = subprocess.run(
+        [REAL_TMUX, "-S", socket_path, "list-panes", "-a"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    server_pid = int(
+        subprocess.run(
+            [REAL_TMUX, "-S", socket_path, "display-message", "-p", "#{{pid}}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
+    try:
+        os.kill(server_pid, 0)
+        pid_alive = True
+    except ProcessLookupError:
+        pid_alive = False
+    with open(PRE_KILL_EVIDENCE, "w", encoding="utf-8") as stream:
+        json.dump(
+            {{
+                "socket_exists": os.path.lexists(socket_path),
+                "client_succeeds": client.returncode == 0,
+                "server_pid": server_pid,
+                "pid_alive": pid_alive,
+            }},
+            stream,
+        )
+
+if FAIL_KILL_SERVER and "kill-server" in args:
+    raise SystemExit(29)
+if ACKNOWLEDGE_KILL_WITHOUT_STOPPING and "kill-server" in args:
+    raise SystemExit(0)
+if UNLINK_SOCKET_WITHOUT_STOPPING and "kill-server" in args:
+    os.unlink(args[args.index("-S") + 1])
+    raise SystemExit(0)
+
+if (
+    SABOTAGE_MARKER
+    and os.path.exists(SABOTAGE_MARKER)
+    and ("kill-pane" in args or "kill-window" in args)
+):
+    socket_path = args[args.index("-S") + 1]
+    target = args[args.index("-t") + 1]
+    listed = subprocess.run(
+        [
+            REAL_TMUX,
+            "-S",
+            socket_path,
+            "list-panes",
+            "-a",
+            "-F",
+            "#{{pane_id}}\\t#{{window_id}}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    victims = []
+    for line in listed.stdout.splitlines():
+        pane_id, window_id = line.split("\\t")
+        if target not in (pane_id, window_id):
+            victims.append(pane_id)
+    if victims:
+        subprocess.run(
+            [REAL_TMUX, "-S", socket_path, "kill-pane", "-t", victims[0]],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    os.unlink(SABOTAGE_MARKER)
+
+os.execv(REAL_TMUX, [REAL_TMUX, *args])
+"""
+    )
+    path.chmod(0o700)
+
+
+def _write_old_tmux(path: Path, *, mutation_marker: Path, log_path: Path) -> None:
+    """A 3.1c executable that proves version refusal precedes server mutation."""
+    path.write_text(
+        f"""#!{sys.executable}
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+with open({str(log_path)!r}, "a", encoding="utf-8") as stream:
+    stream.write(json.dumps(args) + "\\n")
+if args[-1:] == ["-V"]:
+    print("tmux 3.1c")
+    raise SystemExit(0)
+pathlib.Path({str(mutation_marker)!r}).write_text("tmux launch reached")
+raise SystemExit(19)
+"""
+    )
+    path.chmod(0o700)
+
+
+class TmuxContractBase(unittest.TestCase):
+    def setUp(self):
+        # /tmp is intentional.  The production socket locator must also have a
+        # length independent of a generated workspace root.  Using the host's
+        # potentially long TMPDIR here would make the test fixture recreate the
+        # bug it is trying to isolate.
+        self.tmp = Path(tempfile.mkdtemp(prefix="g2tmux-", dir="/tmp"))
+        self.ws = self.tmp / "workspace"
+        # The production socket locator is deliberately outside the workspace's
+        # generated path.  Keep those roots separate in the fixture too, or a
+        # persistence scan rooted at self.tmp can pass while missing everything
+        # the runtime writes beside its socket.
+        self.runtime_dir = Path(tempfile.mkdtemp(prefix="g2tmux-runtime-", dir="/tmp"))
+        self.runtime_dir.chmod(0o700)
+        self.socket = self.runtime_dir / "team.sock"
+        self.session = f"team-{os.getpid()}-{self.tmp.name}"
+        self.sockets: set[Path] = {self.socket}
+        self.logs: list[Path] = []
+
+    def tearDown(self):
+        if TMUX is not None:
+            for socket_path in self.sockets:
+                _tmux("-S", str(socket_path), "kill-server")
+        os.environ.pop(AMBIENT_KEY, None)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.runtime_dir, ignore_errors=True)
+
+    def _runtime_class(self):
+        runtime = getattr(launch_exec, "TmuxPaneRuntime", None)
+        self.assertIsNotNone(
+            runtime,
+            "RED contract: launch_exec must expose TmuxPaneRuntime",
+        )
+        return runtime
+
+    def _runtime(
+        self,
+        *,
+        socket_path: Path | str | None = None,
+        session_name: str | None = None,
+        tmux_binary: str | None = None,
+    ):
+        runtime = self._runtime_class()
+        kwargs = {
+            "socket_path": self.socket if socket_path is None else socket_path,
+            "session_name": self.session if session_name is None else session_name,
+        }
+        if tmux_binary is not None:
+            kwargs["tmux_binary"] = tmux_binary
+        return runtime(**kwargs)
+
+    def _entry(
+        self,
+        key: str,
+        *,
+        workspace: Path | None = None,
+        argv: list[str] | None = None,
+        env_keys: list[str] | None = None,
+    ):
+        root = workspace or self.ws
+        home = root / "units" / key / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        return launch_exec.LaunchEntry.from_mapping(
+            {
+                "unit_key": key,
+                "workdir": f"units/{key}/home",
+                "argv": argv or [sys.executable, "-c", "import time; time.sleep(30)"],
+                "env_allowlist_keys": env_keys or [],
+            }
+        )
+
+    def _launch(
+        self,
+        entries,
+        *,
+        runtime=None,
+        workspace: Path | None = None,
+        env_by_unit: dict[str, dict[str, str]] | None = None,
+        settle_seconds: float = 0.12,
+    ):
+        return launch_exec.launch_team(
+            entries,
+            workspace_root=workspace or self.ws,
+            env_values_by_unit=env_by_unit or {entry.unit_key: {} for entry in entries},
+            settle_seconds=settle_seconds,
+            runtime=runtime or self._runtime(),
+        )
+
+    def _pane_rows(self, socket_path: Path | None = None) -> list[dict[str, object]]:
+        result = _tmux(
+            "-S",
+            str(socket_path or self.socket),
+            "list-panes",
+            "-a",
+            "-F",
+            "#{session_name}\t#{pane_id}\t#{pane_pid}\t#{pane_current_path}\t#{pane_dead}",
+            check=True,
+        )
+        rows = []
+        for line in result.stdout.splitlines():
+            session, pane, pid, cwd, dead = line.split("\t")
+            rows.append(
+                {
+                    "session": session,
+                    "pane_id": pane,
+                    "pid": int(pid),
+                    "cwd": str(Path(cwd).resolve()),
+                    "dead": dead,
+                }
+            )
+        return rows
+
+    def _recording_runtime(
+        self,
+        *,
+        sabotage_marker: Path | None = None,
+        fail_kill_server: bool = False,
+        acknowledge_kill_without_stopping: bool = False,
+        unlink_socket_without_stopping: bool = False,
+        pre_kill_evidence_path: Path | None = None,
+    ):
+        assert TMUX is not None
+        proxy = self.tmp / "tmux-proxy"
+        log = self.tmp / "tmux-argv.jsonl"
+        self.logs.append(log)
+        _write_tmux_proxy(
+            proxy,
+            real_tmux=TMUX,
+            log_path=log,
+            sabotage_marker=sabotage_marker,
+            fail_kill_server=fail_kill_server,
+            acknowledge_kill_without_stopping=acknowledge_kill_without_stopping,
+            unlink_socket_without_stopping=unlink_socket_without_stopping,
+            pre_kill_evidence_path=pre_kill_evidence_path,
+        )
+        return self._runtime(tmux_binary=str(proxy)), log
+
+
+class TestExplicitRuntimeCoordinates(TmuxContractBase):
+    def test_socket_and_session_are_required_constructor_inputs(self):
+        runtime = self._runtime_class()
+        signature = inspect.signature(runtime)
+        self.assertIs(signature.parameters["socket_path"].default, inspect.Parameter.empty)
+        self.assertIs(signature.parameters["session_name"].default, inspect.Parameter.empty)
+
+        with self.assertRaises(TypeError):
+            runtime()
+        with self.assertRaises(TypeError):
+            runtime(socket_path=self.socket)
+        with self.assertRaises(TypeError):
+            runtime(session_name=self.session)
+
+    def test_empty_coordinates_refuse_instead_of_falling_back(self):
+        runtime = self._runtime_class()
+        for socket_path, session_name in (
+            ("", self.session),
+            (self.socket, ""),
+        ):
+            with self.subTest(socket_path=socket_path, session_name=session_name):
+                with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+                    runtime(socket_path=socket_path, session_name=session_name)
+                message = str(ctx.exception).lower()
+                self.assertIn("required", message)
+                self.assertNotIn("synapt", message, "a refusal must not disclose a fallback")
+
+    def test_overlong_explicit_socket_refuses_with_measured_length(self):
+        runtime = self._runtime_class()
+        socket_path = self.runtime_dir / ("s" * 105)
+        measured = len(os.fsencode(socket_path))
+        self.assertGreater(measured, 103)
+
+        with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+            runtime(socket_path=socket_path, session_name=self.session)
+        message = str(ctx.exception)
+        self.assertIn(str(measured), message)
+        self.assertIn("AF_UNIX", message)
+
+    def test_world_accessible_socket_parent_is_refused(self):
+        unsafe = self.tmp / "unsafe-runtime"
+        unsafe.mkdir(mode=0o755)
+        unsafe.chmod(0o755)
+        with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+            self._runtime(socket_path=unsafe / "team.sock")
+        self.assertIn("0700", str(ctx.exception))
+        self.assertFalse((unsafe / "team.sock").exists())
+
+    def test_symlinked_socket_parent_is_refused(self):
+        real = self.tmp / "real-runtime"
+        real.mkdir(mode=0o700)
+        link = self.tmp / "linked-runtime"
+        link.symlink_to(real, target_is_directory=True)
+        with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+            self._runtime(socket_path=link / "team.sock")
+        self.assertIn("symlink", str(ctx.exception).lower())
+        self.assertFalse((real / "team.sock").exists())
+
+
+class TestTmuxVersionPrecondition(TmuxContractBase):
+    def test_tmux_before_3_2_refuses_before_any_server_mutation(self):
+        old_tmux = self.tmp / "tmux-old"
+        marker = self.tmp / "mutation-reached"
+        log = self.tmp / "old-tmux-argv.jsonl"
+        _write_old_tmux(old_tmux, mutation_marker=marker, log_path=log)
+        entry = self._entry("u_old")
+
+        with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+            self._launch([entry], runtime=self._runtime(tmux_binary=str(old_tmux)))
+
+        message = str(ctx.exception)
+        self.assertIn("3.1c", message)
+        self.assertIn("3.2", message)
+        self.assertFalse(marker.exists(), "launch continued after the failed version gate")
+        invocations = [json.loads(line) for line in log.read_text().splitlines()]
+        self.assertEqual(invocations, [["-S", str(self.socket), "-V"]])
+
+
+@unittest.skipUnless(TMUX is not None and os.name == "posix", "requires tmux on POSIX")
+class TestTmuxLaunchFruit(TmuxContractBase):
+    def test_returned_handles_name_the_panes_that_actually_exist(self):
+        entries = [self._entry("u_one"), self._entry("u_two")]
+        runtime, log = self._recording_runtime()
+        handles = self._launch(entries, runtime=runtime)
+
+        rows = self._pane_rows()
+        self.assertEqual(len(rows), 2, "bootstrap pane survived or a unit pane is absent")
+        by_pane = {row["pane_id"]: row for row in rows}
+        self.assertEqual({handle.pane_id for handle in handles}, set(by_pane))
+        for handle in handles:
+            row = by_pane[handle.pane_id]
+            self.assertEqual(row["pid"], handle.pid)
+            self.assertEqual(row["cwd"], str(Path(handle.workdir).resolve()))
+            self.assertEqual(row["dead"], "0")
+            os.kill(handle.server_pid, 0)
+            self.assertIs(handle.alive_at_launch, True)
+            self.assertFalse(
+                hasattr(handle, "alive"),
+                "a launch-time observation must not be named as current truth",
+            )
+            self.assertEqual(Path(handle.socket_path), self.socket)
+
+        mode = stat.S_IMODE(self.socket.stat().st_mode)
+        self.assertEqual(mode, 0o600)
+
+        invocations = [json.loads(line) for line in log.read_text().splitlines()]
+        self.assertGreaterEqual(len(invocations), 6)
+        for args in invocations:
+            self.assertEqual(
+                args[:2],
+                ["-S", str(self.socket)],
+                f"bare tmux operation escaped the workspace server: {args}",
+            )
+
+    def test_a_long_generated_workspace_uses_the_short_explicit_socket(self):
+        long_component = "generated-session-" + ("x" * 170)
+        workspace = self.tmp / long_component / "scratchpad" / "workspace"
+        self.assertGreater(len(os.fsencode(workspace)), 136)
+        entry = self._entry("u_long", workspace=workspace)
+
+        handles = self._launch([entry], workspace=workspace)
+
+        self.assertEqual(len(handles), 1)
+        self.assertLess(len(os.fsencode(handles[0].socket_path)), 100)
+        self.assertEqual(self._pane_rows()[0]["cwd"], str((workspace / entry.workdir).resolve()))
+
+    def test_another_socket_and_the_default_server_cannot_see_the_session(self):
+        other_dir = self.tmp / "other-runtime"
+        other_dir.mkdir(mode=0o700)
+        other_socket = other_dir / "other.sock"
+        self.sockets.add(other_socket)
+        decoy_session = f"decoy-{self.tmp.name}"
+        _tmux(
+            "-S",
+            str(other_socket),
+            "new-session",
+            "-d",
+            "-s",
+            decoy_session,
+            "/bin/sleep",
+            "30",
+            check=True,
+        )
+
+        # Positive control: the other-socket instrument can see its own pane.
+        visible = _tmux("-S", str(other_socket), "list-panes", "-t", f"={decoy_session}")
+        self.assertEqual(visible.returncode, 0)
+
+        self._launch([self._entry("u_isolated")])
+
+        foreign = _tmux("-S", str(other_socket), "list-panes", "-t", f"={self.session}")
+        self.assertNotEqual(foreign.returncode, 0)
+
+        default_env = _test_client_env()
+        default_env.pop("TMUX", None)
+        default_server = subprocess.run(
+            [TMUX, "has-session", "-t", f"={self.session}"],
+            env=default_env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(default_server.returncode, 0)
+
+    def test_existing_socket_is_create_only_and_remains_unchanged(self):
+        existing = f"existing-{self.tmp.name}"
+        _tmux(
+            "-S",
+            str(self.socket),
+            "new-session",
+            "-d",
+            "-s",
+            existing,
+            "/bin/sleep",
+            "30",
+            check=True,
+        )
+        before = _tmux(
+            "-S",
+            str(self.socket),
+            "list-panes",
+            "-a",
+            "-F",
+            "#{pane_id} #{pane_pid}",
+            check=True,
+        ).stdout
+
+        with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+            self._launch([self._entry("u_must_not_attach")])
+
+        after = _tmux(
+            "-S",
+            str(self.socket),
+            "list-panes",
+            "-a",
+            "-F",
+            "#{pane_id} #{pane_pid}",
+            check=True,
+        ).stdout
+        self.assertEqual(after, before)
+        self.assertIn("create-only", str(ctx.exception))
+
+    def test_declared_env_arrives_but_ambient_env_does_not(self):
+        os.environ[AMBIENT_KEY] = "leaked-from-parent"
+        seen = self.ws / "units" / "u_env" / "home" / "seen.json"
+        entry = self._entry(
+            "u_env",
+            argv=[
+                sys.executable,
+                "-c",
+                f"import json,os,time;open({str(seen)!r},'w').write("
+                "json.dumps(dict(os.environ)));time.sleep(30)",
+            ],
+            env_keys=[DECLARED_KEY],
+        )
+        self._launch(
+            [entry],
+            env_by_unit={entry.unit_key: {DECLARED_KEY: DECLARED_VALUE}},
+        )
+        for _ in range(80):
+            if seen.is_file() and seen.read_text():
+                break
+            time.sleep(0.05)
+
+        child_env = json.loads(seen.read_text())
+        self.assertEqual(child_env[DECLARED_KEY], DECLARED_VALUE)
+        self.assertNotIn(AMBIENT_KEY, child_env)
+
+        session_env = _tmux(
+            "-S",
+            str(self.socket),
+            "show-environment",
+            "-t",
+            f"={self.session}",
+            check=True,
+        ).stdout
+        self.assertNotIn(DECLARED_VALUE, session_env)
+        self.assertNotIn(AMBIENT_KEY, session_env)
+
+    def test_environment_value_is_not_persisted_by_the_launcher(self):
+        entry = self._entry("u_secret", env_keys=[DECLARED_KEY])
+        self._launch(
+            [entry],
+            env_by_unit={entry.unit_key: {DECLARED_KEY: DECLARED_VALUE}},
+        )
+
+        searched_roots = (self.tmp, self.socket.parent)
+        self.assertEqual(
+            {root.resolve() for root in searched_roots},
+            {self.tmp.resolve(), self.runtime_dir.resolve()},
+            "the persistence instrument must enumerate every controlled write root",
+        )
+        found = []
+        for root in searched_roots:
+            for path in root.rglob("*"):
+                if not path.is_file():
+                    continue
+                try:
+                    if DECLARED_VALUE in path.read_text(errors="ignore"):
+                        found.append(str(path))
+                except OSError:  # pragma: no cover
+                    pass
+        self.assertEqual(found, [], f"environment value persisted to disk: {found}")
+
+    def test_partial_failure_rolls_back_only_the_created_socket_server(self):
+        entries = [
+            self._entry("u_survivor"),
+            self._entry(
+                "u_failure",
+                argv=[sys.executable, "-c", "raise SystemExit(23)"],
+            ),
+        ]
+        pre_kill = self.tmp / "pre-kill-evidence.json"
+        runtime, log = self._recording_runtime(pre_kill_evidence_path=pre_kill)
+
+        with self.assertRaises(launch_exec.LaunchExecutionError):
+            self._launch(entries, runtime=runtime)
+
+        control = json.loads(pre_kill.read_text())
+        self.addCleanup(_terminate_process, control["server_pid"])
+        self.assertIs(control["socket_exists"], True)
+        self.assertIs(control["client_succeeds"], True)
+        self.assertIs(control["pid_alive"], True)
+
+        for _ in range(100):
+            if not self.socket.exists():
+                break
+            time.sleep(0.02)
+        self.assertFalse(self.socket.exists(), "failed launch left its tmux server alive")
+        after_client = _tmux("-S", str(self.socket), "list-panes", "-a")
+        self.assertNotEqual(after_client.returncode, 0)
+        for _ in range(100):
+            if not _pid_is_alive(control["server_pid"]):
+                break
+            time.sleep(0.02)
+        self.assertFalse(
+            _pid_is_alive(control["server_pid"]),
+            "failed launch left its captured tmux server process alive",
+        )
+
+        invocations = [json.loads(line) for line in log.read_text().splitlines()]
+        self.assertTrue(any("kill-server" in args for args in invocations))
+        for args in invocations:
+            self.assertEqual(
+                args[:2],
+                ["-S", str(self.socket)],
+                f"rollback escaped the explicit socket: {args}",
+            )
+
+    def test_failed_server_termination_is_not_hidden_by_unlinking_the_socket(self):
+        entry = self._entry(
+            "u_failure",
+            argv=[sys.executable, "-c", "raise SystemExit(23)"],
+        )
+        runtime, log = self._recording_runtime(fail_kill_server=True)
+
+        with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+            self._launch([entry], runtime=runtime)
+
+        self.assertIn("rollback", str(ctx.exception))
+        self.assertTrue(
+            self.socket.exists(),
+            "a failed termination was hidden by unlinking its still-live server socket",
+        )
+        still_live = _tmux("-S", str(self.socket), "list-panes", "-a")
+        self.assertEqual(
+            still_live.returncode,
+            0,
+            "the failure proxy did not prove that an unacknowledged kill leaves a live server",
+        )
+        invocations = [json.loads(line) for line in log.read_text().splitlines()]
+        self.assertTrue(any("kill-server" in args for args in invocations))
+
+    def test_acknowledged_termination_must_still_be_observed_by_fruit(self):
+        entry = self._entry(
+            "u_failure",
+            argv=[sys.executable, "-c", "raise SystemExit(23)"],
+        )
+        runtime, log = self._recording_runtime(acknowledge_kill_without_stopping=True)
+
+        with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+            self._launch([entry], runtime=runtime)
+
+        self.assertIn("still reachable", str(ctx.exception))
+        self.assertTrue(
+            self.socket.exists(),
+            "a false-success termination was hidden by unlinking its live server socket",
+        )
+        still_live = _tmux("-S", str(self.socket), "list-panes", "-a")
+        self.assertEqual(still_live.returncode, 0)
+        invocations = [json.loads(line) for line in log.read_text().splitlines()]
+        self.assertTrue(any("kill-server" in args for args in invocations))
+
+    def test_listener_death_does_not_mask_an_orphaned_server_process(self):
+        entry = self._entry(
+            "u_failure",
+            argv=[sys.executable, "-c", "raise SystemExit(23)"],
+        )
+        pre_kill = self.tmp / "orphan-pre-kill-evidence.json"
+        runtime, _ = self._recording_runtime(
+            unlink_socket_without_stopping=True,
+            pre_kill_evidence_path=pre_kill,
+        )
+
+        with self.assertRaises(launch_exec.LaunchExecutionError) as ctx:
+            self._launch([entry], runtime=runtime)
+
+        control = json.loads(pre_kill.read_text())
+        self.addCleanup(_terminate_process, control["server_pid"])
+        self.assertIs(control["socket_exists"], True)
+        self.assertIs(control["client_succeeds"], True)
+        self.assertIs(control["pid_alive"], True)
+        self.assertIn("process", str(ctx.exception))
+        self.assertIn("still alive", str(ctx.exception))
+        self.assertFalse(self.socket.exists())
+        after_client = _tmux("-S", str(self.socket), "list-panes", "-a")
+        self.assertNotEqual(after_client.returncode, 0)
+        self.assertTrue(
+            _pid_is_alive(control["server_pid"]),
+            "orphan witness did not preserve the server process after listener removal",
+        )
+
+        _terminate_process(control["server_pid"])
+        self.assertFalse(_pid_is_alive(control["server_pid"]))
+
+    def test_unit_death_during_bootstrap_removal_is_caught_before_return(self):
+        sabotage = self.tmp / "sabotage-on-bootstrap-removal"
+        sabotage.write_text("armed")
+        runtime, _ = self._recording_runtime(sabotage_marker=sabotage)
+        entries = [self._entry("u_first"), self._entry("u_second")]
+
+        with self.assertRaises(launch_exec.LaunchExecutionError):
+            self._launch(entries, runtime=runtime)
+
+        for _ in range(50):
+            if not self.socket.exists():
+                break
+            time.sleep(0.02)
+        self.assertFalse(
+            self.socket.exists(),
+            "runtime returned or left a server after a unit died between observations",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a socket-isolated tmux launch runtime behind the existing launch interface
- require explicit socket path and session name with create-only behavior
- return pane, process, session, and server handles backed by launch-time observations
- fail closed unless rollback observes both listener and server-process termination

## Boundary

The public launch primitive accepts opaque launch entries plus an explicit socket path and session name. It does not derive either coordinate, inspect caller-specific configuration, use the default tmux server, attach, or reuse an existing socket. Coordinate naming and mapping remain caller responsibilities.

## Verification

- 31 focused tests plus 2 subtests
- 740 non-packaging tests plus 41 subtests
- 8 editable-install packaging tests
- ruff check and format check
- py_compile
- rollback PID-only mutation is RED