### PR TITLE
fix(gr2): preserve completed event outcomes

### DIFF
--- a/gr2/docs/event-outcome-classification.md
+++ b/gr2/docs/event-outcome-classification.md
@@ -1,0 +1,54 @@
+# Event outcome classification
+
+`emit` is strict. A sink failure raises and stops the caller. Sites that run
+after an outcome which cannot honestly be reported as failed use
+`emit_after_outcome` instead. That helper preserves the outcome and reports the
+recording failure on stderr. It is not a general event wrapper.
+
+## Direct call sites
+
+| Site | Event | Position | Policy |
+|---|---|---|---|
+| `hooks.run_lifecycle_stage` skipped branch | `hook.skipped` | no hook ran | strict |
+| `hooks.run_lifecycle_stage` before subprocess | `hook.started` | before command | strict |
+| `hooks.run_lifecycle_stage` success branch | `hook.completed` | after command | preserve outcome |
+| `hooks.run_lifecycle_stage` failure branch | `hook.failed` | after command | preserve outcome |
+| `spec_apply.apply_plan` projection loop | `workspace.file_projected` | after projection | preserve outcome |
+| `spec_apply.apply_plan` completion | `workspace.materialized` | after filesystem work | preserve outcome |
+| `execops.run_exec` start | `exec.started` | after lease acquisition | preserve outcome |
+| `execops.run_exec` success | `exec.completed` | after subprocesses | preserve outcome |
+| `execops.run_exec` failure | `exec.failed` | after subprocesses | preserve outcome |
+| `failures.resolve_failure_marker` | `failure.resolved` | after marker removal | preserve outcome |
+| `pr.create_pr_group` | `pr.created` | after host creation and state save | preserve outcome |
+| `pr.merge_pr_group` | `pr.merged` | after host merge and state save | preserve outcome |
+| `pr._record_merge_failure` | `pr.merge_failed` | after a host attempt | existing guarded error channel |
+| `pr.check_pr_group_status` state change | `pr.status_changed` | before cache mutation | strict |
+| `pr.check_pr_group_status` failed checks | `pr.checks_failed` | read-only observation | strict |
+| `pr.check_pr_group_status` passed checks | `pr.checks_passed` | read-only observation | strict |
+| `pr.record_pr_review` | `pr.review_submitted` | no local work | strict |
+| `syncops._emit_sync_event` | dynamic | dispatch only | classified by caller below |
+| `app.lane_create` | `lane.created` | after lane materialization | preserve outcome |
+| `app.lane_enter` | `lane.entered` | after entry mutation | preserve outcome |
+| `app.lane_exit` | `lane.exited` | after exit mutation | preserve outcome |
+| `app.lane_lease_acquire` | `lease.acquired` | after lease mutation | preserve outcome |
+| `app.lane_lease_release` | `lease.released` | after lease mutation | preserve outcome |
+
+## Dynamic sync callers
+
+The sync wrapper does not determine position. Each caller does.
+
+| Caller outcome | Position | Policy |
+|---|---|---|
+| cache seeded or refreshed | after cache mutation | preserve outcome |
+| shared repo cloned and hooks run | after filesystem and hook work | preserve outcome |
+| remote refs fetched | after network and ref mutation | preserve outcome |
+| lane repo materialized and hooks run | after filesystem and hook work | preserve outcome |
+| dirty repo stashed | after working-tree mutation | preserve outcome |
+| dirty repo discarded | after working-tree mutation | preserve outcome |
+| lock-held conflict | no mutation | strict |
+| lock-held terminal result | no mutation | strict |
+| sync started | before planned operations | strict, with lock cleanup on failure |
+| active-lease conflict | no mutation | strict |
+| dirty-repo conflict | no mutation | strict |
+| blocked terminal result | no mutation | strict |
+| terminal result after operations | after repo and state mutation | preserve outcome |

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -15,7 +15,7 @@ from gr2.prototypes import repo_maintenance_prototype as repo_proto
 from . import branch as branch_ops
 from . import execops, failures, migration, spec_apply, syncops
 from . import pr as pr_ops
-from .events import EventType, emit
+from .events import EventType, emit_after_outcome
 from .gitops import (
     branch_exists,
     checkout_branch,
@@ -765,7 +765,7 @@ def lane_create(
         else:
             for r in repo_list:
                 branch_map[r] = part.strip()
-    emit(
+    emit_after_outcome(
         event_type=EventType.LANE_CREATED,
         workspace_root=workspace_root,
         actor=source,
@@ -833,7 +833,7 @@ def lane_enter(
     )
     _exit(lane_proto.enter_lane(ns))
     lane_doc = lane_proto.load_lane_doc(workspace_root, owner_unit, lane_name)
-    emit(
+    emit_after_outcome(
         event_type=EventType.LANE_ENTERED,
         workspace_root=workspace_root,
         actor=actor,
@@ -899,7 +899,7 @@ def lane_exit(
         recall=recall,
     )
     _exit(lane_proto.exit_lane(ns))
-    emit(
+    emit_after_outcome(
         event_type=EventType.LANE_EXITED,
         workspace_root=workspace_root,
         actor=actor,
@@ -947,7 +947,7 @@ def lane_lease_acquire(
         force=force,
     )
     _exit(lane_proto.acquire_lane_lease(ns))
-    emit(
+    emit_after_outcome(
         event_type=EventType.LEASE_ACQUIRED,
         workspace_root=workspace_root,
         actor=actor,
@@ -976,7 +976,7 @@ def lane_lease_release(
         actor=actor,
     )
     _exit(lane_proto.release_lane_lease(ns))
-    emit(
+    emit_after_outcome(
         event_type=EventType.LEASE_RELEASED,
         workspace_root=workspace_root,
         actor=actor,

--- a/gr2/python_cli/events.py
+++ b/gr2/python_cli/events.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import sys
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -190,6 +191,37 @@ def emit(
                 os.fsync(event_file.fileno())
     except Exception as exc:
         raise EventEmitError(f"event emit failed for {outbox}") from exc
+
+
+def emit_after_outcome(
+    event_type: EventType,
+    workspace_root: Path,
+    actor: str,
+    owner_unit: str,
+    payload: dict[str, object],
+    *,
+    agent_id: str | None = None,
+) -> None:
+    """Report a completed outcome without replacing it on sink failure.
+
+    Callers must use this only after work that cannot honestly be reported as
+    failed. Pre-work and no-work sites use strict ``emit`` directly.
+    """
+
+    try:
+        emit(
+            event_type=event_type,
+            workspace_root=workspace_root,
+            actor=actor,
+            owner_unit=owner_unit,
+            payload=payload,
+            agent_id=agent_id,
+        )
+    except EventEmitError as exc:
+        print(
+            f"gr2: could not record {event_type.value} after its outcome completed ({exc})",
+            file=sys.stderr,
+        )
 
 
 def read_events(workspace_root: Path, consumer: str) -> list[dict[str, object]]:

--- a/gr2/python_cli/execops.py
+++ b/gr2/python_cli/execops.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from gr2.prototypes import lane_workspace_prototype as lane_proto
-from gr2.python_cli.events import emit, EventType
+from gr2.python_cli.events import EventType, emit_after_outcome
 
 
 @dataclass
@@ -281,7 +281,7 @@ def run_exec(
     parallelism = str(rows[0]["parallelism"]) if rows else "sequential"
     acquire_exec_lease(workspace_root, owner_unit, resolved_lane, actor, ttl_seconds)
 
-    emit(
+    emit_after_outcome(
         event_type=EventType.EXEC_STARTED,
         workspace_root=workspace_root,
         actor=actor,
@@ -318,7 +318,7 @@ def run_exec(
     failed_repos = [r.repo for r in exec_results if not r.succeeded]
 
     if overall == "success":
-        emit(
+        emit_after_outcome(
             event_type=EventType.EXEC_COMPLETED,
             workspace_root=workspace_root,
             actor=actor,
@@ -331,7 +331,7 @@ def run_exec(
             },
         )
     else:
-        emit(
+        emit_after_outcome(
             event_type=EventType.EXEC_FAILED,
             workspace_root=workspace_root,
             actor=actor,

--- a/gr2/python_cli/failures.py
+++ b/gr2/python_cli/failures.py
@@ -5,7 +5,7 @@ import os
 from datetime import UTC, datetime
 from pathlib import Path
 
-from .events import EventType, emit
+from .events import EventType, emit_after_outcome
 
 
 def _now_utc() -> str:
@@ -78,7 +78,7 @@ def resolve_failure_marker(
         raise SystemExit(f"failure marker not found: {operation_id}")
     marker = json.loads(path.read_text())
     path.unlink()
-    emit(
+    emit_after_outcome(
         event_type=EventType.FAILURE_RESOLVED,
         workspace_root=workspace_root,
         actor=resolved_by,

--- a/gr2/python_cli/hooks.py
+++ b/gr2/python_cli/hooks.py
@@ -8,7 +8,7 @@ import time
 import tomllib
 from pathlib import Path
 
-from .events import emit, EventType
+from .events import EventType, emit, emit_after_outcome
 
 
 VALID_IF_EXISTS = {"skip", "overwrite", "merge", "error"}
@@ -350,7 +350,7 @@ def run_lifecycle_stage(
         )
         duration_ms = int((time.monotonic() - t0) * 1000)
         if proc.returncode == 0:
-            emit(
+            emit_after_outcome(
                 event_type=EventType.HOOK_COMPLETED,
                 workspace_root=ctx.workspace_root,
                 actor="system",
@@ -378,7 +378,7 @@ def run_lifecycle_stage(
             )
             continue
         stderr_tail = proc.stderr[-500:] if proc.stderr else ""
-        emit(
+        emit_after_outcome(
             event_type=EventType.HOOK_FAILED,
             workspace_root=ctx.workspace_root,
             actor="system",

--- a/gr2/python_cli/pr.py
+++ b/gr2/python_cli/pr.py
@@ -19,7 +19,7 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
-from .events import EventType, emit
+from .events import EventType, emit, emit_after_outcome
 from .merge_verification import (
     CompletedMerge,
     MergeVerificationTarget,
@@ -237,7 +237,7 @@ def create_pr_group(
     }
     path = _save_group(workspace_root, group)
 
-    emit(
+    emit_after_outcome(
         event_type=EventType.PR_CREATED,
         workspace_root=workspace_root,
         actor=actor,
@@ -337,7 +337,11 @@ def merge_pr_group(
 
     records = _completed_records(merged)
 
-    emit(
+    group["completed"] = records
+    group["group_state"] = "merged"
+    _save_group(workspace_root, group)
+
+    emit_after_outcome(
         event_type=EventType.PR_MERGED,
         workspace_root=workspace_root,
         actor=actor,
@@ -345,9 +349,6 @@ def merge_pr_group(
         payload={"pr_group_id": pr_group_id, "repos": records},
     )
 
-    group["completed"] = records
-    group["group_state"] = "merged"
-    _save_group(workspace_root, group)
     return group
 
 

--- a/gr2/python_cli/spec_apply.py
+++ b/gr2/python_cli/spec_apply.py
@@ -18,7 +18,7 @@ from types import MappingProxyType
 
 from jsonschema import Draft202012Validator
 
-from .events import EventType, emit
+from .events import EventType, emit_after_outcome
 from .gitops import clone_repo, ensure_repo_cache, is_git_dir, is_git_repo, repo_dirty
 from .hooks import HookContext, apply_file_projections, load_repo_hooks, run_lifecycle_stage
 
@@ -314,7 +314,7 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
                 manual_hooks=manual_hooks,
             )
             for projection in hook_payload["projected_files"]:
-                emit(
+                emit_after_outcome(
                     event_type=EventType.WORKSPACE_FILE_PROJECTED,
                     workspace_root=workspace_root,
                     actor="system",
@@ -371,7 +371,7 @@ def apply_plan(workspace_root: Path, *, yes: bool, manual_hooks: bool = False) -
     if applied:
         _record_apply_state(workspace_root, applied)
     if materialized_repos:
-        emit(
+        emit_after_outcome(
             event_type=EventType.WORKSPACE_MATERIALIZED,
             workspace_root=workspace_root,
             actor="system",

--- a/gr2/python_cli/syncops.py
+++ b/gr2/python_cli/syncops.py
@@ -25,7 +25,7 @@ from .gitops import (
     repo_dirty,
     stash_if_dirty,
 )
-from .events import EventType, emit
+from .events import EventType, emit, emit_after_outcome
 from .hooks import load_repo_hooks
 from .spec_apply import (
     ValidationIssue,
@@ -205,11 +205,17 @@ def _sync_lock_file(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "state" / "sync.lock"
 
 
-def _emit_sync_event(workspace_root: Path, payload: dict[str, object]) -> None:
+def _emit_sync_event(
+    workspace_root: Path,
+    payload: dict[str, object],
+    *,
+    after_outcome: bool = False,
+) -> None:
     event_type = EventType(str(payload.pop("type")))
     payload.pop("workspace", None)
     agent_id = payload.pop("agent_id", None)
-    emit(
+    emitter = emit_after_outcome if after_outcome else emit
+    emitter(
         event_type=event_type,
         workspace_root=workspace_root,
         actor=str(payload.pop("actor")),
@@ -555,6 +561,7 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                 "strategy": SYNC_STRATEGY,
                 "cache_path": str(cache_path),
             },
+            after_outcome=True,
         )
         if op.kind == "seed_repo_cache":
             return f"seeded repo cache for '{op.subject}' at {cache_path}"
@@ -580,6 +587,7 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                 "strategy": SYNC_STRATEGY,
                 "commits_pulled": commits_between(repo_root, before_sha, after_sha),
             },
+            after_outcome=True,
         )
         return f"cloned shared repo '{op.subject}' into {repo_root}"
 
@@ -602,6 +610,7 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                 "old_ref": old_ref,
                 "new_ref": new_ref,
             },
+            after_outcome=True,
         )
         return f"fetched remote refs for shared repo '{op.subject}'"
 
@@ -637,6 +646,7 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                 "strategy": SYNC_STRATEGY,
                 "commits_pulled": commits_between(target_repo_root, before_sha, after_sha),
             },
+            after_outcome=True,
         )
         return f"materialized lane repo '{op.subject}' at {target_repo_root}"
 
@@ -661,6 +671,7 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                     "repo": op.subject.split(":")[-1],
                     "reason": "dirty_stashed",
                 },
+                after_outcome=True,
             )
             return f"stashed dirty repo state for '{op.subject}'"
         return f"repo already clean for '{op.subject}'"
@@ -676,6 +687,7 @@ def _execute_operation(workspace_root: Path, spec: dict[str, object], op: SyncOp
                     "repo": op.subject.split(":")[-1],
                     "reason": "dirty_discarded",
                 },
+                after_outcome=True,
             )
             return f"discarded dirty repo state for '{op.subject}'"
         return f"repo already clean for '{op.subject}'"
@@ -753,56 +765,70 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
             operation_id=operation_id,
         )
 
-    _emit_sync_event(
-        workspace_root,
-        {
-            "type": "sync.started",
-            **_sync_context(workspace_root),
-            "repos": _plan_repo_names(build_sync_plan(workspace_root, dirty_mode=dirty_mode)),
-            "strategy": SYNC_STRATEGY,
-        },
-    )
-    plan = build_sync_plan(workspace_root, dirty_mode=dirty_mode)
-    blocked = [issue for issue in plan.issues if issue.blocks]
-    if blocked:
-        for issue in blocked:
-            if issue.code == "lease_blocked_sync":
-                _emit_sync_event(
-                    workspace_root,
-                    {
-                        "type": "sync.conflict",
-                        **_sync_context(workspace_root, owner_unit=issue.subject.split("/", 1)[0]),
-                        "reason": "active_lease",
-                        "repo": issue.subject,
-                        "conflicting_files": [],
-                    },
-                )
-            elif issue.code in {"dirty_shared_repo", "dirty_lane_repo"} and issue.details.get("conflicting_files"):
-                repo_name = issue.subject.split(":")[-1]
-                _emit_sync_event(
-                    workspace_root,
-                    {
-                        "type": "sync.conflict",
-                        **_sync_context(
-                            workspace_root,
-                            owner_unit=issue.subject.split("/", 1)[0] if issue.scope == "lane" else "workspace",
-                        ),
-                        "repo": repo_name,
-                        "conflicting_files": list(issue.details.get("conflicting_files", [])),
-                    },
-                )
+    try:
         _emit_sync_event(
             workspace_root,
             {
-                "type": "sync.completed",
+                "type": "sync.started",
                 **_sync_context(workspace_root),
-                "status": "blocked",
-                "repos_updated": 0,
-                "repos_skipped": 0,
-                "repos_failed": len(blocked),
-                "duration_ms": int((time.monotonic() - started_at) * 1000),
+                "repos": _plan_repo_names(build_sync_plan(workspace_root, dirty_mode=dirty_mode)),
+                "strategy": SYNC_STRATEGY,
             },
         )
+    except Exception:
+        _release_sync_lock(lock_fh)
+        raise
+    plan = build_sync_plan(workspace_root, dirty_mode=dirty_mode)
+    blocked = [issue for issue in plan.issues if issue.blocks]
+    if blocked:
+        try:
+            for issue in blocked:
+                if issue.code == "lease_blocked_sync":
+                    _emit_sync_event(
+                        workspace_root,
+                        {
+                            "type": "sync.conflict",
+                            **_sync_context(workspace_root, owner_unit=issue.subject.split("/", 1)[0]),
+                            "reason": "active_lease",
+                            "repo": issue.subject,
+                            "conflicting_files": [],
+                        },
+                    )
+                elif issue.code in {"dirty_shared_repo", "dirty_lane_repo"} and issue.details.get(
+                    "conflicting_files"
+                ):
+                    repo_name = issue.subject.split(":")[-1]
+                    _emit_sync_event(
+                        workspace_root,
+                        {
+                            "type": "sync.conflict",
+                            **_sync_context(
+                                workspace_root,
+                                owner_unit=(
+                                    issue.subject.split("/", 1)[0]
+                                    if issue.scope == "lane"
+                                    else "workspace"
+                                ),
+                            ),
+                            "repo": repo_name,
+                            "conflicting_files": list(issue.details.get("conflicting_files", [])),
+                        },
+                    )
+            _emit_sync_event(
+                workspace_root,
+                {
+                    "type": "sync.completed",
+                    **_sync_context(workspace_root),
+                    "status": "blocked",
+                    "repos_updated": 0,
+                    "repos_skipped": 0,
+                    "repos_failed": len(blocked),
+                    "duration_ms": int((time.monotonic() - started_at) * 1000),
+                },
+            )
+        except Exception:
+            _release_sync_lock(lock_fh)
+            raise
         _release_sync_lock(lock_fh)
         return SyncResult(
             workspace_root=str(workspace_root),
@@ -848,6 +874,7 @@ def run_sync(workspace_root: Path, *, dirty_mode: str = "stash") -> SyncResult:
                 "repos_failed": len(failures),
                 "duration_ms": int((time.monotonic() - started_at) * 1000),
             },
+            after_outcome=True,
         )
 
         return SyncResult(

--- a/gr2/tests/test_app_event_outcomes.py
+++ b/gr2/tests/test_app_event_outcomes.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from gr2.python_cli import app as app_module
+from gr2.python_cli import events
+from gr2.python_cli.events import EventEmitError
+
+
+@pytest.mark.parametrize(
+    "operation,event_type",
+    [
+        ("create", "lane.created"),
+        ("enter", "lane.entered"),
+        ("exit", "lane.exited"),
+        ("lease_acquire", "lease.acquired"),
+        ("lease_release", "lease.released"),
+    ],
+)
+def test_sink_failure_cannot_replace_lane_or_lease_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    event_type: str,
+) -> None:
+    completed: list[str] = []
+    monkeypatch.setattr(app_module, "_exit", lambda _result: completed.append(operation))
+    monkeypatch.setattr(app_module, "_materialize_lane_repos", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(app_module, "_run_lane_stage", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(app_module, "stash_if_dirty", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(app_module.failures, "unresolved_lane_failure", lambda *_args: None)
+    for name in (
+        "create_lane",
+        "enter_lane",
+        "exit_lane",
+        "acquire_lane_lease",
+        "release_lane_lease",
+    ):
+        monkeypatch.setattr(app_module.lane_proto, name, lambda _args: 0)
+    monkeypatch.setattr(
+        app_module.lane_proto,
+        "load_lane_doc",
+        lambda *_args: {"type": "feature", "repos": []},
+    )
+    monkeypatch.setattr(
+        app_module.lane_proto,
+        "load_current_lane_doc",
+        lambda *_args: {"current": {"lane_name": "feat/test"}},
+    )
+    monkeypatch.setattr(
+        events,
+        "emit",
+        lambda **kwargs: (
+            (_ for _ in ()).throw(EventEmitError("sink unavailable"))
+            if kwargs["event_type"].value == event_type
+            else None
+        ),
+    )
+
+    if operation == "create":
+        app_module.lane_create(
+            tmp_path, "atlas", "feat/test", "app", "dev", "feature", "manual", [], False
+        )
+    elif operation == "enter":
+        app_module.lane_enter(tmp_path, "atlas", "feat/test", "agent:atlas", False, False, False)
+    elif operation == "exit":
+        app_module.lane_exit(tmp_path, "atlas", "agent:atlas", False, False, False)
+    elif operation == "lease_acquire":
+        app_module.lane_lease_acquire(
+            tmp_path, "atlas", "feat/test", "agent:atlas", "edit", 900, False
+        )
+    else:
+        app_module.lane_lease_release(tmp_path, "atlas", "feat/test", "agent:atlas")
+
+    assert completed == [operation]

--- a/gr2/tests/test_event_outcome_policy.py
+++ b/gr2/tests/test_event_outcome_policy.py
@@ -1,0 +1,149 @@
+"""Mutation locks for the event/outcome classification in grip#844."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+
+import pytest
+from gr2.python_cli.events import EventEmitError, EventType, emit_after_outcome
+
+ROOT = Path(__file__).parents[1] / "python_cli"
+
+
+def _calls(path: Path) -> list[tuple[str, str, str | None, bool]]:
+    tree = ast.parse(path.read_text())
+    rows: list[tuple[str, str, str | None, bool]] = []
+    functions = (
+        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    )
+    for function in functions:
+        for call in (node for node in ast.walk(function) if isinstance(node, ast.Call)):
+            if not isinstance(call.func, ast.Name) or call.func.id not in {
+                "emit",
+                "emit_after_outcome",
+                "_emit_sync_event",
+            }:
+                continue
+            event: str | None = None
+            if (
+                call.func.id == "_emit_sync_event"
+                and len(call.args) >= 2
+                and isinstance(call.args[1], ast.Dict)
+            ):
+                for key, value in zip(call.args[1].keys, call.args[1].values):
+                    if (
+                        isinstance(key, ast.Constant)
+                        and key.value == "type"
+                        and isinstance(value, ast.Constant)
+                    ):
+                        event = str(value.value)
+                    elif (
+                        isinstance(key, ast.Constant)
+                        and key.value == "type"
+                        and isinstance(value, ast.IfExp)
+                        and isinstance(value.body, ast.Constant)
+                        and isinstance(value.orelse, ast.Constant)
+                    ):
+                        event = f"{value.body.value}|{value.orelse.value}"
+            else:
+                for keyword in call.keywords:
+                    if keyword.arg == "event_type" and isinstance(keyword.value, ast.Attribute):
+                        event = keyword.value.attr
+            after = any(
+                keyword.arg == "after_outcome"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value is True
+                for keyword in call.keywords
+            )
+            rows.append((function.name, call.func.id, event, after))
+    return rows
+
+
+def test_every_direct_site_has_the_classified_policy() -> None:
+    actual: Counter[tuple[str, str, str | None, bool]] = Counter()
+    for name in ("hooks.py", "spec_apply.py", "execops.py", "failures.py", "pr.py", "app.py"):
+        actual.update(_calls(ROOT / name))
+
+    expected = Counter(
+        {
+            ("run_lifecycle_stage", "emit", "HOOK_SKIPPED", False): 1,
+            ("run_lifecycle_stage", "emit", "HOOK_STARTED", False): 1,
+            ("run_lifecycle_stage", "emit_after_outcome", "HOOK_COMPLETED", False): 1,
+            ("run_lifecycle_stage", "emit_after_outcome", "HOOK_FAILED", False): 1,
+            ("apply_plan", "emit_after_outcome", "WORKSPACE_FILE_PROJECTED", False): 1,
+            ("apply_plan", "emit_after_outcome", "WORKSPACE_MATERIALIZED", False): 1,
+            ("run_exec", "emit_after_outcome", "EXEC_STARTED", False): 1,
+            ("run_exec", "emit_after_outcome", "EXEC_COMPLETED", False): 1,
+            ("run_exec", "emit_after_outcome", "EXEC_FAILED", False): 1,
+            ("resolve_failure_marker", "emit_after_outcome", "FAILURE_RESOLVED", False): 1,
+            ("create_pr_group", "emit_after_outcome", "PR_CREATED", False): 1,
+            ("merge_pr_group", "emit_after_outcome", "PR_MERGED", False): 1,
+            ("_record_merge_failure", "emit", "PR_MERGE_FAILED", False): 1,
+            ("check_pr_group_status", "emit", "PR_STATUS_CHANGED", False): 1,
+            ("check_pr_group_status", "emit", "PR_CHECKS_FAILED", False): 1,
+            ("check_pr_group_status", "emit", "PR_CHECKS_PASSED", False): 1,
+            ("record_pr_review", "emit", "PR_REVIEW_SUBMITTED", False): 1,
+            ("lane_create", "emit_after_outcome", "LANE_CREATED", False): 1,
+            ("lane_enter", "emit_after_outcome", "LANE_ENTERED", False): 1,
+            ("lane_exit", "emit_after_outcome", "LANE_EXITED", False): 1,
+            ("lane_lease_acquire", "emit_after_outcome", "LEASE_ACQUIRED", False): 1,
+            ("lane_lease_release", "emit_after_outcome", "LEASE_RELEASED", False): 1,
+        }
+    )
+    assert actual == expected
+
+
+def test_every_dynamic_sync_site_has_the_classified_policy() -> None:
+    rows = [row for row in _calls(ROOT / "syncops.py") if row[1] == "_emit_sync_event"]
+    actual = Counter((function, event, after) for function, _call, event, after in rows)
+    expected = Counter(
+        {
+            ("_execute_operation", "sync.cache_seeded|sync.cache_refreshed", True): 1,
+            ("_execute_operation", "sync.repo_updated", True): 2,
+            ("_execute_operation", "sync.repo_fetched", True): 1,
+            ("_execute_operation", "sync.repo_skipped", True): 2,
+            ("run_sync", "sync.conflict", False): 3,
+            ("run_sync", "sync.completed", False): 2,
+            ("run_sync", "sync.started", False): 1,
+            ("run_sync", "sync.completed", True): 1,
+        }
+    )
+    assert actual == expected
+
+
+def test_after_outcome_reports_sink_failure_without_replacing_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from gr2.python_cli import events
+
+    monkeypatch.setattr(
+        events,
+        "emit",
+        lambda **_kwargs: (_ for _ in ()).throw(EventEmitError("sink unavailable")),
+    )
+    assert (
+        emit_after_outcome(
+            EventType.EXEC_COMPLETED,
+            tmp_path,
+            "system",
+            "workspace",
+            {"status": "success"},
+        )
+        is None
+    )
+    assert "could not record exec.completed" in capsys.readouterr().err
+
+
+def test_after_outcome_does_not_swallow_non_sink_defects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gr2.python_cli import events
+
+    monkeypatch.setattr(events, "emit", lambda **_kwargs: (_ for _ in ()).throw(ValueError("bug")))
+    with pytest.raises(ValueError, match="bug"):
+        emit_after_outcome(EventType.EXEC_COMPLETED, tmp_path, "system", "workspace", {})

--- a/gr2/tests/test_execops.py
+++ b/gr2/tests/test_execops.py
@@ -16,7 +16,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-from gr2.python_cli.events import EventType, _outbox_path
+from gr2.python_cli.events import EventEmitError, EventType, _outbox_path
 from gr2.python_cli.execops import run_exec, ExecResult, run_exec_parallel
 
 
@@ -89,6 +89,53 @@ class ExecTestBase(unittest.TestCase):
 
 class TestExecRunSequential(ExecTestBase):
     """Test sequential execution across lane repos."""
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_sink_failure_cannot_replace_started_or_completed_outcomes(self, mock_proto):
+        from gr2.python_cli import events
+
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+        real_emit = events.emit
+        for victim in (EventType.EXEC_STARTED, EventType.EXEC_COMPLETED):
+            with self.subTest(victim=victim.value), patch.object(
+                events,
+                "emit",
+                side_effect=lambda **kwargs: (
+                    (_ for _ in ()).throw(EventEmitError("sink unavailable"))
+                    if kwargs["event_type"] is victim
+                    else real_emit(**kwargs)
+                ),
+            ):
+                result = run_exec(
+                    self.workspace, self.owner_unit, self.lane_name,
+                    actor=self.actor, command=["echo", "hello"],
+                )
+                self.assertEqual(result["status"], "success")
+                self.assertEqual(len(result["results"]), 3)
+
+    @patch("gr2.python_cli.execops.lane_proto")
+    def test_sink_failure_cannot_replace_failed_outcome(self, mock_proto):
+        from gr2.python_cli import events
+
+        for attr in dir(self._mock_lane_proto()):
+            if not attr.startswith("_"):
+                setattr(mock_proto, attr, getattr(self._mock_lane_proto(), attr))
+        real_emit = events.emit
+
+        def fail_exec_failed(**kwargs):
+            if kwargs["event_type"] is EventType.EXEC_FAILED:
+                raise EventEmitError("sink unavailable")
+            return real_emit(**kwargs)
+
+        with patch.object(events, "emit", side_effect=fail_exec_failed):
+            result = run_exec(
+                self.workspace, self.owner_unit, self.lane_name,
+                actor=self.actor, command=["false"],
+            )
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["results"][0]["returncode"], 1)
 
     @patch("gr2.python_cli.execops.lane_proto")
     def test_runs_command_in_each_repo(self, mock_proto):

--- a/gr2/tests/test_failure_event_outcome.py
+++ b/gr2/tests/test_failure_event_outcome.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gr2.python_cli import events
+from gr2.python_cli.events import EventEmitError
+from gr2.python_cli.failures import resolve_failure_marker, write_failure_marker
+
+
+def test_sink_failure_cannot_restore_a_resolved_failure_marker(tmp_path: Path, monkeypatch) -> None:
+    marker = write_failure_marker(
+        tmp_path,
+        operation="lane.enter",
+        stage="on_enter",
+        hook_name="check",
+        repo="app",
+        owner_unit="atlas",
+        lane_name="feat/test",
+    )
+    monkeypatch.setattr(
+        events,
+        "emit",
+        lambda **_kwargs: (_ for _ in ()).throw(EventEmitError("sink unavailable")),
+    )
+
+    result = resolve_failure_marker(
+        tmp_path,
+        operation_id=str(marker["operation_id"]),
+        resolved_by="agent:atlas",
+        resolution="retry",
+        owner_unit="atlas",
+    )
+
+    assert result["operation_id"] == marker["operation_id"]
+    marker_path = tmp_path / ".grip" / "state" / "failures" / f"{marker['operation_id']}.json"
+    assert not marker_path.exists()

--- a/gr2/tests/test_hook_events.py
+++ b/gr2/tests/test_hook_events.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from gr2.python_cli.events import EventEmitError
+
 from gr2.python_cli.hooks import (
     HookContext,
     HookRuntimeError,
@@ -61,6 +63,29 @@ def _read_outbox(workspace: Path) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 class TestHookCompleted:
+
+    def test_sink_failure_after_success_preserves_success(
+        self, workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from gr2.python_cli import events
+
+        ctx = _make_ctx(workspace)
+        hooks = _make_hooks([LifecycleHook(
+            stage="on_enter", name="completed-outcome", command="true",
+            cwd=str(ctx.repo_root), when="always", on_failure="block",
+        )])
+        real_emit = events.emit
+
+        def fail_completed(**kwargs):
+            if kwargs["event_type"].value == "hook.completed":
+                raise EventEmitError("sink unavailable")
+            return real_emit(**kwargs)
+
+        monkeypatch.setattr(events, "emit", fail_completed)
+        results = run_lifecycle_stage(
+            hooks, "on_enter", ctx, repo_dirty=False, first_materialize=False
+        )
+        assert results[0].status == "applied"
 
     def test_emits_started_and_completed(self, workspace: Path):
         """Successful hook emits hook.started then hook.completed."""
@@ -116,6 +141,30 @@ class TestHookCompleted:
 # ---------------------------------------------------------------------------
 
 class TestHookFailedBlock:
+
+    def test_sink_failure_after_command_failure_preserves_hook_failure(
+        self, workspace: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from gr2.python_cli import events
+
+        ctx = _make_ctx(workspace)
+        hooks = _make_hooks([LifecycleHook(
+            stage="on_enter", name="failed-outcome", command="false",
+            cwd=str(ctx.repo_root), when="always", on_failure="block",
+        )])
+        real_emit = events.emit
+
+        def fail_failed(**kwargs):
+            if kwargs["event_type"].value == "hook.failed":
+                raise EventEmitError("sink unavailable")
+            return real_emit(**kwargs)
+
+        monkeypatch.setattr(events, "emit", fail_failed)
+        with pytest.raises(HookRuntimeError) as exc_info:
+            run_lifecycle_stage(
+                hooks, "on_enter", ctx, repo_dirty=False, first_materialize=False
+            )
+        assert exc_info.value.payload["returncode"] != 0
 
     def test_emits_started_and_failed(self, workspace: Path):
         ctx = _make_ctx(workspace)

--- a/gr2/tests/test_pr_events.py
+++ b/gr2/tests/test_pr_events.py
@@ -13,6 +13,7 @@ import json
 from pathlib import Path
 
 import pytest
+from gr2.python_cli.events import EventEmitError
 from gr2.python_cli.merge_verification import MergeVerificationTarget
 from gr2.python_cli.platform import (
     AdapterError,
@@ -120,6 +121,39 @@ def _merge_contract(workspace: Path, group: dict) -> dict[str, object]:
 
 class TestPRCreated:
 
+    def test_event_failure_does_not_erase_created_prs(
+        self,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from gr2.python_cli import events as events_module
+        from gr2.python_cli import pr as pr_module
+
+        adapter = FakeAdapter()
+        monkeypatch.setattr(
+            events_module,
+            "emit",
+            lambda **_kwargs: (_ for _ in ()).throw(EventEmitError("event sink unavailable")),
+        )
+
+        result = pr_module.create_pr_group(
+            workspace_root=workspace,
+            owner_unit="apollo",
+            lane_name="feat/hook-events",
+            title="feat: hook events",
+            base_branch="sprint-21",
+            head_branch="test/event-system-runtime",
+            repos=["app", "api"],
+            adapter=adapter,
+            actor="agent:apollo",
+        )
+
+        persisted = json.loads(Path(result["state_path"]).read_text())
+        assert [request.repo for request in adapter.created] == ["app", "api"]
+        assert persisted["prs"] == result["prs"]
+        assert "could not record pr.created" in capsys.readouterr().err
+
     def test_emits_pr_created(self, workspace: Path):
         from gr2.python_cli.pr import create_pr_group
         adapter = FakeAdapter()
@@ -224,6 +258,38 @@ class TestPRCreated:
 # ---------------------------------------------------------------------------
 
 class TestPRMerged:
+
+    def test_event_failure_does_not_erase_merged_outcome(
+        self,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from gr2.python_cli import events as events_module
+        from gr2.python_cli import pr as pr_module
+
+        adapter = FakeAdapter()
+        group = self._create_group(workspace, adapter)
+        monkeypatch.setattr(
+            events_module,
+            "emit",
+            lambda **_kwargs: (_ for _ in ()).throw(EventEmitError("event sink unavailable")),
+        )
+
+        result = pr_module.merge_pr_group(
+            workspace_root=workspace,
+            pr_group_id=group["pr_group_id"],
+            adapter=adapter,
+            actor="agent:apollo",
+            **_merge_contract(workspace, group),
+        )
+
+        state_path = workspace / ".grip" / "pr_groups" / f"{group['pr_group_id']}.json"
+        persisted = json.loads(state_path.read_text())
+        assert [repo for repo, _number in adapter.merged] == ["app", "api"]
+        assert result["group_state"] == "merged"
+        assert persisted["group_state"] == "merged"
+        assert "could not record pr.merged" in capsys.readouterr().err
 
     def _create_group(self, workspace: Path, adapter: FakeAdapter, repos: list[str] | None = None) -> dict:
         from gr2.python_cli.pr import create_pr_group

--- a/gr2/tests/test_spec_apply_event_outcomes.py
+++ b/gr2/tests/test_spec_apply_event_outcomes.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from gr2.python_cli import events, spec_apply
+from gr2.python_cli.events import EventEmitError
+from gr2.python_cli.spec_apply import PlanOperation
+
+
+@pytest.mark.parametrize("victim", ["workspace.file_projected", "workspace.materialized"])
+def test_sink_failure_cannot_replace_materialization_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    victim: str,
+) -> None:
+    repo_root = tmp_path / "repos" / "app"
+    spec = {"repos": [{"name": "app", "path": "repos/app", "url": "file:///app"}]}
+    operation = PlanOperation(
+        kind="clone_repo",
+        subject="app",
+        target_path=str(repo_root),
+        reason="missing",
+        details={},
+    )
+    monkeypatch.setattr(spec_apply, "build_plan", lambda _root: (spec, [operation]))
+    monkeypatch.setattr(spec_apply, "clone_repo", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        spec_apply,
+        "_run_materialize_hooks",
+        lambda *_args, **_kwargs: {
+            "projected_files": [{"kind": "copy", "src": "source", "dest": "destination"}]
+        },
+    )
+    real_emit = events.emit
+
+    def fail_victim(**kwargs):
+        if kwargs["event_type"].value == victim:
+            raise EventEmitError("sink unavailable")
+        return real_emit(**kwargs)
+
+    monkeypatch.setattr(events, "emit", fail_victim)
+    result = spec_apply.apply_plan(tmp_path, yes=True)
+
+    assert result["operation_count"] == 1
+    assert result["applied"] == [f"cloned repo 'app' into {repo_root}"]

--- a/gr2/tests/test_sync_event_outcomes.py
+++ b/gr2/tests/test_sync_event_outcomes.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from gr2.python_cli import events, syncops
+from gr2.python_cli.events import EventEmitError
+from gr2.python_cli.syncops import SyncIssue, SyncPlan
+
+
+def _empty_plan(root: Path) -> SyncPlan:
+    return SyncPlan(
+        workspace_root=str(root),
+        spec_path=str(root / ".grip" / "workspace_spec.toml"),
+        status="ready",
+        dirty_mode="stash",
+        dirty_targets=[],
+        issues=[],
+        operations=[],
+    )
+
+
+def test_after_outcome_sync_dispatch_preserves_completed_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        events,
+        "emit",
+        lambda **_kwargs: (_ for _ in ()).throw(EventEmitError("sink unavailable")),
+    )
+    syncops._emit_sync_event(
+        tmp_path,
+        {
+            "type": "sync.completed",
+            "workspace": tmp_path.name,
+            "actor": "system",
+            "owner_unit": "workspace",
+            "status": "success",
+        },
+        after_outcome=True,
+    )
+
+
+def test_strict_sync_started_failure_releases_acquired_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = object()
+    released: list[object] = []
+    monkeypatch.setattr(syncops, "_acquire_sync_lock", lambda _root: lock)
+    monkeypatch.setattr(syncops, "_release_sync_lock", released.append)
+    monkeypatch.setattr(syncops, "build_sync_plan", lambda *_args, **_kwargs: _empty_plan(tmp_path))
+    monkeypatch.setattr(
+        syncops,
+        "_emit_sync_event",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(EventEmitError("sink unavailable")),
+    )
+
+    with pytest.raises(EventEmitError, match="sink unavailable"):
+        syncops.run_sync(tmp_path)
+    assert released == [lock]
+
+
+def test_strict_blocked_event_failure_releases_acquired_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock = object()
+    released: list[object] = []
+    calls = 0
+    blocked_plan = SyncPlan(
+        workspace_root=str(tmp_path),
+        spec_path=str(tmp_path / ".grip" / "workspace_spec.toml"),
+        status="blocked",
+        dirty_mode="stash",
+        dirty_targets=[],
+        issues=[
+            SyncIssue(
+                level="error",
+                code="lease_blocked_sync",
+                scope="lane",
+                subject="atlas/feat/test:app",
+                message="active lease",
+                blocks=True,
+            )
+        ],
+        operations=[],
+    )
+    monkeypatch.setattr(syncops, "_acquire_sync_lock", lambda _root: lock)
+    monkeypatch.setattr(syncops, "_release_sync_lock", released.append)
+    monkeypatch.setattr(syncops, "build_sync_plan", lambda *_args, **_kwargs: blocked_plan)
+
+    def fail_second_event(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise EventEmitError("sink unavailable")
+
+    monkeypatch.setattr(syncops, "_emit_sync_event", fail_second_event)
+
+    with pytest.raises(EventEmitError, match="sink unavailable"):
+        syncops.run_sync(tmp_path)
+    assert released == [lock]


### PR DESCRIPTION
## Summary

- classify event sites by whether work has already completed
- preserve durable operation results when event recording fails
- retain strict pre-work emission and release held sync locks on failure
- pin every classified site and cleanup path with mutation-loud tests

## Verification

- Python 3.13: 839 passed, 43 subtests passed
- Python 3.11: 838 passed, 43 subtests passed before the final cleanup witness; final targeted policy suite passed
- 25 mutation probes, zero survivors

Ref #844 — closes at promotion.