### PR TITLE
test(gr2): verify spawned worker provenance

### DIFF
--- a/gr2/prototypes/concurrent_event_stress.py
+++ b/gr2/prototypes/concurrent_event_stress.py
@@ -25,14 +25,29 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _worker(workspace: str, actor: str, start: object, queue: object, unlocked: bool) -> None:
-    if unlocked:
-        os.environ["GR2_DISABLE_EVENT_LOCKING"] = "1"
-        os.environ["GR2_EVENT_TEST_DELAY"] = "0.03"
-    if not start.wait(timeout=10):
-        queue.put({"ok": False, "error": "start gate timed out"})
-        return
+def _worker(
+    workspace: str,
+    actor: str,
+    start: object,
+    queue: object,
+    unlocked: bool,
+    expected_source_root: str,
+) -> None:
     try:
+        import gr2
+
+        module_file = Path(gr2.__file__).resolve() if gr2.__file__ is not None else None
+        source_root = Path(expected_source_root).resolve()
+        if module_file is None or not module_file.is_relative_to(source_root):
+            raise RuntimeError(
+                f"spawned worker imported gr2 outside expected worktree: "
+                f"module={module_file}, expected_root={source_root}"
+            )
+        if unlocked:
+            os.environ["GR2_DISABLE_EVENT_LOCKING"] = "1"
+            os.environ["GR2_EVENT_TEST_DELAY"] = "0.03"
+        if not start.wait(timeout=10):
+            raise TimeoutError("start gate timed out")
         emit(
             event_type=EventType.LANE_ENTERED,
             workspace_root=Path(workspace),
@@ -43,7 +58,7 @@ def _worker(workspace: str, actor: str, start: object, queue: object, unlocked: 
     except Exception as exc:
         queue.put({"ok": False, "error": repr(exc)})
     else:
-        queue.put({"ok": True})
+        queue.put({"ok": True, "gr2_module": str(module_file)})
 
 
 def _read_rows(outbox: Path) -> tuple[list[dict[str, object]], int]:
@@ -85,7 +100,14 @@ def _run_round(writers: int, unlocked: bool) -> dict[str, object]:
         processes = [
             ctx.Process(
                 target=_worker,
-                args=(str(workspace), f"writer:{index}", start, queue, unlocked),
+                args=(
+                    str(workspace),
+                    f"writer:{index}",
+                    start,
+                    queue,
+                    unlocked,
+                    str(SOURCE_ROOT),
+                ),
             )
             for index in range(writers)
         ]
@@ -95,9 +117,7 @@ def _run_round(writers: int, unlocked: bool) -> dict[str, object]:
         for process in processes:
             process.join(timeout=15)
         outcomes = [queue.get(timeout=2) for _ in processes]
-        rows, corruption_count = _read_rows(
-            workspace / ".grip" / "events" / "outbox.jsonl"
-        )
+        rows, corruption_count = _read_rows(workspace / ".grip" / "events" / "outbox.jsonl")
         seqs = [row.get("seq") for row in rows]
         return {
             "all_workers_succeeded": all(outcome["ok"] for outcome in outcomes),
@@ -146,9 +166,7 @@ def sequential_control(writes: int = 8) -> dict[str, object]:
                 os.environ.pop("GR2_EVENT_TEST_DELAY", None)
             else:
                 os.environ["GR2_EVENT_TEST_DELAY"] = old_delay
-        rows, corruption_count = _read_rows(
-            workspace / ".grip" / "events" / "outbox.jsonl"
-        )
+        rows, corruption_count = _read_rows(workspace / ".grip" / "events" / "outbox.jsonl")
         seqs = [row.get("seq") for row in rows]
         return {
             "writes": writes,

--- a/gr2/tests/test_event_log_integrity.py
+++ b/gr2/tests/test_event_log_integrity.py
@@ -145,6 +145,39 @@ def test_repeated_stress_distinguishes_unlocked_and_locked_paths() -> None:
     assert locked["worker_failure_rounds"] == 0
 
 
+def test_spawned_worker_rejects_gr2_import_outside_expected_worktree(
+    tmp_path: Path,
+) -> None:
+    """Removing the worker-side provenance guard turns this positive control RED."""
+    from gr2.prototypes.concurrent_event_stress import _worker
+
+    (tmp_path / ".grip").mkdir()
+    ctx = multiprocessing.get_context("spawn")
+    start = ctx.Event()
+    queue = ctx.Queue()
+    process = ctx.Process(
+        target=_worker,
+        args=(
+            str(tmp_path),
+            "provenance-control",
+            start,
+            queue,
+            False,
+            str(tmp_path / "deliberately-wrong-worktree"),
+        ),
+    )
+    process.start()
+    start.set()
+    process.join(timeout=10)
+
+    assert not process.is_alive(), "provenance-control worker hung"
+    assert process.exitcode == 0
+    outcome = queue.get(timeout=2)
+    assert outcome["ok"] is False
+    assert "outside expected worktree" in outcome["error"]
+    assert not (tmp_path / ".grip" / "events" / "outbox.jsonl").exists()
+
+
 def test_cross_mode_child_failure_preserves_exit_and_output() -> None:
     """Captured child failure must be loud rather than indistinguishable from silence."""
     from gr2.prototypes.cross_mode_lane_stress import HarnessCommandError, run


### PR DESCRIPTION
## Summary

- verify the gr2 module path inside each spawned event-stress worker
- reject workers that resolve gr2 outside the parent-supplied source root before measurement begins
- add a real spawned-process positive control for the rejection path

## Verification

- event-log integrity tests: 8 passed
- guard-removal mutation: positive control failed as expected
- repeated harness: unlocked duplicate sequences 3/3, locked 0/3, controls clean
- full gr2 Python suite: 842 passed, 1 inherited failure, 43 subtests
- Ruff and diff checks clean

OSS boundary: this change validates only gr2 runtime provenance and emits no identity or downstream-layer state.

Ref #843 — closes at promotion.
