### PR TITLE
fix(gr2): serialize event-log sequence allocation and append

### DIFF
--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -269,8 +269,23 @@ This harness runs two phases in one command:
 It reports:
 
 - JSON corruption count
+- a malformed-JSON positive control proving the corruption detector
 - rounds where both conflicting edit acquisitions succeeded
 - rounds where the final lease count was wrong
+
+## Concurrent Event Stress
+
+To verify that event sequence allocation survives contention, run:
+
+```bash
+python3 gr2/prototypes/concurrent_event_stress.py --rounds 30 --writers 2
+python3 gr2/prototypes/concurrent_event_stress.py --rounds 30 --writers 8
+```
+
+Each command reports an intentionally unlocked phase, the locked production
+path, and a sequential control. It also injects one malformed event to prove
+that a zero corruption count is an observed zero rather than an unexercised
+field.
 
 Bootstrap command:
 

--- a/gr2/prototypes/concurrent_event_stress.py
+++ b/gr2/prototypes/concurrent_event_stress.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Repeated before/after stress harness for event-log sequence integrity."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SOURCE_ROOT))
+
+from python_cli.events import EventType, emit  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rounds", type=int, default=30)
+    parser.add_argument("--writers", type=int, default=2)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def _worker(workspace: str, actor: str, start: object, queue: object, unlocked: bool) -> None:
+    if unlocked:
+        os.environ["GR2_DISABLE_EVENT_LOCKING"] = "1"
+        os.environ["GR2_EVENT_TEST_DELAY"] = "0.03"
+    if not start.wait(timeout=10):
+        queue.put({"ok": False, "error": "start gate timed out"})
+        return
+    try:
+        emit(
+            event_type=EventType.LANE_ENTERED,
+            workspace_root=Path(workspace),
+            actor=actor,
+            owner_unit="event-stress",
+            payload={"round_actor": actor},
+        )
+    except Exception as exc:
+        queue.put({"ok": False, "error": repr(exc)})
+    else:
+        queue.put({"ok": True})
+
+
+def _read_rows(outbox: Path) -> tuple[list[dict[str, object]], int]:
+    rows: list[dict[str, object]] = []
+    corruption_count = 0
+    for line in outbox.read_text().splitlines() if outbox.exists() else []:
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            corruption_count += 1
+            continue
+        if not isinstance(row, dict):
+            corruption_count += 1
+            continue
+        rows.append(row)
+    return rows, corruption_count
+
+
+def prove_corruption_detector() -> dict[str, object]:
+    """Prove the reported zero can distinguish a known malformed event."""
+    with tempfile.TemporaryDirectory(prefix="gr2-event-corruption-control-") as tmp:
+        outbox = Path(tmp) / "outbox.jsonl"
+        outbox.write_text("{malformed-json\n")
+        _, corruption_count = _read_rows(outbox)
+    return {
+        "proven": corruption_count == 1,
+        "fixture": "malformed-json",
+        "detected_count": corruption_count,
+    }
+
+
+def _run_round(writers: int, unlocked: bool) -> dict[str, object]:
+    ctx = multiprocessing.get_context("spawn")
+    with tempfile.TemporaryDirectory(prefix="gr2-event-stress-") as tmp:
+        workspace = Path(tmp)
+        (workspace / ".grip").mkdir()
+        start = ctx.Event()
+        queue = ctx.Queue()
+        processes = [
+            ctx.Process(
+                target=_worker,
+                args=(str(workspace), f"writer:{index}", start, queue, unlocked),
+            )
+            for index in range(writers)
+        ]
+        for process in processes:
+            process.start()
+        start.set()
+        for process in processes:
+            process.join(timeout=15)
+        outcomes = [queue.get(timeout=2) for _ in processes]
+        rows, corruption_count = _read_rows(
+            workspace / ".grip" / "events" / "outbox.jsonl"
+        )
+        seqs = [row.get("seq") for row in rows]
+        return {
+            "all_workers_succeeded": all(outcome["ok"] for outcome in outcomes),
+            "lost_events": len(rows) != writers,
+            "duplicate_seq": len(seqs) != len(set(seqs)),
+            "corruption_count": corruption_count,
+        }
+
+
+def run_phase(*, rounds: int, writers: int, unlocked: bool) -> dict[str, object]:
+    results = [_run_round(writers, unlocked) for _ in range(rounds)]
+    return {
+        "locking": "disabled" if unlocked else "enabled",
+        "rounds": rounds,
+        "writers": writers,
+        "duplicate_seq_rounds": sum(bool(row["duplicate_seq"]) for row in results),
+        "lost_event_rounds": sum(bool(row["lost_events"]) for row in results),
+        "corruption_count": sum(int(row["corruption_count"]) for row in results),
+        "worker_failure_rounds": sum(not bool(row["all_workers_succeeded"]) for row in results),
+    }
+
+
+def sequential_control(writes: int = 8) -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-event-sequential-control-") as tmp:
+        workspace = Path(tmp)
+        (workspace / ".grip").mkdir()
+        old_disabled = os.environ.get("GR2_DISABLE_EVENT_LOCKING")
+        old_delay = os.environ.get("GR2_EVENT_TEST_DELAY")
+        os.environ["GR2_DISABLE_EVENT_LOCKING"] = "1"
+        os.environ["GR2_EVENT_TEST_DELAY"] = "0"
+        try:
+            for index in range(writes):
+                emit(
+                    event_type=EventType.LANE_ENTERED,
+                    workspace_root=workspace,
+                    actor="sequential-control",
+                    owner_unit="event-stress",
+                    payload={"index": index},
+                )
+        finally:
+            if old_disabled is None:
+                os.environ.pop("GR2_DISABLE_EVENT_LOCKING", None)
+            else:
+                os.environ["GR2_DISABLE_EVENT_LOCKING"] = old_disabled
+            if old_delay is None:
+                os.environ.pop("GR2_EVENT_TEST_DELAY", None)
+            else:
+                os.environ["GR2_EVENT_TEST_DELAY"] = old_delay
+        rows, corruption_count = _read_rows(
+            workspace / ".grip" / "events" / "outbox.jsonl"
+        )
+        seqs = [row.get("seq") for row in rows]
+        return {
+            "writes": writes,
+            "strictly_monotonic": seqs == list(range(1, writes + 1)),
+            "corruption_count": corruption_count,
+        }
+
+
+def main() -> int:
+    args = parse_args()
+    payload = {
+        "corruption_detector_control": prove_corruption_detector(),
+        "sequential_control": sequential_control(),
+        "before_locking": run_phase(rounds=args.rounds, writers=args.writers, unlocked=True),
+        "after_locking": run_phase(rounds=args.rounds, writers=args.writers, unlocked=False),
+    }
+    print(json.dumps(payload, indent=2))
+    after = payload["after_locking"]
+    return int(
+        not payload["corruption_detector_control"]["proven"]
+        or not payload["sequential_control"]["strictly_monotonic"]
+        or after["duplicate_seq_rounds"] != 0
+        or after["lost_event_rounds"] != 0
+        or after["corruption_count"] != 0
+        or after["worker_failure_rounds"] != 0
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/concurrent_lease_stress.py
+++ b/gr2/prototypes/concurrent_lease_stress.py
@@ -29,7 +29,13 @@ def lane_proto(root: Path) -> Path:
     return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
 
 
-def run(argv: list[str], *, env: dict | None = None, check: bool = True, capture: bool = False) -> subprocess.CompletedProcess[str]:
+def run(
+    argv: list[str],
+    *,
+    env: dict | None = None,
+    check: bool = True,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(argv, check=check, text=True, capture_output=capture, env=env)
 
 
@@ -119,6 +125,28 @@ def read_leases(workspace_root: Path) -> tuple[bool, list[dict] | None]:
         return False, None
 
 
+def prove_corruption_detector() -> dict[str, object]:
+    """Prove the corruption counter's detector with a known-bad lease file."""
+    with tempfile.TemporaryDirectory(prefix="gr2-lease-corruption-control-") as tmp:
+        workspace_root = Path(tmp)
+        lease_path = (
+            workspace_root
+            / "agents"
+            / "atlas"
+            / "lanes"
+            / "feat-race"
+            / "leases.json"
+        )
+        lease_path.parent.mkdir(parents=True)
+        lease_path.write_text("{malformed-json")
+        valid_json, _ = read_leases(workspace_root)
+    return {
+        "proven": not valid_json,
+        "fixture": "malformed-json",
+        "detected_as_corrupt": not valid_json,
+    }
+
+
 def release_all(root: Path, workspace_root: Path, disable_locking: bool) -> None:
     env = os.environ.copy()
     if disable_locking:
@@ -195,13 +223,17 @@ def main() -> int:
     args = parse_args()
     before = run_phase(disable_locking=True, rounds=args.rounds)
     after = run_phase(disable_locking=False, rounds=args.rounds)
-    payload = {"before_locking": before, "after_locking": after}
+    payload = {
+        "corruption_detector_control": prove_corruption_detector(),
+        "before_locking": before,
+        "after_locking": after,
+    }
     if args.json:
         print(json.dumps(payload, indent=2))
     else:
         print("gr2 concurrent lease stress")
         print(json.dumps(payload, indent=2))
-    return 0
+    return 0 if payload["corruption_detector_control"]["proven"] else 1
 
 
 if __name__ == "__main__":

--- a/gr2/prototypes/cross_mode_lane_stress.py
+++ b/gr2/prototypes/cross_mode_lane_stress.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
 import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -31,6 +32,10 @@ class ScenarioResult:
     holds: list[str]
     gaps: list[str]
     evidence: list[str]
+
+
+class HarnessCommandError(RuntimeError):
+    """A child command failed with its diagnostic output preserved."""
 
 
 def parse_args() -> argparse.Namespace:
@@ -58,14 +63,24 @@ def lane_proto(root: Path) -> Path:
     return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
 
 
-def run(argv: list[str], *, capture: bool = False, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
+def run(
+    argv: list[str], *, capture: bool = False, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
         argv,
         cwd=cwd,
-        check=True,
+        check=False,
         text=True,
         capture_output=capture,
     )
+    if proc.returncode != 0:
+        stdout = proc.stdout or "<not captured>"
+        stderr = proc.stderr or "<not captured>"
+        raise HarnessCommandError(
+            f"child command failed with exit {proc.returncode}: {' '.join(argv)}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return proc
 
 
 def init_workspace(workspace_root: Path) -> None:
@@ -941,20 +956,23 @@ def print_human(results: list[ScenarioResult], workspace_root: Path) -> None:
 
 def main() -> int:
     args = parse_args()
-
-    if args.workspace_root:
-        workspace_root = args.workspace_root.resolve()
-        workspace_root.mkdir(parents=True, exist_ok=True)
-        results = run_scenarios(workspace_root)
-    else:
-        with tempfile.TemporaryDirectory(prefix="gr2-cross-mode-") as tmp:
-            workspace_root = Path(tmp)
+    try:
+        if args.workspace_root:
+            workspace_root = args.workspace_root.resolve()
+            workspace_root.mkdir(parents=True, exist_ok=True)
             results = run_scenarios(workspace_root)
-            if args.json:
-                print(json.dumps([asdict(result) for result in results], indent=2))
+        else:
+            with tempfile.TemporaryDirectory(prefix="gr2-cross-mode-") as tmp:
+                workspace_root = Path(tmp)
+                results = run_scenarios(workspace_root)
+                if args.json:
+                    print(json.dumps([asdict(result) for result in results], indent=2))
+                    return 0
+                print_human(results, workspace_root)
                 return 0
-            print_human(results, workspace_root)
-            return 0
+    except Exception as exc:
+        print(f"gr2 cross-mode lane stress FAILED: {exc}", file=sys.stderr)
+        return 1
 
     if args.json:
         print(json.dumps([asdict(result) for result in results], indent=2))

--- a/gr2/python_cli/events.py
+++ b/gr2/python_cli/events.py
@@ -8,13 +8,14 @@ Implements the event contract from HOOK-EVENT-CONTRACT.md sections 3-8:
 """
 from __future__ import annotations
 
+import fcntl
 import json
 import os
-import sys
+import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-
 
 _RESERVED_NAMES = frozenset(
     {
@@ -31,6 +32,10 @@ _RESERVED_NAMES = frozenset(
 )
 
 _ROTATION_THRESHOLD = 10 * 1024 * 1024
+
+
+class EventEmitError(RuntimeError):
+    """The event could not be durably recorded."""
 
 
 class EventType(str, Enum):
@@ -87,13 +92,33 @@ def _cursors_dir(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "events" / "cursors"
 
 
+def _lock_path(outbox: Path) -> Path:
+    return outbox.parent / "outbox.lock"
+
+
+def _event_locking_enabled() -> bool:
+    """Allow the stress harness to reproduce the pre-lock behavior."""
+    return os.environ.get("GR2_DISABLE_EVENT_LOCKING") != "1"
+
+
+@contextmanager
+def _event_write_lock(outbox: Path):
+    """Serialize sequence allocation, rotation, and append across processes."""
+    with _lock_path(outbox).open("a+") as lock_file:
+        locking_enabled = _event_locking_enabled()
+        if locking_enabled:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if locking_enabled:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
 def _current_seq(outbox: Path) -> int:
     if not outbox.exists():
         return 0
-    try:
-        text = outbox.read_text()
-    except OSError:
-        return 0
+    text = outbox.read_text()
     last_seq = 0
     for line in text.strip().split("\n"):
         line = line.strip()
@@ -135,33 +160,36 @@ def emit(
     if collisions:
         raise ValueError(f"payload keys collide with reserved envelope/context names: {collisions}")
 
+    outbox = _outbox_path(workspace_root)
     try:
-        outbox = _outbox_path(workspace_root)
         outbox.parent.mkdir(parents=True, exist_ok=True)
+        with _event_write_lock(outbox):
+            seq = _current_seq(outbox) + 1
+            delay = float(os.environ.get("GR2_EVENT_TEST_DELAY", "0"))
+            if delay:
+                time.sleep(delay)
+            _maybe_rotate(outbox)
 
-        seq = _current_seq(outbox) + 1
-        _maybe_rotate(outbox)
+            event: dict[str, object] = {
+                "version": 1,
+                "event_id": os.urandom(8).hex(),
+                "seq": seq,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "type": str(event_type.value),
+                "workspace": workspace_root.name,
+                "actor": actor,
+                "owner_unit": owner_unit,
+            }
+            if agent_id is not None:
+                event["agent_id"] = agent_id
+            event.update(payload)
 
-        event: dict[str, object] = {
-            "version": 1,
-            "event_id": os.urandom(8).hex(),
-            "seq": seq,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "type": str(event_type.value),
-            "workspace": workspace_root.name,
-            "actor": actor,
-            "owner_unit": owner_unit,
-        }
-        if agent_id is not None:
-            event["agent_id"] = agent_id
-        event.update(payload)
-
-        with outbox.open("a") as f:
-            f.write(json.dumps(event, separators=(",", ":")) + "\n")
-            f.flush()
-
+            with outbox.open("a") as event_file:
+                event_file.write(json.dumps(event, separators=(",", ":")) + "\n")
+                event_file.flush()
+                os.fsync(event_file.fileno())
     except Exception as exc:
-        print(f"gr2: event emit failed: {exc}", file=sys.stderr)
+        raise EventEmitError(f"event emit failed for {outbox}") from exc
 
 
 def read_events(workspace_root: Path, consumer: str) -> list[dict[str, object]]:

--- a/gr2/tests/test_event_log_integrity.py
+++ b/gr2/tests/test_event_log_integrity.py
@@ -1,0 +1,219 @@
+"""Integrity tests for concurrent event writes and prototype evidence."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import multiprocessing
+import sys
+import time
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+def _gated_emit_worker(
+    source_root: str,
+    workspace_root: str,
+    read_reached: object,
+    release_read: object,
+    result_queue: object,
+) -> None:
+    """Pause each process after reading seq so an unlocked RMW races deterministically."""
+    events_path = Path(source_root) / "gr2" / "python_cli" / "events.py"
+    spec = importlib.util.spec_from_file_location("event_integrity_worker_events", events_path)
+    assert spec is not None and spec.loader is not None
+    events = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(events)
+
+    original_current_seq = events._current_seq
+
+    def gated_current_seq(outbox: Path) -> int:
+        seq = original_current_seq(outbox)
+        read_reached.set()
+        if not release_read.wait(timeout=10):
+            raise TimeoutError("parent did not release the sequence-read gate")
+        return seq
+
+    events._current_seq = gated_current_seq
+    try:
+        events.emit(
+            event_type=events.EventType.LANE_ENTERED,
+            workspace_root=Path(workspace_root),
+            actor=f"worker:{multiprocessing.current_process().name}",
+            owner_unit="event-stress",
+            payload={"lane_name": "integrity"},
+        )
+    except Exception as exc:  # pragma: no cover - reported across process boundary
+        result_queue.put({"ok": False, "error": repr(exc)})
+    else:
+        result_queue.put({"ok": True})
+
+
+def _wait_until_any(events: list[object], timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if any(event.is_set() for event in events):
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def test_concurrent_emit_serializes_sequence_read_and_append(tmp_path: Path) -> None:
+    """Removing the write lock lets both processes allocate seq=1."""
+    (tmp_path / ".grip").mkdir()
+    ctx = multiprocessing.get_context("spawn")
+    reached = [ctx.Event(), ctx.Event()]
+    release = ctx.Event()
+    results = ctx.Queue()
+    processes = [
+        ctx.Process(
+            target=_gated_emit_worker,
+            args=(
+                str(Path(__file__).resolve().parents[2]),
+                str(tmp_path),
+                reached[index],
+                release,
+                results,
+            ),
+            name=f"emit-{index}",
+        )
+        for index in range(2)
+    ]
+
+    for process in processes:
+        process.start()
+
+    assert _wait_until_any(reached, timeout=10), "neither writer reached sequence allocation"
+    time.sleep(0.25)
+    both_read_before_release = all(event.is_set() for event in reached)
+    release.set()
+
+    for process in processes:
+        process.join(timeout=10)
+        assert not process.is_alive(), "event writer hung"
+        assert process.exitcode == 0
+
+    outcomes = [results.get(timeout=2) for _ in processes]
+    assert outcomes == [{"ok": True}, {"ok": True}]
+    assert not both_read_before_release, "sequence allocation was not serialized"
+
+    outbox = tmp_path / ".grip" / "events" / "outbox.jsonl"
+    rows = [json.loads(line) for line in outbox.read_text().splitlines()]
+    assert sorted(row["seq"] for row in rows) == [1, 2]
+
+
+def test_sequential_emit_control_is_strictly_monotonic(tmp_path: Path) -> None:
+    """The zero-concurrency control proves the sequence detector can report clean fruit."""
+    from gr2.python_cli.events import EventType, emit
+
+    (tmp_path / ".grip").mkdir()
+    for index in range(8):
+        emit(
+            event_type=EventType.LANE_ENTERED,
+            workspace_root=tmp_path,
+            actor="sequential-control",
+            owner_unit="event-stress",
+            payload={"index": index},
+        )
+
+    outbox = tmp_path / ".grip" / "events" / "outbox.jsonl"
+    rows = [json.loads(line) for line in outbox.read_text().splitlines()]
+    assert [row["seq"] for row in rows] == list(range(1, 9))
+
+
+def test_repeated_stress_distinguishes_unlocked_and_locked_paths() -> None:
+    """Repeated fruit must expose the old race while the locked path stays clean."""
+    from gr2.prototypes.concurrent_event_stress import run_phase, sequential_control
+
+    control = sequential_control()
+    unlocked = run_phase(rounds=3, writers=2, unlocked=True)
+    locked = run_phase(rounds=3, writers=2, unlocked=False)
+
+    assert control == {
+        "writes": 8,
+        "strictly_monotonic": True,
+        "corruption_count": 0,
+    }
+    assert unlocked["duplicate_seq_rounds"] == 3
+    assert locked["duplicate_seq_rounds"] == 0
+    assert locked["lost_event_rounds"] == 0
+    assert locked["corruption_count"] == 0
+    assert locked["worker_failure_rounds"] == 0
+
+
+def test_cross_mode_child_failure_preserves_exit_and_output() -> None:
+    """Captured child failure must be loud rather than indistinguishable from silence."""
+    from gr2.prototypes.cross_mode_lane_stress import HarnessCommandError, run
+
+    with pytest.raises(HarnessCommandError) as exc_info:
+        run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; print('child-out'); "
+                "print('child-err', file=sys.stderr); raise SystemExit(7)",
+            ],
+            capture=True,
+        )
+
+    message = str(exc_info.value)
+    assert "exit 7" in message
+    assert "child-out" in message
+    assert "child-err" in message
+
+
+def test_lease_corruption_detector_has_a_positive_control() -> None:
+    """A zero corruption count is proven only if known corruption is detected."""
+    from gr2.prototypes.concurrent_lease_stress import prove_corruption_detector
+
+    receipt = prove_corruption_detector()
+    assert receipt == {
+        "proven": True,
+        "fixture": "malformed-json",
+        "detected_as_corrupt": True,
+    }
+
+
+def test_lease_stress_report_carries_and_enforces_the_positive_control(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Deleting the control from the report or ignoring a failed control turns RED."""
+    from gr2.prototypes import concurrent_lease_stress as stress
+
+    monkeypatch.setattr(stress, "parse_args", lambda: Namespace(rounds=0, json=True))
+    monkeypatch.setattr(
+        stress,
+        "run_phase",
+        lambda disable_locking, rounds: {
+            "locking": "disabled" if disable_locking else "enabled",
+            "rounds": rounds,
+        },
+    )
+    monkeypatch.setattr(
+        stress,
+        "prove_corruption_detector",
+        lambda: {
+            "proven": False,
+            "fixture": "malformed-json",
+            "detected_as_corrupt": False,
+        },
+    )
+
+    assert stress.main() == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["corruption_detector_control"]["proven"] is False
+
+
+def test_event_corruption_detector_has_a_positive_control() -> None:
+    """The event stress report must prove its own corruption counter."""
+    from gr2.prototypes.concurrent_event_stress import prove_corruption_detector
+
+    assert prove_corruption_detector() == {
+        "proven": True,
+        "fixture": "malformed-json",
+        "detected_count": 1,
+    }

--- a/gr2/tests/test_events.py
+++ b/gr2/tests/test_events.py
@@ -462,14 +462,17 @@ class TestOutboxPath:
 
 class TestEmitErrorHandling:
 
-    def test_emit_does_not_raise_on_write_failure(self, workspace: Path):
-        """emit() logs to stderr but does not crash on write failure."""
-        from gr2.python_cli.events import emit, EventType
-        # Make the events directory read-only to force a write failure
+    def test_emit_fails_closed_on_write_failure(self, workspace: Path):
+        """A caller must not receive silent success when no event was recorded."""
+        from gr2.python_cli.events import EventEmitError, EventType, emit
+
+        # A file at the directory path is a deterministic failure on every
+        # runner. Permission-bit tests can stay writable under privileged users.
         events_dir = workspace / ".grip" / "events"
-        events_dir.chmod(0o444)
-        try:
-            # Should not raise
+        events_dir.rmdir()
+        events_dir.write_text("not a directory")
+
+        with pytest.raises(EventEmitError) as exc_info:
             emit(
                 event_type=EventType.LANE_ENTERED,
                 workspace_root=workspace,
@@ -477,8 +480,36 @@ class TestEmitErrorHandling:
                 owner_unit="apollo",
                 payload={"lane_name": "feat/test", "lane_type": "feature", "repos": ["grip"]},
             )
-        finally:
-            events_dir.chmod(0o755)
+
+        assert isinstance(exc_info.value.__cause__, OSError)
+
+    def test_emit_fails_closed_when_existing_sequence_cannot_be_read(
+        self, workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Restoring _current_seq's OSError-to-zero fallback must turn this RED."""
+        from gr2.python_cli.events import EventEmitError, EventType, _outbox_path, emit
+
+        outbox = _outbox_path(workspace)
+        outbox.write_text('{"seq":41}\n')
+        original_read_text = Path.read_text
+
+        def fail_for_outbox(path: Path, *args, **kwargs):
+            if path == outbox:
+                raise OSError("forced sequence-read failure")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", fail_for_outbox)
+        with pytest.raises(EventEmitError) as exc_info:
+            emit(
+                event_type=EventType.LANE_ENTERED,
+                workspace_root=workspace,
+                actor="agent:apollo",
+                owner_unit="apollo",
+                payload={"lane_name": "feat/test"},
+            )
+
+        assert isinstance(exc_info.value.__cause__, OSError)
+        assert outbox.read_bytes() == b'{"seq":41}\n'
 
     def test_emit_creates_events_dir_if_missing(self, workspace: Path):
         """emit() creates .grip/events/ if it doesn't exist."""


### PR DESCRIPTION
Serializes event-log writes so concurrent producers cannot collide.

The event outbox assigned each event a sequence number by reading the file for the current maximum and then appending. That read-modify-write was unsynchronized, so concurrent writers could allocate the same sequence number.

- A lock covering sequence allocation, rotation, and append as one critical section
- The lock lives on a separate lock file, so log rotation cannot invalidate it
- `emit` now raises on failure rather than returning silently
- `os.fsync` on write
- An environment flag to disable locking, so the before/after can be measured
- A concurrency harness with a sequential control

Closes #843

Reviewed by two agents against the exact bytes before push.

Premium boundary: gr2 is OSS — local event-log infrastructure only. No identity, org, or entitlement logic.
