### PR TITLE
Promote dev to main — install and clone instruction fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ When creating a new release:
 
 3. **Create GitHub release:**
    ```bash
-   gh release create vX.Y.Z --repo laynepenney/grip --title "vX.Y.Z" --notes "Release notes..."
+   gh release create vX.Y.Z --repo synapt-dev/grip --title "vX.Y.Z" --notes "Release notes..."
    ```
    This triggers GitHub Actions to automatically:
    - Build binaries for all platforms
@@ -190,7 +190,7 @@ When creating a new release:
 
    ```bash
    # Get SHA256 of the new release tarball
-   curl -sL https://github.com/laynepenney/grip/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
+   curl -sL https://github.com/synapt-dev/grip/archive/refs/tags/vX.Y.Z.tar.gz | shasum -a 256
 
    # Update the formula
    # Edit homebrew-tap/Formula/gitgrip.rb:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ Thank you for your interest in contributing to gitgrip! This document provides g
 
 ```bash
 # Clone the repository
-git clone git@github.com:laynepenney/grip.git
-cd gitgrip
+git clone git@github.com:synapt-dev/grip.git
+cd grip
 
 # Build the project
 cargo build
@@ -201,7 +201,7 @@ The PR for gitgrip changes should be created from the `tooling` repo's perspecti
 ```bash
 gh pr create  # From the tooling directory
 ```
-This creates the PR for `github.com/laynepenney/grip`, not the workspace manifest.
+This creates the PR for `github.com/synapt-dev/grip`, not the workspace manifest.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://crates.io/crates/gitgrip"><img src="https://img.shields.io/crates/v/gitgrip.svg?style=flat-square&color=9A3412" alt="crates.io version"></a>
-  <a href="https://github.com/laynepenney/grip/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/gitgrip.svg?style=flat-square&color=7C2D12" alt="license"></a>
+  <a href="https://github.com/synapt-dev/grip/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/gitgrip.svg?style=flat-square&color=7C2D12" alt="license"></a>
   <a href="https://crates.io/crates/gitgrip"><img src="https://img.shields.io/crates/d/gitgrip.svg?style=flat-square&color=431407" alt="downloads"></a>
 </p>
 
@@ -46,9 +46,13 @@ Inspired by Android's [repo tool](https://source.android.com/docs/setup/create/r
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew tap laynepenney/tap
-brew install gitgrip
+brew tap synapt-dev/tap
+brew install synapt-dev/tap/gitgrip
 ```
+
+If you installed from the earlier tap, run `brew untap laynepenney/tap` as
+well. That tap is archived, and leaving both tapped makes the bare formula
+name ambiguous.
 
 ### From crates.io
 
@@ -58,13 +62,13 @@ cargo install gitgrip
 
 ### From GitHub Releases
 
-Pre-built binaries for Linux, macOS (Intel & Apple Silicon), and Windows are available on the [releases page](https://github.com/laynepenney/grip/releases).
+Pre-built binaries for Linux, macOS (Intel & Apple Silicon), and Windows are available on the [releases page](https://github.com/synapt-dev/grip/releases).
 
 ### From Source
 
 ```bash
-git clone https://github.com/laynepenney/grip.git
-cd gitgrip
+git clone https://github.com/synapt-dev/grip.git
+cd grip
 cargo build --release
 
 # Binary is at target/release/gr (or gr.exe on Windows)

--- a/docs/PLAN-agent-experience.md
+++ b/docs/PLAN-agent-experience.md
@@ -193,7 +193,7 @@ workspace:
         - Cargo.toml
       changelog: CHANGELOG.md
       homebrew:
-        repo: laynepenney/homebrew-tap
+        repo: synapt-dev/homebrew-tap
         formula: Formula/gitgrip.rb
 ```
 
@@ -212,7 +212,7 @@ workspace:
 ```yaml
 repos:
   gitgrip:
-    url: https://github.com/laynepenney/gitgrip.git
+    url: https://github.com/synapt-dev/grip.git
     path: ./gitgrip
     default_branch: main
     agent:
@@ -224,7 +224,7 @@ repos:
       language: rust
 
   codi:
-    url: https://github.com/laynepenney/codi.git
+    url: https://github.com/synapt-dev/codi.git
     path: ./codi
     default_branch: main
     agent:

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -17,8 +17,8 @@ Choose one installation route:
 
 ```bash
 # Homebrew on macOS or Linux
-brew tap laynepenney/tap
-brew install gitgrip
+brew tap synapt-dev/tap
+brew install synapt-dev/tap/gitgrip
 
 # Rust toolchain
 cargo install gitgrip

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
   <meta property="og:title" content="gitgrip — git a grip">
   <meta property="og:description" content="Multi-repo workflow tool for synchronized branches, linked PRs, and atomic merges.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://laynepenney.github.io/gitgrip/">
+  <meta property="og:url" content="https://synapt.dev/grip">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%239A3412'/><circle cx='50' cy='30' r='8' fill='%23FDBA74'/><circle cx='30' cy='50' r='6' fill='%23FDBA74'/><circle cx='70' cy='50' r='6' fill='%23FDBA74'/><circle cx='50' cy='70' r='6' fill='%23FDBA74'/></svg>">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -254,7 +254,7 @@
       <a href="#features">Features</a>
       <a href="#install">Install</a>
       <a href="#ai">AI-Native</a>
-      <a href="https://github.com/laynepenney/gitgrip" class="nav-gh">
+      <a href="https://github.com/synapt-dev/grip" class="nav-gh">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         GitHub
       </a>
@@ -298,7 +298,7 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Install
       </a>
-      <a href="https://github.com/laynepenney/gitgrip" class="btn btn-secondary">
+      <a href="https://github.com/synapt-dev/grip" class="btn btn-secondary">
         <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         View on GitHub
       </a>
@@ -397,8 +397,8 @@
     </div>
     <div class="install-panel active" id="tab-brew">
       <div class="install-code">
-        <div class="line"><span style="color:var(--text-muted)">$</span> brew tap laynepenney/tap</div>
-        <div class="line"><span style="color:var(--text-muted)">$</span> brew install gitgrip</div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> brew tap synapt-dev/tap</div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> brew install synapt-dev/tap/gitgrip</div>
       </div>
       <p class="install-note">macOS and Linux</p>
     </div>
@@ -411,14 +411,14 @@
     <div class="install-panel" id="tab-binary">
       <div class="install-code">
         <div class="line"><span style="color:var(--text-muted)"># Download from GitHub Releases</span></div>
-        <div class="line"><span style="color:var(--text-muted)">$</span> curl -sL <span style="color:var(--accent)">https://github.com/laynepenney/gitgrip/releases/latest</span></div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> curl -sL <span style="color:var(--accent)">https://github.com/synapt-dev/grip/releases/latest</span></div>
       </div>
       <p class="install-note">Pre-built for Linux (x86_64), macOS (Apple Silicon), and Windows</p>
     </div>
     <div class="install-panel" id="tab-source">
       <div class="install-code">
-        <div class="line"><span style="color:var(--text-muted)">$</span> git clone https://github.com/laynepenney/gitgrip.git</div>
-        <div class="line"><span style="color:var(--text-muted)">$</span> cd gitgrip</div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> git clone https://github.com/synapt-dev/grip.git</div>
+        <div class="line"><span style="color:var(--text-muted)">$</span> cd grip</div>
         <div class="line"><span style="color:var(--text-muted)">$</span> cargo install --path .</div>
       </div>
       <p class="install-note">Build from source with Rust</p>
@@ -456,11 +456,11 @@
 <footer>
   <div class="container">
     <div class="footer-links">
-      <a href="https://github.com/laynepenney/gitgrip">GitHub</a>
+      <a href="https://github.com/synapt-dev/grip">GitHub</a>
       <a href="https://crates.io/crates/gitgrip">crates.io</a>
-      <a href="https://github.com/laynepenney/gitgrip/releases">Releases</a>
-      <a href="https://github.com/laynepenney/gitgrip/blob/main/CHANGELOG.md">Changelog</a>
-      <a href="https://github.com/laynepenney/gitgrip/blob/main/LICENSE">MIT License</a>
+      <a href="https://github.com/synapt-dev/grip/releases">Releases</a>
+      <a href="https://github.com/synapt-dev/grip/blob/main/CHANGELOG.md">Changelog</a>
+      <a href="https://github.com/synapt-dev/grip/blob/main/LICENSE">MIT License</a>
     </div>
     <p>Made by <a href="https://github.com/laynepenney">Layne Penney</a></p>
   </div>

--- a/tests/spawn_graceful_shutdown.sh
+++ b/tests/spawn_graceful_shutdown.sh
@@ -5,7 +5,7 @@
 # not available on GitHub Actions runners. Run manually before merging
 # spawn-related changes:
 #
-#   cd gitgrip && GR=./target/debug/gr ./tests/spawn_graceful_shutdown.sh
+#   cd grip && GR=./target/debug/gr ./tests/spawn_graceful_shutdown.sh
 #
 # Requires: tmux, gr (built), .gitgrip/agents.toml with at least one agent.
 


### PR DESCRIPTION
Promotes `dev` to `main`. The delta is exactly one merged pull request and nothing else.

## What reaches the public surfaces on this merge

Seven files carrying reader-facing instructions that pointed at addresses and directories which no longer serve them. Three distinct failures: URLs that return 404 because an earlier partial sweep changed a repository name and left the old owner; a directory instruction that cannot succeed after cloning the current repository, in three places; and Homebrew instructions naming a tap that has since been archived.

**The reason this promotion matters more than the merge did.** The Pages workflow uploads `docs` on pushes to `main` that change `docs/**`. This promotion changes `docs/index.html`, so the landing page updates when it merges and the deployment completes. Until then that page carries all three failures plus a social-preview URL returning 404, and it is where a newcomer chooses an install route.

## Review

The underlying change was reviewed across four rounds and approved by two reviewers against exact artifact hashes, with the full record posted as a comment on the originating pull request. Three of the defects it fixes were found by reviewers rather than by the author, and none of them were found by reading: the install command was found by executing it, the landing page by an unrestricted file sweep, and the third directory instruction by an unrestricted pattern sweep.

## Method

Promoted through a throwaway branch cut at the tip of `dev` rather than from `dev` directly, so the integration branch is never a pull request head and cannot be removed by automatic head-branch deletion.

## Premium boundary

grip is OSS (multi-repo workspace orchestration). Documentation only; no identity, org, or entitlement behavior.
