### PR TITLE
feat(gr2): carry merge evidence from the adapter and verify the resulting commit

### DIFF
--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -9,13 +9,13 @@ from types import SimpleNamespace
 from typing import Optional
 
 import typer
+from gr2.prototypes import lane_workspace_prototype as lane_proto
+from gr2.prototypes import repo_maintenance_prototype as repo_proto
 
 from . import branch as branch_ops
-from . import execops
-from . import failures
-from . import migration
+from . import execops, failures, migration, spec_apply, syncops
 from . import pr as pr_ops
-from . import syncops
+from .events import EventType, emit
 from .gitops import (
     branch_exists,
     checkout_branch,
@@ -27,14 +27,16 @@ from .gitops import (
     repo_dirty,
     stash_if_dirty,
 )
-from .events import emit, EventType
-from .hooks import HookContext, HookRuntimeError, apply_file_projections, load_repo_hooks, run_lifecycle_stage
-from .platform import PRRef, get_platform_adapter
-from . import spec_apply
 from .grip_cli import config_cli_app, grip_app
-from gr2.prototypes import lane_workspace_prototype as lane_proto
-from gr2.prototypes import repo_maintenance_prototype as repo_proto
-
+from .hooks import (
+    HookContext,
+    HookRuntimeError,
+    apply_file_projections,
+    load_repo_hooks,
+    run_lifecycle_stage,
+)
+from .merge_verification import MergeVerificationTarget
+from .platform import PRRef, get_platform_adapter
 
 app = typer.Typer(
     help="Python-first gr2 CLI. This is the production UX proving layer before Rust."
@@ -72,31 +74,6 @@ def _workspace_repo_spec(workspace_root: Path, repo_name: str) -> dict[str, obje
 
 def _workspace_spec_path(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "workspace_spec.toml"
-
-
-def _configured_merge_method(workspace_root: Path) -> str | None:
-    """The workspace's merge-method policy, or None if it never expressed one.
-
-    Lives under `[workspace_constraints]` because that is where merge policy already
-    lives (`merge_order`, `required_reviewers`) -- following the existing section rather
-    than inventing one.
-
-    Returns `None`, never the string "merge", when the key is absent. Collapsing "unset"
-    into "chose merge" would make a workspace that never expressed a preference
-    indistinguishable from one that pinned the current default, so a later change of
-    default would silently never reach the workspaces that were only ever defaulting.
-    Absence is the honest encoding of "take the default, and follow it if it moves".
-
-    Missing spec is tolerated: this is a policy lookup on a merge path, and a workspace
-    without a spec file has plainly not configured a method. It must not become a second
-    failure mode on top of whatever the merge itself is doing.
-    """
-    try:
-        spec = lane_proto.load_workspace_spec(workspace_root)
-    except (FileNotFoundError, OSError):
-        return None
-    value = spec.get("workspace_constraints", {}).get("merge_method")
-    return None if value is None else str(value)
 
 
 def _lane_repo_root(workspace_root: Path, owner_unit: str, lane_name: str, repo_name: str) -> Path:
@@ -274,6 +251,41 @@ def _repo_slug_from_url(url: str, fallback_name: str) -> str:
         slug = cleaned.split("https://github.com/", 1)[1]
         return slug.removesuffix(".git")
     return fallback_name
+
+
+def _merge_verification_targets(
+    workspace_root: Path,
+) -> dict[str, MergeVerificationTarget]:
+    """Bind host slugs to explicit local DAGs and source URLs before merging."""
+
+    workspace_spec = lane_proto.load_workspace_spec(workspace_root)
+    targets: dict[str, MergeVerificationTarget] = {}
+    for repo_spec_value in workspace_spec.get("repos", []):
+        repo_spec = dict(repo_spec_value)
+        repo_name = str(repo_spec.get("name", ""))
+        remote = str(repo_spec.get("url", "")).strip()
+        if not remote:
+            raise SystemExit(f"repo has no source URL for merge verification: {repo_name}")
+        host_repo = _repo_slug_from_url(remote, repo_name)
+        if host_repo in targets:
+            raise SystemExit(f"duplicate host repo in merge verification targets: {host_repo}")
+        repo_root = (workspace_root / str(repo_spec.get("path", ""))).resolve()
+        if not repo_root.is_dir() or not is_git_repo(repo_root):
+            raise SystemExit(f"local merge-verification DAG is unavailable: {repo_root}")
+        targets[host_repo] = MergeVerificationTarget(repo_root=repo_root, remote=remote)
+    return targets
+
+
+def _configured_merge_method(workspace_root: Path) -> str | None:
+    settings = lane_proto.load_workspace_spec(workspace_root).get("settings", {})
+    if not isinstance(settings, dict):
+        raise SystemExit("workspace spec [settings] must be a table")
+    value = settings.get("merge_method")
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SystemExit("workspace setting merge_method must be a string")
+    return value
 
 
 def _write_workspace_spec(workspace_root: Path, repos: list[dict[str, str]], default_unit: str) -> Path:
@@ -1185,7 +1197,7 @@ def pr_merge(
         None,
         "--method",
         "-m",
-        help="merge/squash/rebase. Defaults to a merge commit. An unpermitted method is refused, never substituted.",
+        help="merge/squash/rebase. Defaults to a merge commit.",
     ),
 ) -> None:
     """Merge grouped PRs for a lane."""
@@ -1223,18 +1235,13 @@ def pr_merge(
                 explicit=method,
                 configured=_configured_merge_method(workspace_root),
             ),
+            verification_targets=_merge_verification_targets(
+                workspace_root,
+            ),
+            report=lambda message: typer.echo(message, err=True),
         )
-        # What the merge loop actually completed, not what the group DECLARED.
-        # Re-deriving from `prs` names repos the loop may never have reached.
-        #
-        # BOTH fields come from this ONE source, deliberately. On the success path
-        # `completed` and `prs` hold the same repos in the same order -- the token and
-        # the truth coincide whenever nothing fails -- so a membership list cannot
-        # distinguish them and every error-path test leaves this path free to re-derive.
-        # `merged_receipts` carries the ADAPTER-AUTHORED fields, which the group file
-        # cannot reproduce. Membership coincides on success; provenance does not.
-        completed = result.get("completed", [])
-        merged = [str(c["repo"]) for c in completed]
+        completed = list(result.get("completed", []))
+        merged = [str(item["repo"]) for item in completed]
         payload = {
             "pr_group_id": group["pr_group_id"],
             "owner_unit": owner_unit,
@@ -1244,26 +1251,40 @@ def pr_merge(
             "state_path": str(group_path),
         }
     except pr_ops.PRMergeError as exc:
-        # DECLARED-MINUS-FAILED IS WRONG, and wrong in the dangerous direction.
-        # With prs = [app, api, web] and api failing, it yields [app, web] --
-        # recording web as merged when the loop stopped before ever calling it.
-        # A retry then skips a PR that is still open, and the operator reads a
-        # merge that never happened.
-        #
-        # `exc.completed` is the list the merge loop actually built, carried on
-        # the exception precisely so this layer never has to reconstruct it.
-        merged = [str(c["repo"]) for c in exc.completed]
-        group["group_state"] = "partially_merged" if merged else "merge_failed"
+        completed = [item.as_dict() for item in exc.completed]
+        merged = [str(item["repo"]) for item in completed]
+        if exc.outcome_unknown:
+            group["group_state"] = "merge_outcome_unknown"
+        elif exc.operation_acknowledged:
+            group["group_state"] = "merge_postcondition_failed"
+        else:
+            group["group_state"] = "partially_merged" if merged else "merge_failed"
         group["merged"] = merged
+        group["completed"] = completed
         group_path.write_text(json.dumps(group, indent=2) + "\n")
         payload = {
-            "status": "partial_failure" if merged else "failed",
+            "status": (
+                "outcome_unknown"
+                if exc.outcome_unknown
+                else (
+                    "postcondition_failed"
+                    if exc.operation_acknowledged
+                    else ("partial_failure" if merged else "failed")
+                )
+            ),
             "pr_group_id": group["pr_group_id"],
             "owner_unit": owner_unit,
             "lane_name": resolved_lane,
             "merged": merged,
-            "merged_receipts": exc.completed,
-            "failed": [{"repo": exc.repo, "number": exc.pr_number, "reason": exc.reason}],
+            "merged_receipts": completed,
+            "failed": [
+                {
+                    "repo": exc.repo,
+                    "number": exc.pr_number,
+                    "reason": exc.reason,
+                    "operation_acknowledged": exc.operation_acknowledged,
+                }
+            ],
             "state_path": str(group_path),
         }
         if json_output:

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -1226,12 +1226,21 @@ def pr_merge(
         )
         # What the merge loop actually completed, not what the group DECLARED.
         # Re-deriving from `prs` names repos the loop may never have reached.
-        merged = [str(c["repo"]) for c in result.get("completed", [])]
+        #
+        # BOTH fields come from this ONE source, deliberately. On the success path
+        # `completed` and `prs` hold the same repos in the same order -- the token and
+        # the truth coincide whenever nothing fails -- so a membership list cannot
+        # distinguish them and every error-path test leaves this path free to re-derive.
+        # `merged_receipts` carries the ADAPTER-AUTHORED fields, which the group file
+        # cannot reproduce. Membership coincides on success; provenance does not.
+        completed = result.get("completed", [])
+        merged = [str(c["repo"]) for c in completed]
         payload = {
             "pr_group_id": group["pr_group_id"],
             "owner_unit": owner_unit,
             "lane_name": resolved_lane,
             "merged": merged,
+            "merged_receipts": completed,
             "state_path": str(group_path),
         }
     except pr_ops.PRMergeError as exc:
@@ -1253,6 +1262,7 @@ def pr_merge(
             "owner_unit": owner_unit,
             "lane_name": resolved_lane,
             "merged": merged,
+            "merged_receipts": exc.completed,
             "failed": [{"repo": exc.repo, "number": exc.pr_number, "reason": exc.reason}],
             "state_path": str(group_path),
         }

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -74,6 +74,31 @@ def _workspace_spec_path(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "workspace_spec.toml"
 
 
+def _configured_merge_method(workspace_root: Path) -> str | None:
+    """The workspace's merge-method policy, or None if it never expressed one.
+
+    Lives under `[workspace_constraints]` because that is where merge policy already
+    lives (`merge_order`, `required_reviewers`) -- following the existing section rather
+    than inventing one.
+
+    Returns `None`, never the string "merge", when the key is absent. Collapsing "unset"
+    into "chose merge" would make a workspace that never expressed a preference
+    indistinguishable from one that pinned the current default, so a later change of
+    default would silently never reach the workspaces that were only ever defaulting.
+    Absence is the honest encoding of "take the default, and follow it if it moves".
+
+    Missing spec is tolerated: this is a policy lookup on a merge path, and a workspace
+    without a spec file has plainly not configured a method. It must not become a second
+    failure mode on top of whatever the merge itself is doing.
+    """
+    try:
+        spec = lane_proto.load_workspace_spec(workspace_root)
+    except (FileNotFoundError, OSError):
+        return None
+    value = spec.get("workspace_constraints", {}).get("merge_method")
+    return None if value is None else str(value)
+
+
 def _lane_repo_root(workspace_root: Path, owner_unit: str, lane_name: str, repo_name: str) -> Path:
     return lane_proto.lane_dir(workspace_root, owner_unit, lane_name) / "repos" / repo_name
 
@@ -1189,14 +1214,19 @@ def pr_merge(
             typer.echo(json.dumps(payload, indent=2))
         raise typer.Exit(code=1)
     try:
-        pr_ops.merge_pr_group(
+        result = pr_ops.merge_pr_group(
             workspace_root=workspace_root,
             pr_group_id=str(group["pr_group_id"]),
             adapter=adapter,
             actor=f"agent:{owner_unit}",
-            method=pr_ops.resolve_merge_method(explicit=method, configured=None),
+            method=pr_ops.resolve_merge_method(
+                explicit=method,
+                configured=_configured_merge_method(workspace_root),
+            ),
         )
-        merged = [str(pr_info["repo"]) for pr_info in group.get("prs", [])]
+        # What the merge loop actually completed, not what the group DECLARED.
+        # Re-deriving from `prs` names repos the loop may never have reached.
+        merged = [str(c["repo"]) for c in result.get("completed", [])]
         payload = {
             "pr_group_id": group["pr_group_id"],
             "owner_unit": owner_unit,
@@ -1205,7 +1235,15 @@ def pr_merge(
             "state_path": str(group_path),
         }
     except pr_ops.PRMergeError as exc:
-        merged = [str(pr_info["repo"]) for pr_info in group.get("prs", []) if str(pr_info["repo"]) != exc.repo]
+        # DECLARED-MINUS-FAILED IS WRONG, and wrong in the dangerous direction.
+        # With prs = [app, api, web] and api failing, it yields [app, web] --
+        # recording web as merged when the loop stopped before ever calling it.
+        # A retry then skips a PR that is still open, and the operator reads a
+        # merge that never happened.
+        #
+        # `exc.completed` is the list the merge loop actually built, carried on
+        # the exception precisely so this layer never has to reconstruct it.
+        merged = [str(c["repo"]) for c in exc.completed]
         group["group_state"] = "partially_merged" if merged else "merge_failed"
         group["merged"] = merged
         group_path.write_text(json.dumps(group, indent=2) + "\n")

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -1156,6 +1156,12 @@ def pr_merge(
     owner_unit: str,
     lane_name: Optional[str] = typer.Argument(None, help="Lane name. Defaults to the unit's current lane."),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+    method: Optional[str] = typer.Option(
+        None,
+        "--method",
+        "-m",
+        help="merge/squash/rebase. Defaults to a merge commit. An unpermitted method is refused, never substituted.",
+    ),
 ) -> None:
     """Merge grouped PRs for a lane."""
     workspace_root = workspace_root.resolve()
@@ -1188,6 +1194,7 @@ def pr_merge(
             pr_group_id=str(group["pr_group_id"]),
             adapter=adapter,
             actor=f"agent:{owner_unit}",
+            method=pr_ops.resolve_merge_method(explicit=method, configured=None),
         )
         merged = [str(pr_info["repo"]) for pr_info in group.get("prs", [])]
         payload = {

--- a/gr2/python_cli/merge_verification.py
+++ b/gr2/python_cli/merge_verification.py
@@ -1,0 +1,274 @@
+"""Evidence-bound parent verification for gr2 pull-request merges.
+
+The adapter returns an immutable commit OID from the merged PR record. This
+module brings that exact object into the local DAG without writing FETCH_HEAD,
+counts its parents, reports the result, and only then constructs a completed
+merge record. No step re-resolves the base branch or reads process-global
+mutable fetch state.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from .platform import MergeMethod, MergeReceipt
+
+
+@dataclass(frozen=True)
+class MergeVerificationTarget:
+    """Explicit local evidence source for one host repository."""
+
+    repo_root: Path
+    remote: str
+
+
+class ParentVerdictKind(StrEnum):
+    NOT_PERFORMED = "not_performed"
+    VERIFIED = "verified"
+    WRONG = "wrong"
+    UNVERIFIABLE = "unverifiable"
+    NOT_APPLICABLE = "not_applicable"
+
+
+class ParentVerdict:
+    """Opaque parent-verification result.
+
+    The public constructor deliberately claims only NOT_PERFORMED. Verified,
+    wrong, unverifiable, and not-applicable results are minted by
+    `verify_parent_shape`, which has the evidence needed to earn them. Python
+    code in the same process can always forge an object with `object.__new__`.
+    The invariant covers supported construction routes, not hostile memory
+    mutation inside the verifier's process.
+    """
+
+    __slots__ = ("_commit_sha", "_detail", "_kind", "_parent_count")
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "_kind", ParentVerdictKind.NOT_PERFORMED)
+        object.__setattr__(self, "_commit_sha", None)
+        object.__setattr__(self, "_parent_count", None)
+        object.__setattr__(self, "_detail", "parent verification was not performed")
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("ParentVerdict is immutable")
+
+    @classmethod
+    def _earned(
+        cls,
+        *,
+        kind: ParentVerdictKind,
+        commit_sha: str | None,
+        parent_count: int | None,
+        detail: str,
+    ) -> ParentVerdict:
+        value = object.__new__(cls)
+        object.__setattr__(value, "_kind", kind)
+        object.__setattr__(value, "_commit_sha", commit_sha)
+        object.__setattr__(value, "_parent_count", parent_count)
+        object.__setattr__(value, "_detail", detail)
+        return value
+
+    @property
+    def kind(self) -> ParentVerdictKind:
+        return self._kind
+
+    @property
+    def commit_sha(self) -> str | None:
+        return self._commit_sha
+
+    @property
+    def parent_count(self) -> int | None:
+        return self._parent_count
+
+    @property
+    def detail(self) -> str:
+        return self._detail
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "commit_sha": self.commit_sha,
+            "parent_count": self.parent_count,
+            "detail": self.detail,
+        }
+
+
+class _ReportedParentVerdict:
+    __slots__ = ("verdict",)
+
+    def __init__(self, verdict: ParentVerdict) -> None:
+        self.verdict = verdict
+
+
+class CompletedMerge:
+    """A merge receipt whose parent verdict has been consumed.
+
+    Direct construction is unavailable. `consume_merge_receipt` verifies and
+    reports first, then mints this record from a private reported-verdict
+    carrier. A caller may retain the record, but cannot obtain one merely by
+    holding a raw receipt and choosing to skip the verdict.
+    """
+
+    __slots__ = ("_parent_verdict", "_receipt")
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        raise TypeError("CompletedMerge is constructed by consume_merge_receipt")
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("CompletedMerge is immutable")
+
+    @classmethod
+    def _from_reported(
+        cls,
+        receipt: MergeReceipt,
+        reported: _ReportedParentVerdict,
+    ) -> CompletedMerge:
+        if not isinstance(reported, _ReportedParentVerdict):
+            raise TypeError("completion requires a reported parent verdict")
+        value = object.__new__(cls)
+        object.__setattr__(value, "_receipt", receipt)
+        object.__setattr__(value, "_parent_verdict", reported.verdict)
+        return value
+
+    @property
+    def receipt(self) -> MergeReceipt:
+        return self._receipt
+
+    @property
+    def parent_verdict(self) -> ParentVerdict:
+        return self._parent_verdict
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "repo": self.receipt.observed.repo,
+            "pr_number": self.receipt.observed.number,
+            "url": self.receipt.observed.url,
+            "commit_sha": self.receipt.commit_sha,
+            "requested_method": self.receipt.requested_method.value,
+            "parent_verdict": self.parent_verdict.as_dict(),
+        }
+
+
+def _run_git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def verify_parent_shape(
+    *,
+    repo_root: Path,
+    receipt: MergeReceipt,
+    remote: str,
+) -> ParentVerdict:
+    """Verify the operation-returned commit in the local repository DAG."""
+
+    commit_sha = receipt.commit_sha
+    if commit_sha is None:
+        return ParentVerdict._earned(
+            kind=ParentVerdictKind.UNVERIFIABLE,
+            commit_sha=None,
+            parent_count=None,
+            detail="the host returned no immutable merge commit identity",
+        )
+
+    if receipt.requested_method in {MergeMethod.SQUASH, MergeMethod.REBASE}:
+        return ParentVerdict._earned(
+            kind=ParentVerdictKind.NOT_APPLICABLE,
+            commit_sha=commit_sha,
+            parent_count=None,
+            detail=f"{receipt.requested_method.value} merges are single-parent by design",
+        )
+
+    repo_root = Path(repo_root)
+    try:
+        fetch = _run_git(
+            repo_root,
+            "fetch",
+            "--no-write-fetch-head",
+            remote,
+            commit_sha,
+        )
+    except OSError as exc:
+        return _unverifiable(commit_sha, f"could not execute git fetch: {exc}")
+    if fetch.returncode != 0:
+        detail = fetch.stderr.strip() or fetch.stdout.strip() or "git fetch failed"
+        return _unverifiable(commit_sha, f"could not fetch receipt object: {detail}")
+
+    try:
+        opened = _run_git(repo_root, "rev-list", "--parents", "-n", "1", commit_sha)
+    except OSError as exc:
+        return _unverifiable(commit_sha, f"could not inspect receipt object: {exc}")
+    if opened.returncode != 0:
+        detail = opened.stderr.strip() or opened.stdout.strip() or "git rev-list failed"
+        return _unverifiable(commit_sha, f"could not inspect receipt object: {detail}")
+
+    rows = [line.split() for line in opened.stdout.splitlines() if line.strip()]
+    if len(rows) != 1 or not rows[0] or rows[0][0] != commit_sha:
+        return _unverifiable(
+            commit_sha,
+            "local DAG did not return the exact receipt commit",
+        )
+    parent_count = len(rows[0]) - 1
+    if parent_count == 2:
+        return ParentVerdict._earned(
+            kind=ParentVerdictKind.VERIFIED,
+            commit_sha=commit_sha,
+            parent_count=parent_count,
+            detail=f"merge commit {commit_sha} has two parents in the local DAG",
+        )
+    return ParentVerdict._earned(
+        kind=ParentVerdictKind.WRONG,
+        commit_sha=commit_sha,
+        parent_count=parent_count,
+        detail=(
+            f"merge commit {commit_sha} has {parent_count} parents in the local DAG; "
+            "expected 2"
+        ),
+    )
+
+
+def _unverifiable(commit_sha: str, detail: str) -> ParentVerdict:
+    return ParentVerdict._earned(
+        kind=ParentVerdictKind.UNVERIFIABLE,
+        commit_sha=commit_sha,
+        parent_count=None,
+        detail=detail,
+    )
+
+
+def report_parent_verdict(
+    verdict: ParentVerdict,
+    *,
+    report: Callable[[str], Any],
+) -> _ReportedParentVerdict:
+    if verdict.kind is ParentVerdictKind.NOT_PERFORMED:
+        raise TypeError("an unperformed parent verdict cannot complete a merge")
+    if verdict.kind in {ParentVerdictKind.WRONG, ParentVerdictKind.UNVERIFIABLE}:
+        report(f"merge parent verification {verdict.kind.value}: {verdict.detail}")
+    return _ReportedParentVerdict(verdict)
+
+
+def consume_merge_receipt(
+    *,
+    repo_root: Path,
+    receipt: MergeReceipt,
+    remote: str,
+    report: Callable[[str], Any],
+) -> CompletedMerge:
+    verdict = verify_parent_shape(
+        repo_root=repo_root,
+        receipt=receipt,
+        remote=remote,
+    )
+    reported = report_parent_verdict(verdict, report=report)
+    return CompletedMerge._from_reported(receipt, reported)

--- a/gr2/python_cli/platform.py
+++ b/gr2/python_cli/platform.py
@@ -1,39 +1,14 @@
 from __future__ import annotations
 
-import enum
 import json
+import re
 import shutil
 import subprocess
 from dataclasses import asdict, dataclass, field
+from enum import StrEnum
 from pathlib import Path
 from typing import Protocol
-
-
-class MergeMethod(enum.Enum):
-    """The git strategy a merge uses. Decided by the workspace, never by the host.
-
-    gr1 asked the host which methods it permitted and took the first of
-    `squash > merge > rebase` -- delegating a workspace-policy decision to a party with no
-    knowledge of the workspace. gr2's version of the same class is quieter and harder to
-    see: it passed no strategy flag at all, so gh and the host decided by default. There
-    was no wrong line to point at, only an absent one.
-
-    `MERGE` is the default deliberately. It is the only method that preserves both
-    parents, and losing shared ancestry is not a formatting preference -- it is how two
-    branches become unrelated histories that no later merge can reconcile.
-
-    Lives here rather than in `pr.py` because the flag mapping is a platform concern, and
-    because `pr.py` imports this module: the enum has to sit on the lower side of that
-    edge. `pr.py` re-exports it, so the operational contract reads from either.
-    """
-
-    MERGE = "merge"
-    SQUASH = "squash"
-    REBASE = "rebase"
-
-    @property
-    def gh_flag(self) -> str:
-        return f"--{self.value}"
+from urllib.parse import urlsplit
 
 
 @dataclass(frozen=True)
@@ -47,6 +22,43 @@ class PRRef:
 
     def as_dict(self) -> dict[str, object]:
         return asdict(self)
+
+
+class MergeMethod(StrEnum):
+    MERGE = "merge"
+    SQUASH = "squash"
+    REBASE = "rebase"
+
+    @property
+    def gh_flag(self) -> str:
+        return f"--{self.value}"
+
+
+@dataclass(frozen=True)
+class MergeReceipt:
+    """Host-observed evidence for one completed merge operation.
+
+    `requested` is caller intent. `observed` and `commit_sha` come from the
+    hosting platform's structured PR record after the merge command returns.
+    Keeping both identities prevents a response for a different PR from being
+    accepted merely because the command exited successfully.
+
+    `commit_sha=None` has one meaning: the host explicitly returned no merge
+    commit identity. It never means parent verification succeeded.
+    """
+
+    requested: PRRef
+    observed: PRRef
+    commit_sha: str | None
+    requested_method: MergeMethod
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "requested": self.requested.as_dict(),
+            "observed": self.observed.as_dict(),
+            "commit_sha": self.commit_sha,
+            "requested_method": self.requested_method.value,
+        }
 
 
 @dataclass(frozen=True)
@@ -96,7 +108,13 @@ class PlatformAdapter(Protocol):
 
     def create_pr(self, request: CreatePRRequest) -> PRRef: ...
 
-    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef: ...
+    def merge_pr(
+        self,
+        repo: str,
+        number: int,
+        *,
+        method: MergeMethod,
+    ) -> MergeReceipt: ...
 
     def pr_status(self, repo: str, number: int) -> PRStatus: ...
 
@@ -109,16 +127,47 @@ class AdapterError(RuntimeError):
     pass
 
 
+class MergeEvidenceError(AdapterError):
+    """The host acknowledged a merge, but its immutable receipt is unavailable.
+
+    This is deliberately distinct from a failed merge command. Retrying after
+    this error could merge or report the same operation twice.
+    """
+
+    operation_acknowledged = True
+
+    def __init__(
+        self,
+        *,
+        requested: PRRef,
+        requested_method: MergeMethod,
+        reason: str,
+    ) -> None:
+        self.requested = requested
+        self.requested_method = requested_method
+        self.reason = reason
+        super().__init__(
+            f"merge command succeeded for {requested.repo}#{requested.number}, "
+            f"but its immutable receipt is unavailable: {reason}"
+        )
+
+
 def _run_json(command: list[str], *, cwd: Path | None = None) -> object:
-    proc = subprocess.run(
-        command,
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise AdapterError(
+            f"could not launch command for structured host evidence: {command[0]!r}: {exc}"
+        ) from exc
     if proc.returncode != 0:
-        raise AdapterError(proc.stderr.strip() or proc.stdout.strip() or f"command failed: {' '.join(command)}")
+        detail = proc.stderr.strip() or proc.stdout.strip()
+        raise AdapterError(detail or f"command failed: {' '.join(command)}")
     try:
         return json.loads(proc.stdout)
     except json.JSONDecodeError as exc:
@@ -163,24 +212,58 @@ class GitHubAdapter:
             title=request.title,
         )
 
-    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef:
-        """Merge, naming the strategy explicitly.
-
-        `method` is REQUIRED and has no default on purpose. A default would be a promise
-        that every future call site remembers to think about it; a required argument is a
-        refusal. The absent flag is precisely the defect being closed here -- with no
-        strategy named, gh and the host choose, and a squash reports success identically
-        to a merge commit.
-        """
+    def merge_pr(
+        self,
+        repo: str,
+        number: int,
+        *,
+        method: MergeMethod,
+    ) -> MergeReceipt:
         proc = subprocess.run(
-            [self.gh_binary, "pr", "merge", str(number), "--repo", repo, method.gh_flag],
+            [
+                self.gh_binary,
+                "pr",
+                "merge",
+                str(number),
+                "--repo",
+                repo,
+                method.gh_flag,
+            ],
             capture_output=True,
             text=True,
             check=False,
         )
         if proc.returncode != 0:
             raise AdapterError(proc.stderr.strip() or proc.stdout.strip() or "gh pr merge failed")
-        return PRRef(repo=repo, number=number)
+
+        # `gh pr merge` is silent on successful non-interactive merges. Read
+        # the immutable PR record rather than reconstructing a receipt from
+        # the command inputs or asking what commit the base points at now.
+        requested = PRRef(repo=repo, number=number)
+        try:
+            payload = _run_json(
+                [
+                    self.gh_binary,
+                    "pr",
+                    "view",
+                    str(number),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,url,state,mergeCommit",
+                ]
+            )
+            return _parse_merge_receipt(
+                payload,
+                requested=requested,
+                requested_method=method,
+            )
+        except AdapterError as exc:
+            raise MergeEvidenceError(
+                requested=requested,
+                requested_method=method,
+                reason=str(exc),
+            ) from exc
 
     def pr_status(self, repo: str, number: int) -> PRStatus:
         payload = _run_json(
@@ -208,7 +291,11 @@ class GitHubAdapter:
         return PRStatus(
             ref=ref,
             state=str(payload.get("state", "UNKNOWN")),
-            mergeable=str(payload.get("mergeable")) if payload.get("mergeable") is not None else None,
+            mergeable=(
+                str(payload.get("mergeable"))
+                if payload.get("mergeable") is not None
+                else None
+            ),
             checks=checks,
         )
 
@@ -256,7 +343,11 @@ class GitHubAdapter:
                 PRCheck(
                     name=str(row.get("name", "unknown")),
                     status=str(row.get("status", "UNKNOWN")),
-                    conclusion=(str(row["conclusion"]) if row.get("conclusion") is not None else None),
+                    conclusion=(
+                        str(row["conclusion"])
+                        if row.get("conclusion") is not None
+                        else None
+                    ),
                     details_url=row.get("detailsUrl"),
                 )
             )
@@ -268,3 +359,83 @@ def get_platform_adapter(name: str) -> PlatformAdapter:
     if normalized in {"github", "gh"}:
         return GitHubAdapter()
     raise AdapterError(f"unknown platform adapter: {name}")
+
+
+_GIT_OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+
+
+def _parse_merge_receipt(
+    payload: object,
+    *,
+    requested: PRRef,
+    requested_method: MergeMethod,
+) -> MergeReceipt:
+    if not isinstance(payload, dict):
+        raise AdapterError("gh pr view did not return an object")
+    if payload.get("state") != "MERGED":
+        raise AdapterError(
+            "gh pr merge returned success but the structured PR record is not MERGED"
+        )
+
+    number = payload.get("number")
+    if isinstance(number, bool) or not isinstance(number, int):
+        raise AdapterError("merged PR record has no integer number")
+    url = payload.get("url")
+    if not isinstance(url, str) or not url:
+        raise AdapterError("merged PR record has no URL")
+
+    observed_repo, url_number = _repo_and_number_from_pr_url(url)
+    observed = PRRef(repo=observed_repo, number=number, url=url)
+    if number != requested.number or url_number != requested.number:
+        raise AdapterError(
+            f"merged PR record identifies #{number} at URL #{url_number}, "
+            f"expected #{requested.number}"
+        )
+    if observed.repo != requested.repo:
+        raise AdapterError(
+            f"merged PR record identifies repo {observed.repo!r}, "
+            f"expected {requested.repo!r}"
+        )
+
+    if "mergeCommit" not in payload:
+        raise AdapterError("merged PR record omitted mergeCommit")
+    merge_commit = payload["mergeCommit"]
+    commit_sha: str | None
+    if merge_commit is None:
+        commit_sha = None
+    elif isinstance(merge_commit, dict):
+        oid = merge_commit.get("oid")
+        if not isinstance(oid, str) or _GIT_OBJECT_ID.fullmatch(oid) is None:
+            raise AdapterError("merged PR record contains an invalid mergeCommit.oid")
+        commit_sha = oid
+    else:
+        raise AdapterError("merged PR record contains a malformed mergeCommit")
+
+    return MergeReceipt(
+        requested=requested,
+        observed=observed,
+        commit_sha=commit_sha,
+        requested_method=requested_method,
+    )
+
+
+def _repo_and_number_from_pr_url(url: str) -> tuple[str, int]:
+    try:
+        parsed = urlsplit(url)
+    except ValueError as exc:
+        raise AdapterError(f"merged PR record contains an invalid PR URL: {url!r}") from exc
+    path = [part for part in parsed.path.split("/") if part]
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc.lower() != "github.com"
+        or bool(parsed.query)
+        or bool(parsed.fragment)
+        or len(path) != 4
+        or path[2] != "pull"
+    ):
+        raise AdapterError(f"merged PR record contains an invalid PR URL: {url!r}")
+    try:
+        number = int(path[3])
+    except ValueError as exc:
+        raise AdapterError(f"merged PR record contains an invalid PR URL: {url!r}") from exc
+    return f"{path[0]}/{path[1]}", number

--- a/gr2/python_cli/platform.py
+++ b/gr2/python_cli/platform.py
@@ -1,11 +1,39 @@
 from __future__ import annotations
 
+import enum
 import json
 import shutil
 import subprocess
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Protocol
+
+
+class MergeMethod(enum.Enum):
+    """The git strategy a merge uses. Decided by the workspace, never by the host.
+
+    gr1 asked the host which methods it permitted and took the first of
+    `squash > merge > rebase` -- delegating a workspace-policy decision to a party with no
+    knowledge of the workspace. gr2's version of the same class is quieter and harder to
+    see: it passed no strategy flag at all, so gh and the host decided by default. There
+    was no wrong line to point at, only an absent one.
+
+    `MERGE` is the default deliberately. It is the only method that preserves both
+    parents, and losing shared ancestry is not a formatting preference -- it is how two
+    branches become unrelated histories that no later merge can reconcile.
+
+    Lives here rather than in `pr.py` because the flag mapping is a platform concern, and
+    because `pr.py` imports this module: the enum has to sit on the lower side of that
+    edge. `pr.py` re-exports it, so the operational contract reads from either.
+    """
+
+    MERGE = "merge"
+    SQUASH = "squash"
+    REBASE = "rebase"
+
+    @property
+    def gh_flag(self) -> str:
+        return f"--{self.value}"
 
 
 @dataclass(frozen=True)
@@ -68,7 +96,7 @@ class PlatformAdapter(Protocol):
 
     def create_pr(self, request: CreatePRRequest) -> PRRef: ...
 
-    def merge_pr(self, repo: str, number: int) -> PRRef: ...
+    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef: ...
 
     def pr_status(self, repo: str, number: int) -> PRStatus: ...
 
@@ -135,9 +163,17 @@ class GitHubAdapter:
             title=request.title,
         )
 
-    def merge_pr(self, repo: str, number: int) -> PRRef:
+    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef:
+        """Merge, naming the strategy explicitly.
+
+        `method` is REQUIRED and has no default on purpose. A default would be a promise
+        that every future call site remembers to think about it; a required argument is a
+        refusal. The absent flag is precisely the defect being closed here -- with no
+        strategy named, gh and the host choose, and a squash reports success identically
+        to a merge commit.
+        """
         proc = subprocess.run(
-            [self.gh_binary, "pr", "merge", str(number), "--repo", repo],
+            [self.gh_binary, "pr", "merge", str(number), "--repo", repo, method.gh_flag],
             capture_output=True,
             text=True,
             check=False,

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -234,7 +234,7 @@ def merge_pr_group(
         repo = pr_info["repo"]
         number = pr_info["pr_number"]
         try:
-            adapter.merge_pr(repo, number, method=method)
+            receipt = adapter.merge_pr(repo, number, method=method)
         except AdapterError as exc:
             # Best-effort durable layer. Wrapped so a failure HERE cannot replace the
             # PRMergeError below with the event subsystem's own exception -- if a broken
@@ -264,7 +264,20 @@ def merge_pr_group(
                     file=sys.stderr,
                 )
             raise PRMergeError(repo, number, str(exc), completed=merged) from exc
-        merged.append(pr_info)
+
+        # Carried back from the ADAPTER, never rebuilt from `pr_info`. Rebuilding from the
+        # group file produces the same repo names in the same order -- the loop visits
+        # repos in group order -- so the two are indistinguishable by inspection while one
+        # is evidence that a merge happened and the other is a restatement of what we
+        # intended. The second is exactly what a loop that never contacted the host would
+        # also produce.
+        #
+        # `PRRef` is a thin receipt today and carries no commit id (grip#842 item 3 makes
+        # it real). This shape is the seam: when the richer receipt lands it swaps in here
+        # without the meaning of the record changing.
+        merged.append(
+            {"repo": receipt.repo, "pr_number": receipt.number, "url": receipt.url}
+        )
 
     emit(
         event_type=EventType.PR_MERGED,

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -15,40 +15,49 @@ from __future__ import annotations
 import json
 import os
 import sys
+from collections.abc import Callable, Mapping
 from pathlib import Path
+from typing import Any
 
 from .events import EventType, emit
-from .platform import AdapterError, CreatePRRequest, MergeMethod, PlatformAdapter
+from .merge_verification import (
+    CompletedMerge,
+    MergeVerificationTarget,
+    consume_merge_receipt,
+)
+from .platform import (
+    AdapterError,
+    CreatePRRequest,
+    MergeEvidenceError,
+    MergeMethod,
+    MergeReceipt,
+    PlatformAdapter,
+)
 
 __all__ = [
     "MergeMethod",
-    "UnpermittedMergeMethodError",
-    "resolve_merge_method",
     "PRMergeError",
+    "PRMergeOutcomeUnknownError",
+    "PRMergePostconditionError",
+    "UnpermittedMergeMethodError",
+    "check_pr_group_status",
     "create_pr_group",
     "merge_pr_group",
-    "check_pr_group_status",
     "record_pr_review",
+    "resolve_merge_method",
 ]
 
 
 class UnpermittedMergeMethodError(RuntimeError):
-    """The requested method is not permitted, and no other method was substituted.
-
-    Deliberately NOT a subclass of the parse error. A name we cannot read and a name we
-    can read but may not use are different facts, and a caller that wants to distinguish
-    them should not have to inspect a message to do it.
-    """
+    """The requested method is known, but workspace policy does not permit it."""
 
     def __init__(self, requested: MergeMethod, permitted: list[str]) -> None:
         self.requested = requested
         self.permitted = list(permitted)
+        allowed = ", ".join(self.permitted) or "none"
         super().__init__(
             f"merge method {requested.value!r} is not permitted here "
-            f"(permitted: {', '.join(self.permitted) or 'none'}). "
-            f"Refusing rather than substituting: a merge that silently uses a different "
-            f"strategy than the one requested reports success identically, and the only "
-            f"way to discover it is counting parents afterwards."
+            f"(permitted: {allowed}); refusing rather than substituting another method"
         )
 
 
@@ -56,11 +65,10 @@ def _parse_method(name: str, *, source: str) -> MergeMethod:
     try:
         return MergeMethod(name)
     except ValueError:
+        expected = ", ".join(method.value for method in MergeMethod)
         raise ValueError(
             f"unrecognised merge method {name!r} from {source} "
-            f"(expected one of: {', '.join(m.value for m in MergeMethod)}). "
-            f"Not falling back to a default: you asked for something, and quietly doing "
-            f"something else is the defect this guard exists to prevent."
+            f"(expected one of: {expected}); refusing rather than falling back"
         ) from None
 
 
@@ -69,15 +77,8 @@ def resolve_merge_method(
     configured: str | None = None,
     permitted: list[str] | None = None,
 ) -> MergeMethod:
-    """Resolve the merge strategy. The host is asked *whether*, never *which*.
+    """Resolve explicit, then configured, then merge-commit strategy."""
 
-    Precedence: explicit `--method`, then the workspace setting, then a merge commit.
-
-    `permitted` is what the host allows, when we happen to know it. Passing `None` means
-    **we did not ask** -- which must not read as "anything goes". No refusal is claimed in
-    that case, and nothing asserts the method was permitted; unverifiable stays
-    distinguishable from verified.
-    """
     if explicit is not None:
         chosen = _parse_method(explicit, source="--method")
     elif configured is not None:
@@ -87,33 +88,14 @@ def resolve_merge_method(
 
     if permitted is not None and chosen.value not in permitted:
         raise UnpermittedMergeMethodError(chosen, permitted)
-
     return chosen
 
 
 class PRMergeError(RuntimeError):
-    """Raised when a PR merge fails, carrying the merges that already succeeded.
+    """A merge command failed, carrying prior completed host operations."""
 
-    `completed` is REQUIRED and keyword-only, with no default, because this is the
-    reliable half of G9 (grip#842). Merging is irreversible: by the time one repo fails,
-    earlier repos are merged on the host and no amount of unwinding changes that. A caller
-    that cannot learn which ones will re-attempt them.
-
-        Irreversible work that is not recorded is worse than work not done,
-        because the next actor plans against a state that is false.
-
-    An optional field would be omitted at exactly one call site within a year and the
-    guarantee would quietly become a convention. An empty list is a claim -- "nothing had
-    merged" -- and must be stated, not defaulted; "nothing merged" and "nobody recorded
-    what merged" are different facts and a default would make them identical.
-
-    This is the layer a retry reads. The event log is the other layer and is best-effort:
-    `emit` RAISES `EventEmitError` as of grip#843 (it previously swallowed everything);
-    either way correctness must not rest on it -- fail-open lost the record silently, and
-    fail-closed turns a logging failure into an operation failure. The two
-    fail by different routes, which is the only thing that makes them depth rather than
-    the same chance twice.
-    """
+    operation_acknowledged = False
+    outcome_unknown = False
 
     def __init__(
         self,
@@ -121,20 +103,73 @@ class PRMergeError(RuntimeError):
         pr_number: int,
         reason: str,
         *,
-        completed: list[dict],
+        completed: list[CompletedMerge],
     ) -> None:
         self.repo = repo
         self.pr_number = pr_number
         self.reason = reason
         self.completed = list(completed)
-        already = ", ".join(str(c.get("repo")) for c in self.completed)
-        super().__init__(
-            f"merge failed for {repo}#{pr_number}: {reason}"
-            + (
-                f" (ALREADY MERGED, do not retry: {already})"
-                if self.completed
-                else " (nothing had merged yet)"
-            )
+        already = ", ".join(item.receipt.observed.repo for item in self.completed)
+        suffix = (
+            f" (ALREADY MERGED, do not retry: {already})"
+            if self.completed
+            else " (nothing had merged yet)"
+        )
+        super().__init__(f"merge failed for {repo}#{pr_number}: {reason}{suffix}")
+
+
+class PRMergeOutcomeUnknownError(PRMergeError):
+    """The host acknowledged the command but no immutable receipt was available."""
+
+    operation_acknowledged = True
+    outcome_unknown = True
+
+    def __init__(
+        self,
+        repo: str,
+        pr_number: int,
+        reason: str,
+        *,
+        completed: list[CompletedMerge],
+    ) -> None:
+        self.repo = repo
+        self.pr_number = pr_number
+        self.reason = reason
+        self.completed = list(completed)
+        already = ", ".join(item.receipt.observed.repo for item in self.completed)
+        suffix = f"; earlier completed: {already}" if already else ""
+        RuntimeError.__init__(
+            self,
+            f"merge outcome unknown for {repo}#{pr_number}: {reason}; "
+            f"the command was acknowledged, so do not retry{suffix}",
+        )
+
+
+class PRMergePostconditionError(PRMergeError):
+    """The merge is known to have happened but its evidence was not consumed."""
+
+    operation_acknowledged = True
+    outcome_unknown = False
+
+    def __init__(
+        self,
+        receipt: MergeReceipt,
+        reason: str,
+        *,
+        completed: list[CompletedMerge],
+    ) -> None:
+        observed = receipt.observed
+        self.receipt = receipt
+        self.repo = str(observed.repo)
+        self.pr_number = int(observed.number)
+        self.reason = reason
+        self.completed = list(completed)
+        already = ", ".join(item.receipt.observed.repo for item in self.completed)
+        suffix = f"; earlier completed: {already}" if already else ""
+        RuntimeError.__init__(
+            self,
+            f"merge postcondition failed for {self.repo}#{self.pr_number}: {reason}; "
+            f"the host merge is acknowledged, so do not retry{suffix}",
         )
 
 
@@ -221,81 +256,141 @@ def merge_pr_group(
     actor: str,
     *,
     method: MergeMethod,
+    verification_targets: Mapping[str, MergeVerificationTarget],
+    report: Callable[[str], Any],
 ) -> dict:
-    """Merge all PRs in a group. Stops on first failure.
-
-    `method` is required and keyword-only. Resolving a strategy correctly and then not
-    threading it to the call is the same outcome as never resolving one -- a decided
-    method that never reaches `gh` is indistinguishable from an undecided one, and the
-    unit tests for the resolver stay green either way.
-    """
+    """Merge all PRs, consuming host evidence before recording completion."""
     group = _load_group(workspace_root, pr_group_id)
-    merged: list[dict] = []
+    merged: list[CompletedMerge] = []
+    targets = dict(verification_targets)
+
+    missing_targets = [
+        str(item["repo"]) for item in group["prs"] if str(item["repo"]) not in targets
+    ]
+    if missing_targets:
+        raise ValueError(
+            "merge verification has no explicit local target for: "
+            + ", ".join(missing_targets)
+        )
 
     for pr_info in group["prs"]:
-        repo = pr_info["repo"]
-        number = pr_info["pr_number"]
+        repo = str(pr_info["repo"])
+        number = int(pr_info["pr_number"])
         try:
             receipt = adapter.merge_pr(repo, number, method=method)
+        except MergeEvidenceError as exc:
+            _record_merge_failure(
+                workspace_root=workspace_root,
+                group=group,
+                actor=actor,
+                repo=repo,
+                number=number,
+                reason=str(exc),
+                completed=merged,
+                operation_acknowledged=True,
+            )
+            raise PRMergeOutcomeUnknownError(
+                repo,
+                number,
+                str(exc),
+                completed=merged,
+            ) from exc
         except AdapterError as exc:
-            # Best-effort durable layer. Wrapped so a failure HERE cannot replace the
-            # PRMergeError below with the event subsystem's own exception -- if a broken
-            # event layer can take the in-process layer down with it, they were never two
-            # layers. This was written while `emit` still swallowed everything; grip#843
-            # made it RAISE, so the wrap is now load-bearing rather than defensive. The
-            # broader class -- emits sitting after irreversible work -- is grip#844.
-            try:
-                emit(
-                    event_type=EventType.PR_MERGE_FAILED,
-                    workspace_root=workspace_root,
-                    actor=actor,
-                    owner_unit=group.get("owner_unit", actor),
-                    payload={
-                        "pr_group_id": pr_group_id,
-                        "repo": repo,
-                        "pr_number": number,
-                        "reason": str(exc),
-                        # The irreversible work that already happened. Recorded on the
-                        # FAILURE event because there may never be a success event.
-                        "completed": merged,
-                    },
-                )
-            except Exception as emit_exc:  # noqa: BLE001 - deliberately broad
-                print(
-                    f"gr2: could not record partial merge ({emit_exc}); "
-                    f"the completed list is still on the raised PRMergeError",
-                    file=sys.stderr,
-                )
+            _record_merge_failure(
+                workspace_root=workspace_root,
+                group=group,
+                actor=actor,
+                repo=repo,
+                number=number,
+                reason=str(exc),
+                completed=merged,
+                operation_acknowledged=False,
+            )
             raise PRMergeError(repo, number, str(exc), completed=merged) from exc
 
-        # Carried back from the ADAPTER, never rebuilt from `pr_info`. Rebuilding from the
-        # group file produces the same repo names in the same order -- the loop visits
-        # repos in group order -- so the two are indistinguishable by inspection while one
-        # is evidence that a merge happened and the other is a restatement of what we
-        # intended. The second is exactly what a loop that never contacted the host would
-        # also produce.
-        #
-        # `PRRef` is a thin receipt today and carries no commit id (grip#842 item 3 makes
-        # it real). This shape is the seam: when the richer receipt lands it swaps in here
-        # without the meaning of the record changing.
-        merged.append(
-            {"repo": receipt.repo, "pr_number": receipt.number, "url": receipt.url}
-        )
+        target = targets[repo]
+        try:
+            completed = consume_merge_receipt(
+                repo_root=target.repo_root,
+                receipt=receipt,
+                remote=target.remote,
+                report=report,
+            )
+        except Exception as exc:  # noqa: BLE001 - host operation already happened
+            reason = f"could not consume merge evidence: {exc}"
+            _record_merge_failure(
+                workspace_root=workspace_root,
+                group=group,
+                actor=actor,
+                repo=repo,
+                number=number,
+                reason=reason,
+                completed=merged,
+                operation_acknowledged=True,
+            )
+            raise PRMergePostconditionError(
+                receipt,
+                reason,
+                completed=merged,
+            ) from exc
+        merged.append(completed)
+
+    records = _completed_records(merged)
 
     emit(
         event_type=EventType.PR_MERGED,
         workspace_root=workspace_root,
         actor=actor,
         owner_unit=group.get("owner_unit", actor),
-        payload={"pr_group_id": pr_group_id, "repos": merged},
+        payload={"pr_group_id": pr_group_id, "repos": records},
     )
 
-    # Hand the caller what ACTUALLY merged. Without this the layer above has
-    # nothing to consume and re-derives completion from the group's declared
-    # `prs` -- which names repos the loop may never have reached. G9's list is
-    # only worth carrying if the next consumer can read it.
-    group["completed"] = merged
+    group["completed"] = records
+    group["group_state"] = "merged"
+    _save_group(workspace_root, group)
     return group
+
+
+def _record_merge_failure(
+    *,
+    workspace_root: Path,
+    group: dict[str, object],
+    actor: str,
+    repo: str,
+    number: int,
+    reason: str,
+    completed: list[CompletedMerge],
+    operation_acknowledged: bool,
+) -> None:
+    """Best-effort durable layer; never replaces the in-process error."""
+
+    try:
+        emit(
+            event_type=EventType.PR_MERGE_FAILED,
+            workspace_root=workspace_root,
+            actor=actor,
+            owner_unit=str(group.get("owner_unit", actor)),
+            payload={
+                "pr_group_id": group["pr_group_id"],
+                "repo": repo,
+                "pr_number": number,
+                "reason": reason,
+                "completed": _completed_records(completed),
+                "operation_acknowledged": operation_acknowledged,
+            },
+        )
+    except Exception as emit_exc:  # noqa: BLE001 - event logging is best effort
+        print(
+            f"gr2: could not record partial merge ({emit_exc}); "
+            "the completed list remains on the raised error",
+            file=sys.stderr,
+        )
+
+
+def _completed_records(completed: list[CompletedMerge]) -> list[dict[str, object]]:
+    """Flatten earned evidence only at a JSON serialization boundary."""
+
+    return [item.as_dict() for item in completed]
 
 
 def check_pr_group_status(

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 from .events import EventType, emit
@@ -91,13 +92,48 @@ def resolve_merge_method(
 
 
 class PRMergeError(RuntimeError):
-    """Raised when a PR merge fails."""
+    """Raised when a PR merge fails, carrying the merges that already succeeded.
 
-    def __init__(self, repo: str, pr_number: int, reason: str) -> None:
+    `completed` is REQUIRED and keyword-only, with no default, because this is the
+    reliable half of G9 (grip#842). Merging is irreversible: by the time one repo fails,
+    earlier repos are merged on the host and no amount of unwinding changes that. A caller
+    that cannot learn which ones will re-attempt them.
+
+        Irreversible work that is not recorded is worse than work not done,
+        because the next actor plans against a state that is false.
+
+    An optional field would be omitted at exactly one call site within a year and the
+    guarantee would quietly become a convention. An empty list is a claim -- "nothing had
+    merged" -- and must be stated, not defaulted; "nothing merged" and "nobody recorded
+    what merged" are different facts and a default would make them identical.
+
+    This is the layer a retry reads. The event log is the other layer and is best-effort:
+    `emit` swallows every exception (grip#843), so correctness must not rest on it. The two
+    fail by different routes, which is the only thing that makes them depth rather than
+    the same chance twice.
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        pr_number: int,
+        reason: str,
+        *,
+        completed: list[dict],
+    ) -> None:
         self.repo = repo
         self.pr_number = pr_number
         self.reason = reason
-        super().__init__(f"merge failed for {repo}#{pr_number}: {reason}")
+        self.completed = list(completed)
+        already = ", ".join(str(c.get("repo")) for c in self.completed)
+        super().__init__(
+            f"merge failed for {repo}#{pr_number}: {reason}"
+            + (
+                f" (ALREADY MERGED, do not retry: {already})"
+                if self.completed
+                else " (nothing had merged yet)"
+            )
+        )
 
 
 def _pr_groups_dir(workspace_root: Path) -> Path:
@@ -200,19 +236,34 @@ def merge_pr_group(
         try:
             adapter.merge_pr(repo, number, method=method)
         except AdapterError as exc:
-            emit(
-                event_type=EventType.PR_MERGE_FAILED,
-                workspace_root=workspace_root,
-                actor=actor,
-                owner_unit=group.get("owner_unit", actor),
-                payload={
-                    "pr_group_id": pr_group_id,
-                    "repo": repo,
-                    "pr_number": number,
-                    "reason": str(exc),
-                },
-            )
-            raise PRMergeError(repo, number, str(exc)) from exc
+            # Best-effort durable layer. Wrapped so a failure HERE cannot replace the
+            # PRMergeError below with the event subsystem's own exception -- if a broken
+            # event layer can take the in-process layer down with it, they were never two
+            # layers. `emit` swallows everything today (grip#843); this guards the day it
+            # does not, rather than depending on that staying true.
+            try:
+                emit(
+                    event_type=EventType.PR_MERGE_FAILED,
+                    workspace_root=workspace_root,
+                    actor=actor,
+                    owner_unit=group.get("owner_unit", actor),
+                    payload={
+                        "pr_group_id": pr_group_id,
+                        "repo": repo,
+                        "pr_number": number,
+                        "reason": str(exc),
+                        # The irreversible work that already happened. Recorded on the
+                        # FAILURE event because there may never be a success event.
+                        "completed": merged,
+                    },
+                )
+            except Exception as emit_exc:  # noqa: BLE001 - deliberately broad
+                print(
+                    f"gr2: could not record partial merge ({emit_exc}); "
+                    f"the completed list is still on the raised PRMergeError",
+                    file=sys.stderr,
+                )
+            raise PRMergeError(repo, number, str(exc), completed=merged) from exc
         merged.append(pr_info)
 
     emit(

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -17,7 +17,77 @@ import os
 from pathlib import Path
 
 from .events import EventType, emit
-from .platform import AdapterError, CreatePRRequest, PlatformAdapter
+from .platform import AdapterError, CreatePRRequest, MergeMethod, PlatformAdapter
+
+__all__ = [
+    "MergeMethod",
+    "UnpermittedMergeMethodError",
+    "resolve_merge_method",
+    "PRMergeError",
+    "create_pr_group",
+    "merge_pr_group",
+    "check_pr_group_status",
+    "record_pr_review",
+]
+
+
+class UnpermittedMergeMethodError(RuntimeError):
+    """The requested method is not permitted, and no other method was substituted.
+
+    Deliberately NOT a subclass of the parse error. A name we cannot read and a name we
+    can read but may not use are different facts, and a caller that wants to distinguish
+    them should not have to inspect a message to do it.
+    """
+
+    def __init__(self, requested: MergeMethod, permitted: list[str]) -> None:
+        self.requested = requested
+        self.permitted = list(permitted)
+        super().__init__(
+            f"merge method {requested.value!r} is not permitted here "
+            f"(permitted: {', '.join(self.permitted) or 'none'}). "
+            f"Refusing rather than substituting: a merge that silently uses a different "
+            f"strategy than the one requested reports success identically, and the only "
+            f"way to discover it is counting parents afterwards."
+        )
+
+
+def _parse_method(name: str, *, source: str) -> MergeMethod:
+    try:
+        return MergeMethod(name)
+    except ValueError:
+        raise ValueError(
+            f"unrecognised merge method {name!r} from {source} "
+            f"(expected one of: {', '.join(m.value for m in MergeMethod)}). "
+            f"Not falling back to a default: you asked for something, and quietly doing "
+            f"something else is the defect this guard exists to prevent."
+        ) from None
+
+
+def resolve_merge_method(
+    explicit: str | None = None,
+    configured: str | None = None,
+    permitted: list[str] | None = None,
+) -> MergeMethod:
+    """Resolve the merge strategy. The host is asked *whether*, never *which*.
+
+    Precedence: explicit `--method`, then the workspace setting, then a merge commit.
+
+    `permitted` is what the host allows, when we happen to know it. Passing `None` means
+    **we did not ask** -- which must not read as "anything goes". No refusal is claimed in
+    that case, and nothing asserts the method was permitted; unverifiable stays
+    distinguishable from verified.
+    """
+    if explicit is not None:
+        chosen = _parse_method(explicit, source="--method")
+    elif configured is not None:
+        chosen = _parse_method(configured, source="workspace setting")
+    else:
+        chosen = MergeMethod.MERGE
+
+    if permitted is not None and chosen.value not in permitted:
+        raise UnpermittedMergeMethodError(chosen, permitted)
+
+    return chosen
 
 
 class PRMergeError(RuntimeError):
@@ -111,8 +181,16 @@ def merge_pr_group(
     pr_group_id: str,
     adapter: PlatformAdapter,
     actor: str,
+    *,
+    method: MergeMethod,
 ) -> dict:
-    """Merge all PRs in a group. Stops on first failure."""
+    """Merge all PRs in a group. Stops on first failure.
+
+    `method` is required and keyword-only. Resolving a strategy correctly and then not
+    threading it to the call is the same outcome as never resolving one -- a decided
+    method that never reaches `gh` is indistinguishable from an undecided one, and the
+    unit tests for the resolver stay green either way.
+    """
     group = _load_group(workspace_root, pr_group_id)
     merged: list[dict] = []
 
@@ -120,7 +198,7 @@ def merge_pr_group(
         repo = pr_info["repo"]
         number = pr_info["pr_number"]
         try:
-            adapter.merge_pr(repo, number)
+            adapter.merge_pr(repo, number, method=method)
         except AdapterError as exc:
             emit(
                 event_type=EventType.PR_MERGE_FAILED,

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -108,7 +108,9 @@ class PRMergeError(RuntimeError):
     what merged" are different facts and a default would make them identical.
 
     This is the layer a retry reads. The event log is the other layer and is best-effort:
-    `emit` swallows every exception (grip#843), so correctness must not rest on it. The two
+    `emit` RAISES `EventEmitError` as of grip#843 (it previously swallowed everything);
+    either way correctness must not rest on it -- fail-open lost the record silently, and
+    fail-closed turns a logging failure into an operation failure. The two
     fail by different routes, which is the only thing that makes them depth rather than
     the same chance twice.
     """
@@ -239,8 +241,9 @@ def merge_pr_group(
             # Best-effort durable layer. Wrapped so a failure HERE cannot replace the
             # PRMergeError below with the event subsystem's own exception -- if a broken
             # event layer can take the in-process layer down with it, they were never two
-            # layers. `emit` swallows everything today (grip#843); this guards the day it
-            # does not, rather than depending on that staying true.
+            # layers. This was written while `emit` still swallowed everything; grip#843
+            # made it RAISE, so the wrap is now load-bearing rather than defensive. The
+            # broader class -- emits sitting after irreversible work -- is grip#844.
             try:
                 emit(
                     event_type=EventType.PR_MERGE_FAILED,
@@ -287,6 +290,11 @@ def merge_pr_group(
         payload={"pr_group_id": pr_group_id, "repos": merged},
     )
 
+    # Hand the caller what ACTUALLY merged. Without this the layer above has
+    # nothing to consume and re-derives completion from the group's declared
+    # `prs` -- which names repos the loop may never have reached. G9's list is
+    # only worth carrying if the next consumer can read it.
+    group["completed"] = merged
     return group
 
 

--- a/gr2/tests/test_merge_evidence.py
+++ b/gr2/tests/test_merge_evidence.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from gr2.python_cli.platform import (
+    GitHubAdapter,
+    MergeEvidenceError,
+    MergeMethod,
+    MergeReceipt,
+    PRRef,
+)
+
+
+def _fake_gh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, object],
+) -> tuple[Path, Path]:
+    binary = tmp_path / "gh"
+    log = tmp_path / "argv.jsonl"
+    binary.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["FAKE_GH_ARGV_LOG"], "a", encoding="utf-8") as handle:
+    handle.write(json.dumps(sys.argv[1:]) + "\\n")
+
+args = sys.argv[1:]
+if args[:2] == ["pr", "merge"]:
+    if not any(flag in args for flag in ("--merge", "--squash", "--rebase")):
+        print("an explicit merge method is required", file=sys.stderr)
+        raise SystemExit(2)
+    if os.environ.get("FAKE_GH_DELETE_AFTER_MERGE"):
+        os.unlink(sys.argv[0])
+    raise SystemExit(0)
+if args[:2] == ["pr", "view"]:
+    if os.environ.get("FAKE_GH_VIEW_FAIL"):
+        print("receipt lookup unavailable", file=sys.stderr)
+        raise SystemExit(4)
+    print(os.environ["FAKE_GH_VIEW_PAYLOAD"])
+    raise SystemExit(0)
+print(f"unexpected argv: {args!r}", file=sys.stderr)
+raise SystemExit(3)
+"""
+    )
+    binary.chmod(0o755)
+    monkeypatch.setenv("FAKE_GH_ARGV_LOG", str(log))
+    monkeypatch.setenv("FAKE_GH_VIEW_PAYLOAD", json.dumps(payload))
+    return binary, log
+
+
+def _merged_payload(
+    *,
+    repo: str = "synapt-dev/widget",
+    number: int = 41,
+    commit_sha: str | None = "a" * 40,
+) -> dict[str, object]:
+    return {
+        "number": number,
+        "url": f"https://github.com/{repo}/pull/{number}",
+        "state": "MERGED",
+        "mergeCommit": None if commit_sha is None else {"oid": commit_sha},
+    }
+
+
+def _calls(log: Path) -> list[list[str]]:
+    return [json.loads(line) for line in log.read_text().splitlines()]
+
+
+@pytest.mark.parametrize(
+    ("method", "flag"),
+    [
+        (MergeMethod.MERGE, "--merge"),
+        (MergeMethod.SQUASH, "--squash"),
+        (MergeMethod.REBASE, "--rebase"),
+    ],
+)
+def test_merge_receipt_comes_from_the_structured_host_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    method: MergeMethod,
+    flag: str,
+) -> None:
+    binary, log = _fake_gh(tmp_path, monkeypatch, _merged_payload())
+
+    receipt = GitHubAdapter(str(binary)).merge_pr(
+        "synapt-dev/widget",
+        41,
+        method=method,
+    )
+
+    assert receipt == MergeReceipt(
+        requested=PRRef(repo="synapt-dev/widget", number=41),
+        observed=PRRef(
+            repo="synapt-dev/widget",
+            number=41,
+            url="https://github.com/synapt-dev/widget/pull/41",
+        ),
+        commit_sha="a" * 40,
+        requested_method=method,
+    )
+    assert _calls(log) == [
+        ["pr", "merge", "41", "--repo", "synapt-dev/widget", flag],
+        [
+            "pr",
+            "view",
+            "41",
+            "--repo",
+            "synapt-dev/widget",
+            "--json",
+            "number,url,state,mergeCommit",
+        ],
+    ]
+
+
+def test_host_explicitly_omitting_the_commit_is_not_reported_as_a_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binary, _ = _fake_gh(
+        tmp_path,
+        monkeypatch,
+        _merged_payload(commit_sha=None),
+    )
+
+    receipt = GitHubAdapter(str(binary)).merge_pr(
+        "synapt-dev/widget",
+        41,
+        method=MergeMethod.MERGE,
+    )
+
+    assert receipt.commit_sha is None
+
+
+def test_acknowledged_merge_with_unavailable_receipt_is_not_reported_as_merge_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binary, _ = _fake_gh(tmp_path, monkeypatch, _merged_payload())
+    monkeypatch.setenv("FAKE_GH_VIEW_FAIL", "1")
+
+    with pytest.raises(MergeEvidenceError) as raised:
+        GitHubAdapter(str(binary)).merge_pr(
+            "synapt-dev/widget",
+            41,
+            method=MergeMethod.MERGE,
+        )
+
+    assert raised.value.requested == PRRef(repo="synapt-dev/widget", number=41)
+    assert raised.value.requested_method is MergeMethod.MERGE
+    assert raised.value.operation_acknowledged is True
+    assert "receipt lookup unavailable" in str(raised.value)
+
+
+def test_acknowledged_merge_with_receipt_process_launch_failure_is_outcome_unknown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binary, _ = _fake_gh(tmp_path, monkeypatch, _merged_payload())
+    monkeypatch.setenv("FAKE_GH_DELETE_AFTER_MERGE", "1")
+
+    with pytest.raises(MergeEvidenceError) as raised:
+        GitHubAdapter(str(binary)).merge_pr(
+            "synapt-dev/widget",
+            41,
+            method=MergeMethod.MERGE,
+        )
+
+    assert raised.value.requested == PRRef(repo="synapt-dev/widget", number=41)
+    assert raised.value.requested_method is MergeMethod.MERGE
+    assert raised.value.operation_acknowledged is True
+    assert "receipt" in str(raised.value)
+
+
+def test_receipt_url_with_query_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _merged_payload()
+    payload["url"] = f"{payload['url']}?x=1"
+    binary, _ = _fake_gh(tmp_path, monkeypatch, payload)
+
+    with pytest.raises(MergeEvidenceError):
+        GitHubAdapter(str(binary)).merge_pr(
+            "synapt-dev/widget",
+            41,
+            method=MergeMethod.MERGE,
+        )
+
+
+def test_receipt_url_with_fragment_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _merged_payload()
+    payload["url"] = f"{payload['url']}#frag"
+    binary, _ = _fake_gh(tmp_path, monkeypatch, payload)
+
+    with pytest.raises(MergeEvidenceError):
+        GitHubAdapter(str(binary)).merge_pr(
+            "synapt-dev/widget",
+            41,
+            method=MergeMethod.MERGE,
+        )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {**_merged_payload(), "state": "OPEN"},
+        {**_merged_payload(), "number": 42},
+        {
+            **_merged_payload(),
+            "url": "https://github.com/another-org/widget/pull/41",
+        },
+        {
+            **_merged_payload(),
+            "url": "https://evil.example/synapt-dev/widget/pull/41",
+        },
+        {**_merged_payload(), "url": "https://[broken/pull/41"},
+        {**_merged_payload(), "mergeCommit": {}},
+        {**_merged_payload(), "mergeCommit": {"oid": "not-an-object-id"}},
+    ],
+)
+def test_malformed_or_mismatched_host_evidence_refuses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: dict[str, object],
+) -> None:
+    binary, _ = _fake_gh(tmp_path, monkeypatch, payload)
+
+    with pytest.raises(MergeEvidenceError):
+        GitHubAdapter(str(binary)).merge_pr(
+            "synapt-dev/widget",
+            41,
+            method=MergeMethod.MERGE,
+        )
+
+
+def test_merge_receipt_is_not_a_success_boolean() -> None:
+    assert "merged" not in MergeReceipt.__dataclass_fields__

--- a/gr2/tests/test_merge_parent_verification.py
+++ b/gr2/tests/test_merge_parent_verification.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from gr2.python_cli.merge_verification import (
+    CompletedMerge,
+    ParentVerdict,
+    ParentVerdictKind,
+    consume_merge_receipt,
+    verify_parent_shape,
+)
+from gr2.python_cli.platform import MergeMethod, MergeReceipt, PRRef
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(args)} failed: {completed.stderr or completed.stdout}"
+        )
+    return completed.stdout.strip()
+
+
+def _commit(repo: Path, name: str, content: str) -> str:
+    (repo / name).write_text(content)
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", f"commit {name}")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def dag(tmp_path: Path) -> dict[str, object]:
+    source = tmp_path / "source"
+    source.mkdir()
+    _git(source, "init", "-b", "main")
+    _git(source, "config", "user.name", "gr2 test")
+    _git(source, "config", "user.email", "gr2@example.invalid")
+    root = _commit(source, "root.txt", "root\n")
+
+    # Clone the verifier before the candidate objects exist. A verifier that
+    # only inspects its initial object database therefore cannot pass this
+    # fixture by coincidence. It must fetch the exact receipt OID.
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(source), str(remote)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    checkout = tmp_path / "checkout"
+    subprocess.run(
+        ["git", "clone", str(remote), str(checkout)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _git(source, "remote", "add", "origin", str(remote))
+
+    _git(source, "checkout", "-b", "feature")
+    _commit(source, "feature.txt", "feature\n")
+    _git(source, "checkout", "main")
+    one_parent = _commit(source, "main.txt", "main\n")
+    _git(source, "merge", "--no-ff", "feature", "-m", "merge feature")
+    two_parent = _git(source, "rev-parse", "HEAD")
+    _git(
+        source,
+        "commit",
+        "--allow-empty",
+        "-m",
+        "ordinary one-parent commit",
+        "-m",
+        "parent deadbeef is message text, not a DAG edge",
+    )
+    parent_word_in_message = _git(source, "rev-parse", "HEAD")
+    _git(source, "branch", "target-one-parent", one_parent)
+    _git(source, "branch", "noise-two-parent", two_parent)
+    _git(
+        source,
+        "push",
+        "origin",
+        "main",
+        "feature",
+        "target-one-parent",
+        "noise-two-parent",
+    )
+    return {
+        "root": root,
+        "one_parent": one_parent,
+        "two_parent": two_parent,
+        "parent_word_in_message": parent_word_in_message,
+        "checkout": checkout,
+    }
+
+
+def _receipt(
+    commit_sha: str | None,
+    *,
+    method: MergeMethod = MergeMethod.MERGE,
+) -> MergeReceipt:
+    ref = PRRef(
+        repo="synapt-dev/widget",
+        number=41,
+        url="https://github.com/synapt-dev/widget/pull/41",
+    )
+    return MergeReceipt(
+        requested=PRRef(repo="synapt-dev/widget", number=41),
+        observed=ref,
+        commit_sha=commit_sha,
+        requested_method=method,
+    )
+
+
+def test_merge_commit_parent_shape_is_read_from_the_receipt_oid(
+    dag: dict[str, object],
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+
+    good = verify_parent_shape(
+        repo_root=checkout,
+        receipt=_receipt(str(dag["two_parent"])),
+        remote="origin",
+    )
+    wrong = verify_parent_shape(
+        repo_root=checkout,
+        receipt=_receipt(str(dag["one_parent"])),
+        remote="origin",
+    )
+
+    assert good.kind is ParentVerdictKind.VERIFIED
+    assert wrong.kind is ParentVerdictKind.WRONG
+
+
+def test_parent_words_in_commit_messages_are_not_dag_edges(
+    dag: dict[str, object],
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+
+    verdict = verify_parent_shape(
+        repo_root=checkout,
+        receipt=_receipt(str(dag["parent_word_in_message"])),
+        remote="origin",
+    )
+
+    assert verdict.kind is ParentVerdictKind.WRONG
+    assert verdict.parent_count == 1
+
+
+@pytest.mark.parametrize("method", [MergeMethod.SQUASH, MergeMethod.REBASE])
+def test_single_parent_methods_are_explicitly_not_applicable(
+    dag: dict[str, object],
+    method: MergeMethod,
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+
+    verdict = verify_parent_shape(
+        repo_root=checkout,
+        receipt=_receipt(str(dag["one_parent"]), method=method),
+        remote="origin",
+    )
+
+    assert verdict.kind is ParentVerdictKind.NOT_APPLICABLE
+
+
+@pytest.mark.parametrize(
+    "method",
+    [MergeMethod.MERGE, MergeMethod.SQUASH, MergeMethod.REBASE],
+)
+def test_missing_commit_evidence_is_unverifiable_for_every_method(
+    dag: dict[str, object],
+    method: MergeMethod,
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+
+    verdict = verify_parent_shape(
+        repo_root=checkout,
+        receipt=_receipt(None, method=method),
+        remote="origin",
+    )
+
+    assert verdict.kind is ParentVerdictKind.UNVERIFIABLE
+
+
+def test_broken_local_dag_is_unverifiable_not_verified(tmp_path: Path) -> None:
+    verdict = verify_parent_shape(
+        repo_root=tmp_path / "not-a-repository",
+        receipt=_receipt("a" * 40),
+        remote="origin",
+    )
+
+    assert verdict.kind is ParentVerdictKind.UNVERIFIABLE
+
+
+def test_fetch_head_is_poison_not_evidence(dag: dict[str, object]) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+    git_dir = Path(_git(checkout, "rev-parse", "--git-dir"))
+    if not git_dir.is_absolute():
+        git_dir = checkout / git_dir
+    fetch_head = git_dir / "FETCH_HEAD"
+    fetch_head.write_text(
+        f"{dag['two_parent']}\t\tbranch 'noise-two-parent' of test.invalid\n"
+    )
+
+    verdict = verify_parent_shape(
+        repo_root=checkout,
+        receipt=_receipt(str(dag["one_parent"])),
+        remote="origin",
+    )
+
+    assert verdict.kind is ParentVerdictKind.WRONG
+    assert str(dag["two_parent"]) in fetch_head.read_text()
+
+
+def test_concurrent_fetch_cannot_swap_the_verified_object(
+    dag: dict[str, object],
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+
+    for _ in range(20):
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            verdict_future = pool.submit(
+                verify_parent_shape,
+                repo_root=checkout,
+                receipt=_receipt(str(dag["one_parent"])),
+                remote="origin",
+            )
+            noise_future = pool.submit(
+                _git,
+                checkout,
+                "fetch",
+                "origin",
+                "noise-two-parent",
+            )
+            verdict = verdict_future.result()
+            noise_future.result()
+        assert verdict.kind is ParentVerdictKind.WRONG
+
+
+def test_consumption_reports_the_verdict_before_completion(
+    dag: dict[str, object],
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+    reports: list[str] = []
+
+    completed = consume_merge_receipt(
+        repo_root=checkout,
+        receipt=_receipt(str(dag["one_parent"])),
+        remote="origin",
+        report=reports.append,
+    )
+
+    assert isinstance(completed, CompletedMerge)
+    assert completed.parent_verdict.kind is ParentVerdictKind.WRONG
+    assert len(reports) == 1
+    assert str(dag["one_parent"]) in reports[0]
+
+
+@pytest.mark.parametrize(
+    ("commit_key", "method", "expected_kind", "expected_reports"),
+    [
+        ("two_parent", MergeMethod.MERGE, ParentVerdictKind.VERIFIED, 0),
+        ("one_parent", MergeMethod.MERGE, ParentVerdictKind.WRONG, 1),
+        (None, MergeMethod.MERGE, ParentVerdictKind.UNVERIFIABLE, 1),
+        ("one_parent", MergeMethod.SQUASH, ParentVerdictKind.NOT_APPLICABLE, 0),
+        ("one_parent", MergeMethod.REBASE, ParentVerdictKind.NOT_APPLICABLE, 0),
+    ],
+)
+def test_consumption_reports_exactly_the_verdicts_that_need_operator_attention(
+    dag: dict[str, object],
+    commit_key: str | None,
+    method: MergeMethod,
+    expected_kind: ParentVerdictKind,
+    expected_reports: int,
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+    commit_sha = None if commit_key is None else str(dag[commit_key])
+    reports: list[str] = []
+
+    completed = consume_merge_receipt(
+        repo_root=checkout,
+        receipt=_receipt(commit_sha, method=method),
+        remote="origin",
+        report=reports.append,
+    )
+
+    assert completed.parent_verdict.kind is expected_kind
+    assert len(reports) == expected_reports
+
+
+def test_report_failure_prevents_completion(dag: dict[str, object]) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+
+    def refuse_report(_message: str) -> None:
+        raise RuntimeError("report sink unavailable")
+
+    with pytest.raises(RuntimeError, match="report sink unavailable"):
+        consume_merge_receipt(
+            repo_root=checkout,
+            receipt=_receipt(str(dag["one_parent"])),
+            remote="origin",
+            report=refuse_report,
+        )
+
+
+def test_completion_cannot_be_constructed_from_an_unreported_verdict(
+    dag: dict[str, object],
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+    verdict = verify_parent_shape(
+        repo_root=checkout,
+        receipt=_receipt(str(dag["two_parent"])),
+        remote="origin",
+    )
+
+    with pytest.raises(TypeError):
+        CompletedMerge(_receipt(str(dag["two_parent"])), verdict)
+
+
+def test_public_parent_verdict_constructor_claims_nothing() -> None:
+    verdict = ParentVerdict()
+
+    assert verdict.kind is ParentVerdictKind.NOT_PERFORMED
+    with pytest.raises(TypeError):
+        ParentVerdict(kind=ParentVerdictKind.VERIFIED)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "forged"),
+    [
+        ("_kind", ParentVerdictKind.VERIFIED),
+        ("_commit_sha", "f" * 40),
+        ("_parent_count", 2),
+        ("_detail", "forged verification"),
+    ],
+)
+def test_parent_verdict_cannot_be_rewritten_after_construction(
+    attribute: str,
+    forged: object,
+) -> None:
+    verdict = ParentVerdict()
+
+    with pytest.raises(AttributeError, match="immutable"):
+        setattr(verdict, attribute, forged)
+
+    assert verdict.kind is ParentVerdictKind.NOT_PERFORMED
+    assert verdict.commit_sha is None
+    assert verdict.parent_count is None
+    assert verdict.detail == "parent verification was not performed"
+
+
+@pytest.mark.parametrize(
+    ("attribute", "forged"),
+    [
+        ("_receipt", object()),
+        ("_parent_verdict", ParentVerdict()),
+    ],
+)
+def test_completed_merge_cannot_be_rewritten_after_construction(
+    dag: dict[str, object],
+    attribute: str,
+    forged: object,
+) -> None:
+    checkout = dag["checkout"]
+    assert isinstance(checkout, Path)
+    receipt = _receipt(str(dag["two_parent"]))
+    completed = consume_merge_receipt(
+        repo_root=checkout,
+        receipt=receipt,
+        remote="origin",
+        report=lambda _message: None,
+    )
+
+    with pytest.raises(AttributeError, match="immutable"):
+        setattr(completed, attribute, forged)
+
+    assert completed.receipt is receipt
+    assert completed.parent_verdict.kind is ParentVerdictKind.VERIFIED

--- a/gr2/tests/test_pr_events.py
+++ b/gr2/tests/test_pr_events.py
@@ -16,6 +16,7 @@ import pytest
 
 from gr2.python_cli.platform import (
     AdapterError,
+    MergeMethod,
     CreatePRRequest,
     PRCheck,
     PRRef,
@@ -46,7 +47,7 @@ class FakeAdapter:
             title=request.title,
         )
 
-    def merge_pr(self, repo: str, number: int) -> PRRef:
+    def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
         if (repo, number) in self._fail_merge:
             raise AdapterError(f"merge conflict in {repo}#{number}")
         self.merged.append((repo, number))
@@ -221,6 +222,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
+            method=MergeMethod.MERGE,
         )
         events = _events_of_type(workspace, "pr.merged")
         assert len(events) == 1
@@ -234,6 +236,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
+            method=MergeMethod.MERGE,
         )
         event = _events_of_type(workspace, "pr.merged")[0]
         assert event["pr_group_id"] == group["pr_group_id"]
@@ -249,6 +252,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
+            method=MergeMethod.MERGE,
         )
         assert [r for r, _ in adapter.merged] == ["app", "api", "billing"]
 
@@ -286,6 +290,7 @@ class TestPRMergeFailed:
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
+                method=MergeMethod.MERGE,
             )
         events = _events_of_type(workspace, "pr.merge_failed")
         assert len(events) == 1
@@ -302,6 +307,7 @@ class TestPRMergeFailed:
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
+                method=MergeMethod.MERGE,
             )
         event = _events_of_type(workspace, "pr.merge_failed")[0]
         assert event["pr_group_id"] == group["pr_group_id"]
@@ -332,6 +338,7 @@ class TestPRMergeFailed:
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
+                method=MergeMethod.MERGE,
             )
         # Only app was attempted; api and billing were not
         assert len(adapter.merged) == 0  # grip failed, not in merged list

--- a/gr2/tests/test_pr_events.py
+++ b/gr2/tests/test_pr_events.py
@@ -13,11 +13,12 @@ import json
 from pathlib import Path
 
 import pytest
-
+from gr2.python_cli.merge_verification import MergeVerificationTarget
 from gr2.python_cli.platform import (
     AdapterError,
-    MergeMethod,
     CreatePRRequest,
+    MergeMethod,
+    MergeReceipt,
     PRCheck,
     PRRef,
     PRStatus,
@@ -47,11 +48,22 @@ class FakeAdapter:
             title=request.title,
         )
 
-    def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
+    def merge_pr(
+        self,
+        repo: str,
+        number: int,
+        *,
+        method: MergeMethod,
+    ) -> MergeReceipt:
         if (repo, number) in self._fail_merge:
             raise AdapterError(f"merge conflict in {repo}#{number}")
         self.merged.append((repo, number))
-        return PRRef(repo=repo, number=number)
+        return MergeReceipt(
+            requested=PRRef(repo=repo, number=number),
+            observed=PRRef(repo=repo, number=number, url=f"observed://{repo}/{number}"),
+            commit_sha=None,
+            requested_method=method,
+        )
 
     def pr_status(self, repo: str, number: int) -> PRStatus:
         key = (repo, number)
@@ -86,6 +98,20 @@ def _read_outbox(workspace: Path) -> list[dict]:
 
 def _events_of_type(workspace: Path, event_type: str) -> list[dict]:
     return [e for e in _read_outbox(workspace) if e["type"] == event_type]
+
+
+def _merge_contract(workspace: Path, group: dict) -> dict[str, object]:
+    return {
+        "method": MergeMethod.MERGE,
+        "verification_targets": {
+            str(item["repo"]): MergeVerificationTarget(
+                repo_root=workspace / str(item["repo"]),
+                remote="unused-for-missing-oid",
+            )
+            for item in group["prs"]
+        },
+        "report": lambda _message: None,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +248,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
-            method=MergeMethod.MERGE,
+            **_merge_contract(workspace, group),
         )
         events = _events_of_type(workspace, "pr.merged")
         assert len(events) == 1
@@ -236,7 +262,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
-            method=MergeMethod.MERGE,
+            **_merge_contract(workspace, group),
         )
         event = _events_of_type(workspace, "pr.merged")[0]
         assert event["pr_group_id"] == group["pr_group_id"]
@@ -252,7 +278,7 @@ class TestPRMerged:
             pr_group_id=group["pr_group_id"],
             adapter=adapter,
             actor="agent:apollo",
-            method=MergeMethod.MERGE,
+            **_merge_contract(workspace, group),
         )
         assert [r for r, _ in adapter.merged] == ["app", "api", "billing"]
 
@@ -278,7 +304,7 @@ class TestPRMergeFailed:
         )
 
     def test_emits_merge_failed(self, workspace: Path):
-        from gr2.python_cli.pr import merge_pr_group, PRMergeError
+        from gr2.python_cli.pr import PRMergeError, merge_pr_group
         adapter = FakeAdapter()
         group = self._create_group(workspace, adapter)
         # Make api fail
@@ -290,13 +316,13 @@ class TestPRMergeFailed:
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
-                method=MergeMethod.MERGE,
+                **_merge_contract(workspace, group),
             )
         events = _events_of_type(workspace, "pr.merge_failed")
         assert len(events) == 1
 
     def test_merge_failed_payload(self, workspace: Path):
-        from gr2.python_cli.pr import merge_pr_group, PRMergeError
+        from gr2.python_cli.pr import PRMergeError, merge_pr_group
         adapter = FakeAdapter()
         group = self._create_group(workspace, adapter)
         api_pr = [p for p in group["prs"] if p["repo"] == "api"][0]
@@ -307,16 +333,17 @@ class TestPRMergeFailed:
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
-                method=MergeMethod.MERGE,
+                **_merge_contract(workspace, group),
             )
         event = _events_of_type(workspace, "pr.merge_failed")[0]
         assert event["pr_group_id"] == group["pr_group_id"]
         assert event["repo"] == "api"
         assert "reason" in event
+        assert [item["repo"] for item in event["completed"]] == ["app"]
 
     def test_stops_after_first_failure(self, workspace: Path):
         """Merge stops at first failure; remaining repos are not attempted."""
-        from gr2.python_cli.pr import create_pr_group, merge_pr_group, PRMergeError
+        from gr2.python_cli.pr import PRMergeError, create_pr_group, merge_pr_group
         adapter = FakeAdapter()
         group = create_pr_group(
             workspace_root=workspace,
@@ -332,15 +359,16 @@ class TestPRMergeFailed:
         # Make grip (first repo) fail
         grip_pr = [p for p in group["prs"] if p["repo"] == "app"][0]
         adapter.set_fail_merge("app", grip_pr["pr_number"])
-        with pytest.raises(PRMergeError):
+        with pytest.raises(PRMergeError) as raised:
             merge_pr_group(
                 workspace_root=workspace,
                 pr_group_id=group["pr_group_id"],
                 adapter=adapter,
                 actor="agent:apollo",
-                method=MergeMethod.MERGE,
+                **_merge_contract(workspace, group),
             )
         # Only app was attempted; api and billing were not
+        assert raised.value.completed == []
         assert len(adapter.merged) == 0  # grip failed, not in merged list
         assert len(_events_of_type(workspace, "pr.merged")) == 0
 
@@ -366,7 +394,7 @@ class TestPRStatusEvents:
         )
 
     def test_checks_passed_emitted(self, workspace: Path):
-        from gr2.python_cli.pr import create_pr_group, check_pr_group_status
+        from gr2.python_cli.pr import check_pr_group_status, create_pr_group
         adapter = FakeAdapter()
         group = self._create_group(workspace, adapter)
         grip_pr = group["prs"][0]
@@ -391,7 +419,7 @@ class TestPRStatusEvents:
         assert events[0]["pr_group_id"] == group["pr_group_id"]
 
     def test_checks_failed_emitted(self, workspace: Path):
-        from gr2.python_cli.pr import create_pr_group, check_pr_group_status
+        from gr2.python_cli.pr import check_pr_group_status, create_pr_group
         adapter = FakeAdapter()
         group = self._create_group(workspace, adapter)
         grip_pr = group["prs"][0]
@@ -415,7 +443,7 @@ class TestPRStatusEvents:
         assert "ci/test" in events[0]["failed_checks"]
 
     def test_status_changed_emitted(self, workspace: Path):
-        from gr2.python_cli.pr import create_pr_group, check_pr_group_status
+        from gr2.python_cli.pr import check_pr_group_status, create_pr_group
         adapter = FakeAdapter()
         group = self._create_group(workspace, adapter)
         grip_pr = group["prs"][0]
@@ -437,7 +465,7 @@ class TestPRStatusEvents:
 
     def test_no_event_when_status_unchanged(self, workspace: Path):
         """Second status check with no changes emits no events."""
-        from gr2.python_cli.pr import create_pr_group, check_pr_group_status
+        from gr2.python_cli.pr import check_pr_group_status, create_pr_group
         adapter = FakeAdapter()
         group = self._create_group(workspace, adapter)
         # Default status is OPEN with no checks -- first check caches it

--- a/gr2/tests/test_pr_merge_method.py
+++ b/gr2/tests/test_pr_merge_method.py
@@ -1,331 +1,80 @@
-"""Merge-method contract for gr2, ported from gr1's seven-round hardening (grip#842).
-
-Written TDD-first: these must fail until `python_cli/pr.py` implements the contract.
-
-The defect being designed out: gr1's `gr pr merge` **actively chose squash**. It asked the
-host which methods were permitted and took the first of `squash > merge > rebase`,
-delegating a workspace-policy decision to a party with no knowledge of the workspace.
-
-gr2 today has the same class in a form that is harder to see, because there is no wrong
-line to point at -- there is only an absent one. `python_cli/platform.py` invokes
-`gh pr merge <n> --repo <r>` with **no strategy flag at all**, so the method is decided by
-gh and the host, wholesale.
-
-Guarantee 1 (grip#842): the host is asked *whether*, never *which*. Precedence is
-explicit `--method`, then workspace setting, then a merge commit. An unpermitted method is
-**refused, not substituted** -- silent substitution is the original defect in a politer
-form, where the operator asks for one strategy, another happens, and the only way to find
-out is counting parents afterwards.
-"""
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+import json
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
-from python_cli.pr import (  # noqa: E402
+from gr2.python_cli import platform as platform_mod
+from gr2.python_cli.pr import (
     MergeMethod,
     UnpermittedMergeMethodError,
     resolve_merge_method,
 )
 
 
-class TestPrecedence:
-    """Explicit beats configured beats a merge commit. Nothing else participates."""
-
-    def test_explicit_wins_over_configured(self):
-        assert resolve_merge_method(explicit="rebase", configured="squash") is MergeMethod.REBASE
-
-    def test_configured_used_when_no_explicit(self):
-        assert resolve_merge_method(explicit=None, configured="squash") is MergeMethod.SQUASH
-
-    def test_default_is_a_merge_commit(self):
-        """The only method that preserves both parents is the one you get by saying nothing.
-
-        This is the assertion that would have caught gr1's defect directly: there, saying
-        nothing produced a squash.
-        """
-        assert resolve_merge_method(explicit=None, configured=None) is MergeMethod.MERGE
-
-    @pytest.mark.parametrize("bad", ["", "  ", "Squash", "fast-forward", "merge-commit", "none"])
-    def test_an_unrecognised_name_is_an_error_not_a_fallback(self, bad):
-        """Falling back to the default on a name we do not recognise is silent substitution.
-
-        The operator typed something. Guessing what they meant, or quietly ignoring it, is
-        the same failure as letting the host choose -- a strategy happens that nobody asked
-        for. Note `Squash` is in this list deliberately: near-misses are the realistic
-        input, and case-insensitive acceptance is a decision, not a courtesy.
-        """
-        with pytest.raises(ValueError):
-            resolve_merge_method(explicit=bad, configured=None)
-
-    def test_an_unrecognised_CONFIGURED_name_is_also_an_error(self):
-        """A bad value in the workspace file is not more trustworthy than a bad flag.
-
-        It is less visible, which makes silent fallback worse here, not better: nobody is
-        watching a config file at the moment of a merge.
-        """
-        with pytest.raises(ValueError):
-            resolve_merge_method(explicit=None, configured="sqush")
+def test_explicit_method_precedes_configured_method() -> None:
+    assert resolve_merge_method(explicit="rebase", configured="squash") is MergeMethod.REBASE
 
 
-class TestRefuseNeverSubstitute:
-    """The paired control. Neither test means anything without the other.
+def test_configured_method_precedes_merge_commit_default() -> None:
+    assert resolve_merge_method(configured="squash") is MergeMethod.SQUASH
+    assert resolve_merge_method() is MergeMethod.MERGE
 
-    A guard that refuses everything passes the refusal test while breaking all merging;
-    a guard that refuses nothing passes the permitted test while restoring the defect.
-    Only the pair pins the behaviour, and each names what the other proves.
-    """
 
-    def test_a_permitted_method_is_used_verbatim(self):
-        """POSITIVE CONTROL. Proves the guard is not simply refusing everything."""
-        chosen = resolve_merge_method(
-            explicit="squash", configured=None, permitted=["merge", "squash"]
-        )
-        assert chosen is MergeMethod.SQUASH
+@pytest.mark.parametrize("bad", ["", "  ", "Squash", "fast-forward", "none"])
+def test_unrecognised_method_refuses_instead_of_falling_back(bad: str) -> None:
+    with pytest.raises(ValueError):
+        resolve_merge_method(explicit=bad)
 
-    def test_an_unpermitted_method_is_REFUSED(self):
-        """NEGATIVE CONTROL. Proves the guard is not simply permitting everything."""
-        with pytest.raises(UnpermittedMergeMethodError):
-            resolve_merge_method(explicit="squash", configured=None, permitted=["merge"])
 
-    def test_refusal_does_not_fall_back_to_a_permitted_method(self):
-        """The whole guarantee, stated as the thing that must NOT happen.
+def test_permitted_and_unpermitted_methods_are_a_paired_control() -> None:
+    assert (
+        resolve_merge_method(explicit="squash", permitted=["merge", "squash"])
+        is MergeMethod.SQUASH
+    )
+    with pytest.raises(UnpermittedMergeMethodError):
+        resolve_merge_method(explicit="squash", permitted=["merge"])
 
-        gr1's defect was not that it chose badly. It was that it chose AT ALL, then
-        reported success, so the operator's request and the actual outcome differed with
-        nothing in the output saying so. Raising is the only outcome that cannot be
-        mistaken for the request having been honoured.
-        """
-        with pytest.raises(UnpermittedMergeMethodError) as excinfo:
-            resolve_merge_method(explicit="rebase", configured=None, permitted=["merge", "squash"])
 
-        # The error must name what was ASKED FOR, not merely what is allowed -- an operator
-        # reading it needs to see their own request refused, not a list of alternatives
-        # that reads like a suggestion to pick one.
-        assert "rebase" in str(excinfo.value)
+@pytest.mark.parametrize(
+    ("method", "flag"),
+    [
+        (MergeMethod.MERGE, "--merge"),
+        (MergeMethod.SQUASH, "--squash"),
+        (MergeMethod.REBASE, "--rebase"),
+    ],
+)
+def test_resolved_method_reaches_gh_as_an_explicit_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    method: MergeMethod,
+    flag: str,
+) -> None:
+    recorded: list[list[str]] = []
 
-    def test_permitted_None_means_unchecked_not_unrestricted(self):
-        """`permitted=None` is 'we did not ask the host', which must not read as 'anything goes'.
+    class _Proc:
+        returncode = 0
+        stderr = ""
 
-        This is guarantee 4 in miniature: unverifiable must be distinguishable from
-        verified. Here the distinction is that no refusal is claimed either way -- the
-        method resolves, and nothing asserts it was permitted.
-        """
-        assert resolve_merge_method(explicit="rebase", configured=None, permitted=None) is (
-            MergeMethod.REBASE
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout
+
+    def fake_run(argv: list[str], **_kwargs: object) -> _Proc:
+        recorded.append(list(argv))
+        if argv[1:3] == ["pr", "merge"]:
+            return _Proc("")
+        return _Proc(
+            json.dumps(
+                {
+                    "number": 42,
+                    "url": "https://github.com/owner/repo/pull/42",
+                    "state": "MERGED",
+                    "mergeCommit": {"oid": "a" * 40},
+                }
+            )
         )
 
+    monkeypatch.setattr(platform_mod.subprocess, "run", fake_run)
 
-class TestTheFlagActuallyReachesGh:
-    """Resolving a method proves nothing if the resolved value is never passed on.
+    platform_mod.GitHubAdapter().merge_pr("owner/repo", 42, method=method)
 
-    gr1's lesson, stated as guarantee 3: pinning a function does not pin its invocation.
-    A correct `resolve_merge_method` with a caller that still shells out to a bare
-    `gh pr merge` is exactly the defect we started with, and every test above would pass.
-    """
-
-    def test_the_resolved_method_appears_in_the_gh_argv(self, monkeypatch):
-        """Asserts the argv gh actually receives -- behaviour, not internal structure.
-
-        Monkeypatching `subprocess.run` rather than subclassing keeps the test from
-        prescribing how the adapter is built, so a later refactor cannot make it
-        vacuously green by moving the call somewhere the subclass no longer intercepts.
-        """
-        from python_cli import platform as platform_mod
-
-        recorded: list[list[str]] = []
-
-        class _Proc:
-            returncode = 0
-            stdout = "{}"
-            stderr = ""
-
-        def _fake_run(argv, *a, **kw):
-            recorded.append(list(argv))
-            return _Proc()
-
-        monkeypatch.setattr(platform_mod.subprocess, "run", _fake_run)
-        platform_mod.GitHubAdapter().merge_pr("owner/repo", 42, method=MergeMethod.SQUASH)
-
-        assert recorded, "the adapter never invoked gh at all"
-        argv = recorded[0]
-        assert "--squash" in argv, (
-            f"the resolved method never reached gh; argv was {argv}. A method decided and "
-            f"then dropped is indistinguishable from one never decided."
-        )
-
-    def test_no_method_still_names_one_explicitly(self, monkeypatch):
-        """The absent flag IS the defect, so the default must be a POSITIVE assertion.
-
-        A test that only checks `--squash` when squash is asked for would stay green
-        against today's code path for every other case -- and today's code path passes no
-        flag at all, which is how the host ends up choosing.
-        """
-        from python_cli import platform as platform_mod
-
-        recorded: list[list[str]] = []
-
-        class _Proc:
-            returncode = 0
-            stdout = "{}"
-            stderr = ""
-
-        monkeypatch.setattr(
-            platform_mod.subprocess,
-            "run",
-            lambda argv, *a, **kw: (recorded.append(list(argv)), _Proc())[1],
-        )
-        platform_mod.GitHubAdapter().merge_pr(
-            "owner/repo", 42, method=resolve_merge_method(explicit=None, configured=None)
-        )
-
-        argv = recorded[0]
-        assert "--merge" in argv, (
-            f"no strategy flag reached gh; argv was {argv}. With no flag, gh and the host "
-            f"decide -- which is guarantee 1's failure in its least visible form, because "
-            f"there is no wrong line to point at, only an absent one."
-        )
-
-
-class TestTheConfiguredWorkspaceMethodIsActuallyREACHED:
-    """The resolver being correct proves nothing if production never calls it.
-
-    Sentinel's r1 mutation: replace production method resolution with the constant
-    `MergeMethod.MERGE` and all 56 tests stay green -- because every caller passed
-    `configured=None`, so the workspace setting was never read and the default was the
-    only value the resolver could return. The resolver was correct and UNREACHED, which
-    is guarantee 3 again: pinning a function does not pin its invocation.
-
-    These tests fail if the constant is substituted, because they require a NON-default
-    method to arrive at the adapter by way of the workspace file.
-    """
-
-    def _workspace(self, tmp_path, method: str | None):
-        import json as _json
-
-        spec = '\nschema_version = 1\nworkspace_name = "w"\n\n[[repos]]\nname = "app"\npath = "repos/app"\nurl = "https://example.invalid/app.git"\n'
-        if method is not None:
-            spec += f'\n[workspace_constraints]\nmerge_method = "{method}"\n'
-        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
-        (tmp_path / ".grip" / "workspace_spec.toml").write_text(spec)
-        return tmp_path
-
-    def test_the_workspace_setting_is_read_from_the_spec(self, tmp_path):
-        from python_cli.app import _configured_merge_method
-
-        assert _configured_merge_method(self._workspace(tmp_path, "squash")) == "squash"
-
-    def test_absent_setting_reads_as_None_not_as_a_default(self, tmp_path):
-        """`None` means the workspace said nothing, which the resolver turns into a merge
-        commit. Returning the string "merge" here would collapse 'unset' and 'chose
-        merge' into one value, and a later change of default would silently never reach
-        the workspaces that never expressed a preference."""
-        from python_cli.app import _configured_merge_method
-
-        assert _configured_merge_method(self._workspace(tmp_path, None)) is None
-
-    def test_a_configured_method_reaches_resolution(self, tmp_path):
-        """End of the wire: spec file -> helper -> resolver -> a NON-default method.
-
-        This is the assertion the constant-MERGE mutation cannot satisfy.
-        """
-        from python_cli.app import _configured_merge_method
-
-        configured = _configured_merge_method(self._workspace(tmp_path, "squash"))
-        assert resolve_merge_method(explicit=None, configured=configured) is MergeMethod.SQUASH
-
-    def test_explicit_still_beats_the_workspace_setting(self, tmp_path):
-        from python_cli.app import _configured_merge_method
-
-        configured = _configured_merge_method(self._workspace(tmp_path, "squash"))
-        assert resolve_merge_method(explicit="rebase", configured=configured) is MergeMethod.REBASE
-
-
-class TestTheCLICallSiteActuallyResolves:
-    """Pins the INVOCATION, not the resolver -- because the resolver was already correct.
-
-    The first version of the P1-TWO fix added tests for `_configured_merge_method` and
-    for `resolve_merge_method`, both passing, and Sentinel's mutation SURVIVED: replacing
-    the CLI's resolution with the constant `MergeMethod.MERGE` left all of them green,
-    because none of them traversed the call site. Guarantee 3, inside the fix for a
-    guarantee-3 finding, on the third occurrence of the same shape in one change.
-
-    The only assertion that can distinguish "resolved" from "constant" is one that
-    observes what the CLI HANDS DOWNSTREAM when the workspace asks for a NON-default
-    method.
-    """
-
-    def test_a_squash_workspace_makes_the_CLI_pass_SQUASH_downstream(
-        self, tmp_path, monkeypatch
-    ):
-        import json as _json
-
-        from typer.testing import CliRunner
-
-        from python_cli import app as app_mod
-
-        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
-        (tmp_path / ".grip" / "workspace_spec.toml").write_text(
-            '\nschema_version = 1\nworkspace_name = "w"\n\n'
-            '[workspace_constraints]\nmerge_method = "squash"\n'
-        )
-        group = {"pr_group_id": "pg", "owner_unit": "apollo", "lane_name": "lane", "prs": []}
-        gpath = tmp_path / "g.json"
-        gpath.write_text(_json.dumps(group))
-
-        seen: dict[str, object] = {}
-
-        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
-        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
-        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
-        monkeypatch.setattr(
-            app_mod.pr_ops,
-            "merge_pr_group",
-            lambda **kw: seen.update(kw) or {"completed": []},
-        )
-
-        CliRunner().invoke(app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"])
-
-        assert seen.get("method") is MergeMethod.SQUASH, (
-            f"the CLI handed down {seen.get('method')!r}. The workspace configured "
-            f"'squash'; a constant, or an unwired `configured=None`, yields MERGE and is "
-            f"indistinguishable from a correct default."
-        )
-
-    def test_an_explicit_flag_still_overrides_the_workspace_at_the_CLI(
-        self, tmp_path, monkeypatch
-    ):
-        import json as _json
-
-        from typer.testing import CliRunner
-
-        from python_cli import app as app_mod
-
-        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
-        (tmp_path / ".grip" / "workspace_spec.toml").write_text(
-            '\nschema_version = 1\nworkspace_name = "w"\n\n'
-            '[workspace_constraints]\nmerge_method = "squash"\n'
-        )
-        group = {"pr_group_id": "pg", "owner_unit": "apollo", "lane_name": "lane", "prs": []}
-        gpath = tmp_path / "g.json"
-        gpath.write_text(_json.dumps(group))
-        seen: dict[str, object] = {}
-
-        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
-        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
-        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
-        monkeypatch.setattr(
-            app_mod.pr_ops,
-            "merge_pr_group",
-            lambda **kw: seen.update(kw) or {"completed": []},
-        )
-
-        CliRunner().invoke(
-            app_mod.app,
-            ["pr", "merge", str(tmp_path), "apollo", "lane", "--json", "--method", "rebase"],
-        )
-        assert seen.get("method") is MergeMethod.REBASE
+    assert flag in recorded[0]
+    assert recorded[1][-1] == "number,url,state,mergeCommit"

--- a/gr2/tests/test_pr_merge_method.py
+++ b/gr2/tests/test_pr_merge_method.py
@@ -189,3 +189,143 @@ class TestTheFlagActuallyReachesGh:
             f"decide -- which is guarantee 1's failure in its least visible form, because "
             f"there is no wrong line to point at, only an absent one."
         )
+
+
+class TestTheConfiguredWorkspaceMethodIsActuallyREACHED:
+    """The resolver being correct proves nothing if production never calls it.
+
+    Sentinel's r1 mutation: replace production method resolution with the constant
+    `MergeMethod.MERGE` and all 56 tests stay green -- because every caller passed
+    `configured=None`, so the workspace setting was never read and the default was the
+    only value the resolver could return. The resolver was correct and UNREACHED, which
+    is guarantee 3 again: pinning a function does not pin its invocation.
+
+    These tests fail if the constant is substituted, because they require a NON-default
+    method to arrive at the adapter by way of the workspace file.
+    """
+
+    def _workspace(self, tmp_path, method: str | None):
+        import json as _json
+
+        spec = '\nschema_version = 1\nworkspace_name = "w"\n\n[[repos]]\nname = "app"\npath = "repos/app"\nurl = "https://example.invalid/app.git"\n'
+        if method is not None:
+            spec += f'\n[workspace_constraints]\nmerge_method = "{method}"\n'
+        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".grip" / "workspace_spec.toml").write_text(spec)
+        return tmp_path
+
+    def test_the_workspace_setting_is_read_from_the_spec(self, tmp_path):
+        from python_cli.app import _configured_merge_method
+
+        assert _configured_merge_method(self._workspace(tmp_path, "squash")) == "squash"
+
+    def test_absent_setting_reads_as_None_not_as_a_default(self, tmp_path):
+        """`None` means the workspace said nothing, which the resolver turns into a merge
+        commit. Returning the string "merge" here would collapse 'unset' and 'chose
+        merge' into one value, and a later change of default would silently never reach
+        the workspaces that never expressed a preference."""
+        from python_cli.app import _configured_merge_method
+
+        assert _configured_merge_method(self._workspace(tmp_path, None)) is None
+
+    def test_a_configured_method_reaches_resolution(self, tmp_path):
+        """End of the wire: spec file -> helper -> resolver -> a NON-default method.
+
+        This is the assertion the constant-MERGE mutation cannot satisfy.
+        """
+        from python_cli.app import _configured_merge_method
+
+        configured = _configured_merge_method(self._workspace(tmp_path, "squash"))
+        assert resolve_merge_method(explicit=None, configured=configured) is MergeMethod.SQUASH
+
+    def test_explicit_still_beats_the_workspace_setting(self, tmp_path):
+        from python_cli.app import _configured_merge_method
+
+        configured = _configured_merge_method(self._workspace(tmp_path, "squash"))
+        assert resolve_merge_method(explicit="rebase", configured=configured) is MergeMethod.REBASE
+
+
+class TestTheCLICallSiteActuallyResolves:
+    """Pins the INVOCATION, not the resolver -- because the resolver was already correct.
+
+    The first version of the P1-TWO fix added tests for `_configured_merge_method` and
+    for `resolve_merge_method`, both passing, and Sentinel's mutation SURVIVED: replacing
+    the CLI's resolution with the constant `MergeMethod.MERGE` left all of them green,
+    because none of them traversed the call site. Guarantee 3, inside the fix for a
+    guarantee-3 finding, on the third occurrence of the same shape in one change.
+
+    The only assertion that can distinguish "resolved" from "constant" is one that
+    observes what the CLI HANDS DOWNSTREAM when the workspace asks for a NON-default
+    method.
+    """
+
+    def test_a_squash_workspace_makes_the_CLI_pass_SQUASH_downstream(
+        self, tmp_path, monkeypatch
+    ):
+        import json as _json
+
+        from typer.testing import CliRunner
+
+        from python_cli import app as app_mod
+
+        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".grip" / "workspace_spec.toml").write_text(
+            '\nschema_version = 1\nworkspace_name = "w"\n\n'
+            '[workspace_constraints]\nmerge_method = "squash"\n'
+        )
+        group = {"pr_group_id": "pg", "owner_unit": "apollo", "lane_name": "lane", "prs": []}
+        gpath = tmp_path / "g.json"
+        gpath.write_text(_json.dumps(group))
+
+        seen: dict[str, object] = {}
+
+        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
+        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
+        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
+        monkeypatch.setattr(
+            app_mod.pr_ops,
+            "merge_pr_group",
+            lambda **kw: seen.update(kw) or {"completed": []},
+        )
+
+        CliRunner().invoke(app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"])
+
+        assert seen.get("method") is MergeMethod.SQUASH, (
+            f"the CLI handed down {seen.get('method')!r}. The workspace configured "
+            f"'squash'; a constant, or an unwired `configured=None`, yields MERGE and is "
+            f"indistinguishable from a correct default."
+        )
+
+    def test_an_explicit_flag_still_overrides_the_workspace_at_the_CLI(
+        self, tmp_path, monkeypatch
+    ):
+        import json as _json
+
+        from typer.testing import CliRunner
+
+        from python_cli import app as app_mod
+
+        (tmp_path / ".grip").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".grip" / "workspace_spec.toml").write_text(
+            '\nschema_version = 1\nworkspace_name = "w"\n\n'
+            '[workspace_constraints]\nmerge_method = "squash"\n'
+        )
+        group = {"pr_group_id": "pg", "owner_unit": "apollo", "lane_name": "lane", "prs": []}
+        gpath = tmp_path / "g.json"
+        gpath.write_text(_json.dumps(group))
+        seen: dict[str, object] = {}
+
+        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
+        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
+        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
+        monkeypatch.setattr(
+            app_mod.pr_ops,
+            "merge_pr_group",
+            lambda **kw: seen.update(kw) or {"completed": []},
+        )
+
+        CliRunner().invoke(
+            app_mod.app,
+            ["pr", "merge", str(tmp_path), "apollo", "lane", "--json", "--method", "rebase"],
+        )
+        assert seen.get("method") is MergeMethod.REBASE

--- a/gr2/tests/test_pr_merge_method.py
+++ b/gr2/tests/test_pr_merge_method.py
@@ -1,0 +1,191 @@
+"""Merge-method contract for gr2, ported from gr1's seven-round hardening (grip#842).
+
+Written TDD-first: these must fail until `python_cli/pr.py` implements the contract.
+
+The defect being designed out: gr1's `gr pr merge` **actively chose squash**. It asked the
+host which methods were permitted and took the first of `squash > merge > rebase`,
+delegating a workspace-policy decision to a party with no knowledge of the workspace.
+
+gr2 today has the same class in a form that is harder to see, because there is no wrong
+line to point at -- there is only an absent one. `python_cli/platform.py` invokes
+`gh pr merge <n> --repo <r>` with **no strategy flag at all**, so the method is decided by
+gh and the host, wholesale.
+
+Guarantee 1 (grip#842): the host is asked *whether*, never *which*. Precedence is
+explicit `--method`, then workspace setting, then a merge commit. An unpermitted method is
+**refused, not substituted** -- silent substitution is the original defect in a politer
+form, where the operator asks for one strategy, another happens, and the only way to find
+out is counting parents afterwards.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from python_cli.pr import (  # noqa: E402
+    MergeMethod,
+    UnpermittedMergeMethodError,
+    resolve_merge_method,
+)
+
+
+class TestPrecedence:
+    """Explicit beats configured beats a merge commit. Nothing else participates."""
+
+    def test_explicit_wins_over_configured(self):
+        assert resolve_merge_method(explicit="rebase", configured="squash") is MergeMethod.REBASE
+
+    def test_configured_used_when_no_explicit(self):
+        assert resolve_merge_method(explicit=None, configured="squash") is MergeMethod.SQUASH
+
+    def test_default_is_a_merge_commit(self):
+        """The only method that preserves both parents is the one you get by saying nothing.
+
+        This is the assertion that would have caught gr1's defect directly: there, saying
+        nothing produced a squash.
+        """
+        assert resolve_merge_method(explicit=None, configured=None) is MergeMethod.MERGE
+
+    @pytest.mark.parametrize("bad", ["", "  ", "Squash", "fast-forward", "merge-commit", "none"])
+    def test_an_unrecognised_name_is_an_error_not_a_fallback(self, bad):
+        """Falling back to the default on a name we do not recognise is silent substitution.
+
+        The operator typed something. Guessing what they meant, or quietly ignoring it, is
+        the same failure as letting the host choose -- a strategy happens that nobody asked
+        for. Note `Squash` is in this list deliberately: near-misses are the realistic
+        input, and case-insensitive acceptance is a decision, not a courtesy.
+        """
+        with pytest.raises(ValueError):
+            resolve_merge_method(explicit=bad, configured=None)
+
+    def test_an_unrecognised_CONFIGURED_name_is_also_an_error(self):
+        """A bad value in the workspace file is not more trustworthy than a bad flag.
+
+        It is less visible, which makes silent fallback worse here, not better: nobody is
+        watching a config file at the moment of a merge.
+        """
+        with pytest.raises(ValueError):
+            resolve_merge_method(explicit=None, configured="sqush")
+
+
+class TestRefuseNeverSubstitute:
+    """The paired control. Neither test means anything without the other.
+
+    A guard that refuses everything passes the refusal test while breaking all merging;
+    a guard that refuses nothing passes the permitted test while restoring the defect.
+    Only the pair pins the behaviour, and each names what the other proves.
+    """
+
+    def test_a_permitted_method_is_used_verbatim(self):
+        """POSITIVE CONTROL. Proves the guard is not simply refusing everything."""
+        chosen = resolve_merge_method(
+            explicit="squash", configured=None, permitted=["merge", "squash"]
+        )
+        assert chosen is MergeMethod.SQUASH
+
+    def test_an_unpermitted_method_is_REFUSED(self):
+        """NEGATIVE CONTROL. Proves the guard is not simply permitting everything."""
+        with pytest.raises(UnpermittedMergeMethodError):
+            resolve_merge_method(explicit="squash", configured=None, permitted=["merge"])
+
+    def test_refusal_does_not_fall_back_to_a_permitted_method(self):
+        """The whole guarantee, stated as the thing that must NOT happen.
+
+        gr1's defect was not that it chose badly. It was that it chose AT ALL, then
+        reported success, so the operator's request and the actual outcome differed with
+        nothing in the output saying so. Raising is the only outcome that cannot be
+        mistaken for the request having been honoured.
+        """
+        with pytest.raises(UnpermittedMergeMethodError) as excinfo:
+            resolve_merge_method(explicit="rebase", configured=None, permitted=["merge", "squash"])
+
+        # The error must name what was ASKED FOR, not merely what is allowed -- an operator
+        # reading it needs to see their own request refused, not a list of alternatives
+        # that reads like a suggestion to pick one.
+        assert "rebase" in str(excinfo.value)
+
+    def test_permitted_None_means_unchecked_not_unrestricted(self):
+        """`permitted=None` is 'we did not ask the host', which must not read as 'anything goes'.
+
+        This is guarantee 4 in miniature: unverifiable must be distinguishable from
+        verified. Here the distinction is that no refusal is claimed either way -- the
+        method resolves, and nothing asserts it was permitted.
+        """
+        assert resolve_merge_method(explicit="rebase", configured=None, permitted=None) is (
+            MergeMethod.REBASE
+        )
+
+
+class TestTheFlagActuallyReachesGh:
+    """Resolving a method proves nothing if the resolved value is never passed on.
+
+    gr1's lesson, stated as guarantee 3: pinning a function does not pin its invocation.
+    A correct `resolve_merge_method` with a caller that still shells out to a bare
+    `gh pr merge` is exactly the defect we started with, and every test above would pass.
+    """
+
+    def test_the_resolved_method_appears_in_the_gh_argv(self, monkeypatch):
+        """Asserts the argv gh actually receives -- behaviour, not internal structure.
+
+        Monkeypatching `subprocess.run` rather than subclassing keeps the test from
+        prescribing how the adapter is built, so a later refactor cannot make it
+        vacuously green by moving the call somewhere the subclass no longer intercepts.
+        """
+        from python_cli import platform as platform_mod
+
+        recorded: list[list[str]] = []
+
+        class _Proc:
+            returncode = 0
+            stdout = "{}"
+            stderr = ""
+
+        def _fake_run(argv, *a, **kw):
+            recorded.append(list(argv))
+            return _Proc()
+
+        monkeypatch.setattr(platform_mod.subprocess, "run", _fake_run)
+        platform_mod.GitHubAdapter().merge_pr("owner/repo", 42, method=MergeMethod.SQUASH)
+
+        assert recorded, "the adapter never invoked gh at all"
+        argv = recorded[0]
+        assert "--squash" in argv, (
+            f"the resolved method never reached gh; argv was {argv}. A method decided and "
+            f"then dropped is indistinguishable from one never decided."
+        )
+
+    def test_no_method_still_names_one_explicitly(self, monkeypatch):
+        """The absent flag IS the defect, so the default must be a POSITIVE assertion.
+
+        A test that only checks `--squash` when squash is asked for would stay green
+        against today's code path for every other case -- and today's code path passes no
+        flag at all, which is how the host ends up choosing.
+        """
+        from python_cli import platform as platform_mod
+
+        recorded: list[list[str]] = []
+
+        class _Proc:
+            returncode = 0
+            stdout = "{}"
+            stderr = ""
+
+        monkeypatch.setattr(
+            platform_mod.subprocess,
+            "run",
+            lambda argv, *a, **kw: (recorded.append(list(argv)), _Proc())[1],
+        )
+        platform_mod.GitHubAdapter().merge_pr(
+            "owner/repo", 42, method=resolve_merge_method(explicit=None, configured=None)
+        )
+
+        argv = recorded[0]
+        assert "--merge" in argv, (
+            f"no strategy flag reached gh; argv was {argv}. With no flag, gh and the host "
+            f"decide -- which is guarantee 1's failure in its least visible form, because "
+            f"there is no wrong line to point at, only an absent one."
+        )

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -19,8 +19,9 @@ rather than the same chance twice:
 
   - `PRMergeError` carries the completed list. In-process, structural; its failure mode is
     a raised exception. **This is what a retry must read.**
-  - The event stays best-effort and durable. `emit` swallows every exception and returns
-    `None` (see grip#843), so correctness must not rest on it.
+  - The event stays best-effort and durable. As of grip#843 `emit` RAISES rather than
+    swallowing, which is why the wrap below is load-bearing: a failure in the durable
+    layer must not replace the real error. See grip#844 for the wider call-site class.
 """
 from __future__ import annotations
 
@@ -199,8 +200,9 @@ class TestTheTwoLayersAreIndependent:
     """Depth is only depth if the layers fail by different routes.
 
     A durable record that the in-process path depends on is the same chance twice. These
-    tests exist because `emit` swallows every exception (grip#843): if correctness rested
-    on it, G9 would be satisfied by a mechanism that can silently do nothing.
+    tests exist because the durable layer is not trustworthy in either regime: before
+    grip#843 `emit` swallowed everything and could silently do nothing; after it, `emit`
+    raises and can take the caller down with it. Both are reasons not to rest on it.
     """
 
     def test_a_durable_event_records_the_partial_merge(self, tmp_path):
@@ -258,3 +260,84 @@ class TestTheTwoLayersAreIndependent:
             "a failure in the best-effort layer must not erase the reliable one, and "
             "must not replace PRMergeError with the event layer's own exception"
         )
+
+
+class TestTheCLIConsumesTheListRatherThanRebuildingIt:
+    """The survivor relocated one layer out, to the next consumer.
+
+    `merge_pr_group` carries the completed list correctly. The CLI above it was computing
+    `merged` as DECLARED-MINUS-FAILED:
+
+        [repo for repo in group["prs"] if repo != exc.repo]
+
+    With prs = [app, api, web] and api failing, that yields **[app, web]** -- and the loop
+    stopped at api, so web was never called. A repo that was never touched is persisted as
+    merged, a retry skips a PR that is still open, and the operator reads a merge that did
+    not happen.
+
+    Physics 005: a defect does not die when fixed, it moves one layer outward. The list
+    existed and was correct; nothing consumed it.
+    """
+
+    def _invoke(self, tmp_path, monkeypatch, declared, completed, failing):
+        from typer.testing import CliRunner
+
+        from python_cli import app as app_mod
+
+        group = {
+            "pr_group_id": "pg_x",
+            "owner_unit": "apollo",
+            "lane_name": "lane",
+            "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(declared)],
+        }
+        gpath = tmp_path / "group.json"
+        gpath.write_text(json.dumps(group))
+
+        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
+        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
+        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
+
+        def _boom(**kwargs):
+            raise PRMergeError(
+                failing,
+                2,
+                "simulated",
+                completed=[{"repo": r, "pr_number": i + 1, "url": None} for i, r in enumerate(completed)],
+            )
+
+        monkeypatch.setattr(app_mod.pr_ops, "merge_pr_group", _boom)
+        res = CliRunner().invoke(
+            app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"]
+        )
+        return json.loads(res.stdout), json.loads(gpath.read_text())
+
+    def test_a_repo_the_loop_never_reached_is_NOT_recorded_as_merged(
+        self, tmp_path, monkeypatch
+    ):
+        payload, persisted = self._invoke(
+            tmp_path,
+            monkeypatch,
+            declared=["app", "api", "web"],
+            completed=["app"],
+            failing="api",
+        )
+
+        assert payload["merged"] == ["app"], (
+            f"got {payload['merged']}. 'web' is declared in the group and was never "
+            f"called -- the loop stopped at 'api'. Declared-minus-failed cannot tell "
+            f"'not reached' from 'succeeded'."
+        )
+        assert "web" not in persisted.get("merged", []), (
+            "the FALSE record was persisted to disk, which is the part a retry reads"
+        )
+
+    def test_the_persisted_state_matches_what_actually_merged(self, tmp_path, monkeypatch):
+        payload, persisted = self._invoke(
+            tmp_path,
+            monkeypatch,
+            declared=["app", "api", "web", "docs"],
+            completed=["app"],
+            failing="api",
+        )
+        assert persisted["merged"] == ["app"]
+        assert persisted["group_state"] == "partially_merged"

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -53,7 +53,12 @@ class _FailAfter:
         if repo == self.fail_on:
             raise AdapterError(f"simulated host refusal for {repo}")
         self.merged.append(repo)
-        return PRRef(repo=repo, number=number)
+        # `url` is ADAPTER-AUTHORED and appears nowhere in the group file, which is what
+        # makes provenance observable. Without it, a completed list rebuilt from
+        # `group["prs"]` and one carried back from the adapter are byte-identical, and
+        # every assertion passes over either -- the values agree by coincidence because
+        # the loop visits repos in group order.
+        return PRRef(repo=repo, number=number, url=f"observed://{repo}/{number}")
 
 
 def _group(workspace: Path, repos: list[str]) -> str:
@@ -140,10 +145,19 @@ class TestTheErrorCarriesWhatActuallyMerged:
     def test_the_completed_list_matches_the_ADAPTER_not_the_group(self, tmp_path):
         """Evidence, not a token.
 
-        Reconstructing the list from the group's own `prs` would produce a plausible
-        value that is right by construction and could never be wrong -- the same shape as
-        `PRRef(repo=repo, number=number)` returning its own inputs. The assertion is
-        against what the adapter observed, which a shortcut cannot fabricate.
+        Reconstructing the list from the group's own `prs` produces a plausible value that
+        is right by construction and could never be wrong -- the same shape as
+        `PRRef(repo=repo, number=number)` returning its own inputs.
+
+        The first version of this test asserted only on `repo`, and it PASSED against a
+        loop that appended `pr_info` straight from the group file. Both provenances
+        produce the same repo names in the same order, because the loop visits repos in
+        group order. **A value that agrees with the truth by coincidence passes every
+        assertion the real one would**, and the test carried this name while proving
+        nothing of the kind.
+
+        So the assertion moved onto a field only the ADAPTER authors. `url` appears
+        nowhere in the group file; a shortcut cannot fabricate it.
         """
         gid = _group(tmp_path, ["app", "api", "web"])
         adapter = _FailAfter(fail_on="api")
@@ -157,7 +171,14 @@ class TestTheErrorCarriesWhatActuallyMerged:
                 method=MergeMethod.MERGE,
             )
 
-        assert [c["repo"] for c in excinfo.value.completed] == adapter.merged == ["app"]
+        completed = excinfo.value.completed
+        assert [c["repo"] for c in completed] == adapter.merged == ["app"]
+        assert [c.get("url") for c in completed] == ["observed://app/1"], (
+            "the completed list was rebuilt from the group file rather than carried back "
+            "from the adapter. It happens to name the right repos, and it is not evidence "
+            "that anything merged -- the same list is produced by a loop that never "
+            "consulted the host at all."
+        )
 
     def test_failure_on_the_FIRST_repo_reports_an_empty_list_not_a_missing_one(self, tmp_path):
         gid = _group(tmp_path, ["app", "api"])

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -302,7 +302,10 @@ class TestTheCLIConsumesTheListRatherThanRebuildingIt:
                 failing,
                 2,
                 "simulated",
-                completed=[{"repo": r, "pr_number": i + 1, "url": None} for i, r in enumerate(completed)],
+                completed=[
+                    {"repo": r, "pr_number": i + 1, "url": f"observed://{r}/{i + 1}"}
+                    for i, r in enumerate(completed)
+                ],
             )
 
         monkeypatch.setattr(app_mod.pr_ops, "merge_pr_group", _boom)
@@ -330,6 +333,13 @@ class TestTheCLIConsumesTheListRatherThanRebuildingIt:
         assert "web" not in persisted.get("merged", []), (
             "the FALSE record was persisted to disk, which is the part a retry reads"
         )
+        # Provenance on the ERROR path too. Membership alone leaves this substitutable:
+        # `group["prs"]` minus nothing still contains 'app', so an assertion on names
+        # passes over either source. The url is adapter-authored and cannot be rebuilt.
+        assert [r.get("url") for r in payload["merged_receipts"]] == ["observed://app/1"], (
+            f'got {payload["merged_receipts"]}. Rebuilt from the group file, these carry '
+            f"no url -- the same coincidence that hid this on the success path."
+        )
 
     def test_the_persisted_state_matches_what_actually_merged(self, tmp_path, monkeypatch):
         payload, persisted = self._invoke(
@@ -341,3 +351,75 @@ class TestTheCLIConsumesTheListRatherThanRebuildingIt:
         )
         assert persisted["merged"] == ["app"]
         assert persisted["group_state"] == "partially_merged"
+
+
+class TestTheSUCCESSPathCarriesProvenanceToo:
+    """The third layer this one claim had to be pinned at: loop, error path, success path.
+
+    Each time the coincidence was the same: **the two sources agree except when it
+    matters.** On the success path `completed` and the group's declared `prs` hold the
+    same repos in the same order, so replacing one with the other leaves every
+    membership assertion green -- and every partial-failure test pins only the error
+    path, leaving the happy path free to re-derive.
+
+    Membership coincides on success. Provenance does not. So the success assertion has
+    to be on a field only the adapter can author, exactly as inside `merge_pr_group`.
+    """
+
+    def _run(self, tmp_path, monkeypatch, repos):
+        from typer.testing import CliRunner
+
+        from python_cli import app as app_mod
+
+        group = {
+            "pr_group_id": "pg_ok",
+            "owner_unit": "apollo",
+            "lane_name": "lane",
+            "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(repos)],
+        }
+        gpath = tmp_path / "group.json"
+        gpath.write_text(json.dumps(group))
+
+        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
+        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
+        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
+        monkeypatch.setattr(
+            app_mod.pr_ops,
+            "merge_pr_group",
+            lambda **kw: {
+                **group,
+                "completed": [
+                    {"repo": r, "pr_number": i + 1, "url": f"observed://{r}/{i + 1}"}
+                    for i, r in enumerate(repos)
+                ],
+            },
+        )
+        res = CliRunner().invoke(
+            app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"]
+        )
+        return json.loads(res.stdout)
+
+    def test_success_output_carries_the_ADAPTER_AUTHORED_field(self, tmp_path, monkeypatch):
+        payload = self._run(tmp_path, monkeypatch, ["app", "api"])
+
+        urls = [r.get("url") for r in payload["merged_receipts"]]
+        assert urls == ["observed://app/1", "observed://api/2"], (
+            f"got {urls}. The group file has no `url`, so a payload rebuilt from "
+            f"`group['prs']` cannot produce these. Asserting membership here proves "
+            f"nothing: on success, completed and declared are the same list."
+        )
+
+    def test_membership_alone_would_NOT_have_caught_it(self, tmp_path, monkeypatch):
+        """Documents why the assertion above is on `url` and not on repo names.
+
+        This asserts the coincidence itself: the names ARE identical to the group's, so
+        any test pinned to them is satisfied by either source. Kept as an explicit
+        record so a later reader does not 'simplify' the test above back to a
+        membership check.
+        """
+        payload = self._run(tmp_path, monkeypatch, ["app", "api"])
+        declared = ["app", "api"]
+        assert payload["merged"] == declared, (
+            "if this ever differs, the coincidence has broken and the reasoning above "
+            "needs revisiting"
+        )

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -1,0 +1,239 @@
+"""G9: the durable record must survive the failure that produced it (grip#842).
+
+The eight guarantees ported from gr1 all ask *is the claim true*. This one asks *does the
+record survive the failure*, and it is a different axis. gr1 printed to a terminal; gr2
+**emits events other programs read**, so a wrong guard misleads a reviewer while a wrong
+event misleads a program.
+
+The defect: `merge_pr_group` loops over PRs, merges repo A, fails on repo B, and raises.
+`emit(PR_MERGED)` sits *after* the loop, so it never fires. The `merged` list is discarded
+by the raise, and the error carried only the *failing* repo. **A is merged on the host and
+nothing anywhere records it.** A caller cannot learn what already happened, and a retry
+re-attempts A.
+
+    Irreversible work that is not recorded is worse than work not done,
+    because the next actor plans against a state that is false.
+
+The fix is two layers that fail by DIFFERENT ROUTES, which is what makes them independent
+rather than the same chance twice:
+
+  - `PRMergeError` carries the completed list. In-process, structural; its failure mode is
+    a raised exception. **This is what a retry must read.**
+  - The event stays best-effort and durable. `emit` swallows every exception and returns
+    `None` (see grip#843), so correctness must not rest on it.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from python_cli.platform import AdapterError, PRRef  # noqa: E402
+from python_cli.pr import (  # noqa: E402
+    MergeMethod,
+    PRMergeError,
+    merge_pr_group,
+)
+
+
+class _FailAfter:
+    """Merges successfully until `fail_on`, then raises -- the partial-failure case."""
+
+    name = "github"
+
+    def __init__(self, fail_on: str) -> None:
+        self.fail_on = fail_on
+        self.merged: list[str] = []
+
+    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef:
+        if repo == self.fail_on:
+            raise AdapterError(f"simulated host refusal for {repo}")
+        self.merged.append(repo)
+        return PRRef(repo=repo, number=number)
+
+
+def _group(workspace: Path, repos: list[str]) -> str:
+    gid = "pg_test"
+    d = workspace / ".grip" / "pr_groups"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{gid}.json").write_text(
+        json.dumps(
+            {
+                "pr_group_id": gid,
+                "owner_unit": "apollo",
+                "lane_name": "lane",
+                "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(repos)],
+            }
+        )
+    )
+    return gid
+
+
+class TestTheErrorTypeMakesOmissionImpossible:
+    """The completed list is a required constructor argument, with no default.
+
+    An optional field will be omitted at exactly one call site within a year, and G9
+    becomes a convention again. A required argument is not a reminder to think -- it is a
+    refusal to construct. The type is the guarantee.
+    """
+
+    def test_completed_has_NO_DEFAULT_in_the_signature(self):
+        """Asserts the signature, not a symptom -- caught by mutation, not by review.
+
+        The first version of this test was `pytest.raises(TypeError)` on a call with the
+        argument omitted. It survived the mutation that gives `completed` a default of
+        `None`, because `list(None)` raises `TypeError` too. **The test passed for a
+        different reason than the one it claimed**, and a green suite sat over exactly the
+        defect it existed to prevent.
+
+        A raised type is a symptom several mechanisms produce. The parameter having no
+        default is the property itself, and nothing but the real thing satisfies it.
+        """
+        import inspect
+
+        param = inspect.signature(PRMergeError.__init__).parameters["completed"]
+        assert param.default is inspect.Parameter.empty, (
+            f"`completed` has default {param.default!r}. A default makes G9 a convention: "
+            f"one call site omits it, and the partial-merge record silently becomes empty "
+            f"rather than absent -- which reads as 'nothing had merged'."
+        )
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY, (
+            "`completed` must be keyword-only so it cannot be supplied positionally by "
+            "accident, nor silently absorbed by a future signature change"
+        )
+
+    def test_an_EMPTY_completed_list_must_still_be_passed_explicitly(self):
+        """Empty is a fact about the world, not an absence of information.
+
+        "Nothing had merged when this failed" and "nobody recorded what merged" are
+        different claims, and a default of `[]` would make them identical -- the same
+        collapse as a guard reporting verified when it could not check.
+        """
+        err = PRMergeError("app", 1, "boom", completed=[])
+        assert err.completed == []
+
+
+class TestTheErrorCarriesWhatActuallyMerged:
+    def test_partial_failure_reports_the_repos_that_DID_merge(self, tmp_path):
+        gid = _group(tmp_path, ["app", "api", "web"])
+        adapter = _FailAfter(fail_on="web")
+
+        with pytest.raises(PRMergeError) as excinfo:
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=adapter,
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        completed = [c["repo"] for c in excinfo.value.completed]
+        assert completed == ["app", "api"], (
+            "the error must name the irreversible work that already happened; a retry "
+            "reading only the failing repo will merge app and api a second time"
+        )
+
+    def test_the_completed_list_matches_the_ADAPTER_not_the_group(self, tmp_path):
+        """Evidence, not a token.
+
+        Reconstructing the list from the group's own `prs` would produce a plausible
+        value that is right by construction and could never be wrong -- the same shape as
+        `PRRef(repo=repo, number=number)` returning its own inputs. The assertion is
+        against what the adapter observed, which a shortcut cannot fabricate.
+        """
+        gid = _group(tmp_path, ["app", "api", "web"])
+        adapter = _FailAfter(fail_on="api")
+
+        with pytest.raises(PRMergeError) as excinfo:
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=adapter,
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        assert [c["repo"] for c in excinfo.value.completed] == adapter.merged == ["app"]
+
+    def test_failure_on_the_FIRST_repo_reports_an_empty_list_not_a_missing_one(self, tmp_path):
+        gid = _group(tmp_path, ["app", "api"])
+
+        with pytest.raises(PRMergeError) as excinfo:
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=_FailAfter(fail_on="app"),
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        assert excinfo.value.completed == []
+
+
+class TestTheTwoLayersAreIndependent:
+    """Depth is only depth if the layers fail by different routes.
+
+    A durable record that the in-process path depends on is the same chance twice. These
+    tests exist because `emit` swallows every exception (grip#843): if correctness rested
+    on it, G9 would be satisfied by a mechanism that can silently do nothing.
+    """
+
+    def test_a_durable_event_records_the_partial_merge(self, tmp_path):
+        gid = _group(tmp_path, ["app", "api", "web"])
+
+        with pytest.raises(PRMergeError):
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=_FailAfter(fail_on="web"),
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        events = [
+            json.loads(line)
+            for f in tmp_path.rglob("*.jsonl")
+            for line in f.read_text().splitlines()
+            if line.strip()
+        ]
+        merged_records = [e for e in events if e.get("completed") or e.get("repos")]
+        assert merged_records, (
+            f"no event recorded the completed merges; events were "
+            f"{[e.get('type') for e in events]}. The host state changed and the durable "
+            f"log does not say so."
+        )
+
+    def test_the_exception_still_carries_the_list_when_EMIT_ITSELF_FAILS(
+        self, tmp_path, monkeypatch
+    ):
+        """The independence claim, stated as the thing that must survive.
+
+        If a broken event layer can take the in-process layer down with it, they were
+        never two layers. Note this cannot happen today only because `emit` swallows
+        everything -- which is exactly why it must not be the thing correctness rests on.
+        """
+        from python_cli import pr as pr_mod
+
+        def _exploding_emit(**kwargs):
+            raise RuntimeError("event subsystem is down")
+
+        monkeypatch.setattr(pr_mod, "emit", _exploding_emit)
+        gid = _group(tmp_path, ["app", "api", "web"])
+
+        with pytest.raises(PRMergeError) as excinfo:
+            merge_pr_group(
+                workspace_root=tmp_path,
+                pr_group_id=gid,
+                adapter=_FailAfter(fail_on="web"),
+                actor="agent:apollo",
+                method=MergeMethod.MERGE,
+            )
+
+        assert [c["repo"] for c in excinfo.value.completed] == ["app", "api"], (
+            "a failure in the best-effort layer must not erase the reliable one, and "
+            "must not replace PRMergeError with the event layer's own exception"
+        )

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -1,460 +1,214 @@
-"""G9: the durable record must survive the failure that produced it (grip#842).
-
-The eight guarantees ported from gr1 all ask *is the claim true*. This one asks *does the
-record survive the failure*, and it is a different axis. gr1 printed to a terminal; gr2
-**emits events other programs read**, so a wrong guard misleads a reviewer while a wrong
-event misleads a program.
-
-The defect: `merge_pr_group` loops over PRs, merges repo A, fails on repo B, and raises.
-`emit(PR_MERGED)` sits *after* the loop, so it never fires. The `merged` list is discarded
-by the raise, and the error carried only the *failing* repo. **A is merged on the host and
-nothing anywhere records it.** A caller cannot learn what already happened, and a retry
-re-attempts A.
-
-    Irreversible work that is not recorded is worse than work not done,
-    because the next actor plans against a state that is false.
-
-The fix is two layers that fail by DIFFERENT ROUTES, which is what makes them independent
-rather than the same chance twice:
-
-  - `PRMergeError` carries the completed list. In-process, structural; its failure mode is
-    a raised exception. **This is what a retry must read.**
-  - The event stays best-effort and durable. As of grip#843 `emit` RAISES rather than
-    swallowing, which is why the wrap below is load-bearing: a failure in the durable
-    layer must not replace the real error. See grip#844 for the wider call-site class.
-"""
 from __future__ import annotations
 
+import inspect
 import json
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
-from python_cli.platform import AdapterError, PRRef  # noqa: E402
-from python_cli.pr import (  # noqa: E402
+from gr2.python_cli.merge_verification import CompletedMerge, MergeVerificationTarget
+from gr2.python_cli.platform import (
+    AdapterError,
+    MergeEvidenceError,
     MergeMethod,
+    MergeReceipt,
+    PRRef,
+)
+from gr2.python_cli.pr import (
     PRMergeError,
+    PRMergeOutcomeUnknownError,
+    PRMergePostconditionError,
     merge_pr_group,
 )
 
 
 class _FailAfter:
-    """Merges successfully until `fail_on`, then raises -- the partial-failure case."""
-
     name = "github"
 
-    def __init__(self, fail_on: str) -> None:
+    def __init__(self, fail_on: str | None = None, unknown_on: str | None = None) -> None:
         self.fail_on = fail_on
-        self.merged: list[str] = []
+        self.unknown_on = unknown_on
+        self.calls: list[str] = []
 
-    def merge_pr(self, repo: str, number: int, *, method: MergeMethod) -> PRRef:
+    def merge_pr(
+        self,
+        repo: str,
+        number: int,
+        *,
+        method: MergeMethod,
+    ) -> MergeReceipt:
+        self.calls.append(repo)
         if repo == self.fail_on:
             raise AdapterError(f"simulated host refusal for {repo}")
-        self.merged.append(repo)
-        # `url` is ADAPTER-AUTHORED and appears nowhere in the group file, which is what
-        # makes provenance observable. Without it, a completed list rebuilt from
-        # `group["prs"]` and one carried back from the adapter are byte-identical, and
-        # every assertion passes over either -- the values agree by coincidence because
-        # the loop visits repos in group order.
-        return PRRef(repo=repo, number=number, url=f"observed://{repo}/{number}")
+        if repo == self.unknown_on:
+            raise MergeEvidenceError(
+                requested=PRRef(repo=repo, number=number),
+                requested_method=method,
+                reason="receipt lookup unavailable",
+            )
+        return MergeReceipt(
+            requested=PRRef(repo=repo, number=number),
+            observed=PRRef(
+                repo=repo,
+                number=number,
+                url=f"observed://{repo}/{number}",
+            ),
+            commit_sha=None,
+            requested_method=method,
+        )
 
 
 def _group(workspace: Path, repos: list[str]) -> str:
-    gid = "pg_test"
-    d = workspace / ".grip" / "pr_groups"
-    d.mkdir(parents=True, exist_ok=True)
-    (d / f"{gid}.json").write_text(
+    group_id = "pg_test"
+    state_dir = workspace / ".grip" / "pr_groups"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / f"{group_id}.json").write_text(
         json.dumps(
             {
-                "pr_group_id": gid,
-                "owner_unit": "apollo",
-                "lane_name": "lane",
-                "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(repos)],
+                "pr_group_id": group_id,
+                "owner_unit": "test-unit",
+                "lane_name": "test-lane",
+                "prs": [
+                    {"repo": repo, "pr_number": index + 1}
+                    for index, repo in enumerate(repos)
+                ],
             }
         )
     )
-    return gid
+    return group_id
 
 
-class TestTheErrorTypeMakesOmissionImpossible:
-    """The completed list is a required constructor argument, with no default.
-
-    An optional field will be omitted at exactly one call site within a year, and G9
-    becomes a convention again. A required argument is not a reminder to think -- it is a
-    refusal to construct. The type is the guarantee.
-    """
-
-    def test_completed_has_NO_DEFAULT_in_the_signature(self):
-        """Asserts the signature, not a symptom -- caught by mutation, not by review.
-
-        The first version of this test was `pytest.raises(TypeError)` on a call with the
-        argument omitted. It survived the mutation that gives `completed` a default of
-        `None`, because `list(None)` raises `TypeError` too. **The test passed for a
-        different reason than the one it claimed**, and a green suite sat over exactly the
-        defect it existed to prevent.
-
-        A raised type is a symptom several mechanisms produce. The parameter having no
-        default is the property itself, and nothing but the real thing satisfies it.
-        """
-        import inspect
-
-        param = inspect.signature(PRMergeError.__init__).parameters["completed"]
-        assert param.default is inspect.Parameter.empty, (
-            f"`completed` has default {param.default!r}. A default makes G9 a convention: "
-            f"one call site omits it, and the partial-merge record silently becomes empty "
-            f"rather than absent -- which reads as 'nothing had merged'."
+def _targets(workspace: Path, repos: list[str]) -> dict[str, MergeVerificationTarget]:
+    return {
+        repo: MergeVerificationTarget(
+            repo_root=workspace / "repos" / repo,
+            remote=f"https://example.test/{repo}.git",
         )
-        assert param.kind is inspect.Parameter.KEYWORD_ONLY, (
-            "`completed` must be keyword-only so it cannot be supplied positionally by "
-            "accident, nor silently absorbed by a future signature change"
-        )
-
-    def test_an_EMPTY_completed_list_must_still_be_passed_explicitly(self):
-        """Empty is a fact about the world, not an absence of information.
-
-        "Nothing had merged when this failed" and "nobody recorded what merged" are
-        different claims, and a default of `[]` would make them identical -- the same
-        collapse as a guard reporting verified when it could not check.
-        """
-        err = PRMergeError("app", 1, "boom", completed=[])
-        assert err.completed == []
+        for repo in repos
+    }
 
 
-class TestTheErrorCarriesWhatActuallyMerged:
-    def test_partial_failure_reports_the_repos_that_DID_merge(self, tmp_path):
-        gid = _group(tmp_path, ["app", "api", "web"])
-        adapter = _FailAfter(fail_on="web")
+def _merge(
+    workspace: Path,
+    repos: list[str],
+    adapter: _FailAfter,
+) -> dict:
+    return merge_pr_group(
+        workspace_root=workspace,
+        pr_group_id=_group(workspace, repos),
+        adapter=adapter,
+        actor="agent:test",
+        method=MergeMethod.MERGE,
+        verification_targets=_targets(workspace, repos),
+        report=lambda _message: None,
+    )
 
-        with pytest.raises(PRMergeError) as excinfo:
-            merge_pr_group(
-                workspace_root=tmp_path,
-                pr_group_id=gid,
-                adapter=adapter,
-                actor="agent:apollo",
-                method=MergeMethod.MERGE,
-            )
 
-        completed = [c["repo"] for c in excinfo.value.completed]
-        assert completed == ["app", "api"], (
-            "the error must name the irreversible work that already happened; a retry "
-            "reading only the failing repo will merge app and api a second time"
-        )
+def test_completed_is_required_and_keyword_only() -> None:
+    parameter = inspect.signature(PRMergeError.__init__).parameters["completed"]
+    assert parameter.default is inspect.Parameter.empty
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
 
-    def test_the_completed_list_matches_the_ADAPTER_not_the_group(self, tmp_path):
-        """Evidence, not a token.
 
-        Reconstructing the list from the group's own `prs` produces a plausible value that
-        is right by construction and could never be wrong -- the same shape as
-        `PRRef(repo=repo, number=number)` returning its own inputs.
+def test_an_empty_completed_list_is_explicit_evidence_not_missing_evidence() -> None:
+    error = PRMergeError("app", 1, "boom", completed=[])
 
-        The first version of this test asserted only on `repo`, and it PASSED against a
-        loop that appended `pr_info` straight from the group file. Both provenances
-        produce the same repo names in the same order, because the loop visits repos in
-        group order. **A value that agrees with the truth by coincidence passes every
-        assertion the real one would**, and the test carried this name while proving
-        nothing of the kind.
+    assert error.completed == []
 
-        So the assertion moved onto a field only the ADAPTER authors. `url` appears
-        nowhere in the group file; a shortcut cannot fabricate it.
-        """
-        gid = _group(tmp_path, ["app", "api", "web"])
-        adapter = _FailAfter(fail_on="api")
 
-        with pytest.raises(PRMergeError) as excinfo:
-            merge_pr_group(
-                workspace_root=tmp_path,
-                pr_group_id=gid,
-                adapter=adapter,
-                actor="agent:apollo",
-                method=MergeMethod.MERGE,
-            )
+def test_partial_failure_carries_adapter_authored_completed_records(tmp_path: Path) -> None:
+    with pytest.raises(PRMergeError) as raised:
+        _merge(tmp_path, ["app", "api"], _FailAfter(fail_on="api"))
 
-        completed = excinfo.value.completed
-        assert [c["repo"] for c in completed] == adapter.merged == ["app"]
-        assert [c.get("url") for c in completed] == ["observed://app/1"], (
-            "the completed list was rebuilt from the group file rather than carried back "
-            "from the adapter. It happens to name the right repos, and it is not evidence "
-            "that anything merged -- the same list is produced by a loop that never "
-            "consulted the host at all."
+    assert raised.value.operation_acknowledged is False
+    assert all(isinstance(item, CompletedMerge) for item in raised.value.completed)
+    assert [item.receipt.observed.repo for item in raised.value.completed] == ["app"]
+    assert [item.receipt.observed.url for item in raised.value.completed] == [
+        "observed://app/1"
+    ]
+    assert raised.value.completed[0].parent_verdict.kind.value == "unverifiable"
+
+
+def test_failure_on_first_repo_carries_an_explicit_empty_completed_list(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(PRMergeError) as raised:
+        _merge(tmp_path, ["app", "api"], _FailAfter(fail_on="app"))
+
+    assert raised.value.completed == []
+
+
+def test_receipt_failure_is_outcome_unknown_and_must_not_be_retried(tmp_path: Path) -> None:
+    with pytest.raises(PRMergeOutcomeUnknownError) as raised:
+        _merge(tmp_path, ["app", "api"], _FailAfter(unknown_on="api"))
+
+    assert raised.value.operation_acknowledged is True
+    assert [item.receipt.observed.repo for item in raised.value.completed] == ["app"]
+    assert "do not retry" in str(raised.value)
+
+
+def test_postcondition_failure_preserves_the_acknowledged_receipt(
+    tmp_path: Path,
+) -> None:
+    adapter = _FailAfter()
+
+    with pytest.raises(PRMergePostconditionError) as raised:
+        merge_pr_group(
+            workspace_root=tmp_path,
+            pr_group_id=_group(tmp_path, ["app"]),
+            adapter=adapter,
+            actor="agent:test",
+            method=MergeMethod.MERGE,
+            verification_targets=_targets(tmp_path, ["app"]),
+            report=lambda _message: (_ for _ in ()).throw(
+                RuntimeError("report sink unavailable")
+            ),
         )
 
-    def test_failure_on_the_FIRST_repo_reports_an_empty_list_not_a_missing_one(self, tmp_path):
-        gid = _group(tmp_path, ["app", "api"])
-
-        with pytest.raises(PRMergeError) as excinfo:
-            merge_pr_group(
-                workspace_root=tmp_path,
-                pr_group_id=gid,
-                adapter=_FailAfter(fail_on="app"),
-                actor="agent:apollo",
-                method=MergeMethod.MERGE,
-            )
-
-        assert excinfo.value.completed == []
+    assert raised.value.operation_acknowledged is True
+    assert raised.value.outcome_unknown is False
+    assert raised.value.completed == []
+    assert raised.value.receipt.observed.repo == "app"
+    assert "do not retry" in str(raised.value)
 
 
-class TestTheTwoLayersAreIndependent:
-    """Depth is only depth if the layers fail by different routes.
+def test_missing_verification_target_refuses_before_any_host_call(tmp_path: Path) -> None:
+    adapter = _FailAfter()
+    group_id = _group(tmp_path, ["app", "api"])
 
-    A durable record that the in-process path depends on is the same chance twice. These
-    tests exist because the durable layer is not trustworthy in either regime: before
-    grip#843 `emit` swallowed everything and could silently do nothing; after it, `emit`
-    raises and can take the caller down with it. Both are reasons not to rest on it.
-    """
-
-    def test_a_durable_event_records_the_partial_merge(self, tmp_path):
-        gid = _group(tmp_path, ["app", "api", "web"])
-
-        with pytest.raises(PRMergeError):
-            merge_pr_group(
-                workspace_root=tmp_path,
-                pr_group_id=gid,
-                adapter=_FailAfter(fail_on="web"),
-                actor="agent:apollo",
-                method=MergeMethod.MERGE,
-            )
-
-        events = [
-            json.loads(line)
-            for f in tmp_path.rglob("*.jsonl")
-            for line in f.read_text().splitlines()
-            if line.strip()
-        ]
-        merged_records = [e for e in events if e.get("completed") or e.get("repos")]
-        assert merged_records, (
-            f"no event recorded the completed merges; events were "
-            f"{[e.get('type') for e in events]}. The host state changed and the durable "
-            f"log does not say so."
+    with pytest.raises(ValueError, match="api"):
+        merge_pr_group(
+            workspace_root=tmp_path,
+            pr_group_id=group_id,
+            adapter=adapter,
+            actor="agent:test",
+            method=MergeMethod.MERGE,
+            verification_targets=_targets(tmp_path, ["app"]),
+            report=lambda _message: None,
         )
 
-    def test_the_exception_still_carries_the_list_when_EMIT_ITSELF_FAILS(
-        self, tmp_path, monkeypatch
-    ):
-        """The independence claim, stated as the thing that must survive.
-
-        If a broken event layer can take the in-process layer down with it, they were
-        never two layers. Note this cannot happen today only because `emit` swallows
-        everything -- which is exactly why it must not be the thing correctness rests on.
-        """
-        from python_cli import pr as pr_mod
-
-        def _exploding_emit(**kwargs):
-            raise RuntimeError("event subsystem is down")
-
-        monkeypatch.setattr(pr_mod, "emit", _exploding_emit)
-        gid = _group(tmp_path, ["app", "api", "web"])
-
-        with pytest.raises(PRMergeError) as excinfo:
-            merge_pr_group(
-                workspace_root=tmp_path,
-                pr_group_id=gid,
-                adapter=_FailAfter(fail_on="web"),
-                actor="agent:apollo",
-                method=MergeMethod.MERGE,
-            )
-
-        assert [c["repo"] for c in excinfo.value.completed] == ["app", "api"], (
-            "a failure in the best-effort layer must not erase the reliable one, and "
-            "must not replace PRMergeError with the event layer's own exception"
-        )
+    assert adapter.calls == []
 
 
-class TestTheCLIConsumesTheListRatherThanRebuildingIt:
-    """The survivor relocated one layer out, to the next consumer.
+def test_success_state_is_derived_from_consumed_records(tmp_path: Path) -> None:
+    result = _merge(tmp_path, ["app", "api"], _FailAfter())
 
-    `merge_pr_group` carries the completed list correctly. The CLI above it was computing
-    `merged` as DECLARED-MINUS-FAILED:
-
-        [repo for repo in group["prs"] if repo != exc.repo]
-
-    With prs = [app, api, web] and api failing, that yields **[app, web]** -- and the loop
-    stopped at api, so web was never called. A repo that was never touched is persisted as
-    merged, a retry skips a PR that is still open, and the operator reads a merge that did
-    not happen.
-
-    Physics 005: a defect does not die when fixed, it moves one layer outward. The list
-    existed and was correct; nothing consumed it.
-    """
-
-    def _invoke(self, tmp_path, monkeypatch, declared, completed, failing):
-        from typer.testing import CliRunner
-
-        from python_cli import app as app_mod
-
-        group = {
-            "pr_group_id": "pg_x",
-            "owner_unit": "apollo",
-            "lane_name": "lane",
-            "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(declared)],
-        }
-        gpath = tmp_path / "group.json"
-        gpath.write_text(json.dumps(group))
-
-        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
-        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
-        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
-
-        def _boom(**kwargs):
-            raise PRMergeError(
-                failing,
-                2,
-                "simulated",
-                completed=[
-                    {"repo": r, "pr_number": i + 1, "url": f"observed://{r}/{i + 1}"}
-                    for i, r in enumerate(completed)
-                ],
-            )
-
-        monkeypatch.setattr(app_mod.pr_ops, "merge_pr_group", _boom)
-        res = CliRunner().invoke(
-            app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"]
-        )
-        return json.loads(res.stdout), json.loads(gpath.read_text())
-
-    def test_a_repo_the_loop_never_reached_is_NOT_recorded_as_merged(
-        self, tmp_path, monkeypatch
-    ):
-        payload, persisted = self._invoke(
-            tmp_path,
-            monkeypatch,
-            declared=["app", "api", "web"],
-            completed=["app"],
-            failing="api",
-        )
-
-        assert payload["merged"] == ["app"], (
-            f"got {payload['merged']}. 'web' is declared in the group and was never "
-            f"called -- the loop stopped at 'api'. Declared-minus-failed cannot tell "
-            f"'not reached' from 'succeeded'."
-        )
-        assert "web" not in persisted.get("merged", []), (
-            "the FALSE record was persisted to disk, which is the part a retry reads"
-        )
-        # Provenance on the ERROR path too. Membership alone leaves this substitutable:
-        # `group["prs"]` minus nothing still contains 'app', so an assertion on names
-        # passes over either source. The url is adapter-authored and cannot be rebuilt.
-        assert [r.get("url") for r in payload["merged_receipts"]] == ["observed://app/1"], (
-            f'got {payload["merged_receipts"]}. Rebuilt from the group file, these carry '
-            f"no url -- the same coincidence that hid this on the success path."
-        )
-
-    def test_the_persisted_state_matches_what_actually_merged(self, tmp_path, monkeypatch):
-        payload, persisted = self._invoke(
-            tmp_path,
-            monkeypatch,
-            declared=["app", "api", "web", "docs"],
-            completed=["app"],
-            failing="api",
-        )
-        assert persisted["merged"] == ["app"]
-        assert persisted["group_state"] == "partially_merged"
+    assert [item["repo"] for item in result["completed"]] == ["app", "api"]
+    assert all("parent_verdict" in item for item in result["completed"])
 
 
-class TestTheSUCCESSPathCarriesProvenanceToo:
-    """The third layer this one claim had to be pinned at: loop, error path, success path.
+def test_event_failure_cannot_erase_the_in_process_completed_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gr2.python_cli import pr as pr_module
 
-    Each time the coincidence was the same: **the two sources agree except when it
-    matters.** On the success path `completed` and the group's declared `prs` hold the
-    same repos in the same order, so replacing one with the other leaves every
-    membership assertion green -- and every partial-failure test pins only the error
-    path, leaving the happy path free to re-derive.
+    monkeypatch.setattr(
+        pr_module,
+        "emit",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("event sink unavailable")),
+    )
 
-    Membership coincides on success. Provenance does not. So the success assertion has
-    to be on a field only the adapter can author, exactly as inside `merge_pr_group`.
-    """
+    with pytest.raises(PRMergeError) as raised:
+        _merge(tmp_path, ["app", "api"], _FailAfter(fail_on="api"))
 
-    def _run(self, tmp_path, monkeypatch, repos, completed_repos=None):
-        """`completed_repos` defaults to `repos` -- pass a SUBSET to make the two
-        provenances produce different MEMBERSHIPS, which is the only way `merged` itself
-        becomes observable (see the class docstring)."""
-        from typer.testing import CliRunner
-
-        from python_cli import app as app_mod
-
-        group = {
-            "pr_group_id": "pg_ok",
-            "owner_unit": "apollo",
-            "lane_name": "lane",
-            "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(repos)],
-        }
-        done = repos if completed_repos is None else completed_repos
-        gpath = tmp_path / "group.json"
-        gpath.write_text(json.dumps(group))
-
-        monkeypatch.setattr(app_mod, "_resolve_lane_name", lambda *a, **k: "lane")
-        monkeypatch.setattr(app_mod, "_find_pr_group", lambda *a, **k: (gpath, group))
-        monkeypatch.setattr(app_mod, "get_platform_adapter", lambda *a, **k: object())
-        monkeypatch.setattr(
-            app_mod.pr_ops,
-            "merge_pr_group",
-            lambda **kw: {
-                **group,
-                "completed": [
-                    {"repo": r, "pr_number": i + 1, "url": f"observed://{r}/{i + 1}"}
-                    for i, r in enumerate(done)
-                ],
-            },
-        )
-        res = CliRunner().invoke(
-            app_mod.app, ["pr", "merge", str(tmp_path), "apollo", "lane", "--json"]
-        )
-        return json.loads(res.stdout)
-
-    def test_success_output_carries_the_ADAPTER_AUTHORED_field(self, tmp_path, monkeypatch):
-        payload = self._run(tmp_path, monkeypatch, ["app", "api"])
-
-        urls = [r.get("url") for r in payload["merged_receipts"]]
-        assert urls == ["observed://app/1", "observed://api/2"], (
-            f"got {urls}. The group file has no `url`, so a payload rebuilt from "
-            f"`group['prs']` cannot produce these. Asserting membership here proves "
-            f"nothing: on success, completed and declared are the same list."
-        )
-
-    def test_merged_ITSELF_comes_from_completed_when_the_memberships_DIFFER(
-        self, tmp_path, monkeypatch
-    ):
-        """The fifth degree of freedom, and the one my earlier witness could not see.
-
-        Pinning `merged_receipts` by provenance does NOT pin `merged`. In a fixture where
-        completed and declared hold the same repos, `merged` derived from either is the
-        same list -- so substituting `group["prs"]` for `result["completed"]` in the
-        `merged` line alone is invisible, while the receipts assertion beside it stays
-        green and looks like coverage.
-
-        THE FIXTURE LAW: a field is pinned only if the fixture makes its correct value
-        DIFFER from its reconstructed value, **per field**. Receipts-distinguishable does
-        not make merged-distinguishable. Every field needs its own divergence.
-
-        So: declared is a superset. `merged` must follow completed, not the group.
-        """
-        payload = self._run(
-            tmp_path,
-            monkeypatch,
-            ["app", "api", "web"],
-            completed_repos=["app"],
-        )
-
-        assert payload["merged"] == ["app"], (
-            f'got {payload["merged"]}. Rebuilt from the group file this reads '
-            f'["app", "api", "web"] -- the CLI must report what the merge loop returned, '
-            f"not what the group declared."
-        )
-        assert [r.get("url") for r in payload["merged_receipts"]] == ["observed://app/1"]
-
-    def test_membership_alone_would_NOT_have_caught_it(self, tmp_path, monkeypatch):
-        """Documents why the assertion above is on `url` and not on repo names.
-
-        This asserts the coincidence itself: the names ARE identical to the group's, so
-        any test pinned to them is satisfied by either source. Kept as an explicit
-        record so a later reader does not 'simplify' the test above back to a
-        membership check.
-        """
-        payload = self._run(tmp_path, monkeypatch, ["app", "api"])
-        declared = ["app", "api"]
-        assert payload["merged"] == declared, (
-            "if this ever differs, the coincidence has broken and the reasoning above "
-            "needs revisiting"
-        )
+    assert [item.receipt.observed.repo for item in raised.value.completed] == ["app"]

--- a/gr2/tests/test_pr_merge_partial_failure.py
+++ b/gr2/tests/test_pr_merge_partial_failure.py
@@ -366,7 +366,10 @@ class TestTheSUCCESSPathCarriesProvenanceToo:
     to be on a field only the adapter can author, exactly as inside `merge_pr_group`.
     """
 
-    def _run(self, tmp_path, monkeypatch, repos):
+    def _run(self, tmp_path, monkeypatch, repos, completed_repos=None):
+        """`completed_repos` defaults to `repos` -- pass a SUBSET to make the two
+        provenances produce different MEMBERSHIPS, which is the only way `merged` itself
+        becomes observable (see the class docstring)."""
         from typer.testing import CliRunner
 
         from python_cli import app as app_mod
@@ -377,6 +380,7 @@ class TestTheSUCCESSPathCarriesProvenanceToo:
             "lane_name": "lane",
             "prs": [{"repo": r, "pr_number": i + 1} for i, r in enumerate(repos)],
         }
+        done = repos if completed_repos is None else completed_repos
         gpath = tmp_path / "group.json"
         gpath.write_text(json.dumps(group))
 
@@ -390,7 +394,7 @@ class TestTheSUCCESSPathCarriesProvenanceToo:
                 **group,
                 "completed": [
                     {"repo": r, "pr_number": i + 1, "url": f"observed://{r}/{i + 1}"}
-                    for i, r in enumerate(repos)
+                    for i, r in enumerate(done)
                 ],
             },
         )
@@ -408,6 +412,37 @@ class TestTheSUCCESSPathCarriesProvenanceToo:
             f"`group['prs']` cannot produce these. Asserting membership here proves "
             f"nothing: on success, completed and declared are the same list."
         )
+
+    def test_merged_ITSELF_comes_from_completed_when_the_memberships_DIFFER(
+        self, tmp_path, monkeypatch
+    ):
+        """The fifth degree of freedom, and the one my earlier witness could not see.
+
+        Pinning `merged_receipts` by provenance does NOT pin `merged`. In a fixture where
+        completed and declared hold the same repos, `merged` derived from either is the
+        same list -- so substituting `group["prs"]` for `result["completed"]` in the
+        `merged` line alone is invisible, while the receipts assertion beside it stays
+        green and looks like coverage.
+
+        THE FIXTURE LAW: a field is pinned only if the fixture makes its correct value
+        DIFFER from its reconstructed value, **per field**. Receipts-distinguishable does
+        not make merged-distinguishable. Every field needs its own divergence.
+
+        So: declared is a superset. `merged` must follow completed, not the group.
+        """
+        payload = self._run(
+            tmp_path,
+            monkeypatch,
+            ["app", "api", "web"],
+            completed_repos=["app"],
+        )
+
+        assert payload["merged"] == ["app"], (
+            f'got {payload["merged"]}. Rebuilt from the group file this reads '
+            f'["app", "api", "web"] -- the CLI must report what the merge loop returned, '
+            f"not what the group declared."
+        )
+        assert [r.get("url") for r in payload["merged_receipts"]] == ["observed://app/1"]
 
     def test_membership_alone_would_NOT_have_caught_it(self, tmp_path, monkeypatch):
         """Documents why the assertion above is on `url` and not on repo names.

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -518,7 +518,7 @@ def test_pr_commands_route_through_platform_adapter(tmp_path: Path, monkeypatch)
                 title=request.title,
             )
 
-        def merge_pr(self, repo: str, number: int) -> PRRef:
+        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
             calls.append(("merge", (repo, number)))
             return PRRef(repo=repo, number=number, url="https://example.test/pr/42")
 
@@ -588,7 +588,7 @@ def test_pr_create_persists_group_state_by_pr_group_id(tmp_path: Path, monkeypat
                 title=request.title,
             )
 
-        def merge_pr(self, repo: str, number: int) -> PRRef:  # pragma: no cover - not used here
+        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:  # pragma: no cover - not used here
             raise AssertionError("merge_pr should not be called")
 
         def pr_status(self, repo: str, number: int) -> PRStatus:  # pragma: no cover - not used here
@@ -647,7 +647,7 @@ def test_pr_status_aggregates_group_state(tmp_path: Path, monkeypatch) -> None:
         def create_pr(self, request: CreatePRRequest) -> PRRef:  # pragma: no cover
             raise AssertionError("create_pr should not be called")
 
-        def merge_pr(self, repo: str, number: int) -> PRRef:  # pragma: no cover
+        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:  # pragma: no cover
             raise AssertionError("merge_pr should not be called")
 
         def pr_status(self, repo: str, number: int) -> PRStatus:
@@ -703,7 +703,7 @@ def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, mo
         def create_pr(self, request: CreatePRRequest) -> PRRef:  # pragma: no cover
             raise AssertionError("create_pr should not be called")
 
-        def merge_pr(self, repo: str, number: int) -> PRRef:
+        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
             if repo == "api":
                 from gr2.python_cli.platform import AdapterError
 

--- a/gr2/tests/test_sprint21_sync_platform.py
+++ b/gr2/tests/test_sprint21_sync_platform.py
@@ -8,18 +8,38 @@ import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from gr2.python_cli.app import app
-from gr2.python_cli import app as app_module
-from gr2.python_cli.platform import CreatePRRequest, PRCheck, PRRef, PRStatus
-from gr2.python_cli.syncops import run_sync
 from gr2.prototypes import lane_workspace_prototype as lane_proto
-
+from gr2.python_cli import app as app_module
+from gr2.python_cli.app import app
+from gr2.python_cli.platform import (
+    CreatePRRequest,
+    MergeMethod,
+    MergeReceipt,
+    PRCheck,
+    PRRef,
+    PRStatus,
+)
+from gr2.python_cli.syncops import run_sync
 
 runner = CliRunner()
+
+
+def _merge_receipt(repo: str, number: int, method: MergeMethod) -> MergeReceipt:
+    return MergeReceipt(
+        requested=PRRef(repo=repo, number=number),
+        observed=PRRef(
+            repo=repo,
+            number=number,
+            url=f"https://example.test/{repo}/{number}",
+        ),
+        commit_sha=None,
+        requested_method=method,
+    )
 
 
 def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -197,6 +217,59 @@ def _stash_list(repo_root: Path) -> list[str]:
     proc = _git(repo_root, "stash", "list")
     assert proc.returncode == 0
     return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def test_merge_target_uses_source_identity_and_declared_local_path(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    repo_root = workspace_root / "shared" / "product-checkout"
+    repo_root.mkdir(parents=True)
+    assert _git(repo_root, "init", "-b", "main").returncode == 0
+    spec_path = workspace_root / ".grip" / "workspace_spec.toml"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text(
+        textwrap.dedent(
+            """
+            workspace_name = "alias-test"
+
+            [[repos]]
+            name = "product"
+            path = "shared/product-checkout"
+            url = "https://github.com/example/actual-repository.git"
+            """
+        ).strip()
+        + "\n"
+    )
+
+    targets = app_module._merge_verification_targets(workspace_root)
+
+    assert set(targets) == {"example/actual-repository"}
+    target = targets["example/actual-repository"]
+    assert target.repo_root == repo_root.resolve()
+    assert target.remote == "https://github.com/example/actual-repository.git"
+
+
+def test_missing_local_merge_dag_refuses_with_a_domain_error(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    spec_path = workspace_root / ".grip" / "workspace_spec.toml"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text(
+        textwrap.dedent(
+            """
+            workspace_name = "missing-dag"
+
+            [[repos]]
+            name = "product"
+            path = "repos/missing"
+            url = "https://github.com/example/product.git"
+            """
+        ).strip()
+        + "\n"
+    )
+
+    with pytest.raises(SystemExit, match="local merge-verification DAG is unavailable"):
+        app_module._merge_verification_targets(workspace_root)
 
 
 def test_sync_run_emits_contract_payloads_and_cache_events(tmp_path: Path) -> None:
@@ -488,6 +561,8 @@ def test_pr_commands_route_through_platform_adapter(tmp_path: Path, monkeypatch)
     workspace_root.mkdir()
     _, repo_url = _init_bare_remote(tmp_path, "app")
     _write_workspace_spec(workspace_root, "app", repo_url)
+    spec_path = workspace_root / ".grip" / "workspace_spec.toml"
+    spec_path.write_text(spec_path.read_text() + '\n[settings]\nmerge_method = "squash"\n')
     run_sync(workspace_root)
 
     ns = SimpleNamespace(
@@ -518,9 +593,15 @@ def test_pr_commands_route_through_platform_adapter(tmp_path: Path, monkeypatch)
                 title=request.title,
             )
 
-        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
-            calls.append(("merge", (repo, number)))
-            return PRRef(repo=repo, number=number, url="https://example.test/pr/42")
+        def merge_pr(
+            self,
+            repo: str,
+            number: int,
+            *,
+            method: MergeMethod,
+        ) -> MergeReceipt:
+            calls.append(("merge", (repo, number, method)))
+            return _merge_receipt(repo, number, method)
 
         def pr_status(self, repo: str, number: int) -> PRStatus:
             calls.append(("status", (repo, number)))
@@ -551,7 +632,148 @@ def test_pr_commands_route_through_platform_adapter(tmp_path: Path, monkeypatch)
 
     result = runner.invoke(app, ["pr", "merge", str(workspace_root), "atlas", "feat-auth", "--json"])
     assert result.exit_code == 0
-    assert any(kind == "merge" for kind, _ in calls)
+    assert ("merge", ("app", 42, MergeMethod.SQUASH)) in calls
+
+    result = runner.invoke(
+        app,
+        [
+            "pr",
+            "merge",
+            str(workspace_root),
+            "atlas",
+            "feat-auth",
+            "--method",
+            "rebase",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0
+    assert ("merge", ("app", 42, MergeMethod.REBASE)) in calls
+
+
+def test_pr_merge_success_consumes_the_returned_completed_subset(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    repo_rows: list[tuple[str, str]] = []
+    for repo in ("app", "api", "web"):
+        _, repo_url = _init_bare_remote(tmp_path, repo)
+        repo_rows.append((repo, repo_url))
+    _write_workspace_spec_multi(workspace_root, repo_rows)
+    run_sync(workspace_root)
+
+    pr_group_id = "pg_success_subset"
+    group_path = workspace_root / ".grip" / "pr_groups" / f"{pr_group_id}.json"
+    group_path.parent.mkdir(parents=True, exist_ok=True)
+    group = {
+        "pr_group_id": pr_group_id,
+        "owner_unit": "atlas",
+        "lane_name": "feat-subset",
+        "platform": "github",
+        "prs": [
+            {"repo": repo, "pr_number": number}
+            for number, repo in enumerate(("app", "api", "web"), start=41)
+        ],
+    }
+    group_path.write_text(json.dumps(group))
+    returned = {
+        **group,
+        "completed": [
+            {
+                "repo": "app",
+                "pr_number": 41,
+                "url": "https://example.test/app/41",
+                "commit_sha": "a" * 40,
+                "requested_method": "merge",
+                "parent_verdict": {"kind": "verified"},
+            }
+        ],
+    }
+
+    def merge_subset(**_kwargs: object) -> dict[str, object]:
+        group_path.write_text(json.dumps(returned))
+        return returned
+
+    monkeypatch.setattr(app_module, "get_platform_adapter", lambda name="github": object())
+    monkeypatch.setattr(app_module.pr_ops, "merge_pr_group", merge_subset)
+
+    result = runner.invoke(
+        app,
+        ["pr", "merge", str(workspace_root), "atlas", "feat-subset", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["merged"] == ["app"]
+    assert payload["merged_receipts"] == returned["completed"]
+    assert [item["repo"] for item in json.loads(group_path.read_text())["completed"]] == [
+        "app"
+    ]
+
+
+def test_pr_merge_success_receipts_keep_adapter_provenance_when_membership_matches(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    repo_rows: list[tuple[str, str]] = []
+    for repo in ("app", "api"):
+        _, repo_url = _init_bare_remote(tmp_path, repo)
+        repo_rows.append((repo, repo_url))
+    _write_workspace_spec_multi(workspace_root, repo_rows)
+    run_sync(workspace_root)
+
+    pr_group_id = "pg_success_provenance"
+    group_path = workspace_root / ".grip" / "pr_groups" / f"{pr_group_id}.json"
+    group_path.parent.mkdir(parents=True, exist_ok=True)
+    group = {
+        "pr_group_id": pr_group_id,
+        "owner_unit": "atlas",
+        "lane_name": "feat-provenance",
+        "platform": "github",
+        "prs": [
+            {"repo": repo, "pr_number": number}
+            for number, repo in enumerate(("app", "api"), start=41)
+        ],
+    }
+    group_path.write_text(json.dumps(group))
+    returned = {
+        **group,
+        "completed": [
+            {
+                "repo": repo,
+                "pr_number": number,
+                "url": f"observed://{repo}/{number}",
+                "commit_sha": "a" * 40,
+                "requested_method": "merge",
+                "parent_verdict": {"kind": "verified"},
+            }
+            for number, repo in enumerate(("app", "api"), start=41)
+        ],
+    }
+
+    def merge_all(**_kwargs: object) -> dict[str, object]:
+        group_path.write_text(json.dumps(returned))
+        return returned
+
+    monkeypatch.setattr(app_module, "get_platform_adapter", lambda name="github": object())
+    monkeypatch.setattr(app_module.pr_ops, "merge_pr_group", merge_all)
+
+    result = runner.invoke(
+        app,
+        ["pr", "merge", str(workspace_root), "atlas", "feat-provenance", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["merged"] == ["app", "api"]
+    assert [item["url"] for item in payload["merged_receipts"]] == [
+        "observed://app/41",
+        "observed://api/42",
+    ]
 
 
 def test_pr_create_persists_group_state_by_pr_group_id(tmp_path: Path, monkeypatch) -> None:
@@ -588,7 +810,13 @@ def test_pr_create_persists_group_state_by_pr_group_id(tmp_path: Path, monkeypat
                 title=request.title,
             )
 
-        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:  # pragma: no cover - not used here
+        def merge_pr(
+            self,
+            repo: str,
+            number: int,
+            *,
+            method: MergeMethod,
+        ) -> MergeReceipt:  # pragma: no cover - not used here
             raise AssertionError("merge_pr should not be called")
 
         def pr_status(self, repo: str, number: int) -> PRStatus:  # pragma: no cover - not used here
@@ -647,7 +875,13 @@ def test_pr_status_aggregates_group_state(tmp_path: Path, monkeypatch) -> None:
         def create_pr(self, request: CreatePRRequest) -> PRRef:  # pragma: no cover
             raise AssertionError("create_pr should not be called")
 
-        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:  # pragma: no cover
+        def merge_pr(
+            self,
+            repo: str,
+            number: int,
+            *,
+            method: MergeMethod,
+        ) -> MergeReceipt:  # pragma: no cover
             raise AssertionError("merge_pr should not be called")
 
         def pr_status(self, repo: str, number: int) -> PRStatus:
@@ -675,7 +909,11 @@ def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, mo
     workspace_root.mkdir()
     _, app_url = _init_bare_remote(tmp_path, "app")
     _, api_url = _init_bare_remote(tmp_path, "api")
-    _write_workspace_spec_multi(workspace_root, [("app", app_url), ("api", api_url)])
+    _, web_url = _init_bare_remote(tmp_path, "web")
+    _write_workspace_spec_multi(
+        workspace_root,
+        [("app", app_url), ("api", api_url), ("web", web_url)],
+    )
     run_sync(workspace_root)
 
     pr_group_id = "pg_badmerge"
@@ -689,13 +927,15 @@ def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, mo
                 "lane_name": "feat-router",
                 "platform": "github",
                 "prs": [
-                    {"repo": "app", "pr_number": 41, "url": "https://example.test/app/41"},
-                    {"repo": "api", "pr_number": 42, "url": "https://example.test/api/42"},
+                    {"repo": "app", "pr_number": 41, "url": "declared://app/41"},
+                    {"repo": "api", "pr_number": 42, "url": "declared://api/42"},
+                    {"repo": "web", "pr_number": 43, "url": "declared://web/43"},
                 ],
-                "status": {"app": "OPEN", "api": "OPEN"},
+                "status": {"app": "OPEN", "api": "OPEN", "web": "OPEN"},
             }
         )
     )
+    calls: list[str] = []
 
     class FakeAdapter:
         name = "fake"
@@ -703,12 +943,19 @@ def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, mo
         def create_pr(self, request: CreatePRRequest) -> PRRef:  # pragma: no cover
             raise AssertionError("create_pr should not be called")
 
-        def merge_pr(self, repo: str, number: int, *, method=None) -> PRRef:
+        def merge_pr(
+            self,
+            repo: str,
+            number: int,
+            *,
+            method: MergeMethod,
+        ) -> MergeReceipt:
+            calls.append(repo)
             if repo == "api":
                 from gr2.python_cli.platform import AdapterError
 
                 raise AdapterError("merge conflict")
-            return PRRef(repo=repo, number=number, url=f"https://example.test/{repo}/{number}")
+            return _merge_receipt(repo, number, method)
 
         def pr_status(self, repo: str, number: int) -> PRStatus:  # pragma: no cover
             raise AssertionError("pr_status should not be called")
@@ -727,10 +974,18 @@ def test_pr_merge_reports_partial_failure_and_preserves_state(tmp_path: Path, mo
     assert payload["status"] == "partial_failure"
     assert payload["pr_group_id"] == pr_group_id
     assert payload["merged"] == ["app"]
+    assert [item["url"] for item in payload["merged_receipts"]] == [
+        "https://example.test/app/41"
+    ]
     assert payload["failed"][0]["repo"] == "api"
+    assert calls == ["app", "api"]
 
     stored = json.loads(group_path.read_text())
     assert stored["group_state"] == "partially_merged"
+    assert stored["merged"] == ["app"]
+    assert [item["url"] for item in stored["completed"]] == [
+        "https://example.test/app/41"
+    ]
 
 
 def test_sync_run_reports_terminal_blocked_event_on_lock_contention(tmp_path: Path) -> None:


### PR DESCRIPTION
Carries merge evidence back from the platform adapter and verifies the resulting commit.

The adapter previously discarded the host's merge response and returned a value reconstructed from its own inputs, so nothing downstream could tell whether a merge had happened or which commit it produced. The API reports *that* a merge occurred and never *which strategy* produced it, so verification reads the local commit graph instead.

- Adapters return a receipt carrying the merge commit identifier from the host response
- A parent-count check on the resulting commit, run against the immutable merge commit rather than a re-queried branch tip
- Squash and rebase are exempt: they produce single-parent commits by design
- Unverifiable outcomes are distinct from verified ones — a discarded fetch, a non-default remote, or an unreadable repository each produce their own outcome rather than collapsing into success
- The verdict cannot be constructed outside the verifier, and consuming it is structural rather than optional
- Nothing depends on process-global mutable git state, which concurrent fetches can race

Closes #842

Reviewed by two agents against the exact bytes before push.

Premium boundary: gr2 is OSS — local merge mechanics and verification only. No identity, org, entitlement, or policy-management logic.
