### PR TITLE
fix: point install and clone instructions at the current repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ When creating a new release:
 
 3. **Create GitHub release:**
    ```bash
-   gh release create vX.Y.Z --repo laynepenney/grip --title "vX.Y.Z" --notes "Release notes..."
+   gh release create vX.Y.Z --repo synapt-dev/grip --title "vX.Y.Z" --notes "Release notes..."
    ```
    This triggers GitHub Actions to automatically:
    - Build binaries for all platforms
@@ -190,7 +190,7 @@ When creating a new release:
 
    ```bash
    # Get SHA256 of the new release tarball
-   curl -sL https://github.com/laynepenney/grip/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+   curl -sL https://github.com/synapt-dev/grip/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
    # Update the formula
    # Edit homebrew-tap/Formula/gitgrip.rb:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ Thank you for your interest in contributing to gitgrip! This document provides g
 
 ```bash
 # Clone the repository
-git clone git@github.com:laynepenney/grip.git
-cd gitgrip
+git clone git@github.com:synapt-dev/grip.git
+cd grip
 
 # Build the project
 cargo build
@@ -201,7 +201,7 @@ The PR for gitgrip changes should be created from the `tooling` repo's perspecti
 ```bash
 gh pr create  # From the tooling directory
 ```
-This creates the PR for `github.com/laynepenney/grip`, not the workspace manifest.
+This creates the PR for `github.com/synapt-dev/grip`, not the workspace manifest.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://crates.io/crates/gitgrip"><img src="https://img.shields.io/crates/v/gitgrip.svg?style=flat-square&color=9A3412" alt="crates.io version"></a>
-  <a href="https://github.com/laynepenney/grip/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/gitgrip.svg?style=flat-square&color=7C2D12" alt="license"></a>
+  <a href="https://github.com/synapt-dev/grip/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/gitgrip.svg?style=flat-square&color=7C2D12" alt="license"></a>
   <a href="https://crates.io/crates/gitgrip"><img src="https://img.shields.io/crates/d/gitgrip.svg?style=flat-square&color=431407" alt="downloads"></a>
 </p>
 
@@ -46,9 +46,13 @@ Inspired by Android's [repo tool](https://source.android.com/docs/setup/create/r
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew tap laynepenney/tap
-brew install gitgrip
+brew tap synapt-dev/tap
+brew install synapt-dev/tap/gitgrip
 ```
+
+If you installed from the earlier tap, run `brew untap laynepenney/tap` as
+well. That tap is archived, and leaving both tapped makes the bare formula
+name ambiguous.
 
 ### From crates.io
 
@@ -58,13 +62,13 @@ cargo install gitgrip
 
 ### From GitHub Releases
 
-Pre-built binaries for Linux, macOS (Intel & Apple Silicon), and Windows are available on the [releases page](https://github.com/laynepenney/grip/releases).
+Pre-built binaries for Linux, macOS (Intel & Apple Silicon), and Windows are available on the [releases page](https://github.com/synapt-dev/grip/releases).
 
 ### From Source
 
 ```bash
-git clone https://github.com/laynepenney/grip.git
-cd gitgrip
+git clone https://github.com/synapt-dev/grip.git
+cd grip
 cargo build --release
 
 # Binary is at target/release/gr (or gr.exe on Windows)

--- a/docs/PLAN-agent-experience.md
+++ b/docs/PLAN-agent-experience.md
@@ -193,7 +193,7 @@ workspace:
         - Cargo.toml
       changelog: CHANGELOG.md
       homebrew:
-        repo: laynepenney/homebrew-tap
+        repo: synapt-dev/homebrew-tap
         formula: Formula/gitgrip.rb
 ```
 
@@ -212,7 +212,7 @@ workspace:
 ```yaml
 repos:
   gitgrip:
-    url: https://github.com/laynepenney/gitgrip.git
+    url: https://github.com/synapt-dev/grip.git
     path: ./gitgrip
     default_branch: main
     agent:
@@ -224,7 +224,7 @@ repos:
       language: rust
 
   codi:
-    url: https://github.com/laynepenney/codi.git
+    url: https://github.com/synapt-dev/codi.git
     path: ./codi
     default_branch: main
     agent:

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -17,8 +17,8 @@ Choose one installation route:
 
 ```bash
 # Homebrew on macOS or Linux
-brew tap laynepenney/tap
-brew install gitgrip
+brew tap synapt-dev/tap
+brew install synapt-dev/tap/gitgrip
 
 # Rust toolchain
 cargo install gitgrip

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
   <meta property="og:title" content="gitgrip — git a grip">
   <meta property="og:description" content="Multi-repo workflow tool for synchronized branches, linked PRs, and atomic merges.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://laynepenney.github.io/gitgrip/">
+  <meta property="og:url" content="https://synapt.dev/grip">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%239A3412'/><circle cx='50' cy='30' r='8' fill='%23FDBA74'/><circle cx='30' cy='50' r='6' fill='%23FDBA74'/><circle cx='70' cy='50' r='6' fill='%23FDBA74'/><circle cx='50' cy='70' r='6' fill='%23FDBA74'/></svg>">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -254,7 +254,7 @@
       <a href="#features">Features</a>
       <a href="#install">Install</a>
       <a href="#ai">AI-Native</a>
-      <a href="https://github.com/laynepenney/gitgrip" class="nav-gh">
+      <a href="https://github.com/synapt-dev/grip" class="nav-gh">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         GitHub
       </a>
@@ -298,7 +298,7 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Install
       </a>
-      <a href="https://github.com/laynepenney/gitgrip" class="btn btn-secondary">
+      <a href="https://github.com/synapt-dev/grip" class="btn btn-secondary">
         <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         View on GitHub
       </a>
@@ -397,8 +397,8 @@
     </div>
     <div class="install-panel active" id="tab-brew">
       <div class="install-code">
-        <div class="line"><span style="color:var(--text-muted)">$</span> brew tap laynepenney/tap</div>
-        <div class="line"><span style="color:var(--text-muted)">$</span> brew install gitgrip</div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> brew tap synapt-dev/tap</div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> brew install synapt-dev/tap/gitgrip</div>
       </div>
       <p class="install-note">macOS and Linux</p>
     </div>
@@ -411,14 +411,14 @@
     <div class="install-panel" id="tab-binary">
       <div class="install-code">
         <div class="line"><span style="color:var(--text-muted)"># Download from GitHub Releases</span></div>
-        <div class="line"><span style="color:var(--text-muted)">$</span> curl -sL <span style="color:var(--accent)">https://github.com/laynepenney/gitgrip/releases/latest</span></div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> curl -sL <span style="color:var(--accent)">https://github.com/synapt-dev/grip/releases/latest</span></div>
       </div>
       <p class="install-note">Pre-built for Linux (x86_64), macOS (Apple Silicon), and Windows</p>
     </div>
     <div class="install-panel" id="tab-source">
       <div class="install-code">
-        <div class="line"><span style="color:var(--text-muted)">$</span> git clone https://github.com/laynepenney/gitgrip.git</div>
-        <div class="line"><span style="color:var(--text-muted)">$</span> cd gitgrip</div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> git clone https://github.com/synapt-dev/grip.git</div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> cd grip</div>
         <div class="line"><span style="color:var(--text-muted)">$</span> cargo install --path .</div>
       </div>
       <p class="install-note">Build from source with Rust</p>
@@ -456,11 +456,11 @@
 <footer>
   <div class="container">
     <div class="footer-links">
-      <a href="https://github.com/laynepenney/gitgrip">GitHub</a>
+      <a href="https://github.com/synapt-dev/grip">GitHub</a>
       <a href="https://crates.io/crates/gitgrip">crates.io</a>
-      <a href="https://github.com/laynepenney/gitgrip/releases">Releases</a>
-      <a href="https://github.com/laynepenney/gitgrip/blob/main/CHANGELOG.md">Changelog</a>
-      <a href="https://github.com/laynepenney/gitgrip/blob/main/LICENSE">MIT License</a>
+      <a href="https://github.com/synapt-dev/grip/releases">Releases</a>
+      <a href="https://github.com/synapt-dev/grip/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/synapt-dev/grip/blob/main/LICENSE">MIT License</a>
     </div>
     <p>Made by <a href="https://github.com/laynepenney">Layne Penney</a></p>
   </div>

--- a/tests/spawn_graceful_shutdown.sh
+++ b/tests/spawn_graceful_shutdown.sh
@@ -5,7 +5,7 @@
 # not available on GitHub Actions runners. Run manually before merging
 # spawn-related changes:
 #
-#   cd gitgrip && GR=./target/debug/gr ./tests/spawn_graceful_shutdown.sh
+#   cd grip && GR=./target/debug/gr ./tests/spawn_graceful_shutdown.sh
 #
 # Requires: tmux, gr (built), .gitgrip/agents.toml with at least one agent.
 


### PR DESCRIPTION
## What this fixes

Reader-facing instructions across seven files pointed at addresses and directories that no longer serve them. There are three distinct failures here, which is the reason this is not a find-and-replace.

**Dead links, not stale ones.** The repository was renamed and transferred. A previous partial sweep updated the repository name inside URL paths but left the old owner in place, producing an owner-and-name combination that never existed. GitHub has no redirect to offer for it, so those URLs return 404 today. That covered the license badge, the releases link, and both clone commands, which means the README's from-source instructions and the CONTRIBUTING setup steps were each broken for anyone who followed them.

**A consequence of the rename that nobody swept.** Both clone blocks then ran `cd gitgrip`, which cannot succeed after cloning a repository named `grip`. This is invisible to a search for the old owner, because the defective line does not contain it. Fixed alongside the URLs, since the directory name is downstream of the same rename.

**A retired Homebrew tap.** The install instructions named a tap that has since been archived. It still installs the current version, so this is a correction of direction rather than a repair of breakage, and it is worth stating that way rather than overselling it.

## The published landing page, which was nearly missed

`docs/index.html` is deployed by the Pages workflow, which uploads the whole `docs` directory on every push to the default branch. It is a live reader-facing surface and it carried all three failures above, plus a social-preview URL pointing at an address that returns 404.

It is included here. Worth recording why it was absent from the first pass: that sweep filtered by file extension and the list did not include HTML. An extension list is an assumption about which kinds of file carry instructions, and a search narrowed by an assumption cannot find what the assumption excludes. The corrected sweep filters nothing and classifies afterward.

The byline link to a personal profile is deliberately left alone. It identifies a person rather than a repository, and rewriting it would have been the same error in the other direction.

## The install path was run, and the first attempt at it was wrong

Worth recording, because the failure is not obvious from reading.

A single fully-qualified `brew install` command does not work on its own. Homebrew declines and asks for the tap to be added explicitly first. Reachability of the formula file is not installability, and this only surfaces by running it.

Adding the tap and then installing the *bare* formula name is also wrong, though it works fine on a clean machine. Anyone who followed the previous instructions has the old tap, and two taps carrying the same formula make the short name ambiguous — Homebrew refuses and asks for a fully-qualified name. That population is not hypothetical; our own documentation created it.

So the documented form is an explicit tap followed by a fully-qualified install, which is the one that works for a new reader and an existing user alike. A short note tells the second group to remove the archived tap.

## Verification

Every replacement address was requested before landing and returns 200 or 301. A path under the same owner that should not exist was requested as a control and returned 404, so the check distinguishes a working URL from a broken one rather than reporting success uniformly.

The install commands were executed, not inferred. The failing single-command form, the ambiguity error, and the working form were each observed directly, with a formula name that should not exist used as a control.

## Deliberately unchanged

Recorded so the omissions read as a decision rather than an oversight.

- `IMPROVEMENTS.md` carries six references. It is a dated log of past friction, and editing it would falsify the record of what was true when each entry was written.
- `tests/multi_provider_e2e.rs` carries twelve. Those resolve correctly through redirects to live repositories, so the tests work; editing passing test configuration for tidiness would risk the suite for no reader-facing gain.

## Note on timing

This targets `dev`, per the branching model. The broken links are live on `main` until a promotion, so this is a reasonable candidate to promote soon after merge — it is documentation only and carries no code risk.

## Premium boundary

grip is OSS (multi-repo workspace orchestration). This change is documentation only and introduces no identity, org, or entitlement behavior.
