### PR TITLE
feat(compose): source parts from repo checkouts and compose across gripspace layers

### DIFF
--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -732,10 +732,12 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
             // Apply composefiles
             if let Some(ref composefiles) = manifest_config.composefile {
                 if !composefiles.is_empty() {
+                    let repo_paths = crate::files::repo_checkout_paths(manifest);
                     match process_composefiles(
                         workspace_root,
                         &manifests_dir,
                         &spaces_dir,
+                        &repo_paths,
                         composefiles,
                     ) {
                         Ok(()) => {

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -305,10 +305,12 @@ pub async fn run_sync(
                 let manifests_dir = manifest_paths::resolve_manifest_content_dir(workspace_root);
                 let spaces_dir = manifest_paths::spaces_dir(workspace_root);
 
+                let repo_paths = crate::files::repo_checkout_paths(manifest);
                 match process_composefiles(
                     workspace_root,
                     &manifests_dir,
                     &spaces_dir,
+                    &repo_paths,
                     composefiles,
                 ) {
                     Ok(()) => {

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -589,6 +589,7 @@ pub fn resolve_all_gripspaces(
     let mut merged_hooks_post_checkout: Vec<HookCommand> = Vec::new();
     let mut merged_linkfiles = Vec::new();
     let mut merged_copyfiles = Vec::new();
+    let mut merged_composefiles: Vec<crate::core::manifest::ComposeFileConfig> = Vec::new();
     let mut merged_agent: Option<WorkspaceAgentConfig> = None;
 
     // Process each gripspace
@@ -606,6 +607,7 @@ pub fn resolve_all_gripspaces(
             &mut merged_hooks_post_checkout,
             &mut merged_linkfiles,
             &mut merged_copyfiles,
+            &mut merged_composefiles,
             &mut merged_agent,
         )?;
     }
@@ -697,7 +699,10 @@ pub fn resolve_all_gripspaces(
     // Linkfiles from gripspaces are tracked separately — they'll be applied by the link command
     // We store them as manifest-level linkfiles, with local ones overriding by dest
     // Create the manifest config if it doesn't exist and there are gripspace files to merge
-    if manifest.manifest.is_none() && (!merged_linkfiles.is_empty() || !merged_copyfiles.is_empty())
+    if manifest.manifest.is_none()
+        && (!merged_linkfiles.is_empty()
+            || !merged_copyfiles.is_empty()
+            || !merged_composefiles.is_empty())
     {
         manifest.manifest = Some(crate::core::manifest::ManifestRepoConfig {
             url: String::new(),
@@ -709,6 +714,13 @@ pub fn resolve_all_gripspaces(
         });
     }
     if let Some(ref mut manifest_config) = manifest.manifest {
+        if !merged_composefiles.is_empty() {
+            let local = manifest_config.composefile.take();
+            manifest_config.composefile = Some(merge_composefiles_in_layer_order(
+                merged_composefiles,
+                local,
+            ));
+        }
         if !merged_linkfiles.is_empty() {
             let local_linkfiles = manifest_config.linkfile.take().unwrap_or_default();
             let local_dests: HashSet<String> =
@@ -745,6 +757,55 @@ pub fn resolve_all_gripspaces(
     Ok(())
 }
 
+/// Merge composefiles from included gripspaces with the local ones.
+///
+/// *** LAYER ORDER: ANCESTORS FIRST, LOCAL LAST. ***
+///
+/// `included` arrives in resolution order, which is depth-first — the deepest
+/// include (the furthest ancestor) first. Parts targeting the same `dest`
+/// concatenate in that order, so a layer's contribution appends after every
+/// layer it extends and the file reads base-to-tip.
+///
+/// This is what makes inclusion COMPOSITIONAL. Before it, an included
+/// gripspace's composefile was dropped entirely and only the gripspace you
+/// happened to clone composed anything — so every layer had to re-enumerate
+/// the whole chain.
+///
+/// A `dest` the local manifest never mentions is still produced: an ancestor
+/// declaring a composed file must not need the tip to redeclare it, or the
+/// re-enumeration is back.
+pub fn merge_composefiles_in_layer_order(
+    included: Vec<crate::core::manifest::ComposeFileConfig>,
+    local: Option<Vec<crate::core::manifest::ComposeFileConfig>>,
+) -> Vec<crate::core::manifest::ComposeFileConfig> {
+    let mut order: Vec<String> = Vec::new();
+    let mut by_dest: HashMap<String, crate::core::manifest::ComposeFileConfig> = HashMap::new();
+
+    for cf in included.into_iter().chain(local.unwrap_or_default()) {
+        match by_dest.entry(cf.dest.clone()) {
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                let existing = e.get_mut();
+                existing.parts.extend(cf.parts);
+                // A later layer may set the separator; the earliest one that
+                // states a preference keeps it, so a tip cannot silently
+                // restyle an ancestor's file.
+                if existing.separator.is_none() {
+                    existing.separator = cf.separator;
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(e) => {
+                order.push(cf.dest.clone());
+                e.insert(cf);
+            }
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|d| by_dest.remove(&d))
+        .collect()
+}
+
 /// Recursively resolve a single gripspace and its nested gripspaces.
 #[allow(clippy::too_many_arguments)]
 fn resolve_gripspace_recursive(
@@ -760,6 +821,7 @@ fn resolve_gripspace_recursive(
     merged_hooks_post_checkout: &mut Vec<HookCommand>,
     merged_linkfiles: &mut Vec<crate::core::manifest::LinkFileConfig>,
     merged_copyfiles: &mut Vec<crate::core::manifest::CopyFileConfig>,
+    merged_composefiles: &mut Vec<crate::core::manifest::ComposeFileConfig>,
     merged_agent: &mut Option<WorkspaceAgentConfig>,
 ) -> Result<(), ManifestError> {
     if depth >= MAX_GRIPSPACE_DEPTH {
@@ -834,6 +896,7 @@ fn resolve_gripspace_recursive(
                 merged_hooks_post_checkout,
                 merged_linkfiles,
                 merged_copyfiles,
+                merged_composefiles,
                 merged_agent,
             )?;
         }
@@ -912,6 +975,41 @@ fn resolve_gripspace_recursive(
                 });
             }
         }
+        // COMPOSEFILES, with their bare parts REBASED onto this gripspace.
+        //
+        // A part with no source kind is manifest-relative — and "the manifest"
+        // means the gripspace that WROTE it, not the root that included it.
+        // Carrying it through unrebased would resolve it against the root's
+        // manifest dir and read the wrong file, or silently read nothing. So a
+        // bare `src:` becomes `gripspace: <dir_name>`, exactly as linkfiles are
+        // rewritten just above.
+        //
+        // `gripspace:` and `repo:` parts pass through: both name something in
+        // the shared, already-merged namespace, so they mean the same thing
+        // from either side of the include.
+        if let Some(ref composefiles) = manifest_config.composefile {
+            for cf in composefiles {
+                merged_composefiles.push(crate::core::manifest::ComposeFileConfig {
+                    dest: cf.dest.clone(),
+                    separator: cf.separator.clone(),
+                    parts: cf
+                        .parts
+                        .iter()
+                        .map(|p| {
+                            if p.gripspace.is_none() && p.repo.is_none() {
+                                crate::core::manifest::ComposeFilePart {
+                                    src: p.src.clone(),
+                                    gripspace: Some(dir_name.to_string()),
+                                    repo: None,
+                                }
+                            } else {
+                                p.clone()
+                            }
+                        })
+                        .collect(),
+                });
+            }
+        }
     }
 
     active_stack.remove(&identity_key);
@@ -948,6 +1046,94 @@ pub fn get_gripspace_rev(gripspace_path: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    // ── GAP 2: included gripspaces' composefiles ────────────────────────────
+
+    fn cf(
+        dest: &str,
+        parts: Vec<crate::core::manifest::ComposeFilePart>,
+    ) -> crate::core::manifest::ComposeFileConfig {
+        crate::core::manifest::ComposeFileConfig {
+            dest: dest.to_string(),
+            parts,
+            separator: None,
+        }
+    }
+    fn bare(src: &str) -> crate::core::manifest::ComposeFilePart {
+        crate::core::manifest::ComposeFilePart {
+            src: src.to_string(),
+            gripspace: None,
+            repo: None,
+        }
+    }
+    fn from_gs(gs: &str, src: &str) -> crate::core::manifest::ComposeFilePart {
+        crate::core::manifest::ComposeFilePart {
+            src: src.to_string(),
+            gripspace: Some(gs.to_string()),
+            repo: None,
+        }
+    }
+
+    #[test]
+    fn test_composefiles_merge_same_dest_ancestors_first() {
+        // THE ORDERING IS THE FEATURE. `included` arrives depth-first, so the
+        // furthest ancestor is first and the file reads base-to-tip. A merge
+        // that only unioned parts would pass a "both present" assertion and
+        // still produce a scrambled file.
+        let included = vec![
+            cf("CLAUDE.md", vec![from_gs("base", "BASE.md")]),
+            cf("CLAUDE.md", vec![from_gs("standards", "STD.md")]),
+        ];
+        let local = Some(vec![cf("CLAUDE.md", vec![bare("LOCAL.md")])]);
+
+        let merged = merge_composefiles_in_layer_order(included, local);
+
+        assert_eq!(
+            merged.len(),
+            1,
+            "same dest must collapse to one composefile"
+        );
+        let srcs: Vec<&str> = merged[0].parts.iter().map(|p| p.src.as_str()).collect();
+        assert_eq!(srcs, vec!["BASE.md", "STD.md", "LOCAL.md"]);
+    }
+
+    #[test]
+    fn test_composefile_dest_only_an_ancestor_declares_is_still_produced() {
+        // If a dest had to be redeclared by the tip, every layer would still
+        // be re-enumerating the chain — which is the thing GAP 2 exists to end.
+        let included = vec![cf("AGENTS.md", vec![from_gs("base", "A.md")])];
+        let merged = merge_composefiles_in_layer_order(included, None);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].dest, "AGENTS.md");
+    }
+
+    #[test]
+    fn test_composefile_local_only_dest_survives_the_merge() {
+        let included = vec![cf("CLAUDE.md", vec![from_gs("base", "B.md")])];
+        let local = Some(vec![cf("OWN.md", vec![bare("O.md")])]);
+        let merged = merge_composefiles_in_layer_order(included, local);
+        let dests: Vec<&str> = merged.iter().map(|c| c.dest.as_str()).collect();
+        assert_eq!(dests, vec!["CLAUDE.md", "OWN.md"]);
+    }
+
+    #[test]
+    fn test_composefile_earliest_separator_wins_so_a_tip_cannot_restyle() {
+        let mut anc = cf("X.md", vec![from_gs("base", "B.md")]);
+        anc.separator = Some("---".to_string());
+        let mut tip = cf("X.md", vec![bare("L.md")]);
+        tip.separator = Some("###".to_string());
+        let merged = merge_composefiles_in_layer_order(vec![anc], Some(vec![tip]));
+        assert_eq!(merged[0].separator.as_deref(), Some("---"));
+    }
+
+    #[test]
+    fn test_composefile_separator_is_adopted_when_the_ancestor_stated_none() {
+        let anc = cf("X.md", vec![from_gs("base", "B.md")]);
+        let mut tip = cf("X.md", vec![bare("L.md")]);
+        tip.separator = Some("###".to_string());
+        let merged = merge_composefiles_in_layer_order(vec![anc], Some(vec![tip]));
+        assert_eq!(merged[0].separator.as_deref(), Some("###"));
+    }
+
     use super::*;
     use std::path::Path;
 

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -93,11 +93,23 @@ pub struct GripspaceConfig {
 /// A part of a composed file
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComposeFilePart {
-    /// Source path relative to the gripspace or manifest repo
+    /// Source path, relative to whichever source kind this part names
     pub src: String,
-    /// Name of the gripspace to source from (if omitted, sources from local manifest)
+    /// Name of the gripspace to source from
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gripspace: Option<String>,
+    /// Name of a repo from `repos:` to source from, resolved against that
+    /// repo's checkout path.
+    ///
+    /// The third source kind, and the one that lets a gripspace compose from
+    /// the repos it actually manages. Without it a part could only read from a
+    /// gripspace or from the manifest repo, so a plain repo had to become a
+    /// gripspace before it could contribute to a composed file.
+    ///
+    /// Mutually exclusive with `gripspace`: a part naming both is ambiguous
+    /// and is refused rather than silently resolved to one of them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
 }
 
 /// Composed file configuration

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -48,15 +48,32 @@ fn validate_gripspace_name(name: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Repo name -> configured checkout path, for composefile `repo:` parts.
+///
+/// Built from the manifest the caller already resolved, so a `repo:` part
+/// reads from the same checkout `gr sync` maintains rather than from a second
+/// idea of where repos live.
+pub fn repo_checkout_paths(
+    manifest: &crate::core::manifest::Manifest,
+) -> std::collections::HashMap<String, std::path::PathBuf> {
+    manifest
+        .repos
+        .iter()
+        .map(|(name, cfg)| (name.clone(), std::path::PathBuf::from(&cfg.path)))
+        .collect()
+}
+
 /// Process composefile entries, writing composed files to the workspace root.
 ///
 /// Each composefile concatenates parts in order. Parts can come from:
 /// - A gripspace: reads from `.gitgrip/spaces/<name>/<src>`
+/// - A repo (`repo: <name>`): reads from that repo's checkout path
 /// - The local manifest: reads from the manifest content directory
 pub fn process_composefiles(
     workspace_root: &Path,
     manifests_dir: &Path,
     spaces_dir: &Path,
+    repo_paths: &std::collections::HashMap<String, std::path::PathBuf>,
     composefiles: &[ComposeFileConfig],
 ) -> anyhow::Result<()> {
     for compose in composefiles {
@@ -67,7 +84,50 @@ pub fn process_composefiles(
         let mut parts_content: Vec<String> = Vec::new();
 
         for part in &compose.parts {
-            let source_path = if let Some(ref gs_name) = part.gripspace {
+            // AMBIGUOUS PARTS ARE REFUSED, NOT RESOLVED. Naming two source
+            // kinds does not mean "try both" or "prefer one"; it means the
+            // manifest does not say where the content comes from, and quietly
+            // picking would compose a file nobody asked for.
+            if part.repo.is_some() && part.gripspace.is_some() {
+                eprintln!(
+                    "Warning: composefile '{}' part '{}' names both repo: and gripspace:; \
+                     skipping (they are mutually exclusive)",
+                    compose.dest, part.src
+                );
+                continue;
+            }
+
+            let source_path = if let Some(ref repo_name) = part.repo {
+                if let Err(e) = validate_relative_source_path(&part.src, "composefile part src") {
+                    eprintln!(
+                        "Warning: composefile '{}' has invalid part src: {}",
+                        compose.dest, e
+                    );
+                    continue;
+                }
+                match repo_paths.get(repo_name) {
+                    Some(repo_path) => workspace_root.join(repo_path).join(&part.src),
+                    None => {
+                        // Consistent with every other unresolvable part: warn
+                        // and skip. A repo that is not in the manifest must not
+                        // take the whole sync down.
+                        let mut known: Vec<&str> = repo_paths.keys().map(|k| k.as_str()).collect();
+                        known.sort_unstable();
+                        eprintln!(
+                            "Warning: composefile '{}' part repo:{} names no repo; \
+                             it must match a key under `repos:` (known: {})",
+                            compose.dest,
+                            repo_name,
+                            if known.is_empty() {
+                                "none".to_string()
+                            } else {
+                                known.join(", ")
+                            }
+                        );
+                        continue;
+                    }
+                }
+            } else if let Some(ref gs_name) = part.gripspace {
                 if let Err(e) = validate_gripspace_name(gs_name) {
                     eprintln!(
                         "Warning: composefile '{}' has invalid gripspace name: {}",
@@ -102,9 +162,14 @@ pub fn process_composefiles(
                 }
                 Err(e) => {
                     let gs_label = part
-                        .gripspace
+                        .repo
                         .as_deref()
-                        .map(|g| format!("gripspace:{}", g))
+                        .map(|r| format!("repo:{}", r))
+                        .or_else(|| {
+                            part.gripspace
+                                .as_deref()
+                                .map(|g| format!("gripspace:{}", g))
+                        })
                         .unwrap_or_else(|| "manifest".to_string());
                     eprintln!(
                         "Warning: composefile '{}' part {}:{} not found: {}",
@@ -168,7 +233,227 @@ pub fn resolve_file_source(
 mod tests {
     use super::*;
     use crate::core::manifest::{ComposeFileConfig, ComposeFilePart};
+    use std::collections::HashMap;
+    use std::path::PathBuf;
     use tempfile::TempDir;
+
+    // ── GAP 1: a part sourced from a repo CHECKOUT ──────────────────────────
+    //
+    // A composefile could source from a gripspace or from the manifest repo,
+    // and from nothing else -- so a repo the gripspace actually manages could
+    // not contribute to a composed file. Sourcing `standards/CONVENTIONS.md`
+    // with `standards` checked out at ./standards resolved MANIFEST-relative
+    // and warned `manifest:standards/CONVENTIONS.md not found`.
+
+    fn repo_paths(pairs: &[(&str, &str)]) -> HashMap<String, PathBuf> {
+        pairs
+            .iter()
+            .map(|(name, path)| (name.to_string(), PathBuf::from(path)))
+            .collect()
+    }
+
+    #[test]
+    fn test_composefile_part_sources_from_a_repo_checkout() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::create_dir_all(workspace.join("standards")).unwrap();
+        std::fs::write(
+            workspace.join("standards").join("CONVENTIONS.md"),
+            "# Conventions",
+        )
+        .unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "CLAUDE.md".to_string(),
+            parts: vec![ComposeFilePart {
+                repo: Some("standards".to_string()),
+                gripspace: None,
+                src: "CONVENTIONS.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[("standards", "./standards")]),
+            &composefiles,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("CLAUDE.md")).unwrap(),
+            "# Conventions"
+        );
+    }
+
+    #[test]
+    fn test_composefile_repo_part_is_not_resolved_manifest_relative() {
+        // THE ACTUAL BUG, pinned. Before `repo:` existed the same file was
+        // looked for under the manifest dir. A same-named decoy there would
+        // make a naive fix pass while still reading the wrong file.
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(manifests_dir.join("standards")).unwrap();
+        std::fs::create_dir_all(workspace.join("standards")).unwrap();
+        std::fs::write(
+            manifests_dir.join("standards").join("CONVENTIONS.md"),
+            "DECOY FROM MANIFEST",
+        )
+        .unwrap();
+        std::fs::write(
+            workspace.join("standards").join("CONVENTIONS.md"),
+            "REAL FROM REPO",
+        )
+        .unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "OUT.md".to_string(),
+            parts: vec![ComposeFilePart {
+                repo: Some("standards".to_string()),
+                gripspace: None,
+                src: "CONVENTIONS.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[("standards", "./standards")]),
+            &composefiles,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
+            "REAL FROM REPO"
+        );
+    }
+
+    #[test]
+    fn test_composefile_unknown_repo_warns_and_skips() {
+        // Consistent with every other unresolvable part: warn, skip, do not
+        // fail the sync. A missing repo must not take the workspace down.
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::write(manifests_dir.join("LOCAL.md"), "# Local").unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "OUT.md".to_string(),
+            parts: vec![
+                ComposeFilePart {
+                    repo: Some("nope".to_string()),
+                    gripspace: None,
+                    src: "X.md".to_string(),
+                },
+                ComposeFilePart {
+                    repo: None,
+                    gripspace: None,
+                    src: "LOCAL.md".to_string(),
+                },
+            ],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[]),
+            &composefiles,
+        )
+        .unwrap();
+
+        // The resolvable part still composes; the unknown one is skipped.
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
+            "# Local"
+        );
+    }
+
+    #[test]
+    fn test_composefile_repo_part_rejects_path_traversal() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::create_dir_all(workspace.join("standards")).unwrap();
+        std::fs::write(workspace.join("SECRET.md"), "secret").unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "OUT.md".to_string(),
+            parts: vec![ComposeFilePart {
+                repo: Some("standards".to_string()),
+                gripspace: None,
+                src: "../SECRET.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[("standards", "./standards")]),
+            &composefiles,
+        )
+        .unwrap();
+
+        assert!(
+            !workspace.join("OUT.md").exists(),
+            "path traversal out of a repo checkout was composed"
+        );
+    }
+
+    #[test]
+    fn test_composefile_repo_and_gripspace_together_is_rejected() {
+        // Two source kinds on one part is ambiguous. Refuse rather than pick.
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::create_dir_all(spaces_dir.join("base")).unwrap();
+        std::fs::create_dir_all(workspace.join("standards")).unwrap();
+        std::fs::write(spaces_dir.join("base").join("A.md"), "from gripspace").unwrap();
+        std::fs::write(workspace.join("standards").join("A.md"), "from repo").unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "OUT.md".to_string(),
+            parts: vec![ComposeFilePart {
+                repo: Some("standards".to_string()),
+                gripspace: Some("base".to_string()),
+                src: "A.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[("standards", "./standards")]),
+            &composefiles,
+        )
+        .unwrap();
+
+        assert!(
+            !workspace.join("OUT.md").exists(),
+            "an ambiguous part with both repo: and gripspace: was composed anyway"
+        );
+    }
 
     #[test]
     fn test_process_composefiles_basic() {
@@ -192,10 +477,12 @@ mod tests {
             dest: "COMPOSED.md".to_string(),
             parts: vec![
                 ComposeFilePart {
+                    repo: None,
                     gripspace: Some("base-space".to_string()),
                     src: "BASE.md".to_string(),
                 },
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "LOCAL.md".to_string(),
                 },
@@ -203,8 +490,13 @@ mod tests {
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
 
         let content = std::fs::read_to_string(workspace.join("COMPOSED.md")).unwrap();
@@ -228,10 +520,12 @@ mod tests {
             dest: "OUTPUT.md".to_string(),
             parts: vec![
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "PART1.md".to_string(),
                 },
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "PART2.md".to_string(),
                 },
@@ -239,8 +533,13 @@ mod tests {
             separator: Some("\n\n---\n\n".to_string()),
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
 
         let content = std::fs::read_to_string(workspace.join("OUTPUT.md")).unwrap();
@@ -263,10 +562,12 @@ mod tests {
             dest: "OUTPUT.md".to_string(),
             parts: vec![
                 ComposeFilePart {
+                    repo: None,
                     gripspace: Some("nonexistent".to_string()),
                     src: "MISSING.md".to_string(),
                 },
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "EXISTS.md".to_string(),
                 },
@@ -274,8 +575,13 @@ mod tests {
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
 
         // Should still write the available part
@@ -298,14 +604,20 @@ mod tests {
         let composefiles = vec![ComposeFileConfig {
             dest: "nested/dir/output.txt".to_string(),
             parts: vec![ComposeFilePart {
+                repo: None,
                 gripspace: None,
                 src: "content.txt".to_string(),
             }],
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
         assert!(workspace.join("nested/dir/output.txt").exists());
     }
@@ -389,14 +701,20 @@ mod tests {
         let composefiles = vec![ComposeFileConfig {
             dest: "../escaped.md".to_string(),
             parts: vec![ComposeFilePart {
+                repo: None,
                 gripspace: None,
                 src: "file.md".to_string(),
             }],
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_err());
     }
 
@@ -414,14 +732,20 @@ mod tests {
         let composefiles = vec![ComposeFileConfig {
             dest: "C:\\temp\\escaped.md".to_string(),
             parts: vec![ComposeFilePart {
+                repo: None,
                 gripspace: None,
                 src: "file.md".to_string(),
             }],
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_err());
     }
 
@@ -441,10 +765,12 @@ mod tests {
             dest: "output.md".to_string(),
             parts: vec![
                 ComposeFilePart {
+                    repo: None,
                     gripspace: Some("../evil".to_string()),
                     src: "file.md".to_string(),
                 },
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "fallback.md".to_string(),
                 },
@@ -452,8 +778,13 @@ mod tests {
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
 
         // Only the valid part should be written
@@ -493,14 +824,20 @@ mod tests {
         let composefiles = vec![ComposeFileConfig {
             dest: "\\escaped.md".to_string(),
             parts: vec![ComposeFilePart {
+                repo: None,
                 gripspace: None,
                 src: "file.md".to_string(),
             }],
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_err());
     }
 }

--- a/tests/layered_composition.rs
+++ b/tests/layered_composition.rs
@@ -1,0 +1,227 @@
+//! Composition ACROSS gripspace layers, exercised through the real seam.
+//!
+//! *** WHY THIS FILE EXISTS, AND IT IS A REVIEW FINDING, NOT A PREFERENCE. ***
+//!
+//! The unit tests for this feature call `merge_composefiles_in_layer_order`
+//! and `process_composefiles` DIRECTLY. Both are downstream of the thing that
+//! actually makes layered composition work: the point inside
+//! `resolve_gripspace_recursive` where an included manifest's bare part is
+//! rewritten to `gripspace: <resolved-dir>` and carried into the merged
+//! manifest.
+//!
+//! A reviewer pointed out that a mutation removing that rewrite, or dropping
+//! included composefiles before the helper is reached, leaves every one of
+//! those unit tests GREEN. They pin the functions; they do not pin the USE.
+//! A manual end-to-end run is evidence about one head, not a regression
+//! witness that survives the next refactor.
+//!
+//! So this drives the real `gr` binary through init and sync, and it is built
+//! to go RED on either mutation:
+//!
+//!   - remove the REBASE  -> base's bare `src: SHARED.md` resolves
+//!     manifest-relative again and reads the root's DECOY file, so the decoy
+//!     content appears and the layer's own content does not
+//!   - remove the CARRY   -> the ancestors' parts never reach the merge at all
+//!
+//! The decoy is the load-bearing part. Without a same-named file at the old
+//! resolution path, a broken rebase would simply find nothing, and "absent"
+//! is indistinguishable from "the layer contributed nothing" — which is the
+//! bug this feature fixes, passing itself off as the fix.
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {:?} failed in {:?}: {}",
+        args,
+        dir,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A local git repo holding `files`, usable as a gripspace URL.
+fn repo(root: &Path, name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let dir = root.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    git(&dir, &["init", "-q", "-b", "main"]);
+    git(&dir, &["config", "user.email", "test@example.com"]);
+    git(&dir, &["config", "user.name", "test"]);
+    for (path, body) in files {
+        let full = dir.join(path);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(full, body).unwrap();
+    }
+    git(&dir, &["add", "-A"]);
+    git(&dir, &["commit", "-qm", "init"]);
+    dir
+}
+
+#[test]
+fn composition_accumulates_across_layers_and_prefers_the_declaring_layers_file() {
+    let origin = TempDir::new().unwrap();
+    let root = origin.path();
+
+    // THE DEEPEST ANCESTOR. Its part is BARE — the case that must be rebased.
+    let base = repo(
+        root,
+        "base",
+        &[
+            ("SHARED.md", "FROM BASE"),
+            (
+                "gripspace.yml",
+                "repos: {}\n\
+                 manifest:\n  \
+                   url: \"\"\n  \
+                   composefile:\n    \
+                     - dest: CLAUDE.md\n      \
+                       parts:\n        \
+                         - src: SHARED.md\n",
+            ),
+        ],
+    );
+
+    // THE MIDDLE LAYER, also bare, and it uses THE SAME FILENAME as base and
+    // as the root decoy. Same name across all three is deliberate: it is what
+    // makes a wrong resolution produce wrong CONTENT rather than no content.
+    let standards = repo(
+        root,
+        "standards",
+        &[
+            ("SHARED.md", "FROM STANDARDS"),
+            (
+                "gripspace.yml",
+                &format!(
+                    "repos: {{}}\n\
+                     gripspaces:\n  \
+                       - url: {}\n\
+                     manifest:\n  \
+                       url: \"\"\n  \
+                       composefile:\n    \
+                         - dest: CLAUDE.md\n      \
+                           parts:\n        \
+                             - src: SHARED.md\n",
+                    base.display()
+                ),
+            ),
+        ],
+    );
+
+    // THE ROOT, carrying a DECOY at the manifest-relative path the ancestors'
+    // bare parts USED to resolve to.
+    let top = repo(
+        root,
+        "top",
+        &[
+            ("SHARED.md", "DECOY FROM ROOT MANIFEST"),
+            ("TOP.md", "FROM TOP"),
+            (
+                "gripspace.yml",
+                &format!(
+                    "repos: {{}}\n\
+                     gripspaces:\n  \
+                       - url: {}\n\
+                     manifest:\n  \
+                       url: \"\"\n  \
+                       composefile:\n    \
+                         - dest: CLAUDE.md\n      \
+                           parts:\n        \
+                             - src: TOP.md\n",
+                    standards.display()
+                ),
+            ),
+        ],
+    );
+
+    let ws = TempDir::new().unwrap();
+    let init = Command::cargo_bin("gr")
+        .unwrap()
+        .args(["init", top.to_str().unwrap()])
+        .current_dir(ws.path())
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "PRECONDITION FAILED: gr init did not succeed, so anything below is a \
+         fact about the harness rather than about gr.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr),
+    );
+    let workspace = ws.path().join("workspace");
+
+    let sync = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+
+    // PRECONDITION: gripspace resolution must not have degraded to a warning.
+    // Without this, a fixture mistake reads as a feature failure — resolution
+    // failure currently warns while sync still reports success.
+    let stderr = String::from_utf8_lossy(&sync.stderr);
+    let stdout = String::from_utf8_lossy(&sync.stdout);
+    assert!(
+        !stdout.contains("Gripspace resolution failed")
+            && !stderr.contains("Gripspace resolution failed"),
+        "PRECONDITION FAILED: gripspace resolution failed, so this test is \
+         about the fixture rather than about composition.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // PRECONDITION: every layer materialized, or "missing content" would just
+    // mean "the layer was never fetched".
+    for layer in ["base", "standards"] {
+        assert!(
+            workspace.join(".gitgrip/spaces").join(layer).is_dir(),
+            "PRECONDITION FAILED: gripspace '{layer}' did not materialize"
+        );
+    }
+
+    let composed_path = workspace.join("CLAUDE.md");
+    assert!(
+        composed_path.is_file(),
+        "no composed file was produced at all.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let composed = std::fs::read_to_string(&composed_path).unwrap();
+
+    // THE CARRY: ancestors' composefiles reached the merge.
+    assert!(
+        composed.contains("FROM BASE"),
+        "the deepest ancestor's composefile was dropped.\ngot:\n{composed}"
+    );
+    assert!(
+        composed.contains("FROM STANDARDS"),
+        "the middle layer's composefile was dropped.\ngot:\n{composed}"
+    );
+    assert!(
+        composed.contains("FROM TOP"),
+        "the root's own part is missing"
+    );
+
+    // THE REBASE: a bare part resolved against the layer that WROTE it, not
+    // against the root manifest. This is what the decoy exists to catch.
+    assert!(
+        !composed.contains("DECOY"),
+        "a bare part from an included gripspace resolved against the ROOT \
+         manifest and picked up the decoy.\ngot:\n{composed}"
+    );
+
+    // THE ORDER: ancestors first, local last, checked at this same boundary.
+    let base_at = composed.find("FROM BASE").unwrap();
+    let std_at = composed.find("FROM STANDARDS").unwrap();
+    let top_at = composed.find("FROM TOP").unwrap();
+    assert!(
+        base_at < std_at && std_at < top_at,
+        "layers are not ancestors-first.\ngot:\n{composed}"
+    );
+}


### PR DESCRIPTION
Two composition gaps that together prevented a layered gripspace model from working at all.

## GAP 1 — a part could not source from a repo checkout

A `composefile` part could source from a gripspace or from the manifest repo, and from nothing else. A repo checked out via `repos:` was unreachable, so a bare `src: standards/CONVENTIONS.md` resolved **manifest-relative** and warned `manifest:standards/CONVENTIONS.md not found`. Any repo that wanted to contribute content had to become a gripspace first.

Adds a third source kind:

```yaml
parts:
  - repo: standards
    src: CONVENTIONS.md
```

resolved against that repo's configured checkout path.

- **`repo:` and `gripspace:` together are refused, not resolved.** Two source kinds means the manifest does not say where the content comes from; quietly picking one would compose a file nobody asked for.
- **An unknown `repo:` warns and skips rather than failing the sync**, and the warning names where the key belongs — `must match a key under repos:`, with the known names listed. This follows the existing precedent that chose warn-and-name over `deny_unknown_fields`, because denying breaks forward compatibility. Same defect family, same instinct, so the two compose rather than fight.
- Path traversal out of a repo checkout is rejected like every other source kind.

## GAP 2 — included gripspaces' composefiles were dropped

The resolved form of an included gripspace carried `composefile: None`, and only the root manifest's composefiles were ever processed. So only the gripspace you happened to clone composed anything, and every layer had to re-enumerate the whole chain.

Composefiles now ride the gripspace merge alongside repos, env, hooks and links, and parts targeting the same `dest` concatenate in **layer order, ancestors first**, so a file reads base-to-tip.

- **Parts are rebased onto the gripspace that wrote them.** A part with no source kind is manifest-relative — and "the manifest" means the gripspace that authored it, not the root that included it. `src: X` becomes `gripspace: <dir>, src: X`, exactly as linkfiles are already rewritten. Carrying it through unrebased would resolve against the root's manifest dir and read the wrong file, or nothing.
- `gripspace:` and `repo:` parts pass through unchanged: both name something in the shared, already-merged namespace, so they mean the same thing from either side of the include.
- **A `dest` only an ancestor declares is still produced.** Requiring the tip to redeclare it would leave exactly the re-enumeration this change removes.
- **The earliest layer to state a `separator` keeps it**, so a tip cannot silently restyle an ancestor's file.

## End-to-end proof

Three real layers (`base` ← `standards` ← `top`) plus a plain repo contributing via `repo:`, **identical fixtures on both binaries**:

| | root `CLAUDE.md` |
|---|---|
| released gr 1.0.2 | **1 of 4** parts — only the root's own |
| this branch | **4 of 4**, in layer order |
| second sync | 4 of 4 — idempotent, no duplication |

Both binaries materialized the same gripspaces, so the difference is **composition**, not materialization.

## Tests

Ten new tests, and two carry the weight:

- GAP 1 includes a **decoy** — a same-named file at the old manifest-relative path with different content — so a fix that keeps resolving manifest-relative passes the happy path and fails the decoy.
- GAP 2 pins the **order**, because a merge that merely unioned parts would satisfy a "both present" assertion and still produce a scrambled file.

726 tests pass. `clippy` is exactly at the pre-change baseline: 3 pre-existing warnings, none added.

Ref grip#870, grip#871 — closes at promotion
