### PR TITLE
fix(pr): waive merge gates by name, and print what a merge is about to do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`gr pr merge` gates are individually waivable, and what is waived is printed at the moment of the merge** (#837) — `--force` was a single boolean that suppressed the approval, checks and mergeability gates together. In a workspace whose ratification convention is review *comments* rather than formal platform approvals, the approval gate can never pass, so `--force` became mandatory on every merge — and took the other gates with it, silently. A gate that must always be bypassed does not gate; it trains the bypass. New `--skip-gate <approval|checks|mergeable>` waives exactly one, repeatable; `--force` still waives all but now names what it suppressed. An unknown gate name is an error rather than a silent no-op, because a misspelled waiver that quietly waives nothing reads exactly like a gate that passed.
+- **`gr pr merge` prints the resolved target and method at the moment of the irreversible act** (#837) — `owner/repo#N branch -> base method=Merge`, printed durably immediately before the merge call rather than from the plan beforehand or the result afterwards. `gr pr merge` takes no PR number: it merges whatever PR the current branch owns, so the operator's belief about the target and the command's resolution of it are separate facts. Everything that goes wrong with this command goes wrong in that gap.
+
 ## [1.0.1] - 2026-07-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,8 @@ All commands use `gr` (or `gitgrip`):
   - `gr pr create --push --draft` - Push and create as draft
   - `gr pr merge --update` - Update branch from base if behind, then merge
   - `gr pr merge --auto` - Enable auto-merge (merges when checks pass)
-  - `gr pr merge --force` - Merge even if checks pending
+  - `gr pr merge --skip-gate <gate>` - Waive ONE named gate (`approval`, `checks`, `mergeable`) and no others; repeatable
+  - `gr pr merge --force` - Waive every gate. Prefer `--skip-gate`; both print what was waived at the moment of the merge
 - `gr repo add/list/remove` - Manage repositories
 - `gr group list` - List all groups and their repos
   - `gr group add <group> <repos...>` - Add repos to a group

--- a/README.md
+++ b/README.md
@@ -349,9 +349,30 @@ Merge all linked PRs atomically.
 | Option | Description |
 |--------|-------------|
 | `-m, --method <method>` | merge, squash, or rebase |
-| `-f, --force` | Merge even if checks pending |
+| `--skip-gate <gate>` | Waive ONE named gate and no others: `approval`, `checks`, `mergeable`. Repeatable |
+| `-f, --force` | Waive every gate. Prefer `--skip-gate` |
 | `-u, --update` | Update branch from base if behind, then retry merge |
 | `--auto` | Enable auto-merge (merges when all checks pass) |
+
+Three gates run before a merge: `approval` (a formal platform approval exists),
+`checks` (status checks are passing), and `mergeable` (the platform reports the
+PR as mergeable). Waiving one names it; `--force` waives all three.
+
+Prefer `--skip-gate` whenever a single gate does not apply to your workflow. A
+workspace that ratifies by review *comments* rather than formal approvals, for
+example, can never pass the `approval` gate — reaching for `--force` there
+suppresses the check and mergeability gates too, every time, invisibly.
+
+Whatever is waived is printed **at the moment of the merge**, alongside the
+resolved target:
+
+```
+MERGING acme/widgets#412  fix/parser -> main  method=Merge  WAIVED=approval
+  suppressed: widgets PR #412: no formal approval [approval]
+```
+
+`gr pr merge` takes no PR number — it merges whatever PR the current branch
+owns — so that line is what tells you the command resolved to the PR you meant.
 
 #### `gr repo add <url>`
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -721,9 +721,17 @@ pub enum PrCommands {
         /// Merge method (merge, squash, rebase)
         #[arg(long, value_enum)]
         method: Option<MergeMethod>,
-        /// Force merge without readiness checks
+        /// Waive EVERY readiness gate. Prefer --skip-gate, which names the one
+        /// you mean; whatever is waived is printed at the moment of the merge.
         #[arg(short, long)]
         force: bool,
+        /// Waive ONE named gate and no others: approval, checks, mergeable.
+        /// Repeatable. Use this instead of --force when a single gate does not
+        /// apply -- e.g. a workspace that ratifies by review comments rather
+        /// than formal platform approvals, where the approval gate can never
+        /// pass and --force would silently take the others with it.
+        #[arg(long = "skip-gate", value_name = "GATE")]
+        skip_gate: Vec<String>,
         /// Update branch from base if behind before merging
         #[arg(short = 'u', long)]
         update: bool,

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -67,10 +67,72 @@ async fn detect_merge_method(
     }
 }
 
+/// A single pre-merge gate, nameable so it can be waived individually.
+///
+/// `--force` used to be one boolean that suppressed every check at once. On a
+/// gripspace whose ratification convention is review COMMENTS rather than formal
+/// GitHub approvals, the approval gate can never pass, so `--force` became
+/// mandatory on every merge -- and with it went the checks, mergeability and
+/// method assertions nobody intended to waive.
+///
+/// A gate that must always be bypassed does not gate; it trains the bypass. The
+/// point of naming them is that waiving one says which one, out loud, at the
+/// moment of the act.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeGate {
+    /// The PR carries a formal platform approval.
+    Approval,
+    /// Status checks are passing (not failing, not still running).
+    Checks,
+    /// The platform reports the PR as mergeable.
+    Mergeable,
+}
+
+impl MergeGate {
+    /// The name a caller passes to `--skip-gate`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MergeGate::Approval => "approval",
+            MergeGate::Checks => "checks",
+            MergeGate::Mergeable => "mergeable",
+        }
+    }
+
+    /// Every gate, so `--force` and the help text cannot drift from the enum.
+    pub fn all() -> [MergeGate; 3] {
+        [MergeGate::Approval, MergeGate::Checks, MergeGate::Mergeable]
+    }
+
+    /// Parse a caller-supplied name. Unknown names are an error rather than a
+    /// silent no-op: a misspelled gate that quietly waives nothing reads exactly
+    /// like a gate that passed.
+    pub fn parse(name: &str) -> anyhow::Result<Self> {
+        let wanted = name.trim().to_ascii_lowercase();
+        MergeGate::all()
+            .into_iter()
+            .find(|g| g.as_str() == wanted)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "unknown merge gate '{}'. Known gates: {}",
+                    name.trim(),
+                    MergeGate::all()
+                        .iter()
+                        .map(|g| g.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+    }
+}
+
 /// Options for the PR merge command.
 pub struct MergeOptions<'a> {
     pub method: Option<&'a crate::platform::MergeMethod>,
+    /// Waive EVERY gate. Retained for compatibility; prefer naming the one you
+    /// mean via `skip_gates`, so the record says what was actually waived.
     pub force: bool,
+    /// Gates waived by name. Composes with `force`, which implies all of them.
+    pub skip_gates: Vec<MergeGate>,
     pub update: bool,
     pub auto: bool,
     pub json: bool,
@@ -147,6 +209,10 @@ pub async fn run_pr_merge(
         owner: String,
         repo: String,
         branch: String,
+        /// The branch this merge is irreversible INTO. Carried so the act-time
+        /// line can name it: "which PR" and "into what" are different facts and
+        /// only the second one says where the commits land.
+        base: String,
         pr_number: u64,
         platform: Arc<dyn crate::platform::HostingPlatform>,
         approved: bool,
@@ -230,6 +296,7 @@ pub async fn run_pr_merge(
                     owner: repo.owner.clone(),
                     repo: repo.repo.clone(),
                     branch: branch.clone(),
+                    base: repo.target_branch().to_string(),
                     pr_number: pr.number,
                     platform,
                     approved,
@@ -401,55 +468,83 @@ pub async fn run_pr_merge(
         println!();
     }
 
-    // Check readiness if not forcing
-    if !opts.force {
-        let mut issues = Vec::new();
-        for pr in &prs_to_merge {
-            if !pr.approved {
-                issues.push(format!(
-                    "{} PR #{}: not approved",
+    // Which gates the caller waived, and by which flag. `--force` implies all
+    // of them; naming one waives exactly one. Recorded rather than folded into a
+    // boolean, because the whole point is that the record says what was waived.
+    let waived: Vec<MergeGate> = if opts.force {
+        MergeGate::all().to_vec()
+    } else {
+        opts.skip_gates.clone()
+    };
+    let is_waived = |gate: MergeGate| waived.contains(&gate);
+
+    // Evaluate every gate, then subtract the waived ones. Evaluating first means
+    // a waiver still reports what it suppressed -- a gate that was never run
+    // cannot say whether it would have failed, and "no output" is exactly how a
+    // suppressed failure disguises itself as a pass.
+    let mut blocking = Vec::new();
+    let mut suppressed = Vec::new();
+    for pr in &prs_to_merge {
+        let mut failures: Vec<(MergeGate, String)> = Vec::new();
+        if !pr.approved {
+            failures.push((
+                MergeGate::Approval,
+                format!("{} PR #{}: no formal approval", pr.repo_name, pr.pr_number),
+            ));
+        }
+        match pr.check_status {
+            CheckStatus::Failing => failures.push((
+                MergeGate::Checks,
+                format!("{} PR #{}: checks failing", pr.repo_name, pr.pr_number),
+            )),
+            CheckStatus::Pending => failures.push((
+                MergeGate::Checks,
+                format!(
+                    "{} PR #{}: checks still running",
+                    pr.repo_name, pr.pr_number
+                ),
+            )),
+            CheckStatus::Unknown => {
+                Output::warning(&format!(
+                    "{} PR #{}: check status unknown - proceeding with caution",
                     pr.repo_name, pr.pr_number
                 ));
             }
-            match pr.check_status {
-                CheckStatus::Failing => {
-                    issues.push(format!(
-                        "{} PR #{}: checks failing",
-                        pr.repo_name, pr.pr_number
-                    ));
-                }
-                CheckStatus::Pending => {
-                    issues.push(format!(
-                        "{} PR #{}: checks still running",
-                        pr.repo_name, pr.pr_number
-                    ));
-                }
-                CheckStatus::Unknown => {
-                    // Don't block on unknown - warn but allow merge
-                    Output::warning(&format!(
-                        "{} PR #{}: check status unknown - proceeding with caution",
-                        pr.repo_name, pr.pr_number
-                    ));
-                }
-                CheckStatus::Passing => {} // All good
-            }
-            if !pr.mergeable {
-                issues.push(format!(
+            CheckStatus::Passing => {}
+        }
+        if !pr.mergeable {
+            failures.push((
+                MergeGate::Mergeable,
+                format!(
                     "{} PR #{}: not mergeable (branch may be behind base — try --update)",
                     pr.repo_name, pr.pr_number
-                ));
+                ),
+            ));
+        }
+        for (gate, message) in failures {
+            if is_waived(gate) {
+                suppressed.push(format!("{} [{}]", message, gate.as_str()));
+            } else {
+                blocking.push(format!("{} [{}]", message, gate.as_str()));
             }
         }
+    }
 
-        if !issues.is_empty() {
-            Output::warning("Some PRs have issues:");
-            for issue in &issues {
-                println!("  - {}", issue);
-            }
-            println!();
-            println!("Use --force to merge anyway.");
-            return Ok(());
+    if !blocking.is_empty() {
+        Output::warning("Some PRs have issues:");
+        for issue in &blocking {
+            println!("  - {}", issue);
         }
+        println!();
+        println!(
+            "Waive one gate with --skip-gate <{}>, or --force to waive all.",
+            MergeGate::all()
+                .iter()
+                .map(|g| g.as_str())
+                .collect::<Vec<_>>()
+                .join("|")
+        );
+        return Ok(());
     }
 
     // Auto-merge flow: enable auto-merge and return early
@@ -536,6 +631,40 @@ pub async fn run_pr_merge(
         } else {
             detect_merge_method(pr.platform.as_ref(), &pr.owner, &pr.repo).await
         };
+
+        // THE MOMENT OF THE IRREVERSIBLE ACT. Printed here -- not earlier from
+        // the plan, not afterwards from the result -- and durably rather than
+        // in a spinner that erases itself.
+        //
+        // Everything that goes wrong with this command goes wrong in the gap
+        // between what it is about to do and what the operator believes it is
+        // about to do. `gr pr merge` takes no PR number: it merges whatever PR
+        // the current branch owns. So the resolved slug, number, branch, base
+        // and method are the facts that close that gap, and they are only facts
+        // at this point in the code.
+        if !opts.json {
+            let mut line = format!(
+                "MERGING {}/{}#{}  {} -> {}  method={:?}",
+                pr.owner, pr.repo, pr.pr_number, pr.branch, pr.base, effective_method
+            );
+            if !waived.is_empty() {
+                line.push_str(&format!(
+                    "  WAIVED={}",
+                    waived
+                        .iter()
+                        .map(|g| g.as_str())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                ));
+            }
+            println!("{}", line);
+            for note in suppressed
+                .iter()
+                .filter(|n| n.contains(&format!("PR #{}", pr.pr_number)))
+            {
+                println!("  suppressed: {}", note);
+            }
+        }
 
         let spinner = if !opts.json {
             Some(Output::spinner(&format!(
@@ -915,5 +1044,87 @@ mod tests {
             resolve_check_status(&status(true, CheckState::Pending)),
             CheckStatus::Pending
         );
+    }
+}
+
+#[cfg(test)]
+mod gate_tests {
+    use super::MergeGate;
+
+    #[test]
+    fn every_known_gate_round_trips_through_its_name() {
+        for gate in MergeGate::all() {
+            let parsed = MergeGate::parse(gate.as_str()).expect("known gate must parse");
+            assert_eq!(parsed, gate, "{} did not round-trip", gate.as_str());
+        }
+    }
+
+    #[test]
+    fn gate_names_are_case_insensitive_and_trimmed() {
+        assert_eq!(MergeGate::parse("APPROVAL").unwrap(), MergeGate::Approval);
+        assert_eq!(MergeGate::parse("  checks ").unwrap(), MergeGate::Checks);
+    }
+
+    /// An unknown gate name must be an ERROR, never a silent no-op.
+    ///
+    /// This is the whole failure mode the flag exists to remove. A misspelled
+    /// `--skip-gate aproval` that quietly waives nothing produces a run that
+    /// looks exactly like one where the gate passed -- and the operator, having
+    /// typed a waiver, believes the opposite of what happened.
+    #[test]
+    fn an_unknown_gate_is_rejected_rather_than_ignored() {
+        let err = MergeGate::parse("aproval").expect_err("a typo must not be accepted");
+        let message = err.to_string();
+        assert!(
+            message.contains("unknown merge gate"),
+            "message should name the problem: {message}"
+        );
+        assert!(
+            message.contains("approval")
+                && message.contains("checks")
+                && message.contains("mergeable"),
+            "message should list the valid gates so the typo is fixable: {message}"
+        );
+    }
+
+    #[test]
+    fn an_empty_gate_name_is_rejected() {
+        assert!(MergeGate::parse("").is_err());
+        assert!(MergeGate::parse("   ").is_err());
+    }
+
+    /// `all()` is hand-written, so it can drift from the enum. This match is
+    /// exhaustive on purpose: adding a variant without adding it to `all()`
+    /// fails to COMPILE rather than silently shrinking what `--force` waives.
+    ///
+    /// A compile error is the right instrument here. A runtime test can only
+    /// check the variants it was told about, which is the same gap that let a
+    /// parsed-and-dropped field through three review rounds elsewhere today.
+    #[test]
+    fn the_enumeration_cannot_silently_grow() {
+        fn enumerated(gate: MergeGate) -> bool {
+            match gate {
+                MergeGate::Approval => MergeGate::all().contains(&gate),
+                MergeGate::Checks => MergeGate::all().contains(&gate),
+                MergeGate::Mergeable => MergeGate::all().contains(&gate),
+            }
+        }
+        for gate in MergeGate::all() {
+            assert!(enumerated(gate), "{} missing from all()", gate.as_str());
+        }
+        assert_eq!(
+            MergeGate::all().len(),
+            3,
+            "a gate was added or removed; update --force's waiver set and this count deliberately"
+        );
+    }
+
+    #[test]
+    fn gate_names_are_distinct() {
+        let mut names: Vec<&str> = MergeGate::all().iter().map(|g| g.as_str()).collect();
+        names.sort_unstable();
+        let before = names.len();
+        names.dedup();
+        assert_eq!(before, names.len(), "two gates share a name: {names:?}");
     }
 }

--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -125,6 +125,26 @@ impl MergeGate {
     }
 }
 
+/// The suppression notes belonging to one PR, selected by its index.
+///
+/// A free function so the attribution can be tested directly. The previous form
+/// was an inline filter matching a SUBSTRING of the rendered message, which
+/// mis-attributes in two ways that a fix aimed at the first would leave open:
+/// "PR #77" is a substring of "PR #777", and this command is multi-repo so two
+/// different repos can each carry a PR #42.
+///
+/// The line this feeds is the one telling an operator exactly what is being
+/// suppressed on exactly this PR. A suppression they do not recognise teaches
+/// them to distrust the line, and a safety disclosure people distrust stops
+/// being a safety disclosure.
+fn notes_for(index: usize, suppressed: &[(usize, String)]) -> Vec<&str> {
+    suppressed
+        .iter()
+        .filter(|(i, _)| *i == index)
+        .map(|(_, note)| note.as_str())
+        .collect()
+}
+
 /// Options for the PR merge command.
 pub struct MergeOptions<'a> {
     pub method: Option<&'a crate::platform::MergeMethod>,
@@ -483,8 +503,19 @@ pub async fn run_pr_merge(
     // cannot say whether it would have failed, and "no output" is exactly how a
     // suppressed failure disguises itself as a pass.
     let mut blocking = Vec::new();
-    let mut suppressed = Vec::new();
-    for pr in &prs_to_merge {
+    // Keyed by INDEX into `prs_to_merge`, never by re-reading the PR number out
+    // of the rendered message. Two collisions live in that shortcut, and the
+    // second survives a fix aimed only at the first:
+    //
+    //   * "PR #77" is a SUBSTRING of "PR #777", and one invocation can carry
+    //     both, so #77's merge line would print #777's suppression note
+    //   * this command is multi-repo, so two DIFFERENT repos can each have a
+    //     PR #42 -- matching on the number alone still mis-attributes
+    //
+    // An index is unique across both. A value reconstructed from a rendering is
+    // a value that can be reconstructed wrong; carrying it cannot be.
+    let mut suppressed: Vec<(usize, String)> = Vec::new();
+    for (index, pr) in prs_to_merge.iter().enumerate() {
         let mut failures: Vec<(MergeGate, String)> = Vec::new();
         if !pr.approved {
             failures.push((
@@ -523,7 +554,7 @@ pub async fn run_pr_merge(
         }
         for (gate, message) in failures {
             if is_waived(gate) {
-                suppressed.push(format!("{} [{}]", message, gate.as_str()));
+                suppressed.push((index, format!("{} [{}]", message, gate.as_str())));
             } else {
                 blocking.push(format!("{} [{}]", message, gate.as_str()));
             }
@@ -624,7 +655,7 @@ pub async fn run_pr_merge(
     let mut json_merged: Vec<JsonMergedPr> = Vec::new();
     let mut json_failed_prs: Vec<JsonFailedPr> = Vec::new();
 
-    for pr in prs_to_merge {
+    for (pr_index, pr) in prs_to_merge.into_iter().enumerate() {
         // Auto-detect merge method per repo when not explicitly set (#380)
         let effective_method = if opts.method.is_some() {
             merge_method
@@ -658,10 +689,7 @@ pub async fn run_pr_merge(
                 ));
             }
             println!("{}", line);
-            for note in suppressed
-                .iter()
-                .filter(|n| n.contains(&format!("PR #{}", pr.pr_number)))
-            {
+            for note in notes_for(pr_index, &suppressed) {
                 println!("  suppressed: {}", note);
             }
         }
@@ -1126,5 +1154,88 @@ mod gate_tests {
         let before = names.len();
         names.dedup();
         assert_eq!(before, names.len(), "two gates share a name: {names:?}");
+    }
+}
+
+#[cfg(test)]
+mod attribution_tests {
+    use super::notes_for;
+
+    /// PR numbers where one is a prefix of another, in a single invocation.
+    ///
+    /// This is the exact collision the previous implementation had: it filtered
+    /// notes by `message.contains("PR #77")`, and "PR #777" contains that. The
+    /// merge line for #77 printed #777's suppression as its own.
+    ///
+    /// It could only ever over-attribute, never omit — which is why it is narrow
+    /// and why it still mattered: the line's entire job is saying precisely what
+    /// is suppressed on precisely this PR.
+    #[test]
+    fn a_pr_number_that_is_a_prefix_of_another_does_not_steal_its_notes() {
+        let suppressed = vec![
+            (
+                0usize,
+                "app PR #77: no formal approval [approval]".to_string(),
+            ),
+            (1usize, "app PR #777: checks failing [checks]".to_string()),
+        ];
+        assert_eq!(
+            notes_for(0, &suppressed),
+            vec!["app PR #77: no formal approval [approval]"],
+            "#77 must not receive #777's note"
+        );
+        assert_eq!(
+            notes_for(1, &suppressed),
+            vec!["app PR #777: checks failing [checks]"],
+        );
+    }
+
+    /// Two repos can each carry the SAME PR number in one invocation.
+    ///
+    /// Matching on the number alone — the obvious repair for the substring bug —
+    /// still mis-attributes here. Only an identifier unique across the whole run
+    /// closes both, which is why the notes are keyed by index rather than by any
+    /// value re-read from the rendered text.
+    #[test]
+    fn the_same_pr_number_in_two_repos_keeps_its_notes_separate() {
+        let suppressed = vec![
+            (
+                0usize,
+                "frontend PR #42: no formal approval [approval]".to_string(),
+            ),
+            (
+                1usize,
+                "backend PR #42: checks failing [checks]".to_string(),
+            ),
+        ];
+        assert_eq!(
+            notes_for(0, &suppressed),
+            vec!["frontend PR #42: no formal approval [approval]"],
+        );
+        assert_eq!(
+            notes_for(1, &suppressed),
+            vec!["backend PR #42: checks failing [checks]"],
+        );
+    }
+
+    #[test]
+    fn a_pr_with_several_suppressions_gets_all_of_them_and_only_them() {
+        let suppressed = vec![
+            (
+                0usize,
+                "app PR #1: no formal approval [approval]".to_string(),
+            ),
+            (1usize, "other PR #2: checks failing [checks]".to_string()),
+            (0usize, "app PR #1: checks failing [checks]".to_string()),
+        ];
+        assert_eq!(notes_for(0, &suppressed).len(), 2);
+        assert_eq!(notes_for(1, &suppressed).len(), 1);
+    }
+
+    /// The negative control: no suppressions means no line, not a stray one.
+    #[test]
+    fn a_pr_with_no_suppressions_reports_none() {
+        let suppressed = vec![(1usize, "other PR #2: checks failing [checks]".to_string())];
+        assert!(notes_for(0, &suppressed).is_empty());
     }
 }

--- a/src/cli/commands/pr/mod.rs
+++ b/src/cli/commands/pr/mod.rs
@@ -17,7 +17,7 @@ pub use create::run_pr_create;
 pub use diff::run_pr_diff;
 pub use edit::run_pr_edit;
 pub use list::run_pr_list;
-pub use merge::{run_pr_merge, MergeOptions};
+pub use merge::{run_pr_merge, MergeGate, MergeOptions};
 pub use review::run_pr_review;
 pub use status::run_pr_status;
 pub use view::{run_pr_view, PRViewOptions};

--- a/src/cli/commands/release.rs
+++ b/src/cli/commands/release.rs
@@ -624,6 +624,7 @@ pub async fn run_release(opts: ReleaseOptions<'_>) -> anyhow::Result<()> {
                 &crate::cli::commands::pr::MergeOptions {
                     method: None,
                     force: false,
+                    skip_gates: Vec::new(),
                     update: false,
                     auto: false,
                     json: opts.json,

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -295,6 +295,7 @@ pub async fn dispatch_command(
                 PrCommands::Merge {
                     method,
                     force,
+                    skip_gate,
                     update,
                     auto,
                     wait,
@@ -310,6 +311,10 @@ pub async fn dispatch_command(
                         &crate::cli::commands::pr::MergeOptions {
                             method: method.as_ref(),
                             force,
+                            skip_gates: skip_gate
+                                .iter()
+                                .map(|g| crate::cli::commands::pr::MergeGate::parse(g))
+                                .collect::<anyhow::Result<Vec<_>>>()?,
                             update,
                             auto,
                             json: ctx.json,

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -782,7 +782,12 @@ async fn test_skip_gate_approval_does_not_also_waive_checks() {
     let mut manifest = ws.load_manifest();
 
     git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
-    git_helpers::commit_file(&ws.repo_path("app"), "feature.txt", "feature", "Add feature");
+    git_helpers::commit_file(
+        &ws.repo_path("app"),
+        "feature.txt",
+        "feature",
+        "Add feature",
+    );
 
     let repo_config = manifest.repos.get_mut("app").unwrap();
     repo_config.url = Some("https://github.com/owner/repo.git".to_string());
@@ -820,7 +825,11 @@ async fn test_skip_gate_approval_does_not_also_waive_checks() {
     )
     .await;
 
-    assert!(result.is_ok(), "should report, not error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "should report, not error: {:?}",
+        result.err()
+    );
 
     let requests = server.received_requests().await.unwrap();
     assert!(
@@ -845,7 +854,12 @@ async fn test_skip_gate_approval_allows_a_comment_ratified_merge() {
     let mut manifest = ws.load_manifest();
 
     git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
-    git_helpers::commit_file(&ws.repo_path("app"), "feature.txt", "feature", "Add feature");
+    git_helpers::commit_file(
+        &ws.repo_path("app"),
+        "feature.txt",
+        "feature",
+        "Add feature",
+    );
 
     let repo_config = manifest.repos.get_mut("app").unwrap();
     repo_config.url = Some("https://github.com/owner/repo.git".to_string());
@@ -861,7 +875,12 @@ async fn test_skip_gate_approval_allows_a_comment_ratified_merge() {
     // the waiver failing. The scenario was wrong, not the waiver.
     mock_get_pr(&server, 42, "open", false).await;
     mock_pr_reviews(&server, 42, vec![("COMMENTED", "alice")]).await;
-    mock_check_runs(&server, "feat/test", vec![("CI", "completed", Some("success"))]).await;
+    mock_check_runs(
+        &server,
+        "feat/test",
+        vec![("CI", "completed", Some("success"))],
+    )
+    .await;
     mock_merge_pr(&server, 42, true).await;
 
     let result = gitgrip::cli::commands::pr::run_pr_merge(

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -35,6 +35,7 @@ async fn test_pr_merge_no_open_prs() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: false,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -87,6 +88,7 @@ async fn test_pr_merge_skip_default_branch() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: false,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -133,6 +135,7 @@ async fn test_pr_merge_skip_reference_repos() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: false,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -178,6 +181,7 @@ async fn test_pr_merge_mixed_repos_all_skipped() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: false,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -242,6 +246,7 @@ async fn test_pr_merge_force_bypasses_checks() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: true,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -312,6 +317,7 @@ async fn test_pr_merge_branch_behind_suggests_update() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: true,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -391,6 +397,7 @@ async fn test_pr_merge_repo_filter_excludes_non_target() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: true,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -442,6 +449,7 @@ async fn test_pr_merge_repo_filter_no_match_finds_no_prs() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: false,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -500,6 +508,7 @@ async fn test_pr_merge_force_yes_merges_without_prompt() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: true,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -572,6 +581,7 @@ async fn test_pr_merge_unscoped_multi_match_sends_zero_merge_puts() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: false,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -636,6 +646,7 @@ async fn test_pr_merge_all_flag_proceeds_and_merges_every_match() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: false,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -714,6 +725,7 @@ async fn test_pr_merge_wait_does_not_block_when_no_checks_are_configured() {
         &gitgrip::cli::commands::pr::MergeOptions {
             method: None,
             force: false,
+            skip_gates: Vec::new(),
             update: false,
             auto: false,
             json: false,
@@ -747,5 +759,138 @@ async fn test_pr_merge_wait_does_not_block_when_no_checks_are_configured() {
             .iter()
             .any(|r| r.method == Method::PUT && r.url.path().ends_with("/merge")),
         "expected the merge to actually proceed, not just avoid timing out"
+    );
+}
+
+// ── Gate decomposition ──────────────────────────────────────────
+// `--force` waived approval, checks and mergeability together. On a workspace
+// that ratifies by review COMMENTS rather than formal approvals, the approval
+// gate can never pass — so `--force` became mandatory on every merge and took
+// the other gates with it, invisibly. These pin that waiving one waives ONE.
+
+/// Waiving `approval` must NOT waive `checks`.
+///
+/// This is the test that makes the decomposition real rather than cosmetic. The
+/// PR here has no approval AND a still-running check. Under `--force` it merges.
+/// Under `--skip-gate approval` it must refuse, because the caller waived the
+/// gate that does not apply to their workflow and nothing else.
+#[tokio::test]
+async fn test_skip_gate_approval_does_not_also_waive_checks() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let mut manifest = ws.load_manifest();
+
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
+    git_helpers::commit_file(&ws.repo_path("app"), "feature.txt", "feature", "Add feature");
+
+    let repo_config = manifest.repos.get_mut("app").unwrap();
+    repo_config.url = Some("https://github.com/owner/repo.git".to_string());
+    repo_config.platform = Some(PlatformConfig {
+        platform_type: PlatformType::GitHub,
+        base_url: Some(server.uri()),
+    });
+
+    mock_list_prs(&server, vec![(42, "feat/test")]).await;
+    mock_get_pr(&server, 42, "open", false).await;
+    // Reviewed by comment only — the ratification this workspace actually uses,
+    // and never a formal approval.
+    mock_pr_reviews(&server, 42, vec![("COMMENTED", "alice")]).await;
+    // And a check that has not finished.
+    mock_check_runs(&server, "feat/test", vec![("CI", "in_progress", None)]).await;
+    mock_merge_pr(&server, 42, true).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            skip_gates: vec![gitgrip::cli::commands::pr::MergeGate::Approval],
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: None,
+            yes: true,
+            allow_all: false,
+        },
+    )
+    .await;
+
+    assert!(result.is_ok(), "should report, not error: {:?}", result.err());
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.method == Method::PUT && r.url.path().ends_with("/merge")),
+        "checks were still running and only `approval` was waived — no merge must be sent. \
+         If this fires, --skip-gate is behaving as a blanket --force."
+    );
+}
+
+/// Waiving `approval` on a PR whose only failing gate IS approval must proceed.
+///
+/// The negative control for the test above. Without it, a `--skip-gate` that
+/// simply refused everything would pass — "waives nothing" and "waives only what
+/// was named" are indistinguishable from a single blocked case.
+#[tokio::test]
+async fn test_skip_gate_approval_allows_a_comment_ratified_merge() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let mut manifest = ws.load_manifest();
+
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
+    git_helpers::commit_file(&ws.repo_path("app"), "feature.txt", "feature", "Add feature");
+
+    let repo_config = manifest.repos.get_mut("app").unwrap();
+    repo_config.url = Some("https://github.com/owner/repo.git".to_string());
+    repo_config.platform = Some(PlatformConfig {
+        platform_type: PlatformType::GitHub,
+        base_url: Some(server.uri()),
+    });
+
+    mock_list_prs(&server, vec![(42, "feat/test")]).await;
+    // `merged: false` — the mock derives `mergeable` as `!merged`, so this is a
+    // PR that is open and mergeable. Passing `true` here made it UNmergeable and
+    // the merge was correctly blocked by the `mergeable` gate, which looked like
+    // the waiver failing. The scenario was wrong, not the waiver.
+    mock_get_pr(&server, 42, "open", false).await;
+    mock_pr_reviews(&server, 42, vec![("COMMENTED", "alice")]).await;
+    mock_check_runs(&server, "feat/test", vec![("CI", "completed", Some("success"))]).await;
+    mock_merge_pr(&server, 42, true).await;
+
+    let result = gitgrip::cli::commands::pr::run_pr_merge(
+        &ws.workspace_root,
+        &manifest,
+        &gitgrip::cli::commands::pr::MergeOptions {
+            method: None,
+            force: false,
+            skip_gates: vec![gitgrip::cli::commands::pr::MergeGate::Approval],
+            update: false,
+            auto: false,
+            json: false,
+            wait: false,
+            timeout: 600,
+            delete_branch: true,
+            repo_filter: None,
+            yes: true,
+            allow_all: false,
+        },
+    )
+    .await;
+
+    assert!(result.is_ok(), "should not error: {:?}", result.err());
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.method == Method::PUT && r.url.path().ends_with("/merge")),
+        "approval was the only failing gate and it was waived by name — the merge must proceed"
     );
 }


### PR DESCRIPTION
Closes #837. Reviewers: **Stromus** (approved, r2), **Sentinel**.

## The problem

`gr pr merge` runs three readiness gates — formal approval, status checks, mergeability — behind a single boolean. `--force` waives all three at once.

That is fine until one gate cannot apply. Where a workspace ratifies by review **comments** rather than formal platform approvals, the approval gate can never pass, so `--force` becomes mandatory on every merge and silently takes the check and mergeability gates with it.

**A gate that must always be bypassed does not gate anything; it trains the bypass.** And the flag reached for by habit is the one suppressing everything else — on a command that takes no PR number and merges whatever PR the current branch owns.

## What changed

`--skip-gate <approval|checks|mergeable>`, repeatable, waives exactly one. `--force` still waives all three and now names what it suppressed.

Gates are **evaluated first and waived ones subtracted after**, deliberately: a gate that never ran cannot report what it would have said, and silence is exactly how a suppressed failure disguises itself as a pass.

An unknown gate name is an **error, not a silent no-op**. A misspelled waiver that waives nothing produces a run indistinguishable from one where the gate passed — and the operator, having typed a waiver, believes the opposite of what happened.

```
- app PR #412: no formal approval [approval]
Waive one gate with --skip-gate <approval|checks|mergeable>, or --force to waive all.
```

## The merge announces itself at the moment of the act

```
MERGING acme/widgets#412  fix/parser -> main  method=Merge  WAIVED=approval
  suppressed: widgets PR #412: no formal approval [approval]
```

Printed immediately before the platform call — not from the plan beforehand, not from the result afterwards — and durably rather than in a spinner that erases itself. Since the command resolves its target from the current branch rather than an argument, that point is the only place the slug, number, branch, base and method are simultaneously facts.

## Attribution is keyed by identity, not by rendered text

Review found the defect in the safety line itself. Notes were selected with `message.contains(&format!("PR #{}", n))` — and `"PR #77"` is a substring of `"PR #777"`, which one invocation can carry both of.

The obvious repair, matching the number as a field, fixes that and leaves a second collision: this command is multi-repo, so two **different** repos can each carry a PR #42. Notes are therefore keyed by **index into the run**, unique across both.

The general form: the notes were pre-formatted strings, so the number had to be re-derived by re-parsing text that had been structured a moment earlier. **A value reconstructed from a rendering is a value that can be reconstructed wrong.**

## Tests

Two integration tests **as a pair**, because either alone is satisfiable by a wrong implementation:

- waiving `approval` on a PR that *also* has a running check must **not** merge — catches `--skip-gate` degenerating into `--force`
- waiving `approval` on a PR whose only failing gate is approval **must** merge — catches it waiving nothing

Mutation-verified in both directions; neither test catches both failures.

Unit tests cover round-tripping, case handling, and rejection of unknown and empty names. One uses an **exhaustive match**, so adding a gate variant without adding it to `all()` fails to *compile* rather than silently shrinking what `--force` waives.

Four more pin attribution directly, including the same PR number in two repos and the negative control that no suppressions yields no line. Restoring the substring filter fails three of the four.

704 lib tests, 14 pr-merge integration tests, `fmt` and `clippy --all-targets` clean.
