### PR TITLE
fix: gripspaces from one repo at different revisions coexist as distinct spaces

### DIFF
--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -164,23 +164,26 @@ pub fn run_status(
 
             for gs in gripspaces {
                 let name = gripspace_name(&gs.url);
-                let dir_name =
-                    match crate::core::gripspace::resolve_space_name(&gs.url, &spaces_dir) {
-                        Ok(dir_name) => dir_name,
-                        Err(e) => {
-                            let rev = "—".to_string();
-                            // Extract the inner message from ManifestError::GripspaceError
-                            let msg = match &e {
-                                crate::core::manifest::ManifestError::GripspaceError(msg) => {
-                                    msg.clone()
-                                }
-                                other => other.to_string(),
-                            };
-                            let status_str = format!("error: {}", msg);
-                            gs_table.add_row(vec![&Output::repo_name(&name), &rev, &status_str]);
-                            continue;
-                        }
-                    };
+                let dir_name = match crate::core::gripspace::resolve_space_name(
+                    &gs.url,
+                    gs.rev.as_deref(),
+                    &spaces_dir,
+                ) {
+                    Ok(dir_name) => dir_name,
+                    Err(e) => {
+                        let rev = "—".to_string();
+                        // Extract the inner message from ManifestError::GripspaceError
+                        let msg = match &e {
+                            crate::core::manifest::ManifestError::GripspaceError(msg) => {
+                                msg.clone()
+                            }
+                            other => other.to_string(),
+                        };
+                        let status_str = format!("error: {}", msg);
+                        gs_table.add_row(vec![&Output::repo_name(&name), &rev, &status_str]);
+                        continue;
+                    }
+                };
                 let gs_path = spaces_dir.join(&dir_name);
 
                 let (rev, status_str) = if gs_path.exists() {

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -406,9 +406,13 @@ fn sync_gripspaces(
 
     for gs_config in gripspaces {
         let name = gripspace_name(&gs_config.url);
-        // Use resolve_space_name to find the actual directory (handles reserved names)
-        let dir_name = match crate::core::gripspace::resolve_space_name(&gs_config.url, &spaces_dir)
-        {
+        // Use resolve_space_name to find the actual directory (handles reserved
+        // names and multi-rev disambiguation)
+        let dir_name = match crate::core::gripspace::resolve_space_name(
+            &gs_config.url,
+            gs_config.rev.as_deref(),
+            &spaces_dir,
+        ) {
             Ok(dir_name) => dir_name,
             Err(e) => {
                 Output::warning(&format!(

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -82,12 +82,31 @@ fn validate_space_name(name: &str) -> Result<(), ManifestError> {
 
 /// Resolve the directory name for a gripspace within `.gitgrip/spaces/`.
 ///
-/// Handles reserved name conflicts (`main`, `local`) and duplicate names by
-/// auto-suffixing with `-1`, `-2`, etc. If the directory already exists and
-/// has the same git remote, it is reused.
-pub fn resolve_space_name(url: &str, spaces_dir: &Path) -> Result<String, ManifestError> {
+/// A gripspace's identity is `url#rev` (see [`gripspace_identity`]), and the
+/// directory allocation follows the identity, not the URL alone: one repo may
+/// host several gripspaces as different revisions (orphan-branch roots), and
+/// each must materialize as its own space.
+///
+/// Allocation order:
+/// 1. The first gripspace of a URL keeps the pretty basename (`frag`).
+/// 2. A second rev of the same URL gets the deterministic `<base>-<rev>`
+///    (`frag-extras`) — deterministic so a manifest author can reference it
+///    in composefile bindings without discovering an invented name.
+/// 3. Residual collisions fall through to numeric suffixing, as before.
+///
+/// A directory is only ever REUSED for the same `url#rev` identity. Reusing a
+/// same-remote clone across revs is how one rev's space silently vanished
+/// (and how the survivor's checkout got flipped between revs on sync).
+pub fn resolve_space_name(
+    url: &str,
+    rev: Option<&str>,
+    spaces_dir: &Path,
+) -> Result<String, ManifestError> {
     let base = gripspace_name(url);
     validate_space_name(&base)?;
+    if let Some(rev) = rev {
+        validate_rev(rev)?;
+    }
 
     // If the base name is reserved, start from suffix -1
     let candidate = if manifest_paths::RESERVED_SPACE_NAMES.contains(&base.as_str()) {
@@ -101,9 +120,28 @@ pub fn resolve_space_name(url: &str, spaces_dir: &Path) -> Result<String, Manife
         return Ok(candidate);
     }
 
-    // Directory exists — reuse if it's the same remote
-    if is_same_remote(&candidate_path, url) {
+    // Directory exists — reuse only for the same identity (remote AND rev).
+    if is_same_remote_and_rev(&candidate_path, url, rev) {
         return Ok(candidate);
+    }
+
+    // Same remote at a different rev: allocate the deterministic
+    // `<base>-<rev>` name so the author can predict and reference it.
+    if let Some(rev) = rev {
+        if is_same_remote(&candidate_path, url) {
+            let rev_name = format!("{}-{}", base, sanitize_rev_for_name(rev));
+            validate_space_name(&rev_name)?;
+            let rev_path = spaces_dir.join(&rev_name);
+            if !rev_path.exists() || is_same_remote_and_rev(&rev_path, url, Some(rev)) {
+                if !rev_path.exists() {
+                    eprintln!(
+                        "Warning: gripspace '{}' at rev '{}' uses space name '{}' ('{}' is held by a different revision of the same repository)",
+                        url, rev, rev_name, candidate
+                    );
+                }
+                return Ok(rev_name);
+            }
+        }
     }
 
     // Warn when an unrecognized directory occupies the expected name
@@ -118,7 +156,7 @@ pub fn resolve_space_name(url: &str, spaces_dir: &Path) -> Result<String, Manife
     for i in 2..100 {
         let suffixed = format!("{}-{}", base, i);
         let path = spaces_dir.join(&suffixed);
-        if !path.exists() || is_same_remote(&path, url) {
+        if !path.exists() || is_same_remote_and_rev(&path, url, rev) {
             return Ok(suffixed);
         }
     }
@@ -127,6 +165,68 @@ pub fn resolve_space_name(url: &str, spaces_dir: &Path) -> Result<String, Manife
         "Could not allocate a space name for '{}' (too many collisions)",
         url
     )))
+}
+
+/// Make a revision safe for use as a space-name segment.
+///
+/// Revisions may carry `/` (e.g. `feature/x`) or other characters outside the
+/// space-name allowlist; map anything disallowed to `-`.
+fn sanitize_rev_for_name(rev: &str) -> String {
+    rev.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Check whether an existing directory should be reused for `url` at `rev`.
+///
+/// Same remote is necessary but not sufficient: the clone must also sit at the
+/// requested revision. `rev == None` preserves the historical remote-only
+/// check (a rev-less gripspace tracks the clone's current branch).
+fn is_same_remote_and_rev(dir: &Path, url: &str, rev: Option<&str>) -> bool {
+    if !is_same_remote(dir, url) {
+        return false;
+    }
+    let Some(rev) = rev else {
+        return true;
+    };
+
+    // Branch checkouts (the common case): current branch name matches.
+    let branch = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(dir)
+        .output();
+    if let Ok(out) = &branch {
+        if out.status.success() {
+            let current = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !current.is_empty() && current == rev {
+                return true;
+            }
+        }
+    }
+
+    // Tags / SHAs / detached checkouts: compare resolved commits. Failure to
+    // resolve means "cannot confirm same", which must read as different — the
+    // conservative direction costs an extra clone, never a wrong reuse.
+    let head = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output();
+    let want = Command::new("git")
+        .args(["rev-parse", &format!("{}^{{commit}}", rev)])
+        .current_dir(dir)
+        .output();
+    match (head, want) {
+        (Ok(h), Ok(w)) if h.status.success() && w.status.success() => {
+            String::from_utf8_lossy(&h.stdout).trim() == String::from_utf8_lossy(&w.stdout).trim()
+        }
+        _ => false,
+    }
 }
 
 /// Check whether an existing directory should be reused for the given URL.
@@ -203,7 +303,7 @@ pub fn ensure_gripspace(
     spaces_dir: &Path,
     config: &GripspaceConfig,
 ) -> Result<PathBuf, ManifestError> {
-    let dir_name = resolve_space_name(&config.url, spaces_dir)?;
+    let dir_name = resolve_space_name(&config.url, config.rev.as_deref(), spaces_dir)?;
     let gripspace_path = spaces_dir.join(&dir_name);
 
     if gripspace_path.exists() {
@@ -290,15 +390,24 @@ pub fn update_gripspace(
     Ok(())
 }
 
-/// Checkout a specific revision (branch, tag, or SHA) in a gripspace.
-fn checkout_rev(path: &Path, rev: &str) -> Result<(), ManifestError> {
-    // Reject revs that look like flags or contain whitespace
+/// Reject revs that look like flags, are empty, or contain whitespace.
+///
+/// A rev is untrusted manifest input; validate it at FIRST use. Space-name
+/// derivation consumes the rev before any checkout, so allocation must refuse
+/// an invalid rev rather than sanitize it into a directory name.
+fn validate_rev(rev: &str) -> Result<(), ManifestError> {
     if rev.starts_with('-') || rev.chars().any(|c| c.is_whitespace()) || rev.is_empty() {
         return Err(ManifestError::GripspaceError(format!(
             "Invalid rev '{}': must not be empty, start with '-', or contain whitespace",
             rev
         )));
     }
+    Ok(())
+}
+
+/// Checkout a specific revision (branch, tag, or SHA) in a gripspace.
+fn checkout_rev(path: &Path, rev: &str) -> Result<(), ManifestError> {
+    validate_rev(rev)?;
 
     // If `rev` names a fetched remote branch, advance the local branch to it.
     // A plain `git checkout rev` leaves an existing local branch stale after
@@ -679,8 +788,9 @@ fn resolve_gripspace_recursive(
     }
 
     let gripspace_path = ensure_gripspace(spaces_dir, config)?;
-    // Resolve the actual directory name (may differ from `name` due to reserved name suffixing)
-    let dir_name = resolve_space_name(&config.url, spaces_dir)?;
+    // Resolve the actual directory name (may differ from `name` due to reserved
+    // name suffixing or multi-rev disambiguation)
+    let dir_name = resolve_space_name(&config.url, config.rev.as_deref(), spaces_dir)?;
 
     // Load the gripspace's manifest
     let Some(manifest_path) = manifest_paths::resolve_manifest_file_in_dir(&gripspace_path) else {
@@ -1897,7 +2007,8 @@ repos:
     fn test_resolve_space_name_normal() {
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
-        let name = resolve_space_name("https://github.com/user/my-gripspace.git", spaces).unwrap();
+        let name =
+            resolve_space_name("https://github.com/user/my-gripspace.git", None, spaces).unwrap();
         assert_eq!(name, "my-gripspace");
     }
 
@@ -1905,7 +2016,7 @@ repos:
     fn test_resolve_space_name_rejects_dotdot() {
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
-        let err = resolve_space_name("https://github.com/user/..", spaces).unwrap_err();
+        let err = resolve_space_name("https://github.com/user/..", None, spaces).unwrap_err();
         assert!(err.to_string().contains("Invalid gripspace name"));
     }
 
@@ -1913,8 +2024,8 @@ repos:
     fn test_resolve_space_name_rejects_invalid_characters() {
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
-        let err =
-            resolve_space_name("https://github.com/user/my gripspace.git", spaces).unwrap_err();
+        let err = resolve_space_name("https://github.com/user/my gripspace.git", None, spaces)
+            .unwrap_err();
         assert!(err.to_string().contains("Invalid gripspace name"));
     }
 
@@ -1923,7 +2034,7 @@ repos:
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
         // "main" is reserved — should auto-suffix to "main-1"
-        let name = resolve_space_name("https://github.com/user/main.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/main.git", None, spaces).unwrap();
         assert_eq!(name, "main-1");
     }
 
@@ -1931,7 +2042,7 @@ repos:
     fn test_resolve_space_name_reserved_local() {
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
-        let name = resolve_space_name("https://github.com/user/local.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/local.git", None, spaces).unwrap();
         assert_eq!(name, "local-1");
     }
 
@@ -1960,7 +2071,7 @@ repos:
             .unwrap();
 
         // A different URL producing the same name should auto-increment
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo-2");
     }
 
@@ -1989,7 +2100,7 @@ repos:
             .unwrap();
 
         // Same URL should reuse the existing directory name
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo");
     }
 
@@ -2003,7 +2114,7 @@ repos:
         std::fs::create_dir_all(&existing).unwrap();
         std::fs::write(existing.join("README.md"), "local").unwrap();
 
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo-2");
     }
 
@@ -2020,7 +2131,7 @@ repos:
             .output()
             .unwrap();
 
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo-2");
     }
 
@@ -2033,7 +2144,7 @@ repos:
         std::fs::create_dir_all(&existing).unwrap();
         init_git_with_origin(&existing, "git@github.com:user/my-repo.git");
 
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo");
     }
 

--- a/tests/gripspace_multi_rev.rs
+++ b/tests/gripspace_multi_rev.rs
@@ -1,0 +1,286 @@
+//! Command-level witnesses: multiple gripspaces from ONE repository at
+//! DIFFERENT revisions must coexist as first-class spaces.
+//!
+//! *** THE DEFECT THESE WERE BORN RED AGAINST (2026-08-12). ***
+//!
+//! `gripspace_identity()` already knows a gripspace is `url#rev`. But
+//! `resolve_space_name()` derived the space directory from the URL alone, and
+//! the reuse check asked only "same remote?" — so the second gripspace of a
+//! repo silently REUSED the first rev's clone. Measured live: a manifest
+//! declaring `rev: standards` and `rev: api` from one repo materialized ONE
+//! space at `standards`; the `api` binding resolved to nothing; compose
+//! printed a warning and then a success line.
+//!
+//! One repo hosting many gripspaces as orphan-branch roots is the tutorial's
+//! and the product's core shape ("the whole point is multiple gripspaces" —
+//! the ruling that opened this fix). These witnesses drive the real binary
+//! end to end, because the naming function, the reuse check, the sync
+//! mapping, and the compose binding all have to agree before the feature
+//! exists — a green unit test on the naming helper alone proves none of that.
+
+use assert_cmd::Command;
+use std::path::Path;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// One bare repo, three orphan-branch roots:
+///   `main`      — the workspace manifest + a local fragment
+///   `standards` — fragment MARKER-STANDARDS-a83f
+///   `extras`    — fragment MARKER-EXTRAS-b17c
+/// The manifest declares the SAME url as two gripspaces at the two revs and
+/// composes one CLAUDE.md from both plus the local part.
+fn build_one_repo_two_gripspace_origin(root: &Path) -> String {
+    let bare = root.join("frag.git");
+    git(root, &["init", "--bare", "frag.git"]);
+    let url = format!("file://{}", bare.display());
+
+    let w = root.join("seed");
+    std::fs::create_dir_all(&w).unwrap();
+    git(&w, &["init"]);
+
+    git(&w, &["checkout", "-b", "standards"]);
+    std::fs::write(w.join("CONVENTIONS.md"), "MARKER-STANDARDS-a83f\n").unwrap();
+    std::fs::write(w.join("gripspace.yml"), "version: 2\n").unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "standards root"]);
+
+    git(&w, &["checkout", "--orphan", "extras"]);
+    git(&w, &["rm", "-rf", "."]);
+    std::fs::write(w.join("EXTRA.md"), "MARKER-EXTRAS-b17c\n").unwrap();
+    std::fs::write(w.join("gripspace.yml"), "version: 2\n").unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "extras root"]);
+
+    git(&w, &["checkout", "--orphan", "main"]);
+    git(&w, &["rm", "-rf", "."]);
+    std::fs::write(w.join("PROJECT.md"), "MARKER-LOCAL-c29d\n").unwrap();
+    std::fs::write(
+        w.join("gripspace.yml"),
+        format!(
+            r#"version: 2
+manifest:
+  url: {url}
+  composefile:
+    - dest: CLAUDE.md
+      separator: "\n"
+      parts:
+        - gripspace: frag
+          src: CONVENTIONS.md
+        - gripspace: frag-extras
+          src: EXTRA.md
+        - src: PROJECT.md
+gripspaces:
+  - url: {url}
+    rev: standards
+  - url: {url}
+    rev: extras
+repos:
+  extras-checkout:
+    url: {url}
+    path: ./extras-checkout
+    revision: extras
+"#
+        ),
+    )
+    .unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "manifest root"]);
+    git(&w, &["push", &url, "standards", "extras", "main"]);
+
+    url
+}
+
+fn gr() -> Command {
+    let mut c = Command::cargo_bin("gr").expect("gr binary");
+    c.env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t");
+    c
+}
+
+/// Locate the workspace directory `gr init` created under `parent`.
+fn workspace_dir(parent: &Path) -> std::path::PathBuf {
+    std::fs::read_dir(parent)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| p.is_dir() && p.join(".gitgrip").exists())
+        .expect("gr init produced a workspace directory")
+}
+
+#[test]
+fn two_revs_of_one_repo_materialize_as_two_spaces_and_both_compose() {
+    let tmp = TempDir::new().unwrap();
+    let url = build_one_repo_two_gripspace_origin(tmp.path());
+    let ws_parent = tmp.path().join("ws");
+    std::fs::create_dir_all(&ws_parent).unwrap();
+
+    let assert = gr().args(["init", &url]).current_dir(&ws_parent).assert();
+    let out = assert.get_output().clone();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert.success();
+
+    let ws = workspace_dir(&ws_parent);
+    let spaces = ws.join(".gitgrip").join("spaces");
+
+    // Both revs exist as first-class spaces, each carrying ITS branch's file.
+    assert!(
+        spaces.join("frag").join("CONVENTIONS.md").exists(),
+        "first-declared rev keeps the base name and its content; spaces present: {:?}",
+        std::fs::read_dir(&spaces)
+            .map(|d| d
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name())
+                .collect::<Vec<_>>())
+            .unwrap_or_default()
+    );
+    assert!(
+        spaces.join("frag-extras").join("EXTRA.md").exists(),
+        "second rev materializes under the deterministic name '<base>-<rev>'"
+    );
+
+    // The composed file carries fragments from BOTH branches of the ONE repo.
+    let claude = std::fs::read_to_string(ws.join("CLAUDE.md"))
+        .expect("CLAUDE.md composed at workspace root");
+    assert!(
+        claude.contains("MARKER-STANDARDS-a83f"),
+        "standards fragment present"
+    );
+    assert!(
+        claude.contains("MARKER-EXTRAS-b17c"),
+        "extras fragment present"
+    );
+    assert!(
+        claude.contains("MARKER-LOCAL-c29d"),
+        "local fragment present"
+    );
+
+    // The disambiguation is NAMED, on stderr — an invented space name that
+    // appears in no manifest must not be invented silently.
+    assert!(
+        stderr.contains("frag-extras"),
+        "stderr names the deterministic space name; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn sync_reuses_both_spaces_instead_of_proliferating() {
+    let tmp = TempDir::new().unwrap();
+    let url = build_one_repo_two_gripspace_origin(tmp.path());
+    let ws_parent = tmp.path().join("ws");
+    std::fs::create_dir_all(&ws_parent).unwrap();
+    gr().args(["init", &url])
+        .current_dir(&ws_parent)
+        .assert()
+        .success();
+    let ws = workspace_dir(&ws_parent);
+
+    gr().arg("sync").current_dir(&ws).assert().success();
+    gr().arg("sync").current_dir(&ws).assert().success();
+
+    let spaces = ws.join(".gitgrip").join("spaces");
+    let named: Vec<String> = std::fs::read_dir(&spaces)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("frag"))
+        .collect();
+    let mut sorted = named.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec!["frag".to_string(), "frag-extras".to_string()],
+        "repeat syncs reuse the two spaces — no frag-2/frag-3 proliferation"
+    );
+
+    // Idempotent compose still carries both fragments after repeat syncs.
+    let claude = std::fs::read_to_string(ws.join("CLAUDE.md")).unwrap();
+    assert!(claude.contains("MARKER-STANDARDS-a83f"));
+    assert!(claude.contains("MARKER-EXTRAS-b17c"));
+}
+
+/// Discriminating control: the fix must key on url+rev, not "always allocate a
+/// new space". The SAME url at the SAME rev declared twice still collapses to
+/// one space — if this test fails while the others pass, the implementation
+/// went to per-entry allocation, which is right by accident and wrong by design.
+#[test]
+fn same_url_same_rev_twice_still_yields_one_space() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let bare = root.join("frag.git");
+    git(root, &["init", "--bare", "frag.git"]);
+    let url = format!("file://{}", bare.display());
+
+    let w = root.join("seed");
+    std::fs::create_dir_all(&w).unwrap();
+    git(&w, &["init"]);
+    git(&w, &["checkout", "-b", "standards"]);
+    std::fs::write(w.join("CONVENTIONS.md"), "MARKER-STANDARDS-a83f\n").unwrap();
+    std::fs::write(w.join("gripspace.yml"), "version: 2\n").unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "standards root"]);
+    git(&w, &["checkout", "--orphan", "main"]);
+    git(&w, &["rm", "-rf", "."]);
+    std::fs::write(
+        w.join("gripspace.yml"),
+        format!(
+            r#"version: 2
+manifest:
+  url: {url}
+gripspaces:
+  - url: {url}
+    rev: standards
+  - url: {url}
+    rev: standards
+repos:
+  standards-checkout:
+    url: {url}
+    path: ./standards-checkout
+    revision: standards
+"#
+        ),
+    )
+    .unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "manifest"]);
+    git(&w, &["push", &url, "standards", "main"]);
+
+    let ws_parent = root.join("ws");
+    std::fs::create_dir_all(&ws_parent).unwrap();
+    gr().args(["init", &url])
+        .current_dir(&ws_parent)
+        .assert()
+        .success();
+    let ws = workspace_dir(&ws_parent);
+
+    let spaces = ws.join(".gitgrip").join("spaces");
+    let named: Vec<String> = std::fs::read_dir(&spaces)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("frag"))
+        .collect();
+    assert_eq!(
+        named,
+        vec!["frag".to_string()],
+        "identical url+rev dedups to one space — allocation is by identity, not by entry"
+    );
+}


### PR DESCRIPTION
Gripspaces declared from one repository at different revisions now materialize as distinct spaces.

`resolve_space_name` takes the revision into account: allocation follows the `url#rev` identity, the first gripspace of a URL keeps the basename, a second revision gets the deterministic `<base>-<rev>` (named on stderr), and a clone is only reused for the same identity. Revisions are validated at first use.

Three born-red command-level witnesses drive the real binary: two revisions of one repo materialize and compose into one file, repeat syncs reuse rather than proliferate, and a control pins that identical url+rev entries still dedup to one space.

Evidence: full suite green (716 lib tests plus all integration suites, zero failures), `cargo fmt --check` clean, clippy differential shows zero findings on touched files.

Premium boundary: core OSS (workspace orchestration).

Ref: tracked privately; deliberately not linked.
