### PR TITLE
fix: warn on manifest input that was being discarded silently

### DIFF
--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -535,7 +535,91 @@ fn default_version() -> u32 {
     2
 }
 
+/// Keys `Manifest` accepts at the top level.
+///
+/// Kept beside the struct deliberately: if a field is added there and not here,
+/// a valid manifest starts warning, which is a loud failure rather than a silent
+/// one. That is the correct direction for this list to rot in.
+const TOP_LEVEL_KEYS: &[&str] = &[
+    "version",
+    "remotes",
+    "gripspaces",
+    "manifest",
+    "repos",
+    "settings",
+    "workspace",
+];
+
+/// Keys that are VALID somewhere else, mapped to where they belong.
+///
+/// MISPLACEMENT IS THE COMMON CASE, NOT TYPOS. Every entry here is a real field
+/// on `ManifestRepoConfig`, i.e. something a user writes at the top level
+/// because that is where it reads like it should go. Naming the right home
+/// turns a warning into a fix.
+const MISPLACED_KEY_HOMES: &[(&str, &str)] = &[
+    ("composefile", "manifest.composefile"),
+    ("copyfile", "manifest.copyfile"),
+    ("linkfile", "manifest.linkfile"),
+    ("platform", "manifest.platform"),
+    ("url", "manifest.url"),
+    ("revision", "manifest.revision"),
+];
+
 impl Manifest {
+    /// Top-level keys present in the YAML that no field will receive.
+    ///
+    /// *** WHY THIS EXISTS: SERDE DISCARDS UNKNOWN KEYS IN SILENCE. ***
+    ///
+    /// No manifest struct carries `deny_unknown_fields`, so a key that matches
+    /// no field is dropped during deserialization with no error, no warning and
+    /// exit 0. A `composefile:` block written at the top level instead of under
+    /// `manifest:` therefore vanishes: the block is in the file, `gr manifest
+    /// schema` knows the key, nothing is a parse failure, and nothing is
+    /// produced. Measured 2026-08-11; it cost two rounds of misdiagnosis
+    /// because every visible signal said success.
+    ///
+    /// `deny_unknown_fields` is the obvious fix and is the wrong one: it turns
+    /// every extra key into a hard parse error, so a manifest carrying a
+    /// forward-compatibility key stops loading on upgrade. That trades a silent
+    /// failure for a breaking one. Warning keeps every existing manifest
+    /// loading while making the discard impossible to miss.
+    ///
+    /// Returns messages rather than printing, so this is testable and so the
+    /// caller decides where they go.
+    pub fn unknown_top_level_keys(yaml: &str) -> Vec<String> {
+        let value: serde_yaml::Value = match serde_yaml::from_str(yaml) {
+            Ok(value) => value,
+            // A genuine syntax error is reported by the real parse; this pass
+            // must never turn one error into two.
+            Err(_) => return Vec::new(),
+        };
+        let mapping = match value.as_mapping() {
+            Some(mapping) => mapping,
+            None => return Vec::new(),
+        };
+
+        let mut warnings = Vec::new();
+        for (key, _) in mapping {
+            let key = match key.as_str() {
+                Some(key) => key,
+                None => continue,
+            };
+            if TOP_LEVEL_KEYS.contains(&key) {
+                continue;
+            }
+            match MISPLACED_KEY_HOMES.iter().find(|(name, _)| *name == key) {
+                Some((_, home)) => warnings.push(format!(
+                    "manifest key '{key}' is not valid at the top level and was IGNORED \
+                     - did you mean '{home}'?"
+                )),
+                None => warnings.push(format!(
+                    "manifest key '{key}' is not a known key and was IGNORED"
+                )),
+            }
+        }
+        warnings
+    }
+
     /// Load a manifest from a YAML file
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ManifestError> {
         let content = std::fs::read_to_string(path)?;
@@ -547,6 +631,21 @@ impl Manifest {
     /// Use this when you need to process the manifest before validation,
     /// e.g., resolving gripspace includes that merge additional repos.
     pub fn parse_raw(yaml: &str) -> Result<Self, ManifestError> {
+        // WARN HERE, NOT IN `load`. This is the single chokepoint: `parse`
+        // calls `parse_raw`, `load` calls `parse`, and `sync` calls `parse_raw`
+        // DIRECTLY -- so a hook in `load` fires on the least-used path and is
+        // silent for the command that matters. Verified by call-site count
+        // rather than assumed, after a first attempt hooked `load` and produced
+        // exactly nothing on `gr sync`, which is the same mistake as assuming
+        // where composition was invoked from.
+        //
+        // STDERR, not `Output::warning`, which uses println!. A correctness
+        // warning on stdout is swallowed by redirection and corrupts `--json`
+        // consumers, and a warning nobody reads is the defect this fixes one
+        // layer up.
+        for warning in Self::unknown_top_level_keys(yaml) {
+            eprintln!("\u{26a0} {warning}");
+        }
         let mut manifest: Manifest = serde_yaml::from_str(yaml)?;
         manifest.migrate_v1();
         Ok(manifest)
@@ -1195,6 +1294,73 @@ repos:
             "https://github.com/user/other-gripspace.git"
         );
         assert!(gripspaces[1].rev.is_none());
+    }
+
+    #[test]
+    fn unknown_top_level_key_that_belongs_elsewhere_names_its_home() {
+        // The exact defect: composefile written at the top level instead of
+        // under `manifest:`. Serde discards it, so without this warning the
+        // whole block vanishes at exit 0.
+        let yaml = r#"
+version: 2
+repos: {}
+composefile:
+  - dest: CLAUDE.md
+    parts:
+      - src: A.md
+"#;
+        let warnings = Manifest::unknown_top_level_keys(yaml);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        assert!(warnings[0].contains("composefile"));
+        assert!(
+            warnings[0].contains("manifest.composefile"),
+            "a misplacement warning must name where the key belongs: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn unknown_top_level_key_with_no_home_is_still_reported() {
+        let yaml = "version: 2\nrepos: {}\nreposs: {}\n";
+        let warnings = Manifest::unknown_top_level_keys(yaml);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        assert!(warnings[0].contains("reposs"));
+    }
+
+    #[test]
+    fn a_correct_manifest_produces_no_warnings() {
+        // CONTROL. A warning that fires on valid input is worse than none --
+        // it trains readers to ignore the channel. Every top-level field is
+        // exercised here so adding one to the struct without adding it to
+        // TOP_LEVEL_KEYS turns this RED.
+        let yaml = r#"
+version: 2
+remotes: {}
+gripspaces: []
+manifest:
+  url: file:///tmp/x.git
+  revision: main
+  composefile:
+    - dest: CLAUDE.md
+      parts:
+        - src: A.md
+repos: {}
+settings: {}
+workspace: {}
+"#;
+        assert!(
+            Manifest::unknown_top_level_keys(yaml).is_empty(),
+            "valid manifest warned: {:?}",
+            Manifest::unknown_top_level_keys(yaml)
+        );
+    }
+
+    #[test]
+    fn a_syntax_error_does_not_become_two_errors() {
+        // The real parse reports genuine syntax errors; this pass must stay
+        // quiet so one failure is not reported twice in different words.
+        assert!(Manifest::unknown_top_level_keys("this: [is: not: yaml").is_empty());
+        assert!(Manifest::unknown_top_level_keys("- a list, not a mapping").is_empty());
     }
 
     #[test]

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -275,18 +275,67 @@ pub fn filter_repos(
     group_filter: Option<&[String]>,
     include_reference: bool,
 ) -> Vec<RepoInfo> {
-    manifest
+    // *** A DECLARED REPO MUST NEVER DISAPPEAR IN SILENCE. ***
+    //
+    // `from_config` returns Option and drops a repo for TWO reasons -- no
+    // usable url, or a url `parse_git_url` cannot read -- and `filter_map`
+    // discarded both without a word. Every downstream view then printed a
+    // smaller count, or zero, styled as success. `gr init` clones from that
+    // same url perfectly well, so a bare filesystem path gave a workspace that
+    // materialised correctly and afterwards read as empty: two code paths
+    // disagreeing about what a url is, with only one of them saying so.
+    //
+    // The reason it matters more than a missing warning: it cost a
+    // misdiagnosis. A defect report was filed against repo registration on the
+    // strength of this silence, and the registration was never broken.
+    //
+    // Collect-and-surface rather than drop-quietly, which is the same fix the
+    // unknown-manifest-key warning applies at parse time. Same defect class,
+    // one layer apart.
+    let mut dropped: Vec<String> = Vec::new();
+    let resolved: Vec<RepoInfo> = manifest
         .repos
         .iter()
         .filter_map(|(name, config)| {
-            RepoInfo::from_config(
+            let info = RepoInfo::from_config(
                 name,
                 config,
                 workspace_root,
                 &manifest.settings,
                 manifest.remotes.as_ref(),
-            )
+            );
+            if info.is_none() {
+                // Distinguish the two causes, because they need different
+                // fixes: one is a missing field, the other a malformed value.
+                let reason = match config.url.as_deref().filter(|u| !u.is_empty()) {
+                    None => "no url, and none could be derived from its remote".to_string(),
+                    Some(url) => format!("url could not be parsed: '{url}'"),
+                };
+                dropped.push(format!("{name} ({reason})"));
+            }
+            info
         })
+        .collect();
+
+    if !dropped.is_empty() {
+        // STDERR: survives stdout redirection and does not corrupt `--json`.
+        eprintln!(
+            "\u{26a0} {} declared repositor{} could not be resolved and {} EXCLUDED from this command:",
+            dropped.len(),
+            if dropped.len() == 1 { "y" } else { "ies" },
+            if dropped.len() == 1 { "was" } else { "were" },
+        );
+        for entry in &dropped {
+            eprintln!("    {entry}");
+        }
+        eprintln!(
+            "    A count of zero below does not mean the manifest declared none. \
+             Filesystem paths need a file:// prefix."
+        );
+    }
+
+    resolved
+        .into_iter()
         .filter(|r| include_reference || !r.reference)
         .filter(|r| {
             repos_filter

--- a/tests/manifest_input_warnings.rs
+++ b/tests/manifest_input_warnings.rs
@@ -1,0 +1,287 @@
+//! Command-level witnesses for manifest input that would otherwise be discarded
+//! in silence.
+//!
+//! *** WHY THESE ARE NOT UNIT TESTS, WHICH IS THE WHOLE POINT. ***
+//!
+//! The first attempt at covering this shipped four unit tests against
+//! `Manifest::unknown_top_level_keys`. Review blocked it: every one exercised
+//! the HELPER, none drove `filter_repos` with a bad URL, and none proved the
+//! warning reaches STDERR through a real command. So a revert to a silent
+//! `filter_map`, or a warning quietly moved back to stdout where `--json`
+//! consumers would swallow it, left all four GREEN.
+//!
+//! The author had just counted call sites to find the right chokepoint
+//! (`parse_raw`, not `load`) and then tested the helper anyway. VERIFYING WHERE
+//! YOUR CODE GOES AND VERIFYING THROUGH WHERE IT GOES ARE TWO DIFFERENT ACTS,
+//! and the second is easier to skip because the first felt like diligence.
+//!
+//! So these drive the real binary, and assert on the STREAM as well as the
+//! text, because the routing is half the contract: a correctness warning on
+//! stdout is swallowed by redirection and corrupts `--json`.
+
+use assert_cmd::Command;
+use std::path::Path;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A bare origin carrying a manifest on `main` and one content branch `api`.
+///
+/// Returns (tempdir, file:// url of the bare repo).
+fn origin_with_manifest(manifest_body: &str) -> (TempDir, String) {
+    let temp = TempDir::new().unwrap();
+    let bare = temp.path().join("origin.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(temp.path(), &["init", "-q", "--bare", "origin.git"]);
+    let url = format!("file://{}", bare.display());
+
+    let work = temp.path().join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    git(&work, &["init", "-q"]);
+    git(&work, &["remote", "add", "origin", bare.to_str().unwrap()]);
+
+    // content branch
+    git(&work, &["checkout", "-q", "--orphan", "api"]);
+    std::fs::write(work.join("API.md"), "api\n").unwrap();
+    git(&work, &["add", "-A"]);
+    git(&work, &["commit", "-qm", "api"]);
+    git(&work, &["push", "-q", "origin", "api"]);
+
+    // manifest branch
+    git(&work, &["checkout", "-q", "--orphan", "main"]);
+    let _ = StdCommand::new("git")
+        .args(["rm", "-rqf", "."])
+        .current_dir(&work)
+        .output();
+    std::fs::write(work.join("PROJECT.md"), "project\n").unwrap();
+    std::fs::write(
+        work.join("gripspace.yml"),
+        manifest_body.replace("__URL__", &url),
+    )
+    .unwrap();
+    git(&work, &["add", "-A"]);
+    git(&work, &["commit", "-qm", "manifest"]);
+    git(&work, &["push", "-qf", "origin", "main"]);
+
+    (temp, url)
+}
+
+/// `gr init <url>` then `gr sync` inside the created workspace. Returns sync's output.
+fn init_then_sync(url: &str, extra: &[&str]) -> (TempDir, std::process::Output) {
+    let ws = TempDir::new().unwrap();
+    let init = Command::cargo_bin("gr")
+        .unwrap()
+        .args(["init", url])
+        .current_dir(ws.path())
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "PRECONDITION FAILED: gr init did not succeed, so anything below is a \
+         fact about the harness rather than about gr.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr),
+    );
+    let workspace = ws.path().join("workspace");
+    assert!(
+        workspace.is_dir(),
+        "PRECONDITION FAILED: gr init created no workspace/ directory"
+    );
+
+    let mut args = vec!["sync"];
+    args.extend_from_slice(extra);
+    let out = Command::cargo_bin("gr")
+        .unwrap()
+        .args(&args)
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    (ws, out)
+}
+
+const VALID_MANIFEST: &str = r#"version: 2
+repos:
+  api: { url: "__URL__", path: ./api, revision: api }
+"#;
+
+/// A bare filesystem path instead of a `file://` URL. `gr init` clones from it
+/// happily; `parse_git_url` cannot read it, so `filter_repos` used to drop the
+/// repo without a word and every downstream count printed zero, styled as
+/// success. That silence produced a defect report against repo registration,
+/// which was never broken.
+const UNPARSEABLE_URL_MANIFEST: &str = r#"version: 2
+repos:
+  api: { url: "/tmp/definitely-not-a-url/origin.git", path: ./api, revision: api }
+"#;
+
+/// `composefile` at the TOP level. It belongs under `manifest:`, serde discards
+/// unknown keys in silence, and the block vanishes at exit 0.
+const MISPLACED_KEY_MANIFEST: &str = r#"version: 2
+repos:
+  api: { url: "__URL__", path: ./api, revision: api }
+composefile:
+  - dest: CLAUDE.md
+    parts:
+      - src: PROJECT.md
+"#;
+
+#[test]
+fn sync_names_a_repo_it_could_not_resolve_and_says_so_on_stderr() {
+    let (_origin, url) = origin_with_manifest(UNPARSEABLE_URL_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // THE REPO, so the user knows which declaration was ignored.
+    assert!(
+        stderr.contains("api"),
+        "stderr must name the dropped repo.\nstderr: {stderr}"
+    );
+    // THE REASON, because "excluded" without a cause is not actionable.
+    assert!(
+        stderr.contains("could not be parsed"),
+        "stderr must give the reason.\nstderr: {stderr}"
+    );
+    // THE REMEDY, which is the whole difference between a warning and a fix.
+    assert!(
+        stderr.contains("file://"),
+        "stderr must point at the remedy.\nstderr: {stderr}"
+    );
+    // AND THE ROUTING IS HALF THE CONTRACT. On stdout this warning is swallowed
+    // by redirection and corrupts --json; that is why the stream is asserted
+    // rather than just the text.
+    assert!(
+        !stdout.contains("could not be parsed"),
+        "the warning must not be on stdout.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn sync_names_a_misplaced_manifest_key_and_says_where_it_belongs() {
+    let (_origin, url) = origin_with_manifest(MISPLACED_KEY_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stderr.contains("composefile"),
+        "stderr must name the ignored key.\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("manifest.composefile"),
+        "misplacement is the common case, so the warning must name where the \
+         key belongs.\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("manifest.composefile"),
+        "the warning must not be on stdout.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn a_valid_manifest_warns_on_neither_stream() {
+    // *** THE CONTROL THAT MATTERS MOST. ***
+    //
+    // A warning that fires on valid input is worse than no warning, because it
+    // trains readers to ignore the channel -- which is the defect being fixed,
+    // one layer up. Without this, both tests above would still pass on an
+    // implementation that warned about everything.
+    let (_origin, url) = origin_with_manifest(VALID_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "a valid manifest must sync cleanly.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("IGNORED"),
+        "valid manifest produced an unknown-key warning.\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("EXCLUDED"),
+        "valid manifest produced a dropped-repo warning.\nstderr: {stderr}"
+    );
+    // Positive half: the repo really did resolve, so the silence above is a
+    // clean run rather than a run that did nothing.
+    assert!(
+        stdout.contains("api") || stdout.contains("1 repositor"),
+        "the valid repo should appear in normal output.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn a_warning_never_enters_the_json_stdout_stream() {
+    // MY contract, narrowly: whatever else is on stdout, the warning is not.
+    // That is the half this change owns, and it is asserted in --json mode
+    // because that is where stdout pollution actually costs a consumer.
+    let (_origin, url) = origin_with_manifest(UNPARSEABLE_URL_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &["--json"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // PRECONDITION: the warning actually fired, or this asserts nothing.
+    assert!(
+        stderr.contains("EXCLUDED"),
+        "the warning did not fire, so this test proves nothing.\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("EXCLUDED") && !stdout.contains("could not be parsed"),
+        "the warning leaked into --json stdout.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+#[ignore = "PRE-EXISTING defect, not introduced here; see the body. Un-ignore \
+            when gr's warning/success output is routed off stdout."]
+fn json_stdout_should_be_parseable_json_and_currently_is_not() {
+    // *** A DEFECT THIS TEST FOUND, RECORDED RATHER THAN HIDDEN. ***
+    //
+    // `gr sync --json` prints a human success line BEFORE the JSON document:
+    //
+    //     ✓ Applied 0 link(s)
+    //     { "success": true, ... }
+    //
+    // so stdout is not parseable JSON and every machine consumer of `--json`
+    // is already broken. This is INDEPENDENT of the warning change in this
+    // branch -- it reproduces without any manifest defect at all -- and it is
+    // an instance of the same root cause: `Output` writes through `println!`,
+    // at ~124 call sites across the tree, so every "warning" and success line
+    // lands on stdout.
+    //
+    // Deliberately NOT fixed here. Moving 124 call sites off stdout changes
+    // observable output everywhere and is its own change with its own gate;
+    // folding it into a manifest-parsing fix would make both unreviewable.
+    //
+    // Left as an ignored test rather than a comment because a comment is not
+    // runnable and cannot tell you when it stops being true. Un-ignore it and
+    // it becomes the acceptance criterion for that change.
+    let (_origin, url) = origin_with_manifest(VALID_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &["--json"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    serde_json::from_str::<serde_json::Value>(stdout.trim()).unwrap_or_else(|e| {
+        panic!("--json stdout is not parseable JSON ({e}).\nstdout: {stdout}")
+    });
+}


### PR DESCRIPTION
Two related defects where declared manifest input was discarded without a word.

## Unknown manifest keys

No manifest struct sets `deny_unknown_fields`, so a key matching no field is
dropped during deserialization with no error and exit 0. A `composefile:` block
written at the top level instead of under `manifest:` is therefore ignored: the
block is in the file, `gr manifest schema` documents the key, nothing is a parse
failure, and nothing is produced.

`gr` now warns and, when the key is a real field in the wrong place, names where
it belongs:

```
⚠ manifest key 'composefile' is not valid at the top level and was IGNORED - did you mean 'manifest.composefile'?
```

`deny_unknown_fields` was considered and rejected: it turns every extra key into
a hard parse error, so a manifest carrying a forward-compatibility key would
stop loading on upgrade. Warning keeps existing manifests working.

## Repositories dropped during filtering

`RepoInfo::from_config` returns `Option` and yields `None` for two reasons — no
usable URL, or a URL `parse_git_url` cannot read — and `filter_repos` discarded
both silently, so downstream views printed a reduced count, or zero, formatted
as success. `gr init` clones from the same URL successfully, so a bare
filesystem path produced a workspace that materialised correctly and afterwards
reported as empty.

`gr` now names the repository, the reason, and the remedy.

## Output stream

Both warnings are written to stderr rather than through `Output::warning`, which
uses `println!`. A correctness warning on stdout is lost to redirection and is
emitted inside `--json` output.

## Tests

Four command-level tests drive `gr init` then `gr sync` against a local
`file://` fixture with no network:

- a repository whose URL cannot be parsed: stderr names the repository, the
  reason and the remedy; stdout does not carry it
- `composefile` at the top level: stderr names the key and where it belongs
- a valid manifest: no warning on either stream, and its repository still
  appears in normal output
- `--json`: the warning does not enter the stdout stream

One test is marked `#[ignore]` documenting a pre-existing, separate defect:
`gr sync --json` prints a human-readable success line before the JSON document,
so stdout is not parseable JSON. That reproduces without any manifest defect and
is not addressed here.

716 library tests pass.
