### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"


### PR DESCRIPTION
Bumps the gitgrip crate version from 1.0.2 to 1.1.0 ahead of the v1.1.0 release.

- `Cargo.toml`: package version 1.0.2 -> 1.1.0
- `Cargo.lock`: gitgrip entry follows

The gr2 workspace member crates stay at their own pre-1.0 versions; only the root package is released as v1.1.0.

Premium boundary: grip is OSS (workspace orchestration); this PR is a version bump only.
