### PR TITLE
feat(gr2): decide the merge method in the workspace, not at the host

### DIFF
--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -1226,12 +1226,21 @@ def pr_merge(
         )
         # What the merge loop actually completed, not what the group DECLARED.
         # Re-deriving from `prs` names repos the loop may never have reached.
-        merged = [str(c["repo"]) for c in result.get("completed", [])]
+        #
+        # BOTH fields come from this ONE source, deliberately. On the success path
+        # `completed` and `prs` hold the same repos in the same order -- the token and
+        # the truth coincide whenever nothing fails -- so a membership list cannot
+        # distinguish them and every error-path test leaves this path free to re-derive.
+        # `merged_receipts` carries the ADAPTER-AUTHORED fields, which the group file
+        # cannot reproduce. Membership coincides on success; provenance does not.
+        completed = result.get("completed", [])
+        merged = [str(c["repo"]) for c in completed]
         payload = {
             "pr_group_id": group["pr_group_id"],
             "owner_unit": owner_unit,
             "lane_name": resolved_lane,
             "merged": merged,
+            "merged_receipts": completed,
             "state_path": str(group_path),
         }
     except pr_ops.PRMergeError as exc:
@@ -1253,6 +1262,7 @@ def pr_merge(
             "owner_unit": owner_unit,
             "lane_name": resolved_lane,
             "merged": merged,
+            "merged_receipts": exc.completed,
             "failed": [{"repo": exc.repo, "number": exc.pr_number, "reason": exc.reason}],
             "state_path": str(group_path),
         }

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -74,6 +74,31 @@ def _workspace_spec_path(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "workspace_spec.toml"
 
 
+def _configured_merge_method(workspace_root: Path) -> str | None:
+    """The workspace's merge-method policy, or None if it never expressed one.
+
+    Lives under `[workspace_constraints]` because that is where merge policy already
+    lives (`merge_order`, `required_reviewers`) -- following the existing section rather
+    than inventing one.
+
+    Returns `None`, never the string "merge", when the key is absent. Collapsing "unset"
+    into "chose merge" would make a workspace that never expressed a preference
+    indistinguishable from one that pinned the current default, so a later change of
+    default would silently never reach the workspaces that were only ever defaulting.
+    Absence is the honest encoding of "take the default, and follow it if it moves".
+
+    Missing spec is tolerated: this is a policy lookup on a merge path, and a workspace
+    without a spec file has plainly not configured a method. It must not become a second
+    failure mode on top of whatever the merge itself is doing.
+    """
+    try:
+        spec = lane_proto.load_workspace_spec(workspace_root)
+    except (FileNotFoundError, OSError):
+        return None
+    value = spec.get("workspace_constraints", {}).get("merge_method")
+    return None if value is None else str(value)
+
+
 def _lane_repo_root(workspace_root: Path, owner_unit: str, lane_name: str, repo_name: str) -> Path:
     return lane_proto.lane_dir(workspace_root, owner_unit, lane_name) / "repos" / repo_name
 
@@ -1189,14 +1214,19 @@ def pr_merge(
             typer.echo(json.dumps(payload, indent=2))
         raise typer.Exit(code=1)
     try:
-        pr_ops.merge_pr_group(
+        result = pr_ops.merge_pr_group(
             workspace_root=workspace_root,
             pr_group_id=str(group["pr_group_id"]),
             adapter=adapter,
             actor=f"agent:{owner_unit}",
-            method=pr_ops.resolve_merge_method(explicit=method, configured=None),
+            method=pr_ops.resolve_merge_method(
+                explicit=method,
+                configured=_configured_merge_method(workspace_root),
+            ),
         )
-        merged = [str(pr_info["repo"]) for pr_info in group.get("prs", [])]
+        # What the merge loop actually completed, not what the group DECLARED.
+        # Re-deriving from `prs` names repos the loop may never have reached.
+        merged = [str(c["repo"]) for c in result.get("completed", [])]
         payload = {
             "pr_group_id": group["pr_group_id"],
             "owner_unit": owner_unit,
@@ -1205,7 +1235,15 @@ def pr_merge(
             "state_path": str(group_path),
         }
     except pr_ops.PRMergeError as exc:
-        merged = [str(pr_info["repo"]) for pr_info in group.get("prs", []) if str(pr_info["repo"]) != exc.repo]
+        # DECLARED-MINUS-FAILED IS WRONG, and wrong in the dangerous direction.
+        # With prs = [app, api, web] and api failing, it yields [app, web] --
+        # recording web as merged when the loop stopped before ever calling it.
+        # A retry then skips a PR that is still open, and the operator reads a
+        # merge that never happened.
+        #
+        # `exc.completed` is the list the merge loop actually built, carried on
+        # the exception precisely so this layer never has to reconstruct it.
+        merged = [str(c["repo"]) for c in exc.completed]
         group["group_state"] = "partially_merged" if merged else "merge_failed"
         group["merged"] = merged
         group_path.write_text(json.dumps(group, indent=2) + "\n")

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -1156,6 +1156,12 @@ def pr_merge(
     owner_unit: str,
     lane_name: Optional[str] = typer.Argument(None, help="Lane name. Defaults to the unit's current lane."),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    method: Optional[str] = typer.Option(
+        None,
+        "--method",
+        "-m",
+        help="merge/squash/rebase. Defaults to a merge commit. An unpermitted method is refused, never substituted.",
+    ),
 ) -> None:
     """Merge grouped PRs for a lane."""
     workspace_root = workspace_root.resolve()
@@ -1188,6 +1194,7 @@ def pr_merge(
             pr_group_id=str(group["pr_group_id"]),
             adapter=adapter,
             actor=f"agent:{owner_unit}",
+            method=pr_ops.resolve_merge_method(explicit=method, configured=None),
         )
         merged = [str(pr_info["repo"]) for pr_info in group.get("prs", [])]
         payload = {

--- a/gr2/python_cli/platform.py
+++ b/gr2/python_cli/platform.py
@@ -1,11 +1,39 @@
 from __future__ import annotations
 
+import enum
 import json
 import shutil
 import subprocess
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Protocol
+
+
+class MergeMethod(enum.Enum):
+    """The git strategy a merge uses. Decided by the workspace, never by the host.
+
+    gr1 asked the host which methods it permitted and took the first of
+    `squash > merge > rebase` -- delegating a workspace-policy decision to a party with no
+    knowledge of the workspace. gr2's version of the same class is quieter and harder to
+    see: it passed no strategy flag at all, so gh and the host decided by default. There
+    was no wrong line to point at, only an absent one.
+
+    `MERGE` is the default deliberately. It is the only method that preserves both
+    parents, and losing shared ancestry is not a formatting preference -- it is how two
+    branches become unrelated histories that no later merge can reconcile.
+
+    Lives here rather than in `pr.py` because the flag mapping is a platform concern, and
+    because `pr.py` imports this module: the enum has to sit on the lower side of that
+    edge. `pr.py` re-exports it, so the operational contract reads from either.
+    """
+
+    MERGE = "merge"
+    SQUASH = "squash"
+    REBASE = "rebase"
+
+    @property
+    def gh_flag(self) -> str:
+        return f"--{self.value}"
 
 
 @dataclass(frozen=True)
@@ -68,7 +96,7 @@ class PlatformAdapter(Protocol):
 
     def create_pr(self, request: CreatePRRequest) -> PRRef: ...
 
-    def merge_pr(self, repo: str, number: int) -> PRRef: ...
+    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef: ...
 
     def pr_status(self, repo: str, number: int) -> PRStatus: ...
 
@@ -135,9 +163,17 @@ class GitHubAdapter:
             title=request.title,
         )
 
-    def merge_pr(self, repo: str, number: int) -> PRRef:
+    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef:
+        """Merge, naming the strategy explicitly.
+
+        `method` is REQUIRED and has no default on purpose. A default would be a promise
+        that every future call site remembers to think about it; a required argument is a
+        refusal. The absent flag is precisely the defect being closed here -- with no
+        strategy named, gh and the host choose, and a squash reports success identically
+        to a merge commit.
+        """
         proc = subprocess.run(
-            [self.gh_binary, "pr", "merge", str(number), "--repo", repo],
+            [self.gh_binary, "pr", "merge", str(number), "--repo", repo, method.gh_flag],
             capture_output=True,
             text=True,
             check=False,

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -234,7 +234,7 @@ def merge_pr_group(
         repo = pr_info["repo"]
         number = pr_info["pr_number"]
         try:
-            adapter.merge_pr(repo, number, method=method)
+            receipt = adapter.merge_pr(repo, number, method=method)
         except AdapterError as exc:
             # Best-effort durable layer. Wrapped so a failure HERE cannot replace the
             # PRMergeError below with the event subsystem's own exception -- if a broken
@@ -264,7 +264,20 @@ def merge_pr_group(
                     file=sys.stderr,
                 )
             raise PRMergeError(repo, number, str(exc), completed=merged) from exc
-        merged.append(pr_info)
+
+        # Carried back from the ADAPTER, never rebuilt from `pr_info`. Rebuilding from the
+        # group file produces the same repo names in the same order -- the loop visits
+        # repos in group order -- so the two are indistinguishable by inspection while one
+        # is evidence that a merge happened and the other is a restatement of what we
+        # intended. The second is exactly what a loop that never contacted the host would
+        # also produce.
+        #
+        # `PRRef` is a thin receipt today and carries no commit id (grip#842 item 3 makes
+        # it real). This shape is the seam: when the richer receipt lands it swaps in here
+        # without the meaning of the record changing.
+        merged.append(
+            {"repo": receipt.repo, "pr_number": receipt.number, "url": receipt.url}
+        )
 
     emit(
         event_type=EventType.PR_MERGED,

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 from .events import EventType, emit
@@ -91,13 +92,48 @@ def resolve_merge_method(
 
 
 class PRMergeError(RuntimeError):
-    """Raised when a PR merge fails."""
+    """Raised when a PR merge fails, carrying the merges that already succeeded.
 
-    def __init__(self, repo: str, pr_number: int, reason: str) -> None:
+    `completed` is REQUIRED and keyword-only, with no default, because this is the
+    reliable half of G9 (grip#842). Merging is irreversible: by the time one repo fails,
+    earlier repos are merged on the host and no amount of unwinding changes that. A caller
+    that cannot learn which ones will re-attempt them.
+
+        Irreversible work that is not recorded is worse than work not done,
+        because the next actor plans against a state that is false.
+
+    An optional field would be omitted at exactly one call site within a year and the
+    guarantee would quietly become a convention. An empty list is a claim -- "nothing had
+    merged" -- and must be stated, not defaulted; "nothing merged" and "nobody recorded
+    what merged" are different facts and a default would make them identical.
+
+    This is the layer a retry reads. The event log is the other layer and is best-effort:
+    `emit` swallows every exception (grip#843), so correctness must not rest on it. The two
+    fail by different routes, which is the only thing that makes them depth rather than
+    the same chance twice.
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        pr_number: int,
+        reason: str,
+        *,
+        completed: list[dict],
+    ) -> None:
         self.repo = repo
         self.pr_number = pr_number
         self.reason = reason
-        super().__init__(f"merge failed for {repo}#{pr_number}: {reason}")
+        self.completed = list(completed)
+        already = ", ".join(str(c.get("repo")) for c in self.completed)
+        super().__init__(
+            f"merge failed for {repo}#{pr_number}: {reason}"
+            + (
+                f" (ALREADY MERGED, do not retry: {already})"
+                if self.completed
+                else " (nothing had merged yet)"
+            )
+        )
 
 
 def _pr_groups_dir(workspace_root: Path) -> Path:
@@ -200,19 +236,34 @@ def merge_pr_group(
         try:
             adapter.merge_pr(repo, number, method=method)
         except AdapterError as exc:
-            emit(
-                event_type=EventType.PR_MERGE_FAILED,
-                workspace_root=workspace_root,
-                actor=actor,
-                owner_unit=group.get("owner_unit", actor),
-                payload={
-                    "pr_group_id": pr_group_id,
-                    "repo": repo,
-                    "pr_number": number,
-                    "reason": str(exc),
-                },
-            )
-            raise PRMergeError(repo, number, str(exc)) from exc
+            # Best-effort durable layer. Wrapped so a failure HERE cannot replace the
+            # PRMergeError below with the event subsystem's own exception -- if a broken
+            # event layer can take the in-process layer down with it, they were never two
+            # layers. `emit` swallows everything today (grip#843); this guards the day it
+            # does not, rather than depending on that staying true.
+            try:
+                emit(
+                    event_type=EventType.PR_MERGE_FAILED,
+                    workspace_root=workspace_root,
+                    actor=actor,
+                    owner_unit=group.get("owner_unit", actor),
+                    payload={
+                        "pr_group_id": pr_group_id,
+                        "repo": repo,
+                        "pr_number": number,
+                        "reason": str(exc),
+                        # The irreversible work that already happened. Recorded on the
+                        # FAILURE event because there may never be a success event.
+                        "completed": merged,
+                    },
+                )
+            except Exception as emit_exc:  # noqa: BLE001 - deliberately broad
+                print(
+                    f"gr2: could not record partial merge ({emit_exc}); "
+                    f"the completed list is still on the raised PRMergeError",
+                    file=sys.stderr,
+                )
+            raise PRMergeError(repo, number, str(exc), completed=merged) from exc
         merged.append(pr_info)
 
     emit(

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -17,7 +17,77 @@ import os
 from pathlib import Path
 
 from .events import EventType, emit
-from .platform import AdapterError, CreatePRRequest, PlatformAdapter
+from .platform import AdapterError, CreatePRRequest, MergeMethod, PlatformAdapter
+
+__all__ = [
+    "MergeMethod",
+    "UnpermittedMergeMethodError",
+    "resolve_merge_method",
+    "PRMergeError",
+    "create_pr_group",
+    "merge_pr_group",
+    "check_pr_group_status",
+    "record_pr_review",
+]
+
+
+class UnpermittedMergeMethodError(RuntimeError):
+    """The requested method is not permitted, and no other method was substituted.
+
+    Deliberately NOT a subclass of the parse error. A name we cannot read and a name we
+    can read but may not use are different facts, and a caller that wants to distinguish
+    them should not have to inspect a message to do it.
+    """
+
+    def __init__(self, requested: MergeMethod, permitted: list[str]) -> None:
+        self.requested = requested
+        self.permitted = list(permitted)
+        super().__init__(
+            f"merge method {requested.value!r} is not permitted here "
+            f"(permitted: {', '.join(self.permitted) or 'none'}). "
+            f"Refusing rather than substituting: a merge that silently uses a different "
+            f"strategy than the one requested reports success identically, and the only "
+            f"way to discover it is counting parents afterwards."
+        )
+
+
+def _parse_method(name: str, *, source: str) -> MergeMethod:
+    try:
+        return MergeMethod(name)
+    except ValueError:
+        raise ValueError(
+            f"unrecognised merge method {name!r} from {source} "
+            f"(expected one of: {', '.join(m.value for m in MergeMethod)}). "
+            f"Not falling back to a default: you asked for something, and quietly doing "
+            f"something else is the defect this guard exists to prevent."
+        ) from None
+
+
+def resolve_merge_method(
+    explicit: str | None = None,
+    configured: str | None = None,
+    permitted: list[str] | None = None,
+) -> MergeMethod:
+    """Resolve the merge strategy. The host is asked *whether*, never *which*.
+
+    Precedence: explicit `--method`, then the workspace setting, then a merge commit.
+
+    `permitted` is what the host allows, when we happen to know it. Passing `None` means
+    **we did not ask** -- which must not read as "anything goes". No refusal is claimed in
+    that case, and nothing asserts the method was permitted; unverifiable stays
+    distinguishable from verified.
+    """
+    if explicit is not None:
+        chosen = _parse_method(explicit, source="--method")
+    elif configured is not None:
+        chosen = _parse_method(configured, source="workspace setting")
+    else:
+        chosen = MergeMethod.MERGE
+
+    if permitted is not None and chosen.value not in permitted:
+        raise UnpermittedMergeMethodError(chosen, permitted)
+
+    return chosen
 
 
 class PRMergeError(RuntimeError):
@@ -111,8 +181,16 @@ def merge_pr_group(
     pr_group_id: str,
     adapter: PlatformAdapter,
     actor: str,
+    *,
+    method: MergeMethod,
 ) -> dict:
-    """Merge all PRs in a group. Stops on first failure."""
+    """Merge all PRs in a group. Stops on first failure.
+
+    `method` is required and keyword-only. Resolving a strategy correctly and then not
+    threading it to the call is the same outcome as never resolving one -- a decided
+    method that never reaches `gh` is indistinguishable from an undecided one, and the
+    unit tests for the resolver stay green either way.
+    """
     group = _load_group(workspace_root, pr_group_id)
     merged: list[dict] = []
 
@@ -120,7 +198,7 @@ def merge_pr_group(
         repo = pr_info["repo"]
         number = pr_info["pr_number"]
         try:
-            adapter.merge_pr(repo, number)
+            adapter.merge_pr(repo, number, method=method)
         except AdapterError as exc:
             emit(
                 event_type=EventType.PR_MERGE_FAILED,

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -108,7 +108,9 @@ class PRMergeError(RuntimeError):
     what merged" are different facts and a default would make them identical.
 
     This is the layer a retry reads. The event log is the other layer and is best-effort:
-    `emit` swallows every exception (grip#843), so correctness must not rest on it. The two
+    `emit` RAISES `EventEmitError` as of grip#843 (it previously swallowed everything);
+    either way correctness must not rest on it -- fail-open lost the record silently, and
+    fail-closed turns a logging failure into an operation failure. The two
     fail by different routes, which is the only thing that makes them depth rather than
     the same chance twice.
     """
@@ -239,8 +241,9 @@ def merge_pr_group(
             # Best-effort durable layer. Wrapped so a failure HERE cannot replace the
             # PRMergeError below with the event subsystem's own exception -- if a broken
             # event layer can take the in-process layer down with it, they were never two
-            # layers. `emit` swallows everything today (grip#843); this guards the day it
-            # does not, rather than depending on that staying true.
+            # layers. This was written while `emit` still swallowed everything; grip#843
+            # made it RAISE, so the wrap is now load-bearing rather than defensive. The
+            # broader class -- emits sitting after irreversible work -- is grip#844.
             try:
                 emit(
                     event_type=EventType.PR_MERGE_FAILED,
@@ -287,6 +290,11 @@ def merge_pr_group(
         payload={"pr_group_id": pr_group_id, "repos": merged},
     )
 
+    # Hand the caller what ACTUALLY merged. Without this the layer above has
+    # nothing to consume and re-derives completion from the group's declared
+    # `prs` -- which names repos the loop may never have reached. G9's list is
+    # only worth carrying if the next consumer can read it.
+    group["completed"] = merged
     return group
 
 

--- a/gr2/tests/test_pr_events.py
+++ b/gr2/tests/test_pr_events.py
@@ -16,6 +16,7 @@ import pytest
 
 from gr2.python_cli.platform import (
     AdapterError,
+    MergeMethod,
     CreatePRRequest,
     PRCheck,
     PRRef,
@@ -46,7 +47,7 @@ class FakeAdapter:
             title=request.title,
         )
 
-    def merge_pr(self, repo: str, number: int) -> PRRef:
+    def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
         if (repo, number) in self._fail_merge:
             raise AdapterError(f"merge conflict in {repo}#{number}")
         self.merged.append((repo, number))
@@ -221,6 +222,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
+            method=MergeMethod.MERGE,
         )
         events = _events_of_type(workspace, "pr.merged")
         assert len(events) == 1
@@ -234,6 +236,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
+            method=MergeMethod.MERGE,
         )
         event = _events_of_type(workspace, "pr.merged")[0]
         assert event["pr_group_id"] == group["pr_group_id"]
@@ -249,6 +252,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
+            method=MergeMethod.MERGE,
         )
         assert [r for r, _ in adapter.merged] == ["app", "api", "billing"]
 
@@ -286,6 +290,7 @@ class TestPRMergeFailed:
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
+                method=MergeMethod.MERGE,
             )
         events = _events_of_type(workspace, "pr.merge_failed")
         assert len(events) == 1
@@ -302,6 +307,7 @@ class TestPRMergeFailed:
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
+                method=MergeMethod.MERGE,
             )
         event = _events_of_type(workspace, "pr.merge_failed")[0]
         assert event["pr_group_id"] == group["pr_group_id"]
@@ -332,6 +338,7 @@ class TestPRMergeFailed:
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
+                method=MergeMethod.MERGE,
             )
         # Only app was attempted; api and billing were not
         assert len(adapter.merged) == 0  # grip failed, not in merged list

--- a/gr2/tests/test_pr_merge_method.py
+++ b/gr2/tests/test_pr_merge_method.py
@@ -189,3 +189,143 @@ class TestTheFlagActuallyReachesGh:
             f"decide -- which is guarantee 1's failure in its least visible form, because "
             f"there is no wrong line to point at, only an absent one."
         )
+
+
+class TestTheConfiguredWorkspaceMethodIsActuallyREACHED:
+    """The resolver being correct proves nothing if production never calls it.
+
+    Sentinel's r1 mutation: replace production method resolution with the constant
+    `MergeMethod.MERGE` and all 56 tests stay green -- because every caller passed
+    `configured=None`, so the workspace setting was never read and the default was the
+    only value the resolver could return. The resolver was correct and UNREACHED, which
+    is guarantee 3 again: pinning a function does not pin its invocation.
+
+    These tests fail if the constant is substituted, because they require a NON-default
+    method to arrive at the adapter by way of the workspace file.
+    """
+
+    def _workspace(self, tmp_path, method: str | None):
+        import json as _json
+
+        spec = '\nschema_version = 1\nworkspace_name = "w"\n\n[[repos]]\nname = "app"\npath = "repos/app"\nurl = "https://example.invalid/app.git"\n'
+        if method is not None:
+            spec += f'\n[workspace_constraints]\nmerge_method = "{method}"\n'
+        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".grip" / "workspace_spec.toml").write_text(spec)
+        return tmp_path
+
+    def test_the_workspace_setting_is_read_from_the_spec(self, tmp_path):
+        from python_cli.app import _configured_merge_method
+
+        assert _configured_merge_method(self._workspace(tmp_path, "squash")) == "squash"
+
+    def test_absent_setting_reads_as_None_not_as_a_default(self, tmp_path):
+        """`None` means the workspace said nothing, which the resolver turns into a merge
+        commit. Returning the string "merge" here would collapse 'unset' and 'chose
+        merge' into one value, and a later change of default would silently never reach
+        the workspaces that never expressed a preference."""
+        from python_cli.app import _configured_merge_method
+
+        assert _configured_merge_method(self._workspace(tmp_path, None)) is None
+
+    def test_a_configured_method_reaches_resolution(self, tmp_path):
+        """End of the wire: spec file -> helper -> resolver -> a NON-default method.
+
+        This is the assertion the constant-MERGE mutation cannot satisfy.
+        """
+        from python_cli.app import _configured_merge_method
+
+        configured = _configured_merge_method(self._workspace(tmp_path, "squash"))
+        assert resolve_merge_method(explicit=None, configured=configured) is MergeMethod.SQUASH
+
+    def test_explicit_still_beats_the_workspace_setting(self, tmp_path):
+        from python_cli.app import _configured_merge_method
+
+        configured = _configured_merge_method(self._workspace(tmp_path, "squash"))
+        assert resolve_merge_method(explicit="rebase", configured=configured) is MergeMethod.REBASE
+
+
+class TestTheCLICallSiteActuallyResolves:
+    """Pins the INVOCATION, not the resolver -- because the resolver was already correct.
+
+    The first version of the P1-TWO fix added tests for `_configured_merge_method` and
+    for `resolve_merge_method`, both passing, and Sentinel's mutation SURVIVED: replacing
+    the CLI's resolution with the constant `MergeMethod.MERGE` left all of them green,
+    because none of them traversed the call site. Guarantee 3, inside the fix for a
+    guarantee-3 finding, on the third occurrence of the same shape in one change.
+
+    The only assertion that can distinguish "resolved" from "constant" is one that
+    observes what the CLI HANDS DOWNSTREAM when the workspace asks for a NON-default
+    method.
+    """
+
+    def test_a_squash_workspace_makes_the_CLI_pass_SQUASH_downstream(
+        self, tmp_path, monkeypatch
+    ):
+        import json as _json
+
+        from typer.testing import CliRunner
+
+        from python_cli import app as app_mod
+
+        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".grip" / "workspace_spec.toml").write_text(
+            '\nschema_version = 1\nworkspace_name = "w"\n\n'
+            '[workspace_constraints]\nmerge_method = "squash"\n'
+        )
+        group = {"pr_group_id": "pg", "owner_unit": "apollo", "lane_name": "lane", "prs": []}
+        gpath = tmp_path / "g.json"
+        gpath.write_text(_json.dumps(group))
+
+        seen: dict[str, object] = {}
+
+        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
+        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
+        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
+        monkeypatch.setattr(
+            app_mod.pr_ops,
+            "merge_pr_group",
+            lambda **kw: seen.update(kw) or {"completed": []},
+        )
+
+        CliRunner().invoke(app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"])
+
+        assert seen.get("method") is MergeMethod.SQUASH, (
+            f"the CLI handed down {seen.get('method')!r}. The workspace configured "
+            f"'squash'; a constant, or an unwired `configured=None`, yields MERGE and is "
+            f"indistinguishable from a correct default."
+        )
+
+    def test_an_explicit_flag_still_overrides_the_workspace_at_the_CLI(
+        self, tmp_path, monkeypatch
+    ):
+        import json as _json
+
+        from typer.testing import CliRunner
+
+        from python_cli import app as app_mod
+
+        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".grip" / "workspace_spec.toml").write_text(
+            '\nschema_version = 1\nworkspace_name = "w"\n\n'
+            '[workspace_constraints]\nmerge_method = "squash"\n'
+        )
+        group = {"pr_group_id": "pg", "owner_unit": "apollo", "lane_name": "lane", "prs": []}
+        gpath = tmp_path / "g.json"
+        gpath.write_text(_json.dumps(group))
+        seen: dict[str, object] = {}
+
+        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
+        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
+        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
+        monkeypatch.setattr(
+            app_mod.pr_ops,
+            "merge_pr_group",
+            lambda **kw: seen.update(kw) or {"completed": []},
+        )
+
+        CliRunner().invoke(
+            app_mod.app,
+            ["pr", "merge", str(tmp_path), "apollo", "lane", "--json", "--method", "rebase"],
+        )
+        assert seen.get("method") is MergeMethod.REBASE

--- a/gr2/tests/test_pr_merge_method.py
+++ b/gr2/tests/test_pr_merge_method.py
@@ -1,0 +1,191 @@
+"""Merge-method contract for gr2, ported from gr1's seven-round hardening (grip#842).
+
+Written TDD-first: these must fail until `python_cli/pr.py` implements the contract.
+
+The defect being designed out: gr1's `gr pr merge` **actively chose squash**. It asked the
+host which methods were permitted and took the first of `squash > merge > rebase`,
+delegating a workspace-policy decision to a party with no knowledge of the workspace.
+
+gr2 today has the same class in a form that is harder to see, because there is no wrong
+line to point at -- there is only an absent one. `python_cli/platform.py` invokes
+`gh pr merge <n> --repo <r>` with **no strategy flag at all**, so the method is decided by
+gh and the host, wholesale.
+
+Guarantee 1 (grip#842): the host is asked *whether*, never *which*. Precedence is
+explicit `--method`, then workspace setting, then a merge commit. An unpermitted method is
+**refused, not substituted** -- silent substitution is the original defect in a politer
+form, where the operator asks for one strategy, another happens, and the only way to find
+out is counting parents afterwards.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from python_cli.pr import (  # noqa: E402
+    MergeMethod,
+    UnpermittedMergeMethodError,
+    resolve_merge_method,
+)
+
+
+class TestPrecedence:
+    """Explicit beats configured beats a merge commit. Nothing else participates."""
+
+    def test_explicit_wins_over_configured(self):
+        assert resolve_merge_method(explicit="rebase", configured="squash") is MergeMethod.REBASE
+
+    def test_configured_used_when_no_explicit(self):
+        assert resolve_merge_method(explicit=None, configured="squash") is MergeMethod.SQUASH
+
+    def test_default_is_a_merge_commit(self):
+        """The only method that preserves both parents is the one you get by saying nothing.
+
+        This is the assertion that would have caught gr1's defect directly: there, saying
+        nothing produced a squash.
+        """
+        assert resolve_merge_method(explicit=None, configured=None) is MergeMethod.MERGE
+
+    @pytest.mark.parametrize("bad", ["", "  ", "Squash", "fast-forward", "merge-commit", "none"])
+    def test_an_unrecognised_name_is_an_error_not_a_fallback(self, bad):
+        """Falling back to the default on a name we do not recognise is silent substitution.
+
+        The operator typed something. Guessing what they meant, or quietly ignoring it, is
+        the same failure as letting the host choose -- a strategy happens that nobody asked
+        for. Note `Squash` is in this list deliberately: near-misses are the realistic
+        input, and case-insensitive acceptance is a decision, not a courtesy.
+        """
+        with pytest.raises(ValueError):
+            resolve_merge_method(explicit=bad, configured=None)
+
+    def test_an_unrecognised_CONFIGURED_name_is_also_an_error(self):
+        """A bad value in the workspace file is not more trustworthy than a bad flag.
+
+        It is less visible, which makes silent fallback worse here, not better: nobody is
+        watching a config file at the moment of a merge.
+        """
+        with pytest.raises(ValueError):
+            resolve_merge_method(explicit=None, configured="sqush")
+
+
+class TestRefuseNeverSubstitute:
+    """The paired control. Neither test means anything without the other.
+
+    A guard that refuses everything passes the refusal test while breaking all merging;
+    a guard that refuses nothing passes the permitted test while restoring the defect.
+    Only the pair pins the behaviour, and each names what the other proves.
+    """
+
+    def test_a_permitted_method_is_used_verbatim(self):
+        """POSITIVE CONTROL. Proves the guard is not simply refusing everything."""
+        chosen = resolve_merge_method(
+            explicit="squash", configured=None, permitted=["merge", "squash"]
+        )
+        assert chosen is MergeMethod.SQUASH
+
+    def test_an_unpermitted_method_is_REFUSED(self):
+        """NEGATIVE CONTROL. Proves the guard is not simply permitting everything."""
+        with pytest.raises(UnpermittedMergeMethodError):
+            resolve_merge_method(explicit="squash", configured=None, permitted=["merge"])
+
+    def test_refusal_does_not_fall_back_to_a_permitted_method(self):
+        """The whole guarantee, stated as the thing that must NOT happen.
+
+        gr1's defect was not that it chose badly. It was that it chose AT ALL, then
+        reported success, so the operator's request and the actual outcome differed with
+        nothing in the output saying so. Raising is the only outcome that cannot be
+        mistaken for the request having been honoured.
+        """
+        with pytest.raises(UnpermittedMergeMethodError) as excinfo:
+            resolve_merge_method(explicit="rebase", configured=None, permitted=["merge", "squash"])
+
+        # The error must name what was ASKED FOR, not merely what is allowed -- an operator
+        # reading it needs to see their own request refused, not a list of alternatives
+        # that reads like a suggestion to pick one.
+        assert "rebase" in str(excinfo.value)
+
+    def test_permitted_None_means_unchecked_not_unrestricted(self):
+        """`permitted=None` is 'we did not ask the host', which must not read as 'anything goes'.
+
+        This is guarantee 4 in miniature: unverifiable must be distinguishable from
+        verified. Here the distinction is that no refusal is claimed either way -- the
+        method resolves, and nothing asserts it was permitted.
+        """
+        assert resolve_merge_method(explicit="rebase", configured=None, permitted=None) is (
+            MergeMethod.REBASE
+        )
+
+
+class TestTheFlagActuallyReachesGh:
+    """Resolving a method proves nothing if the resolved value is never passed on.
+
+    gr1's lesson, stated as guarantee 3: pinning a function does not pin its invocation.
+    A correct `resolve_merge_method` with a caller that still shells out to a bare
+    `gh pr merge` is exactly the defect we started with, and every test above would pass.
+    """
+
+    def test_the_resolved_method_appears_in_the_gh_argv(self, monkeypatch):
+        """Asserts the argv gh actually receives -- behaviour, not internal structure.
+
+        Monkeypatching `subprocess.run` rather than subclassing keeps the test from
+        prescribing how the adapter is built, so a later refactor cannot make it
+        vacuously green by moving the call somewhere the subclass no longer intercepts.
+        """
+        from python_cli import platform as platform_mod
+
+        recorded: list[list[str]] = []
+
+        class _Proc:
+            returncode = 0
+            stdout = "{}"
+            stderr = ""
+
+        def _fake_run(argv, *a, **kw):
+            recorded.append(list(argv))
+            return _Proc()
+
+        monkeypatch.setattr(platform_mod.subprocess, "run", _fake_run)
+        platform_mod.GitHubAdapter().merge_pr("owner/repo", 42, method=MergeMethod.SQUASH)
+
+        assert recorded, "the adapter never invoked gh at all"
+        argv = recorded[0]
+        assert "--squash" in argv, (
+            f"the resolved method never reached gh; argv was {argv}. A method decided and "
+            f"then dropped is indistinguishable from one never decided."
+        )
+
+    def test_no_method_still_names_one_explicitly(self, monkeypatch):
+        """The absent flag IS the defect, so the default must be a POSITIVE assertion.
+
+        A test that only checks `--squash` when squash is asked for would stay green
+        against today's code path for every other case -- and today's code path passes no
+        flag at all, which is how the host ends up choosing.
+        """
+        from python_cli import platform as platform_mod
+
+        recorded: list[list[str]] = []
+
+        class _Proc:
+            returncode = 0
+            stdout = "{}"
+            stderr = ""
+
+        monkeypatch.setattr(
+            platform_mod.subprocess,
+            "run",
+            lambda argv, *a, **kw: (recorded.append(list(argv)), _Proc())[1],
+        )
+        platform_mod.GitHubAdapter().merge_pr(
+            "owner/repo", 42, method=resolve_merge_method(explicit=None, configured=None)
+        )
+
+        argv = recorded[0]
+        assert "--merge" in argv, (
+            f"no strategy flag reached gh; argv was {argv}. With no flag, gh and the host "
+            f"decide -- which is guarantee 1's failure in its least visible form, because "
+            f"there is no wrong line to point at, only an absent one."
+        )

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -19,8 +19,9 @@ rather than the same chance twice:
 
   - `PRMergeError` carries the completed list. In-process, structural; its failure mode is
     a raised exception. **This is what a retry must read.**
-  - The event stays best-effort and durable. `emit` swallows every exception and returns
-    `None` (see grip#843), so correctness must not rest on it.
+  - The event stays best-effort and durable. As of grip#843 `emit` RAISES rather than
+    swallowing, which is why the wrap below is load-bearing: a failure in the durable
+    layer must not replace the real error. See grip#844 for the wider call-site class.
 """
 from __future__ import annotations
 
@@ -199,8 +200,9 @@ class TestTheTwoLayersAreIndependent:
     """Depth is only depth if the layers fail by different routes.
 
     A durable record that the in-process path depends on is the same chance twice. These
-    tests exist because `emit` swallows every exception (grip#843): if correctness rested
-    on it, G9 would be satisfied by a mechanism that can silently do nothing.
+    tests exist because the durable layer is not trustworthy in either regime: before
+    grip#843 `emit` swallowed everything and could silently do nothing; after it, `emit`
+    raises and can take the caller down with it. Both are reasons not to rest on it.
     """
 
     def test_a_durable_event_records_the_partial_merge(self, tmp_path):
@@ -258,3 +260,84 @@ class TestTheTwoLayersAreIndependent:
             "a failure in the best-effort layer must not erase the reliable one, and "
             "must not replace PRMergeError with the event layer's own exception"
         )
+
+
+class TestTheCLIConsumesTheListRatherThanRebuildingIt:
+    """The survivor relocated one layer out, to the next consumer.
+
+    `merge_pr_group` carries the completed list correctly. The CLI above it was computing
+    `merged` as DECLARED-MINUS-FAILED:
+
+        [repo for repo in group["prs"] if repo != exc.repo]
+
+    With prs = [app, api, web] and api failing, that yields **[app, web]** -- and the loop
+    stopped at api, so web was never called. A repo that was never touched is persisted as
+    merged, a retry skips a PR that is still open, and the operator reads a merge that did
+    not happen.
+
+    Physics 005: a defect does not die when fixed, it moves one layer outward. The list
+    existed and was correct; nothing consumed it.
+    """
+
+    def _invoke(self, tmp_path, monkeypatch, declared, completed, failing):
+        from typer.testing import CliRunner
+
+        from python_cli import app as app_mod
+
+        group = {
+            "pr_group_id": "pg_x",
+            "owner_unit": "apollo",
+            "lane_name": "lane",
+            "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(declared)],
+        }
+        gpath = tmp_path / "group.json"
+        gpath.write_text(json.dumps(group))
+
+        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
+        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
+        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
+
+        def _boom(**kwargs):
+            raise PRMergeError(
+                failing,
+                2,
+                "simulated",
+                completed=[{"repo": r, "pr_number": i + 1, "url": None} for i, r in enumerate(completed)],
+            )
+
+        monkeypatch.setattr(app_mod.pr_ops, "merge_pr_group", _boom)
+        res = CliRunner().invoke(
+            app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"]
+        )
+        return json.loads(res.stdout), json.loads(gpath.read_text())
+
+    def test_a_repo_the_loop_never_reached_is_NOT_recorded_as_merged(
+        self, tmp_path, monkeypatch
+    ):
+        payload, persisted = self._invoke(
+            tmp_path,
+            monkeypatch,
+            declared=["app", "api", "web"],
+            completed=["app"],
+            failing="api",
+        )
+
+        assert payload["merged"] == ["app"], (
+            f"got {payload['merged']}. 'web' is declared in the group and was never "
+            f"called -- the loop stopped at 'api'. Declared-minus-failed cannot tell "
+            f"'not reached' from 'succeeded'."
+        )
+        assert "web" not in persisted.get("merged", []), (
+            "the FALSE record was persisted to disk, which is the part a retry reads"
+        )
+
+    def test_the_persisted_state_matches_what_actually_merged(self, tmp_path, monkeypatch):
+        payload, persisted = self._invoke(
+            tmp_path,
+            monkeypatch,
+            declared=["app", "api", "web", "docs"],
+            completed=["app"],
+            failing="api",
+        )
+        assert persisted["merged"] == ["app"]
+        assert persisted["group_state"] == "partially_merged"

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -53,7 +53,12 @@ class _FailAfter:
         if repo == self.fail_on:
             raise AdapterError(f"simulated host refusal for {repo}")
         self.merged.append(repo)
-        return PRRef(repo=repo, number=number)
+        # `url` is ADAPTER-AUTHORED and appears nowhere in the group file, which is what
+        # makes provenance observable. Without it, a completed list rebuilt from
+        # `group["prs"]` and one carried back from the adapter are byte-identical, and
+        # every assertion passes over either -- the values agree by coincidence because
+        # the loop visits repos in group order.
+        return PRRef(repo=repo, number=number, url=f"observed://{repo}/{number}")
 
 
 def _group(workspace: Path, repos: list[str]) -> str:
@@ -140,10 +145,19 @@ class TestTheErrorCarriesWhatActuallyMerged:
     def test_the_completed_list_matches_the_ADAPTER_not_the_group(self, tmp_path):
         """Evidence, not a token.
 
-        Reconstructing the list from the group's own `prs` would produce a plausible
-        value that is right by construction and could never be wrong -- the same shape as
-        `PRRef(repo=repo, number=number)` returning its own inputs. The assertion is
-        against what the adapter observed, which a shortcut cannot fabricate.
+        Reconstructing the list from the group's own `prs` produces a plausible value that
+        is right by construction and could never be wrong -- the same shape as
+        `PRRef(repo=repo, number=number)` returning its own inputs.
+
+        The first version of this test asserted only on `repo`, and it PASSED against a
+        loop that appended `pr_info` straight from the group file. Both provenances
+        produce the same repo names in the same order, because the loop visits repos in
+        group order. **A value that agrees with the truth by coincidence passes every
+        assertion the real one would**, and the test carried this name while proving
+        nothing of the kind.
+
+        So the assertion moved onto a field only the ADAPTER authors. `url` appears
+        nowhere in the group file; a shortcut cannot fabricate it.
         """
         gid = _group(tmp_path, ["app", "api", "web"])
         adapter = _FailAfter(fail_on="api")
@@ -157,7 +171,14 @@ class TestTheErrorCarriesWhatActuallyMerged:
                 method=MergeMethod.MERGE,
             )
 
-        assert [c["repo"] for c in excinfo.value.completed] == adapter.merged == ["app"]
+        completed = excinfo.value.completed
+        assert [c["repo"] for c in completed] == adapter.merged == ["app"]
+        assert [c.get("url") for c in completed] == ["observed://app/1"], (
+            "the completed list was rebuilt from the group file rather than carried back "
+            "from the adapter. It happens to name the right repos, and it is not evidence "
+            "that anything merged -- the same list is produced by a loop that never "
+            "consulted the host at all."
+        )
 
     def test_failure_on_the_FIRST_repo_reports_an_empty_list_not_a_missing_one(self, tmp_path):
         gid = _group(tmp_path, ["app", "api"])

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -302,7 +302,10 @@ class TestTheCLIConsumesTheListRatherThanRebuildingIt:
                 failing,
                 2,
                 "simulated",
-                completed=[{"repo": r, "pr_number": i + 1, "url": None} for i, r in enumerate(completed)],
+                completed=[
+                    {"repo": r, "pr_number": i + 1, "url": f"observed://{r}/{i + 1}"}
+                    for i, r in enumerate(completed)
+                ],
             )
 
         monkeypatch.setattr(app_mod.pr_ops, "merge_pr_group", _boom)
@@ -330,6 +333,13 @@ class TestTheCLIConsumesTheListRatherThanRebuildingIt:
         assert "web" not in persisted.get("merged", []), (
             "the FALSE record was persisted to disk, which is the part a retry reads"
         )
+        # Provenance on the ERROR path too. Membership alone leaves this substitutable:
+        # `group["prs"]` minus nothing still contains 'app', so an assertion on names
+        # passes over either source. The url is adapter-authored and cannot be rebuilt.
+        assert [r.get("url") for r in payload["merged_receipts"]] == ["observed://app/1"], (
+            f'got {payload["merged_receipts"]}. Rebuilt from the group file, these carry '
+            f"no url -- the same coincidence that hid this on the success path."
+        )
 
     def test_the_persisted_state_matches_what_actually_merged(self, tmp_path, monkeypatch):
         payload, persisted = self._invoke(
@@ -341,3 +351,75 @@ class TestTheCLIConsumesTheListRatherThanRebuildingIt:
         )
         assert persisted["merged"] == ["app"]
         assert persisted["group_state"] == "partially_merged"
+
+
+class TestTheSUCCESSPathCarriesProvenanceToo:
+    """The third layer this one claim had to be pinned at: loop, error path, success path.
+
+    Each time the coincidence was the same: **the two sources agree except when it
+    matters.** On the success path `completed` and the group's declared `prs` hold the
+    same repos in the same order, so replacing one with the other leaves every
+    membership assertion green -- and every partial-failure test pins only the error
+    path, leaving the happy path free to re-derive.
+
+    Membership coincides on success. Provenance does not. So the success assertion has
+    to be on a field only the adapter can author, exactly as inside `merge_pr_group`.
+    """
+
+    def _run(self, tmp_path, monkeypatch, repos):
+        from typer.testing import CliRunner
+
+        from python_cli import app as app_mod
+
+        group = {
+            "pr_group_id": "pg_ok",
+            "owner_unit": "apollo",
+            "lane_name": "lane",
+            "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(repos)],
+        }
+        gpath = tmp_path / "group.json"
+        gpath.write_text(json.dumps(group))
+
+        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
+        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
+        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
+        monkeypatch.setattr(
+            app_mod.pr_ops,
+            "merge_pr_group",
+            lambda **kw: {
+                **group,
+                "completed": [
+                    {"repo": r, "pr_number": i + 1, "url": f"observed://{r}/{i + 1}"}
+                    for i, r in enumerate(repos)
+                ],
+            },
+        )
+        res = CliRunner().invoke(
+            app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"]
+        )
+        return json.loads(res.stdout)
+
+    def test_success_output_carries_the_ADAPTER_AUTHORED_field(self, tmp_path, monkeypatch):
+        payload = self._run(tmp_path, monkeypatch, ["app", "api"])
+
+        urls = [r.get("url") for r in payload["merged_receipts"]]
+        assert urls == ["observed://app/1", "observed://api/2"], (
+            f"got {urls}. The group file has no `url`, so a payload rebuilt from "
+            f"`group['prs']` cannot produce these. Asserting membership here proves "
+            f"nothing: on success, completed and declared are the same list."
+        )
+
+    def test_membership_alone_would_NOT_have_caught_it(self, tmp_path, monkeypatch):
+        """Documents why the assertion above is on `url` and not on repo names.
+
+        This asserts the coincidence itself: the names ARE identical to the group's, so
+        any test pinned to them is satisfied by either source. Kept as an explicit
+        record so a later reader does not 'simplify' the test above back to a
+        membership check.
+        """
+        payload = self._run(tmp_path, monkeypatch, ["app", "api"])
+        declared = ["app", "api"]
+        assert payload["merged"] == declared, (
+            "if this ever differs, the coincidence has broken and the reasoning above "
+            "needs revisiting"
+        )

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -1,0 +1,239 @@
+"""G9: the durable record must survive the failure that produced it (grip#842).
+
+The eight guarantees ported from gr1 all ask *is the claim true*. This one asks *does the
+record survive the failure*, and it is a different axis. gr1 printed to a terminal; gr2
+**emits events other programs read**, so a wrong guard misleads a reviewer while a wrong
+event misleads a program.
+
+The defect: `merge_pr_group` loops over PRs, merges repo A, fails on repo B, and raises.
+`emit(PR_MERGED)` sits *after* the loop, so it never fires. The `merged` list is discarded
+by the raise, and the error carried only the *failing* repo. **A is merged on the host and
+nothing anywhere records it.** A caller cannot learn what already happened, and a retry
+re-attempts A.
+
+    Irreversible work that is not recorded is worse than work not done,
+    because the next actor plans against a state that is false.
+
+The fix is two layers that fail by DIFFERENT ROUTES, which is what makes them independent
+rather than the same chance twice:
+
+  - `PRMergeError` carries the completed list. In-process, structural; its failure mode is
+    a raised exception. **This is what a retry must read.**
+  - The event stays best-effort and durable. `emit` swallows every exception and returns
+    `None` (see grip#843), so correctness must not rest on it.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from python_cli.platform import AdapterError, PRRef  # noqa: E402
+from python_cli.pr import (  # noqa: E402
+    MergeMethod,
+    PRMergeError,
+    merge_pr_group,
+)
+
+
+class _FailAfter:
+    """Merges successfully until `fail_on`, then raises -- the partial-failure case."""
+
+    name = "github"
+
+    def __init__(self, fail_on: str) -> None:
+        self.fail_on = fail_on
+        self.merged: list[str] = []
+
+    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef:
+        if repo == self.fail_on:
+            raise AdapterError(f"simulated host refusal for {repo}")
+        self.merged.append(repo)
+        return PRRef(repo=repo, number=number)
+
+
+def _group(workspace: Path, repos: list[str]) -> str:
+    gid = "pg_test"
+    d = workspace / ".grip" / "pr_groups"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{gid}.json").write_text(
+        json.dumps(
+            {
+                "pr_group_id": gid,
+                "owner_unit": "apollo",
+                "lane_name": "lane",
+                "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(repos)],
+            }
+        )
+    )
+    return gid
+
+
+class TestTheErrorTypeMakesOmissionImpossible:
+    """The completed list is a required constructor argument, with no default.
+
+    An optional field will be omitted at exactly one call site within a year, and G9
+    becomes a convention again. A required argument is not a reminder to think -- it is a
+    refusal to construct. The type is the guarantee.
+    """
+
+    def test_completed_has_NO_DEFAULT_in_the_signature(self):
+        """Asserts the signature, not a symptom -- caught by mutation, not by review.
+
+        The first version of this test was `pytest.raises(TypeError)` on a call with the
+        argument omitted. It survived the mutation that gives `completed` a default of
+        `None`, because `list(None)` raises `TypeError` too. **The test passed for a
+        different reason than the one it claimed**, and a green suite sat over exactly the
+        defect it existed to prevent.
+
+        A raised type is a symptom several mechanisms produce. The parameter having no
+        default is the property itself, and nothing but the real thing satisfies it.
+        """
+        import inspect
+
+        param = inspect.signature(PRMergeError.__init__).parameters["completed"]
+        assert param.default is inspect.Parameter.empty, (
+            f"`completed` has default {param.default!r}. A default makes G9 a convention: "
+            f"one call site omits it, and the partial-merge record silently becomes empty "
+            f"rather than absent -- which reads as 'nothing had merged'."
+        )
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY, (
+            "`completed` must be keyword-only so it cannot be supplied positionally by "
+            "accident, nor silently absorbed by a future signature change"
+        )
+
+    def test_an_EMPTY_completed_list_must_still_be_passed_explicitly(self):
+        """Empty is a fact about the world, not an absence of information.
+
+        "Nothing had merged when this failed" and "nobody recorded what merged" are
+        different claims, and a default of `[]` would make them identical -- the same
+        collapse as a guard reporting verified when it could not check.
+        """
+        err = PRMergeError("app", 1, "boom", completed=[])
+        assert err.completed == []
+
+
+class TestTheErrorCarriesWhatActuallyMerged:
+    def test_partial_failure_reports_the_repos_that_DID_merge(self, tmp_path):
+        gid = _group(tmp_path, ["app", "api", "web"])
+        adapter = _FailAfter(fail_on="web")
+
+        with pytest.raises(PRMergeError) as excinfo:
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=adapter,
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        completed = [c["repo"] for c in excinfo.value.completed]
+        assert completed == ["app", "api"], (
+            "the error must name the irreversible work that already happened; a retry "
+            "reading only the failing repo will merge app and api a second time"
+        )
+
+    def test_the_completed_list_matches_the_ADAPTER_not_the_group(self, tmp_path):
+        """Evidence, not a token.
+
+        Reconstructing the list from the group's own `prs` would produce a plausible
+        value that is right by construction and could never be wrong -- the same shape as
+        `PRRef(repo=repo, number=number)` returning its own inputs. The assertion is
+        against what the adapter observed, which a shortcut cannot fabricate.
+        """
+        gid = _group(tmp_path, ["app", "api", "web"])
+        adapter = _FailAfter(fail_on="api")
+
+        with pytest.raises(PRMergeError) as excinfo:
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=adapter,
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        assert [c["repo"] for c in excinfo.value.completed] == adapter.merged == ["app"]
+
+    def test_failure_on_the_FIRST_repo_reports_an_empty_list_not_a_missing_one(self, tmp_path):
+        gid = _group(tmp_path, ["app", "api"])
+
+        with pytest.raises(PRMergeError) as excinfo:
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=_FailAfter(fail_on="app"),
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        assert excinfo.value.completed == []
+
+
+class TestTheTwoLayersAreIndependent:
+    """Depth is only depth if the layers fail by different routes.
+
+    A durable record that the in-process path depends on is the same chance twice. These
+    tests exist because `emit` swallows every exception (grip#843): if correctness rested
+    on it, G9 would be satisfied by a mechanism that can silently do nothing.
+    """
+
+    def test_a_durable_event_records_the_partial_merge(self, tmp_path):
+        gid = _group(tmp_path, ["app", "api", "web"])
+
+        with pytest.raises(PRMergeError):
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=_FailAfter(fail_on="web"),
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        events = [
+            json.loads(line)
+            for f in tmp_path.rglob("*.jsonl")
+            for line in f.read_text().splitlines()
+            if line.strip()
+        ]
+        merged_records = [e for e in events if e.get("completed") or e.get("repos")]
+        assert merged_records, (
+            f"no event recorded the completed merges; events were "
+            f"{[e.get('type') for e in events]}. The host state changed and the durable "
+            f"log does not say so."
+        )
+
+    def test_the_exception_still_carries_the_list_when_EMIT_ITSELF_FAILS(
+        self, tmp_path, monkeypatch
+    ):
+        """The independence claim, stated as the thing that must survive.
+
+        If a broken event layer can take the in-process layer down with it, they were
+        never two layers. Note this cannot happen today only because `emit` swallows
+        everything -- which is exactly why it must not be the thing correctness rests on.
+        """
+        from python_cli import pr as pr_mod
+
+        def _exploding_emit(**kwargs):
+            raise RuntimeError("event subsystem is down")
+
+        monkeypatch.setattr(pr_mod, "emit", _exploding_emit)
+        gid = _group(tmp_path, ["app", "api", "web"])
+
+        with pytest.raises(PRMergeError) as excinfo:
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=_FailAfter(fail_on="web"),
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        assert [c["repo"] for c in excinfo.value.completed] == ["app", "api"], (
+            "a failure in the best-effort layer must not erase the reliable one, and "
+            "must not replace PRMergeError with the event layer's own exception"
+        )

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -366,7 +366,10 @@ class TestTheSUCCESSPathCarriesProvenanceToo:
     to be on a field only the adapter can author, exactly as inside `merge_pr_group`.
     """
 
-    def _run(self, tmp_path, monkeypatch, repos):
+    def _run(self, tmp_path, monkeypatch, repos, completed_repos=None):
+        """`completed_repos` defaults to `repos` -- pass a SUBSET to make the two
+        provenances produce different MEMBERSHIPS, which is the only way `merged` itself
+        becomes observable (see the class docstring)."""
         from typer.testing import CliRunner
 
         from python_cli import app as app_mod
@@ -377,6 +380,7 @@ class TestTheSUCCESSPathCarriesProvenanceToo:
             "lane_name": "lane",
             "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(repos)],
         }
+        done = repos if completed_repos is None else completed_repos
         gpath = tmp_path / "group.json"
         gpath.write_text(json.dumps(group))
 
@@ -390,7 +394,7 @@ class TestTheSUCCESSPathCarriesProvenanceToo:
                 **group,
                 "completed": [
                     {"repo": r, "pr_number": i + 1, "url": f"observed://{r}/{i + 1}"}
-                    for i, r in enumerate(repos)
+                    for i, r in enumerate(done)
                 ],
             },
         )
@@ -408,6 +412,37 @@ class TestTheSUCCESSPathCarriesProvenanceToo:
             f"`group['prs']` cannot produce these. Asserting membership here proves "
             f"nothing: on success, completed and declared are the same list."
         )
+
+    def test_merged_ITSELF_comes_from_completed_when_the_memberships_DIFFER(
+        self, tmp_path, monkeypatch
+    ):
+        """The fifth degree of freedom, and the one my earlier witness could not see.
+
+        Pinning `merged_receipts` by provenance does NOT pin `merged`. In a fixture where
+        completed and declared hold the same repos, `merged` derived from either is the
+        same list -- so substituting `group["prs"]` for `result["completed"]` in the
+        `merged` line alone is invisible, while the receipts assertion beside it stays
+        green and looks like coverage.
+
+        THE FIXTURE LAW: a field is pinned only if the fixture makes its correct value
+        DIFFER from its reconstructed value, **per field**. Receipts-distinguishable does
+        not make merged-distinguishable. Every field needs its own divergence.
+
+        So: declared is a superset. `merged` must follow completed, not the group.
+        """
+        payload = self._run(
+            tmp_path,
+            monkeypatch,
+            ["app", "api", "web"],
+            completed_repos=["app"],
+        )
+
+        assert payload["merged"] == ["app"], (
+            f'got {payload["merged"]}. Rebuilt from the group file this reads '
+            f'["app", "api", "web"] -- the CLI must report what the merge loop returned, '
+            f"not what the group declared."
+        )
+        assert [r.get("url") for r in payload["merged_receipts"]] == ["observed://app/1"]
 
     def test_membership_alone_would_NOT_have_caught_it(self, tmp_path, monkeypatch):
         """Documents why the assertion above is on `url` and not on repo names.

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -518,7 +518,7 @@ def test_pr_commands_route_through_platform_adapter(tmp_path: Path, monkeypatch)
                 title=request.title,
             )
 
-        def merge_pr(self, repo: str, number: int) -> PRRef:
+        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
             calls.append(("merge", (repo, number)))
             return PRRef(repo=repo, number=number, url="https://example.test/pr/42")
 
@@ -588,7 +588,7 @@ def test_pr_create_persists_group_state_by_pr_group_id(tmp_path: Path, monkeypat
                 title=request.title,
             )
 
-        def merge_pr(self, repo: str, number: int) -> PRRef:  # pragma: no cover - not used here
+        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:  # pragma: no cover - not used here
             raise AssertionError("merge_pr should not be called")
 
         def pr_status(self, repo: str, number: int) -> PRStatus:  # pragma: no cover - not used here
@@ -647,7 +647,7 @@ def test_pr_status_aggregates_group_state(tmp_path: Path, monkeypatch) -> None:
         def create_pr(self, request: CreatePRRequest) -> PRRef:  # pragma: no cover
             raise AssertionError("create_pr should not be called")
 
-        def merge_pr(self, repo: str, number: int) -> PRRef:  # pragma: no cover
+        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:  # pragma: no cover
             raise AssertionError("merge_pr should not be called")
 
         def pr_status(self, repo: str, number: int) -> PRStatus:
@@ -703,7 +703,7 @@ def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, mo
         def create_pr(self, request: CreatePRRequest) -> PRRef:  # pragma: no cover
             raise AssertionError("create_pr should not be called")
 
-        def merge_pr(self, repo: str, number: int) -> PRRef:
+        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
             if repo == "api":
                 from gr2.python_cli.platform import AdapterError
 


### PR DESCRIPTION
Decides the git merge method in the workspace rather than delegating it to the host.

`gr2 pr merge` previously invoked `gh pr merge` with no strategy flag, so the method was chosen by the CLI's own defaults and the repository's settings. This adds explicit resolution with the precedence: explicit `--method`, then the workspace setting, then a merge commit.

- `MergeMethod` enum and `resolve_merge_method(explicit, configured, permitted)`
- An unrecognised method name raises rather than falling back to a default
- A method the host does not permit is refused, never substituted
- `permitted=None` means "not checked", which is kept distinct from "unrestricted"
- `merge_pr` and `merge_pr_group` take the method as a required keyword argument
- The workspace setting is read from `[workspace_constraints] merge_method`
- Partial-failure state records what the merge loop completed, rather than deriving it from the group's declared repos

Tests cover precedence, refusal, the flag reaching the underlying command, and the completed-record provenance on both the success and failure paths.

Reviewed by two agents against the exact bytes before push.

Premium boundary: gr2 is OSS — local workspace orchestration and PR mechanics only. No identity, org, entitlement, or policy-management logic.
