### PR TITLE
fix(gr2): serialize workspace edit leases

### DIFF
--- a/gr2/prototypes/concurrent_workspace_cap_stress.py
+++ b/gr2/prototypes/concurrent_workspace_cap_stress.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Repeated stress harness for the workspace-wide edit-lease cap."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rounds", type=int, default=20)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def lane_proto(root: Path) -> Path:
+    return root / "gr2" / "prototypes" / "lane_workspace_prototype.py"
+
+
+def _run(argv: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, text=True, capture_output=True, env=env, check=False)
+
+
+def _init_workspace(workspace_root: Path) -> None:
+    (workspace_root / ".grip").mkdir(parents=True)
+    (workspace_root / "agents").mkdir()
+    (workspace_root / ".grip" / "workspace_spec.toml").write_text(
+        """schema_version = 1
+workspace_name = "workspace-cap-stress"
+
+[cache]
+root = ".grip/cache"
+
+[workspace_constraints]
+max_concurrent_edit_leases_global = 1
+
+[[repos]]
+name = "app"
+path = "repos/app"
+url = "https://example.invalid/app.git"
+
+[[units]]
+name = "atlas"
+path = "agents/atlas"
+repos = ["app"]
+
+[[units]]
+name = "apollo"
+path = "agents/apollo"
+repos = ["app"]
+""",
+        encoding="utf-8",
+    )
+    root = repo_root()
+    for unit, lane in (("atlas", "lane-a"), ("apollo", "lane-b")):
+        result = _run(
+            [
+                "python3",
+                str(lane_proto(root)),
+                "create-lane",
+                str(workspace_root),
+                unit,
+                lane,
+                "--repos",
+                "app",
+                "--branch",
+                f"feat/{lane}",
+            ]
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr or result.stdout)
+
+
+def _acquire_worker(
+    workspace_root: str,
+    unit: str,
+    lane: str,
+    actor: str,
+    start: object,
+    queue: object,
+    disable_locking: bool,
+) -> None:
+    if not start.wait(timeout=10):
+        queue.put({"returncode": 99, "error": "start gate timed out"})
+        return
+    env = os.environ.copy()
+    env["GR2_WORKSPACE_CAP_TEST_DELAY"] = "0.04"
+    if disable_locking:
+        env["GR2_DISABLE_LEASE_LOCKING"] = "1"
+        env["GR2_LEASE_TEST_DELAY"] = "0.04"
+    result = _run(
+        [
+            "python3",
+            str(lane_proto(repo_root())),
+            "acquire-lane-lease",
+            workspace_root,
+            unit,
+            lane,
+            "--actor",
+            actor,
+            "--mode",
+            "edit",
+            "--ttl-seconds",
+            "900",
+        ],
+        env=env,
+    )
+    queue.put(
+        {
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+    )
+
+
+def _active_edit_count(workspace_root: Path) -> int:
+    count = 0
+    for path in workspace_root.glob("agents/*/lanes/*/leases.json"):
+        for lease in json.loads(path.read_text()):
+            count += lease.get("mode") == "edit"
+    return count
+
+
+def _run_round(*, disable_locking: bool) -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-workspace-cap-") as tmp:
+        workspace_root = Path(tmp)
+        _init_workspace(workspace_root)
+        ctx = multiprocessing.get_context("spawn")
+        start = ctx.Event()
+        queue = ctx.Queue()
+        processes = [
+            ctx.Process(
+                target=_acquire_worker,
+                args=(
+                    str(workspace_root),
+                    unit,
+                    lane,
+                    f"agent:{unit}",
+                    start,
+                    queue,
+                    disable_locking,
+                ),
+            )
+            for unit, lane in (("atlas", "lane-a"), ("apollo", "lane-b"))
+        ]
+        for process in processes:
+            process.start()
+        start.set()
+        for process in processes:
+            process.join(timeout=15)
+            if process.is_alive():
+                process.terminate()
+                raise RuntimeError("workspace-cap worker hung")
+        outcomes = [queue.get(timeout=2) for _ in processes]
+        active_count = _active_edit_count(workspace_root)
+        return {
+            "worker_failures": sum(row["returncode"] not in (0, 1) for row in outcomes),
+            "active_edit_count": active_count,
+            "cap_violation": active_count > 1,
+        }
+
+
+def run_phase(*, rounds: int, disable_locking: bool) -> dict[str, object]:
+    results = [_run_round(disable_locking=disable_locking) for _ in range(rounds)]
+    return {
+        "locking": "disabled" if disable_locking else "enabled",
+        "rounds": rounds,
+        "cap_violation_rounds": sum(bool(row["cap_violation"]) for row in results),
+        "worker_failure_rounds": sum(bool(row["worker_failures"]) for row in results),
+    }
+
+
+def sequential_control() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="gr2-workspace-cap-sequential-") as tmp:
+        workspace_root = Path(tmp)
+        _init_workspace(workspace_root)
+        outcomes = []
+        for unit, lane in (("atlas", "lane-a"), ("apollo", "lane-b")):
+            outcomes.append(
+                _run(
+                    [
+                        "python3",
+                        str(lane_proto(repo_root())),
+                        "acquire-lane-lease",
+                        str(workspace_root),
+                        unit,
+                        lane,
+                        "--actor",
+                        f"agent:{unit}",
+                        "--mode",
+                        "edit",
+                    ]
+                ).returncode
+            )
+        active_count = _active_edit_count(workspace_root)
+        return {
+            "returncodes": outcomes,
+            "active_edit_count": active_count,
+            "cap_violation": active_count > 1,
+        }
+
+
+def main() -> int:
+    args = parse_args()
+    payload = {
+        "sequential_control": sequential_control(),
+        "before_workspace_lock": run_phase(rounds=args.rounds, disable_locking=True),
+        "after_workspace_lock": run_phase(rounds=args.rounds, disable_locking=False),
+    }
+    print(json.dumps(payload, indent=2))
+    after = payload["after_workspace_lock"]
+    return int(
+        payload["sequential_control"]["cap_violation"]
+        or after["cap_violation_rounds"] != 0
+        or after["worker_failure_rounds"] != 0
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gr2/prototypes/cross_mode_lane_stress.py
+++ b/gr2/prototypes/cross_mode_lane_stress.py
@@ -803,6 +803,7 @@ def scenario_solo_human_forgets_lane(root: Path, workspace_root: Path) -> Scenar
 
 
 def scenario_global_edit_lease_cap(root: Path, workspace_root: Path) -> ScenarioResult:
+    """Verify the workspace cap sequentially; concurrency has a separate stress harness."""
     create_lane(root, workspace_root, "atlas", "feat-cap-a", "app", "feat/cap-a")
     create_lane(root, workspace_root, "apollo", "feat-cap-b", "api", "feat/cap-b")
     create_lane(root, workspace_root, "layne", "feat-cap-c", "web", "feat/cap-c")
@@ -833,7 +834,7 @@ def scenario_global_edit_lease_cap(root: Path, workspace_root: Path) -> Scenario
     evidence = [lease_c.stdout.strip(), stale_force.stdout.strip()]
 
     if lease_a.returncode == 0 and lease_b.returncode == 0 and lease_c.returncode != 0:
-        holds.append("third edit lease is blocked when global cap of 2 is reached")
+        holds.append("third sequential edit lease is blocked when global cap of 2 is reached")
     else:
         gaps.append("global edit lease cap did not block the third concurrent edit lease")
 
@@ -865,7 +866,7 @@ def scenario_global_edit_lease_cap(root: Path, workspace_root: Path) -> Scenario
     return ScenarioResult(
         scenario_id="global-edit-lease-cap",
         user_mode="cross-mode",
-        title="workspace-wide edit lease cap is enforced across all units",
+        title="workspace-wide edit lease cap is enforced sequentially across all units",
         verdict=verdict,
         holds=holds,
         gaps=gaps,

--- a/gr2/prototypes/lane_workspace_prototype.py
+++ b/gr2/prototypes/lane_workspace_prototype.py
@@ -359,6 +359,10 @@ def lane_leases_lock_file(workspace_root: Path, owner_unit: str, lane_name: str)
     return lane_dir(workspace_root, owner_unit, lane_name) / "leases.lock"
 
 
+def workspace_edit_leases_lock_file(workspace_root: Path) -> Path:
+    return workspace_root / ".grip" / "state" / "workspace_edit_leases.lock"
+
+
 def shared_lane_access_file(workspace_root: Path, owner_unit: str, lane_name: str) -> Path:
     return (
         workspace_root
@@ -551,6 +555,55 @@ def mutate_lane_leases(
         if lease_locking_enabled():
             fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
         return result
+
+
+def mutate_workspace_edit_lease(
+    workspace_root: Path,
+    owner_unit: str,
+    lane_name: str,
+    actor: str,
+    mutator,
+):
+    """Check the workspace cap and mutate one lane in a single critical section."""
+    lock_path = workspace_edit_leases_lock_file(workspace_root)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_fh:
+        if lease_locking_enabled():
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+
+        cap = max_global_edit_leases(workspace_root)
+        if cap is not None:
+            active_edits = [
+                lease
+                for lease in active_workspace_edit_leases(workspace_root)
+                if not (
+                    lease["owner_unit"] == owner_unit
+                    and lease["lane_name"] == lane_name
+                    and lease["actor"] == actor
+                )
+            ]
+            if len(active_edits) >= cap:
+                return {
+                    "status": "blocked",
+                    "payload": {
+                        "status": "blocked",
+                        "reason": "workspace-edit-lease-cap",
+                        "requested": {
+                            "owner_unit": owner_unit,
+                            "lane_name": lane_name,
+                            "actor": actor,
+                            "mode": "edit",
+                        },
+                        "active_edit_leases": active_edits,
+                        "max_concurrent_edit_leases_global": cap,
+                    },
+                    "write": False,
+                }
+
+        delay = float(os.environ.get("GR2_WORKSPACE_CAP_TEST_DELAY", "0"))
+        if delay > 0:
+            time.sleep(delay)
+        return mutate_lane_leases(workspace_root, owner_unit, lane_name, mutator)
 
 
 def iter_lane_files(workspace_root: Path, owner_unit: str | None = None) -> list[Path]:
@@ -863,40 +916,22 @@ def lane_history(args: argparse.Namespace) -> int:
 def acquire_lane_lease(args: argparse.Namespace) -> int:
     workspace_root = args.workspace_root.resolve()
     load_lane_doc(workspace_root, args.owner_unit, args.lane_name)
+    mutator = lambda leases: _acquire_lane_lease_mutation(leases, args)
     if args.mode == "edit":
-        cap = max_global_edit_leases(workspace_root)
-        if cap is not None:
-            active_edits = active_workspace_edit_leases(workspace_root)
-            active_edits = [
-                lease
-                for lease in active_edits
-                if not (
-                    lease["owner_unit"] == args.owner_unit
-                    and lease["lane_name"] == args.lane_name
-                    and lease["actor"] == args.actor
-                )
-            ]
-            if len(active_edits) >= cap:
-                payload = {
-                    "status": "blocked",
-                    "reason": "workspace-edit-lease-cap",
-                    "requested": {
-                        "owner_unit": args.owner_unit,
-                        "lane_name": args.lane_name,
-                        "actor": args.actor,
-                        "mode": args.mode,
-                    },
-                    "active_edit_leases": active_edits,
-                    "max_concurrent_edit_leases_global": cap,
-                }
-                print(json.dumps(payload, indent=2))
-                return 1
-    result = mutate_lane_leases(
-        workspace_root,
-        args.owner_unit,
-        args.lane_name,
-        lambda leases: _acquire_lane_lease_mutation(leases, args),
-    )
+        result = mutate_workspace_edit_lease(
+            workspace_root,
+            args.owner_unit,
+            args.lane_name,
+            args.actor,
+            mutator,
+        )
+    else:
+        result = mutate_lane_leases(
+            workspace_root,
+            args.owner_unit,
+            args.lane_name,
+            mutator,
+        )
     if result["status"] == "blocked":
         print(json.dumps(result["payload"], indent=2))
         return 1
@@ -921,7 +956,6 @@ def acquire_lane_lease(args: argparse.Namespace) -> int:
     )
     print(lane_leases_file(workspace_root, args.owner_unit, args.lane_name))
     return 0
-
 
 def _acquire_lane_lease_mutation(leases: list[dict], args: argparse.Namespace) -> dict:
     retained = [lease for lease in leases if lease["actor"] != args.actor]

--- a/gr2/tests/test_workspace_edit_lease_cap.py
+++ b/gr2/tests/test_workspace_edit_lease_cap.py
@@ -1,0 +1,28 @@
+"""Contract for the workspace-wide edit-lease cap."""
+
+from __future__ import annotations
+
+
+def test_concurrent_workspace_cap_has_sequential_and_unlocked_controls() -> None:
+    """A per-lane lock cannot protect a workspace-global cap."""
+    from gr2.prototypes.concurrent_workspace_cap_stress import run_phase, sequential_control
+
+    sequential = sequential_control()
+    unlocked = run_phase(rounds=3, disable_locking=True)
+    locked = run_phase(rounds=3, disable_locking=False)
+
+    assert sequential == {
+        "returncodes": [0, 1],
+        "active_edit_count": 1,
+        "cap_violation": False,
+    }
+    assert unlocked["cap_violation_rounds"] == 3
+    assert unlocked["worker_failure_rounds"] == 0
+    assert locked["cap_violation_rounds"] == 0
+    assert locked["worker_failure_rounds"] == 0
+
+
+def test_cross_mode_cap_verdict_names_its_sequential_axis() -> None:
+    from gr2.prototypes.cross_mode_lane_stress import scenario_global_edit_lease_cap
+
+    assert "sequential" in scenario_global_edit_lease_cap.__doc__.lower()


### PR DESCRIPTION
## Summary\n\n- serialize the workspace-wide edit-lease cap with a workspace-scoped lock\n- keep the existing per-lane lease mutation lock inside that critical section\n- add a repeated concurrent harness with sequential and disabled-lock controls\n- qualify the existing cross-mode cap report as a sequential check\n\n## Verification\n\n- RED first: current code violated the cap in 3/3 nominally locked rounds\n- repeated fruit: disabled locking violated 20/20; enabled locking violated 0/20\n- workspace-lock removal and edit-path bypass each turn the focused test RED\n- full gr2 suite: 841 passed, 43 subtests; one unrelated failure reproduced on the exact base\n\nRef #845 — closes at promotion.