### PR TITLE
chore: promote dev to main for v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "gitgrip"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitgrip"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Multi-repo workflow tool - manage multiple git repositories as one"

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -732,10 +732,12 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
             // Apply composefiles
             if let Some(ref composefiles) = manifest_config.composefile {
                 if !composefiles.is_empty() {
+                    let repo_paths = crate::files::repo_checkout_paths(manifest);
                     match process_composefiles(
                         workspace_root,
                         &manifests_dir,
                         &spaces_dir,
+                        &repo_paths,
                         composefiles,
                     ) {
                         Ok(()) => {

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -164,23 +164,26 @@ pub fn run_status(
 
             for gs in gripspaces {
                 let name = gripspace_name(&gs.url);
-                let dir_name =
-                    match crate::core::gripspace::resolve_space_name(&gs.url, &spaces_dir) {
-                        Ok(dir_name) => dir_name,
-                        Err(e) => {
-                            let rev = "—".to_string();
-                            // Extract the inner message from ManifestError::GripspaceError
-                            let msg = match &e {
-                                crate::core::manifest::ManifestError::GripspaceError(msg) => {
-                                    msg.clone()
-                                }
-                                other => other.to_string(),
-                            };
-                            let status_str = format!("error: {}", msg);
-                            gs_table.add_row(vec![&Output::repo_name(&name), &rev, &status_str]);
-                            continue;
-                        }
-                    };
+                let dir_name = match crate::core::gripspace::resolve_space_name(
+                    &gs.url,
+                    gs.rev.as_deref(),
+                    &spaces_dir,
+                ) {
+                    Ok(dir_name) => dir_name,
+                    Err(e) => {
+                        let rev = "—".to_string();
+                        // Extract the inner message from ManifestError::GripspaceError
+                        let msg = match &e {
+                            crate::core::manifest::ManifestError::GripspaceError(msg) => {
+                                msg.clone()
+                            }
+                            other => other.to_string(),
+                        };
+                        let status_str = format!("error: {}", msg);
+                        gs_table.add_row(vec![&Output::repo_name(&name), &rev, &status_str]);
+                        continue;
+                    }
+                };
                 let gs_path = spaces_dir.join(&dir_name);
 
                 let (rev, status_str) = if gs_path.exists() {

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -406,9 +406,13 @@ fn sync_gripspaces(
 
     for gs_config in gripspaces {
         let name = gripspace_name(&gs_config.url);
-        // Use resolve_space_name to find the actual directory (handles reserved names)
-        let dir_name = match crate::core::gripspace::resolve_space_name(&gs_config.url, &spaces_dir)
-        {
+        // Use resolve_space_name to find the actual directory (handles reserved
+        // names and multi-rev disambiguation)
+        let dir_name = match crate::core::gripspace::resolve_space_name(
+            &gs_config.url,
+            gs_config.rev.as_deref(),
+            &spaces_dir,
+        ) {
             Ok(dir_name) => dir_name,
             Err(e) => {
                 Output::warning(&format!(

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -305,10 +305,12 @@ pub async fn run_sync(
                 let manifests_dir = manifest_paths::resolve_manifest_content_dir(workspace_root);
                 let spaces_dir = manifest_paths::spaces_dir(workspace_root);
 
+                let repo_paths = crate::files::repo_checkout_paths(manifest);
                 match process_composefiles(
                     workspace_root,
                     &manifests_dir,
                     &spaces_dir,
+                    &repo_paths,
                     composefiles,
                 ) {
                     Ok(()) => {

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -82,12 +82,31 @@ fn validate_space_name(name: &str) -> Result<(), ManifestError> {
 
 /// Resolve the directory name for a gripspace within `.gitgrip/spaces/`.
 ///
-/// Handles reserved name conflicts (`main`, `local`) and duplicate names by
-/// auto-suffixing with `-1`, `-2`, etc. If the directory already exists and
-/// has the same git remote, it is reused.
-pub fn resolve_space_name(url: &str, spaces_dir: &Path) -> Result<String, ManifestError> {
+/// A gripspace's identity is `url#rev` (see [`gripspace_identity`]), and the
+/// directory allocation follows the identity, not the URL alone: one repo may
+/// host several gripspaces as different revisions (orphan-branch roots), and
+/// each must materialize as its own space.
+///
+/// Allocation order:
+/// 1. The first gripspace of a URL keeps the pretty basename (`frag`).
+/// 2. A second rev of the same URL gets the deterministic `<base>-<rev>`
+///    (`frag-extras`) — deterministic so a manifest author can reference it
+///    in composefile bindings without discovering an invented name.
+/// 3. Residual collisions fall through to numeric suffixing, as before.
+///
+/// A directory is only ever REUSED for the same `url#rev` identity. Reusing a
+/// same-remote clone across revs is how one rev's space silently vanished
+/// (and how the survivor's checkout got flipped between revs on sync).
+pub fn resolve_space_name(
+    url: &str,
+    rev: Option<&str>,
+    spaces_dir: &Path,
+) -> Result<String, ManifestError> {
     let base = gripspace_name(url);
     validate_space_name(&base)?;
+    if let Some(rev) = rev {
+        validate_rev(rev)?;
+    }
 
     // If the base name is reserved, start from suffix -1
     let candidate = if manifest_paths::RESERVED_SPACE_NAMES.contains(&base.as_str()) {
@@ -101,9 +120,28 @@ pub fn resolve_space_name(url: &str, spaces_dir: &Path) -> Result<String, Manife
         return Ok(candidate);
     }
 
-    // Directory exists — reuse if it's the same remote
-    if is_same_remote(&candidate_path, url) {
+    // Directory exists — reuse only for the same identity (remote AND rev).
+    if is_same_remote_and_rev(&candidate_path, url, rev) {
         return Ok(candidate);
+    }
+
+    // Same remote at a different rev: allocate the deterministic
+    // `<base>-<rev>` name so the author can predict and reference it.
+    if let Some(rev) = rev {
+        if is_same_remote(&candidate_path, url) {
+            let rev_name = format!("{}-{}", base, sanitize_rev_for_name(rev));
+            validate_space_name(&rev_name)?;
+            let rev_path = spaces_dir.join(&rev_name);
+            if !rev_path.exists() || is_same_remote_and_rev(&rev_path, url, Some(rev)) {
+                if !rev_path.exists() {
+                    eprintln!(
+                        "Warning: gripspace '{}' at rev '{}' uses space name '{}' ('{}' is held by a different revision of the same repository)",
+                        url, rev, rev_name, candidate
+                    );
+                }
+                return Ok(rev_name);
+            }
+        }
     }
 
     // Warn when an unrecognized directory occupies the expected name
@@ -118,7 +156,7 @@ pub fn resolve_space_name(url: &str, spaces_dir: &Path) -> Result<String, Manife
     for i in 2..100 {
         let suffixed = format!("{}-{}", base, i);
         let path = spaces_dir.join(&suffixed);
-        if !path.exists() || is_same_remote(&path, url) {
+        if !path.exists() || is_same_remote_and_rev(&path, url, rev) {
             return Ok(suffixed);
         }
     }
@@ -127,6 +165,68 @@ pub fn resolve_space_name(url: &str, spaces_dir: &Path) -> Result<String, Manife
         "Could not allocate a space name for '{}' (too many collisions)",
         url
     )))
+}
+
+/// Make a revision safe for use as a space-name segment.
+///
+/// Revisions may carry `/` (e.g. `feature/x`) or other characters outside the
+/// space-name allowlist; map anything disallowed to `-`.
+fn sanitize_rev_for_name(rev: &str) -> String {
+    rev.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Check whether an existing directory should be reused for `url` at `rev`.
+///
+/// Same remote is necessary but not sufficient: the clone must also sit at the
+/// requested revision. `rev == None` preserves the historical remote-only
+/// check (a rev-less gripspace tracks the clone's current branch).
+fn is_same_remote_and_rev(dir: &Path, url: &str, rev: Option<&str>) -> bool {
+    if !is_same_remote(dir, url) {
+        return false;
+    }
+    let Some(rev) = rev else {
+        return true;
+    };
+
+    // Branch checkouts (the common case): current branch name matches.
+    let branch = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(dir)
+        .output();
+    if let Ok(out) = &branch {
+        if out.status.success() {
+            let current = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !current.is_empty() && current == rev {
+                return true;
+            }
+        }
+    }
+
+    // Tags / SHAs / detached checkouts: compare resolved commits. Failure to
+    // resolve means "cannot confirm same", which must read as different — the
+    // conservative direction costs an extra clone, never a wrong reuse.
+    let head = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output();
+    let want = Command::new("git")
+        .args(["rev-parse", &format!("{}^{{commit}}", rev)])
+        .current_dir(dir)
+        .output();
+    match (head, want) {
+        (Ok(h), Ok(w)) if h.status.success() && w.status.success() => {
+            String::from_utf8_lossy(&h.stdout).trim() == String::from_utf8_lossy(&w.stdout).trim()
+        }
+        _ => false,
+    }
 }
 
 /// Check whether an existing directory should be reused for the given URL.
@@ -203,7 +303,7 @@ pub fn ensure_gripspace(
     spaces_dir: &Path,
     config: &GripspaceConfig,
 ) -> Result<PathBuf, ManifestError> {
-    let dir_name = resolve_space_name(&config.url, spaces_dir)?;
+    let dir_name = resolve_space_name(&config.url, config.rev.as_deref(), spaces_dir)?;
     let gripspace_path = spaces_dir.join(&dir_name);
 
     if gripspace_path.exists() {
@@ -290,15 +390,24 @@ pub fn update_gripspace(
     Ok(())
 }
 
-/// Checkout a specific revision (branch, tag, or SHA) in a gripspace.
-fn checkout_rev(path: &Path, rev: &str) -> Result<(), ManifestError> {
-    // Reject revs that look like flags or contain whitespace
+/// Reject revs that look like flags, are empty, or contain whitespace.
+///
+/// A rev is untrusted manifest input; validate it at FIRST use. Space-name
+/// derivation consumes the rev before any checkout, so allocation must refuse
+/// an invalid rev rather than sanitize it into a directory name.
+fn validate_rev(rev: &str) -> Result<(), ManifestError> {
     if rev.starts_with('-') || rev.chars().any(|c| c.is_whitespace()) || rev.is_empty() {
         return Err(ManifestError::GripspaceError(format!(
             "Invalid rev '{}': must not be empty, start with '-', or contain whitespace",
             rev
         )));
     }
+    Ok(())
+}
+
+/// Checkout a specific revision (branch, tag, or SHA) in a gripspace.
+fn checkout_rev(path: &Path, rev: &str) -> Result<(), ManifestError> {
+    validate_rev(rev)?;
 
     // If `rev` names a fetched remote branch, advance the local branch to it.
     // A plain `git checkout rev` leaves an existing local branch stale after
@@ -679,8 +788,9 @@ fn resolve_gripspace_recursive(
     }
 
     let gripspace_path = ensure_gripspace(spaces_dir, config)?;
-    // Resolve the actual directory name (may differ from `name` due to reserved name suffixing)
-    let dir_name = resolve_space_name(&config.url, spaces_dir)?;
+    // Resolve the actual directory name (may differ from `name` due to reserved
+    // name suffixing or multi-rev disambiguation)
+    let dir_name = resolve_space_name(&config.url, config.rev.as_deref(), spaces_dir)?;
 
     // Load the gripspace's manifest
     let Some(manifest_path) = manifest_paths::resolve_manifest_file_in_dir(&gripspace_path) else {
@@ -1897,7 +2007,8 @@ repos:
     fn test_resolve_space_name_normal() {
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
-        let name = resolve_space_name("https://github.com/user/my-gripspace.git", spaces).unwrap();
+        let name =
+            resolve_space_name("https://github.com/user/my-gripspace.git", None, spaces).unwrap();
         assert_eq!(name, "my-gripspace");
     }
 
@@ -1905,7 +2016,7 @@ repos:
     fn test_resolve_space_name_rejects_dotdot() {
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
-        let err = resolve_space_name("https://github.com/user/..", spaces).unwrap_err();
+        let err = resolve_space_name("https://github.com/user/..", None, spaces).unwrap_err();
         assert!(err.to_string().contains("Invalid gripspace name"));
     }
 
@@ -1913,8 +2024,8 @@ repos:
     fn test_resolve_space_name_rejects_invalid_characters() {
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
-        let err =
-            resolve_space_name("https://github.com/user/my gripspace.git", spaces).unwrap_err();
+        let err = resolve_space_name("https://github.com/user/my gripspace.git", None, spaces)
+            .unwrap_err();
         assert!(err.to_string().contains("Invalid gripspace name"));
     }
 
@@ -1923,7 +2034,7 @@ repos:
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
         // "main" is reserved — should auto-suffix to "main-1"
-        let name = resolve_space_name("https://github.com/user/main.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/main.git", None, spaces).unwrap();
         assert_eq!(name, "main-1");
     }
 
@@ -1931,7 +2042,7 @@ repos:
     fn test_resolve_space_name_reserved_local() {
         let temp = tempfile::tempdir().unwrap();
         let spaces = temp.path();
-        let name = resolve_space_name("https://github.com/user/local.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/local.git", None, spaces).unwrap();
         assert_eq!(name, "local-1");
     }
 
@@ -1960,7 +2071,7 @@ repos:
             .unwrap();
 
         // A different URL producing the same name should auto-increment
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo-2");
     }
 
@@ -1989,7 +2100,7 @@ repos:
             .unwrap();
 
         // Same URL should reuse the existing directory name
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo");
     }
 
@@ -2003,7 +2114,7 @@ repos:
         std::fs::create_dir_all(&existing).unwrap();
         std::fs::write(existing.join("README.md"), "local").unwrap();
 
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo-2");
     }
 
@@ -2020,7 +2131,7 @@ repos:
             .output()
             .unwrap();
 
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo-2");
     }
 
@@ -2033,7 +2144,7 @@ repos:
         std::fs::create_dir_all(&existing).unwrap();
         init_git_with_origin(&existing, "git@github.com:user/my-repo.git");
 
-        let name = resolve_space_name("https://github.com/user/my-repo.git", spaces).unwrap();
+        let name = resolve_space_name("https://github.com/user/my-repo.git", None, spaces).unwrap();
         assert_eq!(name, "my-repo");
     }
 

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -589,6 +589,7 @@ pub fn resolve_all_gripspaces(
     let mut merged_hooks_post_checkout: Vec<HookCommand> = Vec::new();
     let mut merged_linkfiles = Vec::new();
     let mut merged_copyfiles = Vec::new();
+    let mut merged_composefiles: Vec<crate::core::manifest::ComposeFileConfig> = Vec::new();
     let mut merged_agent: Option<WorkspaceAgentConfig> = None;
 
     // Process each gripspace
@@ -606,6 +607,7 @@ pub fn resolve_all_gripspaces(
             &mut merged_hooks_post_checkout,
             &mut merged_linkfiles,
             &mut merged_copyfiles,
+            &mut merged_composefiles,
             &mut merged_agent,
         )?;
     }
@@ -697,7 +699,10 @@ pub fn resolve_all_gripspaces(
     // Linkfiles from gripspaces are tracked separately — they'll be applied by the link command
     // We store them as manifest-level linkfiles, with local ones overriding by dest
     // Create the manifest config if it doesn't exist and there are gripspace files to merge
-    if manifest.manifest.is_none() && (!merged_linkfiles.is_empty() || !merged_copyfiles.is_empty())
+    if manifest.manifest.is_none()
+        && (!merged_linkfiles.is_empty()
+            || !merged_copyfiles.is_empty()
+            || !merged_composefiles.is_empty())
     {
         manifest.manifest = Some(crate::core::manifest::ManifestRepoConfig {
             url: String::new(),
@@ -709,6 +714,13 @@ pub fn resolve_all_gripspaces(
         });
     }
     if let Some(ref mut manifest_config) = manifest.manifest {
+        if !merged_composefiles.is_empty() {
+            let local = manifest_config.composefile.take();
+            manifest_config.composefile = Some(merge_composefiles_in_layer_order(
+                merged_composefiles,
+                local,
+            ));
+        }
         if !merged_linkfiles.is_empty() {
             let local_linkfiles = manifest_config.linkfile.take().unwrap_or_default();
             let local_dests: HashSet<String> =
@@ -745,6 +757,55 @@ pub fn resolve_all_gripspaces(
     Ok(())
 }
 
+/// Merge composefiles from included gripspaces with the local ones.
+///
+/// *** LAYER ORDER: ANCESTORS FIRST, LOCAL LAST. ***
+///
+/// `included` arrives in resolution order, which is depth-first — the deepest
+/// include (the furthest ancestor) first. Parts targeting the same `dest`
+/// concatenate in that order, so a layer's contribution appends after every
+/// layer it extends and the file reads base-to-tip.
+///
+/// This is what makes inclusion COMPOSITIONAL. Before it, an included
+/// gripspace's composefile was dropped entirely and only the gripspace you
+/// happened to clone composed anything — so every layer had to re-enumerate
+/// the whole chain.
+///
+/// A `dest` the local manifest never mentions is still produced: an ancestor
+/// declaring a composed file must not need the tip to redeclare it, or the
+/// re-enumeration is back.
+pub fn merge_composefiles_in_layer_order(
+    included: Vec<crate::core::manifest::ComposeFileConfig>,
+    local: Option<Vec<crate::core::manifest::ComposeFileConfig>>,
+) -> Vec<crate::core::manifest::ComposeFileConfig> {
+    let mut order: Vec<String> = Vec::new();
+    let mut by_dest: HashMap<String, crate::core::manifest::ComposeFileConfig> = HashMap::new();
+
+    for cf in included.into_iter().chain(local.unwrap_or_default()) {
+        match by_dest.entry(cf.dest.clone()) {
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                let existing = e.get_mut();
+                existing.parts.extend(cf.parts);
+                // A later layer may set the separator; the earliest one that
+                // states a preference keeps it, so a tip cannot silently
+                // restyle an ancestor's file.
+                if existing.separator.is_none() {
+                    existing.separator = cf.separator;
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(e) => {
+                order.push(cf.dest.clone());
+                e.insert(cf);
+            }
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|d| by_dest.remove(&d))
+        .collect()
+}
+
 /// Recursively resolve a single gripspace and its nested gripspaces.
 #[allow(clippy::too_many_arguments)]
 fn resolve_gripspace_recursive(
@@ -760,6 +821,7 @@ fn resolve_gripspace_recursive(
     merged_hooks_post_checkout: &mut Vec<HookCommand>,
     merged_linkfiles: &mut Vec<crate::core::manifest::LinkFileConfig>,
     merged_copyfiles: &mut Vec<crate::core::manifest::CopyFileConfig>,
+    merged_composefiles: &mut Vec<crate::core::manifest::ComposeFileConfig>,
     merged_agent: &mut Option<WorkspaceAgentConfig>,
 ) -> Result<(), ManifestError> {
     if depth >= MAX_GRIPSPACE_DEPTH {
@@ -834,6 +896,7 @@ fn resolve_gripspace_recursive(
                 merged_hooks_post_checkout,
                 merged_linkfiles,
                 merged_copyfiles,
+                merged_composefiles,
                 merged_agent,
             )?;
         }
@@ -912,6 +975,41 @@ fn resolve_gripspace_recursive(
                 });
             }
         }
+        // COMPOSEFILES, with their bare parts REBASED onto this gripspace.
+        //
+        // A part with no source kind is manifest-relative — and "the manifest"
+        // means the gripspace that WROTE it, not the root that included it.
+        // Carrying it through unrebased would resolve it against the root's
+        // manifest dir and read the wrong file, or silently read nothing. So a
+        // bare `src:` becomes `gripspace: <dir_name>`, exactly as linkfiles are
+        // rewritten just above.
+        //
+        // `gripspace:` and `repo:` parts pass through: both name something in
+        // the shared, already-merged namespace, so they mean the same thing
+        // from either side of the include.
+        if let Some(ref composefiles) = manifest_config.composefile {
+            for cf in composefiles {
+                merged_composefiles.push(crate::core::manifest::ComposeFileConfig {
+                    dest: cf.dest.clone(),
+                    separator: cf.separator.clone(),
+                    parts: cf
+                        .parts
+                        .iter()
+                        .map(|p| {
+                            if p.gripspace.is_none() && p.repo.is_none() {
+                                crate::core::manifest::ComposeFilePart {
+                                    src: p.src.clone(),
+                                    gripspace: Some(dir_name.to_string()),
+                                    repo: None,
+                                }
+                            } else {
+                                p.clone()
+                            }
+                        })
+                        .collect(),
+                });
+            }
+        }
     }
 
     active_stack.remove(&identity_key);
@@ -948,6 +1046,94 @@ pub fn get_gripspace_rev(gripspace_path: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    // ── GAP 2: included gripspaces' composefiles ────────────────────────────
+
+    fn cf(
+        dest: &str,
+        parts: Vec<crate::core::manifest::ComposeFilePart>,
+    ) -> crate::core::manifest::ComposeFileConfig {
+        crate::core::manifest::ComposeFileConfig {
+            dest: dest.to_string(),
+            parts,
+            separator: None,
+        }
+    }
+    fn bare(src: &str) -> crate::core::manifest::ComposeFilePart {
+        crate::core::manifest::ComposeFilePart {
+            src: src.to_string(),
+            gripspace: None,
+            repo: None,
+        }
+    }
+    fn from_gs(gs: &str, src: &str) -> crate::core::manifest::ComposeFilePart {
+        crate::core::manifest::ComposeFilePart {
+            src: src.to_string(),
+            gripspace: Some(gs.to_string()),
+            repo: None,
+        }
+    }
+
+    #[test]
+    fn test_composefiles_merge_same_dest_ancestors_first() {
+        // THE ORDERING IS THE FEATURE. `included` arrives depth-first, so the
+        // furthest ancestor is first and the file reads base-to-tip. A merge
+        // that only unioned parts would pass a "both present" assertion and
+        // still produce a scrambled file.
+        let included = vec![
+            cf("CLAUDE.md", vec![from_gs("base", "BASE.md")]),
+            cf("CLAUDE.md", vec![from_gs("standards", "STD.md")]),
+        ];
+        let local = Some(vec![cf("CLAUDE.md", vec![bare("LOCAL.md")])]);
+
+        let merged = merge_composefiles_in_layer_order(included, local);
+
+        assert_eq!(
+            merged.len(),
+            1,
+            "same dest must collapse to one composefile"
+        );
+        let srcs: Vec<&str> = merged[0].parts.iter().map(|p| p.src.as_str()).collect();
+        assert_eq!(srcs, vec!["BASE.md", "STD.md", "LOCAL.md"]);
+    }
+
+    #[test]
+    fn test_composefile_dest_only_an_ancestor_declares_is_still_produced() {
+        // If a dest had to be redeclared by the tip, every layer would still
+        // be re-enumerating the chain — which is the thing GAP 2 exists to end.
+        let included = vec![cf("AGENTS.md", vec![from_gs("base", "A.md")])];
+        let merged = merge_composefiles_in_layer_order(included, None);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].dest, "AGENTS.md");
+    }
+
+    #[test]
+    fn test_composefile_local_only_dest_survives_the_merge() {
+        let included = vec![cf("CLAUDE.md", vec![from_gs("base", "B.md")])];
+        let local = Some(vec![cf("OWN.md", vec![bare("O.md")])]);
+        let merged = merge_composefiles_in_layer_order(included, local);
+        let dests: Vec<&str> = merged.iter().map(|c| c.dest.as_str()).collect();
+        assert_eq!(dests, vec!["CLAUDE.md", "OWN.md"]);
+    }
+
+    #[test]
+    fn test_composefile_earliest_separator_wins_so_a_tip_cannot_restyle() {
+        let mut anc = cf("X.md", vec![from_gs("base", "B.md")]);
+        anc.separator = Some("---".to_string());
+        let mut tip = cf("X.md", vec![bare("L.md")]);
+        tip.separator = Some("###".to_string());
+        let merged = merge_composefiles_in_layer_order(vec![anc], Some(vec![tip]));
+        assert_eq!(merged[0].separator.as_deref(), Some("---"));
+    }
+
+    #[test]
+    fn test_composefile_separator_is_adopted_when_the_ancestor_stated_none() {
+        let anc = cf("X.md", vec![from_gs("base", "B.md")]);
+        let mut tip = cf("X.md", vec![bare("L.md")]);
+        tip.separator = Some("###".to_string());
+        let merged = merge_composefiles_in_layer_order(vec![anc], Some(vec![tip]));
+        assert_eq!(merged[0].separator.as_deref(), Some("###"));
+    }
+
     use super::*;
     use std::path::Path;
 

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -535,7 +535,91 @@ fn default_version() -> u32 {
     2
 }
 
+/// Keys `Manifest` accepts at the top level.
+///
+/// Kept beside the struct deliberately: if a field is added there and not here,
+/// a valid manifest starts warning, which is a loud failure rather than a silent
+/// one. That is the correct direction for this list to rot in.
+const TOP_LEVEL_KEYS: &[&str] = &[
+    "version",
+    "remotes",
+    "gripspaces",
+    "manifest",
+    "repos",
+    "settings",
+    "workspace",
+];
+
+/// Keys that are VALID somewhere else, mapped to where they belong.
+///
+/// MISPLACEMENT IS THE COMMON CASE, NOT TYPOS. Every entry here is a real field
+/// on `ManifestRepoConfig`, i.e. something a user writes at the top level
+/// because that is where it reads like it should go. Naming the right home
+/// turns a warning into a fix.
+const MISPLACED_KEY_HOMES: &[(&str, &str)] = &[
+    ("composefile", "manifest.composefile"),
+    ("copyfile", "manifest.copyfile"),
+    ("linkfile", "manifest.linkfile"),
+    ("platform", "manifest.platform"),
+    ("url", "manifest.url"),
+    ("revision", "manifest.revision"),
+];
+
 impl Manifest {
+    /// Top-level keys present in the YAML that no field will receive.
+    ///
+    /// *** WHY THIS EXISTS: SERDE DISCARDS UNKNOWN KEYS IN SILENCE. ***
+    ///
+    /// No manifest struct carries `deny_unknown_fields`, so a key that matches
+    /// no field is dropped during deserialization with no error, no warning and
+    /// exit 0. A `composefile:` block written at the top level instead of under
+    /// `manifest:` therefore vanishes: the block is in the file, `gr manifest
+    /// schema` knows the key, nothing is a parse failure, and nothing is
+    /// produced. Measured 2026-08-11; it cost two rounds of misdiagnosis
+    /// because every visible signal said success.
+    ///
+    /// `deny_unknown_fields` is the obvious fix and is the wrong one: it turns
+    /// every extra key into a hard parse error, so a manifest carrying a
+    /// forward-compatibility key stops loading on upgrade. That trades a silent
+    /// failure for a breaking one. Warning keeps every existing manifest
+    /// loading while making the discard impossible to miss.
+    ///
+    /// Returns messages rather than printing, so this is testable and so the
+    /// caller decides where they go.
+    pub fn unknown_top_level_keys(yaml: &str) -> Vec<String> {
+        let value: serde_yaml::Value = match serde_yaml::from_str(yaml) {
+            Ok(value) => value,
+            // A genuine syntax error is reported by the real parse; this pass
+            // must never turn one error into two.
+            Err(_) => return Vec::new(),
+        };
+        let mapping = match value.as_mapping() {
+            Some(mapping) => mapping,
+            None => return Vec::new(),
+        };
+
+        let mut warnings = Vec::new();
+        for (key, _) in mapping {
+            let key = match key.as_str() {
+                Some(key) => key,
+                None => continue,
+            };
+            if TOP_LEVEL_KEYS.contains(&key) {
+                continue;
+            }
+            match MISPLACED_KEY_HOMES.iter().find(|(name, _)| *name == key) {
+                Some((_, home)) => warnings.push(format!(
+                    "manifest key '{key}' is not valid at the top level and was IGNORED \
+                     - did you mean '{home}'?"
+                )),
+                None => warnings.push(format!(
+                    "manifest key '{key}' is not a known key and was IGNORED"
+                )),
+            }
+        }
+        warnings
+    }
+
     /// Load a manifest from a YAML file
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ManifestError> {
         let content = std::fs::read_to_string(path)?;
@@ -547,6 +631,21 @@ impl Manifest {
     /// Use this when you need to process the manifest before validation,
     /// e.g., resolving gripspace includes that merge additional repos.
     pub fn parse_raw(yaml: &str) -> Result<Self, ManifestError> {
+        // WARN HERE, NOT IN `load`. This is the single chokepoint: `parse`
+        // calls `parse_raw`, `load` calls `parse`, and `sync` calls `parse_raw`
+        // DIRECTLY -- so a hook in `load` fires on the least-used path and is
+        // silent for the command that matters. Verified by call-site count
+        // rather than assumed, after a first attempt hooked `load` and produced
+        // exactly nothing on `gr sync`, which is the same mistake as assuming
+        // where composition was invoked from.
+        //
+        // STDERR, not `Output::warning`, which uses println!. A correctness
+        // warning on stdout is swallowed by redirection and corrupts `--json`
+        // consumers, and a warning nobody reads is the defect this fixes one
+        // layer up.
+        for warning in Self::unknown_top_level_keys(yaml) {
+            eprintln!("\u{26a0} {warning}");
+        }
         let mut manifest: Manifest = serde_yaml::from_str(yaml)?;
         manifest.migrate_v1();
         Ok(manifest)
@@ -1195,6 +1294,73 @@ repos:
             "https://github.com/user/other-gripspace.git"
         );
         assert!(gripspaces[1].rev.is_none());
+    }
+
+    #[test]
+    fn unknown_top_level_key_that_belongs_elsewhere_names_its_home() {
+        // The exact defect: composefile written at the top level instead of
+        // under `manifest:`. Serde discards it, so without this warning the
+        // whole block vanishes at exit 0.
+        let yaml = r#"
+version: 2
+repos: {}
+composefile:
+  - dest: CLAUDE.md
+    parts:
+      - src: A.md
+"#;
+        let warnings = Manifest::unknown_top_level_keys(yaml);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        assert!(warnings[0].contains("composefile"));
+        assert!(
+            warnings[0].contains("manifest.composefile"),
+            "a misplacement warning must name where the key belongs: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn unknown_top_level_key_with_no_home_is_still_reported() {
+        let yaml = "version: 2\nrepos: {}\nreposs: {}\n";
+        let warnings = Manifest::unknown_top_level_keys(yaml);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        assert!(warnings[0].contains("reposs"));
+    }
+
+    #[test]
+    fn a_correct_manifest_produces_no_warnings() {
+        // CONTROL. A warning that fires on valid input is worse than none --
+        // it trains readers to ignore the channel. Every top-level field is
+        // exercised here so adding one to the struct without adding it to
+        // TOP_LEVEL_KEYS turns this RED.
+        let yaml = r#"
+version: 2
+remotes: {}
+gripspaces: []
+manifest:
+  url: file:///tmp/x.git
+  revision: main
+  composefile:
+    - dest: CLAUDE.md
+      parts:
+        - src: A.md
+repos: {}
+settings: {}
+workspace: {}
+"#;
+        assert!(
+            Manifest::unknown_top_level_keys(yaml).is_empty(),
+            "valid manifest warned: {:?}",
+            Manifest::unknown_top_level_keys(yaml)
+        );
+    }
+
+    #[test]
+    fn a_syntax_error_does_not_become_two_errors() {
+        // The real parse reports genuine syntax errors; this pass must stay
+        // quiet so one failure is not reported twice in different words.
+        assert!(Manifest::unknown_top_level_keys("this: [is: not: yaml").is_empty());
+        assert!(Manifest::unknown_top_level_keys("- a list, not a mapping").is_empty());
     }
 
     #[test]

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -93,11 +93,23 @@ pub struct GripspaceConfig {
 /// A part of a composed file
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComposeFilePart {
-    /// Source path relative to the gripspace or manifest repo
+    /// Source path, relative to whichever source kind this part names
     pub src: String,
-    /// Name of the gripspace to source from (if omitted, sources from local manifest)
+    /// Name of the gripspace to source from
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gripspace: Option<String>,
+    /// Name of a repo from `repos:` to source from, resolved against that
+    /// repo's checkout path.
+    ///
+    /// The third source kind, and the one that lets a gripspace compose from
+    /// the repos it actually manages. Without it a part could only read from a
+    /// gripspace or from the manifest repo, so a plain repo had to become a
+    /// gripspace before it could contribute to a composed file.
+    ///
+    /// Mutually exclusive with `gripspace`: a part naming both is ambiguous
+    /// and is refused rather than silently resolved to one of them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
 }
 
 /// Composed file configuration

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -275,18 +275,67 @@ pub fn filter_repos(
     group_filter: Option<&[String]>,
     include_reference: bool,
 ) -> Vec<RepoInfo> {
-    manifest
+    // *** A DECLARED REPO MUST NEVER DISAPPEAR IN SILENCE. ***
+    //
+    // `from_config` returns Option and drops a repo for TWO reasons -- no
+    // usable url, or a url `parse_git_url` cannot read -- and `filter_map`
+    // discarded both without a word. Every downstream view then printed a
+    // smaller count, or zero, styled as success. `gr init` clones from that
+    // same url perfectly well, so a bare filesystem path gave a workspace that
+    // materialised correctly and afterwards read as empty: two code paths
+    // disagreeing about what a url is, with only one of them saying so.
+    //
+    // The reason it matters more than a missing warning: it cost a
+    // misdiagnosis. A defect report was filed against repo registration on the
+    // strength of this silence, and the registration was never broken.
+    //
+    // Collect-and-surface rather than drop-quietly, which is the same fix the
+    // unknown-manifest-key warning applies at parse time. Same defect class,
+    // one layer apart.
+    let mut dropped: Vec<String> = Vec::new();
+    let resolved: Vec<RepoInfo> = manifest
         .repos
         .iter()
         .filter_map(|(name, config)| {
-            RepoInfo::from_config(
+            let info = RepoInfo::from_config(
                 name,
                 config,
                 workspace_root,
                 &manifest.settings,
                 manifest.remotes.as_ref(),
-            )
+            );
+            if info.is_none() {
+                // Distinguish the two causes, because they need different
+                // fixes: one is a missing field, the other a malformed value.
+                let reason = match config.url.as_deref().filter(|u| !u.is_empty()) {
+                    None => "no url, and none could be derived from its remote".to_string(),
+                    Some(url) => format!("url could not be parsed: '{url}'"),
+                };
+                dropped.push(format!("{name} ({reason})"));
+            }
+            info
         })
+        .collect();
+
+    if !dropped.is_empty() {
+        // STDERR: survives stdout redirection and does not corrupt `--json`.
+        eprintln!(
+            "\u{26a0} {} declared repositor{} could not be resolved and {} EXCLUDED from this command:",
+            dropped.len(),
+            if dropped.len() == 1 { "y" } else { "ies" },
+            if dropped.len() == 1 { "was" } else { "were" },
+        );
+        for entry in &dropped {
+            eprintln!("    {entry}");
+        }
+        eprintln!(
+            "    A count of zero below does not mean the manifest declared none. \
+             Filesystem paths need a file:// prefix."
+        );
+    }
+
+    resolved
+        .into_iter()
         .filter(|r| include_reference || !r.reference)
         .filter(|r| {
             repos_filter

--- a/src/files/mod.rs
+++ b/src/files/mod.rs
@@ -48,15 +48,32 @@ fn validate_gripspace_name(name: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Repo name -> configured checkout path, for composefile `repo:` parts.
+///
+/// Built from the manifest the caller already resolved, so a `repo:` part
+/// reads from the same checkout `gr sync` maintains rather than from a second
+/// idea of where repos live.
+pub fn repo_checkout_paths(
+    manifest: &crate::core::manifest::Manifest,
+) -> std::collections::HashMap<String, std::path::PathBuf> {
+    manifest
+        .repos
+        .iter()
+        .map(|(name, cfg)| (name.clone(), std::path::PathBuf::from(&cfg.path)))
+        .collect()
+}
+
 /// Process composefile entries, writing composed files to the workspace root.
 ///
 /// Each composefile concatenates parts in order. Parts can come from:
 /// - A gripspace: reads from `.gitgrip/spaces/<name>/<src>`
+/// - A repo (`repo: <name>`): reads from that repo's checkout path
 /// - The local manifest: reads from the manifest content directory
 pub fn process_composefiles(
     workspace_root: &Path,
     manifests_dir: &Path,
     spaces_dir: &Path,
+    repo_paths: &std::collections::HashMap<String, std::path::PathBuf>,
     composefiles: &[ComposeFileConfig],
 ) -> anyhow::Result<()> {
     for compose in composefiles {
@@ -67,7 +84,50 @@ pub fn process_composefiles(
         let mut parts_content: Vec<String> = Vec::new();
 
         for part in &compose.parts {
-            let source_path = if let Some(ref gs_name) = part.gripspace {
+            // AMBIGUOUS PARTS ARE REFUSED, NOT RESOLVED. Naming two source
+            // kinds does not mean "try both" or "prefer one"; it means the
+            // manifest does not say where the content comes from, and quietly
+            // picking would compose a file nobody asked for.
+            if part.repo.is_some() && part.gripspace.is_some() {
+                eprintln!(
+                    "Warning: composefile '{}' part '{}' names both repo: and gripspace:; \
+                     skipping (they are mutually exclusive)",
+                    compose.dest, part.src
+                );
+                continue;
+            }
+
+            let source_path = if let Some(ref repo_name) = part.repo {
+                if let Err(e) = validate_relative_source_path(&part.src, "composefile part src") {
+                    eprintln!(
+                        "Warning: composefile '{}' has invalid part src: {}",
+                        compose.dest, e
+                    );
+                    continue;
+                }
+                match repo_paths.get(repo_name) {
+                    Some(repo_path) => workspace_root.join(repo_path).join(&part.src),
+                    None => {
+                        // Consistent with every other unresolvable part: warn
+                        // and skip. A repo that is not in the manifest must not
+                        // take the whole sync down.
+                        let mut known: Vec<&str> = repo_paths.keys().map(|k| k.as_str()).collect();
+                        known.sort_unstable();
+                        eprintln!(
+                            "Warning: composefile '{}' part repo:{} names no repo; \
+                             it must match a key under `repos:` (known: {})",
+                            compose.dest,
+                            repo_name,
+                            if known.is_empty() {
+                                "none".to_string()
+                            } else {
+                                known.join(", ")
+                            }
+                        );
+                        continue;
+                    }
+                }
+            } else if let Some(ref gs_name) = part.gripspace {
                 if let Err(e) = validate_gripspace_name(gs_name) {
                     eprintln!(
                         "Warning: composefile '{}' has invalid gripspace name: {}",
@@ -102,9 +162,14 @@ pub fn process_composefiles(
                 }
                 Err(e) => {
                     let gs_label = part
-                        .gripspace
+                        .repo
                         .as_deref()
-                        .map(|g| format!("gripspace:{}", g))
+                        .map(|r| format!("repo:{}", r))
+                        .or_else(|| {
+                            part.gripspace
+                                .as_deref()
+                                .map(|g| format!("gripspace:{}", g))
+                        })
                         .unwrap_or_else(|| "manifest".to_string());
                     eprintln!(
                         "Warning: composefile '{}' part {}:{} not found: {}",
@@ -168,7 +233,227 @@ pub fn resolve_file_source(
 mod tests {
     use super::*;
     use crate::core::manifest::{ComposeFileConfig, ComposeFilePart};
+    use std::collections::HashMap;
+    use std::path::PathBuf;
     use tempfile::TempDir;
+
+    // ── GAP 1: a part sourced from a repo CHECKOUT ──────────────────────────
+    //
+    // A composefile could source from a gripspace or from the manifest repo,
+    // and from nothing else -- so a repo the gripspace actually manages could
+    // not contribute to a composed file. Sourcing `standards/CONVENTIONS.md`
+    // with `standards` checked out at ./standards resolved MANIFEST-relative
+    // and warned `manifest:standards/CONVENTIONS.md not found`.
+
+    fn repo_paths(pairs: &[(&str, &str)]) -> HashMap<String, PathBuf> {
+        pairs
+            .iter()
+            .map(|(name, path)| (name.to_string(), PathBuf::from(path)))
+            .collect()
+    }
+
+    #[test]
+    fn test_composefile_part_sources_from_a_repo_checkout() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::create_dir_all(workspace.join("standards")).unwrap();
+        std::fs::write(
+            workspace.join("standards").join("CONVENTIONS.md"),
+            "# Conventions",
+        )
+        .unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "CLAUDE.md".to_string(),
+            parts: vec![ComposeFilePart {
+                repo: Some("standards".to_string()),
+                gripspace: None,
+                src: "CONVENTIONS.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[("standards", "./standards")]),
+            &composefiles,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("CLAUDE.md")).unwrap(),
+            "# Conventions"
+        );
+    }
+
+    #[test]
+    fn test_composefile_repo_part_is_not_resolved_manifest_relative() {
+        // THE ACTUAL BUG, pinned. Before `repo:` existed the same file was
+        // looked for under the manifest dir. A same-named decoy there would
+        // make a naive fix pass while still reading the wrong file.
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(manifests_dir.join("standards")).unwrap();
+        std::fs::create_dir_all(workspace.join("standards")).unwrap();
+        std::fs::write(
+            manifests_dir.join("standards").join("CONVENTIONS.md"),
+            "DECOY FROM MANIFEST",
+        )
+        .unwrap();
+        std::fs::write(
+            workspace.join("standards").join("CONVENTIONS.md"),
+            "REAL FROM REPO",
+        )
+        .unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "OUT.md".to_string(),
+            parts: vec![ComposeFilePart {
+                repo: Some("standards".to_string()),
+                gripspace: None,
+                src: "CONVENTIONS.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[("standards", "./standards")]),
+            &composefiles,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
+            "REAL FROM REPO"
+        );
+    }
+
+    #[test]
+    fn test_composefile_unknown_repo_warns_and_skips() {
+        // Consistent with every other unresolvable part: warn, skip, do not
+        // fail the sync. A missing repo must not take the workspace down.
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::write(manifests_dir.join("LOCAL.md"), "# Local").unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "OUT.md".to_string(),
+            parts: vec![
+                ComposeFilePart {
+                    repo: Some("nope".to_string()),
+                    gripspace: None,
+                    src: "X.md".to_string(),
+                },
+                ComposeFilePart {
+                    repo: None,
+                    gripspace: None,
+                    src: "LOCAL.md".to_string(),
+                },
+            ],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[]),
+            &composefiles,
+        )
+        .unwrap();
+
+        // The resolvable part still composes; the unknown one is skipped.
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
+            "# Local"
+        );
+    }
+
+    #[test]
+    fn test_composefile_repo_part_rejects_path_traversal() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::create_dir_all(workspace.join("standards")).unwrap();
+        std::fs::write(workspace.join("SECRET.md"), "secret").unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "OUT.md".to_string(),
+            parts: vec![ComposeFilePart {
+                repo: Some("standards".to_string()),
+                gripspace: None,
+                src: "../SECRET.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[("standards", "./standards")]),
+            &composefiles,
+        )
+        .unwrap();
+
+        assert!(
+            !workspace.join("OUT.md").exists(),
+            "path traversal out of a repo checkout was composed"
+        );
+    }
+
+    #[test]
+    fn test_composefile_repo_and_gripspace_together_is_rejected() {
+        // Two source kinds on one part is ambiguous. Refuse rather than pick.
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path();
+        let manifests_dir = workspace.join(".gitgrip").join("manifests");
+        let spaces_dir = workspace.join(".gitgrip").join("spaces");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        std::fs::create_dir_all(spaces_dir.join("base")).unwrap();
+        std::fs::create_dir_all(workspace.join("standards")).unwrap();
+        std::fs::write(spaces_dir.join("base").join("A.md"), "from gripspace").unwrap();
+        std::fs::write(workspace.join("standards").join("A.md"), "from repo").unwrap();
+
+        let composefiles = vec![ComposeFileConfig {
+            dest: "OUT.md".to_string(),
+            parts: vec![ComposeFilePart {
+                repo: Some("standards".to_string()),
+                gripspace: Some("base".to_string()),
+                src: "A.md".to_string(),
+            }],
+            separator: None,
+        }];
+
+        process_composefiles(
+            workspace,
+            &manifests_dir,
+            &spaces_dir,
+            &repo_paths(&[("standards", "./standards")]),
+            &composefiles,
+        )
+        .unwrap();
+
+        assert!(
+            !workspace.join("OUT.md").exists(),
+            "an ambiguous part with both repo: and gripspace: was composed anyway"
+        );
+    }
 
     #[test]
     fn test_process_composefiles_basic() {
@@ -192,10 +477,12 @@ mod tests {
             dest: "COMPOSED.md".to_string(),
             parts: vec![
                 ComposeFilePart {
+                    repo: None,
                     gripspace: Some("base-space".to_string()),
                     src: "BASE.md".to_string(),
                 },
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "LOCAL.md".to_string(),
                 },
@@ -203,8 +490,13 @@ mod tests {
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
 
         let content = std::fs::read_to_string(workspace.join("COMPOSED.md")).unwrap();
@@ -228,10 +520,12 @@ mod tests {
             dest: "OUTPUT.md".to_string(),
             parts: vec![
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "PART1.md".to_string(),
                 },
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "PART2.md".to_string(),
                 },
@@ -239,8 +533,13 @@ mod tests {
             separator: Some("\n\n---\n\n".to_string()),
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
 
         let content = std::fs::read_to_string(workspace.join("OUTPUT.md")).unwrap();
@@ -263,10 +562,12 @@ mod tests {
             dest: "OUTPUT.md".to_string(),
             parts: vec![
                 ComposeFilePart {
+                    repo: None,
                     gripspace: Some("nonexistent".to_string()),
                     src: "MISSING.md".to_string(),
                 },
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "EXISTS.md".to_string(),
                 },
@@ -274,8 +575,13 @@ mod tests {
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
 
         // Should still write the available part
@@ -298,14 +604,20 @@ mod tests {
         let composefiles = vec![ComposeFileConfig {
             dest: "nested/dir/output.txt".to_string(),
             parts: vec![ComposeFilePart {
+                repo: None,
                 gripspace: None,
                 src: "content.txt".to_string(),
             }],
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
         assert!(workspace.join("nested/dir/output.txt").exists());
     }
@@ -389,14 +701,20 @@ mod tests {
         let composefiles = vec![ComposeFileConfig {
             dest: "../escaped.md".to_string(),
             parts: vec![ComposeFilePart {
+                repo: None,
                 gripspace: None,
                 src: "file.md".to_string(),
             }],
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_err());
     }
 
@@ -414,14 +732,20 @@ mod tests {
         let composefiles = vec![ComposeFileConfig {
             dest: "C:\\temp\\escaped.md".to_string(),
             parts: vec![ComposeFilePart {
+                repo: None,
                 gripspace: None,
                 src: "file.md".to_string(),
             }],
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_err());
     }
 
@@ -441,10 +765,12 @@ mod tests {
             dest: "output.md".to_string(),
             parts: vec![
                 ComposeFilePart {
+                    repo: None,
                     gripspace: Some("../evil".to_string()),
                     src: "file.md".to_string(),
                 },
                 ComposeFilePart {
+                    repo: None,
                     gripspace: None,
                     src: "fallback.md".to_string(),
                 },
@@ -452,8 +778,13 @@ mod tests {
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_ok());
 
         // Only the valid part should be written
@@ -493,14 +824,20 @@ mod tests {
         let composefiles = vec![ComposeFileConfig {
             dest: "\\escaped.md".to_string(),
             parts: vec![ComposeFilePart {
+                repo: None,
                 gripspace: None,
                 src: "file.md".to_string(),
             }],
             separator: None,
         }];
 
-        let result =
-            process_composefiles(workspace, &manifests_dir, &gripspaces_dir, &composefiles);
+        let result = process_composefiles(
+            workspace,
+            &manifests_dir,
+            &gripspaces_dir,
+            &HashMap::new(),
+            &composefiles,
+        );
         assert!(result.is_err());
     }
 }

--- a/tests/gripspace_multi_rev.rs
+++ b/tests/gripspace_multi_rev.rs
@@ -1,0 +1,286 @@
+//! Command-level witnesses: multiple gripspaces from ONE repository at
+//! DIFFERENT revisions must coexist as first-class spaces.
+//!
+//! *** THE DEFECT THESE WERE BORN RED AGAINST (2026-08-12). ***
+//!
+//! `gripspace_identity()` already knows a gripspace is `url#rev`. But
+//! `resolve_space_name()` derived the space directory from the URL alone, and
+//! the reuse check asked only "same remote?" — so the second gripspace of a
+//! repo silently REUSED the first rev's clone. Measured live: a manifest
+//! declaring `rev: standards` and `rev: api` from one repo materialized ONE
+//! space at `standards`; the `api` binding resolved to nothing; compose
+//! printed a warning and then a success line.
+//!
+//! One repo hosting many gripspaces as orphan-branch roots is the tutorial's
+//! and the product's core shape ("the whole point is multiple gripspaces" —
+//! the ruling that opened this fix). These witnesses drive the real binary
+//! end to end, because the naming function, the reuse check, the sync
+//! mapping, and the compose binding all have to agree before the feature
+//! exists — a green unit test on the naming helper alone proves none of that.
+
+use assert_cmd::Command;
+use std::path::Path;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// One bare repo, three orphan-branch roots:
+///   `main`      — the workspace manifest + a local fragment
+///   `standards` — fragment MARKER-STANDARDS-a83f
+///   `extras`    — fragment MARKER-EXTRAS-b17c
+/// The manifest declares the SAME url as two gripspaces at the two revs and
+/// composes one CLAUDE.md from both plus the local part.
+fn build_one_repo_two_gripspace_origin(root: &Path) -> String {
+    let bare = root.join("frag.git");
+    git(root, &["init", "--bare", "frag.git"]);
+    let url = format!("file://{}", bare.display());
+
+    let w = root.join("seed");
+    std::fs::create_dir_all(&w).unwrap();
+    git(&w, &["init"]);
+
+    git(&w, &["checkout", "-b", "standards"]);
+    std::fs::write(w.join("CONVENTIONS.md"), "MARKER-STANDARDS-a83f\n").unwrap();
+    std::fs::write(w.join("gripspace.yml"), "version: 2\n").unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "standards root"]);
+
+    git(&w, &["checkout", "--orphan", "extras"]);
+    git(&w, &["rm", "-rf", "."]);
+    std::fs::write(w.join("EXTRA.md"), "MARKER-EXTRAS-b17c\n").unwrap();
+    std::fs::write(w.join("gripspace.yml"), "version: 2\n").unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "extras root"]);
+
+    git(&w, &["checkout", "--orphan", "main"]);
+    git(&w, &["rm", "-rf", "."]);
+    std::fs::write(w.join("PROJECT.md"), "MARKER-LOCAL-c29d\n").unwrap();
+    std::fs::write(
+        w.join("gripspace.yml"),
+        format!(
+            r#"version: 2
+manifest:
+  url: {url}
+  composefile:
+    - dest: CLAUDE.md
+      separator: "\n"
+      parts:
+        - gripspace: frag
+          src: CONVENTIONS.md
+        - gripspace: frag-extras
+          src: EXTRA.md
+        - src: PROJECT.md
+gripspaces:
+  - url: {url}
+    rev: standards
+  - url: {url}
+    rev: extras
+repos:
+  extras-checkout:
+    url: {url}
+    path: ./extras-checkout
+    revision: extras
+"#
+        ),
+    )
+    .unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "manifest root"]);
+    git(&w, &["push", &url, "standards", "extras", "main"]);
+
+    url
+}
+
+fn gr() -> Command {
+    let mut c = Command::cargo_bin("gr").expect("gr binary");
+    c.env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t");
+    c
+}
+
+/// Locate the workspace directory `gr init` created under `parent`.
+fn workspace_dir(parent: &Path) -> std::path::PathBuf {
+    std::fs::read_dir(parent)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| p.is_dir() && p.join(".gitgrip").exists())
+        .expect("gr init produced a workspace directory")
+}
+
+#[test]
+fn two_revs_of_one_repo_materialize_as_two_spaces_and_both_compose() {
+    let tmp = TempDir::new().unwrap();
+    let url = build_one_repo_two_gripspace_origin(tmp.path());
+    let ws_parent = tmp.path().join("ws");
+    std::fs::create_dir_all(&ws_parent).unwrap();
+
+    let assert = gr().args(["init", &url]).current_dir(&ws_parent).assert();
+    let out = assert.get_output().clone();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert.success();
+
+    let ws = workspace_dir(&ws_parent);
+    let spaces = ws.join(".gitgrip").join("spaces");
+
+    // Both revs exist as first-class spaces, each carrying ITS branch's file.
+    assert!(
+        spaces.join("frag").join("CONVENTIONS.md").exists(),
+        "first-declared rev keeps the base name and its content; spaces present: {:?}",
+        std::fs::read_dir(&spaces)
+            .map(|d| d
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name())
+                .collect::<Vec<_>>())
+            .unwrap_or_default()
+    );
+    assert!(
+        spaces.join("frag-extras").join("EXTRA.md").exists(),
+        "second rev materializes under the deterministic name '<base>-<rev>'"
+    );
+
+    // The composed file carries fragments from BOTH branches of the ONE repo.
+    let claude = std::fs::read_to_string(ws.join("CLAUDE.md"))
+        .expect("CLAUDE.md composed at workspace root");
+    assert!(
+        claude.contains("MARKER-STANDARDS-a83f"),
+        "standards fragment present"
+    );
+    assert!(
+        claude.contains("MARKER-EXTRAS-b17c"),
+        "extras fragment present"
+    );
+    assert!(
+        claude.contains("MARKER-LOCAL-c29d"),
+        "local fragment present"
+    );
+
+    // The disambiguation is NAMED, on stderr — an invented space name that
+    // appears in no manifest must not be invented silently.
+    assert!(
+        stderr.contains("frag-extras"),
+        "stderr names the deterministic space name; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn sync_reuses_both_spaces_instead_of_proliferating() {
+    let tmp = TempDir::new().unwrap();
+    let url = build_one_repo_two_gripspace_origin(tmp.path());
+    let ws_parent = tmp.path().join("ws");
+    std::fs::create_dir_all(&ws_parent).unwrap();
+    gr().args(["init", &url])
+        .current_dir(&ws_parent)
+        .assert()
+        .success();
+    let ws = workspace_dir(&ws_parent);
+
+    gr().arg("sync").current_dir(&ws).assert().success();
+    gr().arg("sync").current_dir(&ws).assert().success();
+
+    let spaces = ws.join(".gitgrip").join("spaces");
+    let named: Vec<String> = std::fs::read_dir(&spaces)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("frag"))
+        .collect();
+    let mut sorted = named.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec!["frag".to_string(), "frag-extras".to_string()],
+        "repeat syncs reuse the two spaces — no frag-2/frag-3 proliferation"
+    );
+
+    // Idempotent compose still carries both fragments after repeat syncs.
+    let claude = std::fs::read_to_string(ws.join("CLAUDE.md")).unwrap();
+    assert!(claude.contains("MARKER-STANDARDS-a83f"));
+    assert!(claude.contains("MARKER-EXTRAS-b17c"));
+}
+
+/// Discriminating control: the fix must key on url+rev, not "always allocate a
+/// new space". The SAME url at the SAME rev declared twice still collapses to
+/// one space — if this test fails while the others pass, the implementation
+/// went to per-entry allocation, which is right by accident and wrong by design.
+#[test]
+fn same_url_same_rev_twice_still_yields_one_space() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let bare = root.join("frag.git");
+    git(root, &["init", "--bare", "frag.git"]);
+    let url = format!("file://{}", bare.display());
+
+    let w = root.join("seed");
+    std::fs::create_dir_all(&w).unwrap();
+    git(&w, &["init"]);
+    git(&w, &["checkout", "-b", "standards"]);
+    std::fs::write(w.join("CONVENTIONS.md"), "MARKER-STANDARDS-a83f\n").unwrap();
+    std::fs::write(w.join("gripspace.yml"), "version: 2\n").unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "standards root"]);
+    git(&w, &["checkout", "--orphan", "main"]);
+    git(&w, &["rm", "-rf", "."]);
+    std::fs::write(
+        w.join("gripspace.yml"),
+        format!(
+            r#"version: 2
+manifest:
+  url: {url}
+gripspaces:
+  - url: {url}
+    rev: standards
+  - url: {url}
+    rev: standards
+repos:
+  standards-checkout:
+    url: {url}
+    path: ./standards-checkout
+    revision: standards
+"#
+        ),
+    )
+    .unwrap();
+    git(&w, &["add", "-A"]);
+    git(&w, &["commit", "-m", "manifest"]);
+    git(&w, &["push", &url, "standards", "main"]);
+
+    let ws_parent = root.join("ws");
+    std::fs::create_dir_all(&ws_parent).unwrap();
+    gr().args(["init", &url])
+        .current_dir(&ws_parent)
+        .assert()
+        .success();
+    let ws = workspace_dir(&ws_parent);
+
+    let spaces = ws.join(".gitgrip").join("spaces");
+    let named: Vec<String> = std::fs::read_dir(&spaces)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("frag"))
+        .collect();
+    assert_eq!(
+        named,
+        vec!["frag".to_string()],
+        "identical url+rev dedups to one space — allocation is by identity, not by entry"
+    );
+}

--- a/tests/layered_composition.rs
+++ b/tests/layered_composition.rs
@@ -1,0 +1,227 @@
+//! Composition ACROSS gripspace layers, exercised through the real seam.
+//!
+//! *** WHY THIS FILE EXISTS, AND IT IS A REVIEW FINDING, NOT A PREFERENCE. ***
+//!
+//! The unit tests for this feature call `merge_composefiles_in_layer_order`
+//! and `process_composefiles` DIRECTLY. Both are downstream of the thing that
+//! actually makes layered composition work: the point inside
+//! `resolve_gripspace_recursive` where an included manifest's bare part is
+//! rewritten to `gripspace: <resolved-dir>` and carried into the merged
+//! manifest.
+//!
+//! A reviewer pointed out that a mutation removing that rewrite, or dropping
+//! included composefiles before the helper is reached, leaves every one of
+//! those unit tests GREEN. They pin the functions; they do not pin the USE.
+//! A manual end-to-end run is evidence about one head, not a regression
+//! witness that survives the next refactor.
+//!
+//! So this drives the real `gr` binary through init and sync, and it is built
+//! to go RED on either mutation:
+//!
+//!   - remove the REBASE  -> base's bare `src: SHARED.md` resolves
+//!     manifest-relative again and reads the root's DECOY file, so the decoy
+//!     content appears and the layer's own content does not
+//!   - remove the CARRY   -> the ancestors' parts never reach the merge at all
+//!
+//! The decoy is the load-bearing part. Without a same-named file at the old
+//! resolution path, a broken rebase would simply find nothing, and "absent"
+//! is indistinguishable from "the layer contributed nothing" — which is the
+//! bug this feature fixes, passing itself off as the fix.
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {:?} failed in {:?}: {}",
+        args,
+        dir,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A local git repo holding `files`, usable as a gripspace URL.
+fn repo(root: &Path, name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let dir = root.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    git(&dir, &["init", "-q", "-b", "main"]);
+    git(&dir, &["config", "user.email", "test@example.com"]);
+    git(&dir, &["config", "user.name", "test"]);
+    for (path, body) in files {
+        let full = dir.join(path);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(full, body).unwrap();
+    }
+    git(&dir, &["add", "-A"]);
+    git(&dir, &["commit", "-qm", "init"]);
+    dir
+}
+
+#[test]
+fn composition_accumulates_across_layers_and_prefers_the_declaring_layers_file() {
+    let origin = TempDir::new().unwrap();
+    let root = origin.path();
+
+    // THE DEEPEST ANCESTOR. Its part is BARE — the case that must be rebased.
+    let base = repo(
+        root,
+        "base",
+        &[
+            ("SHARED.md", "FROM BASE"),
+            (
+                "gripspace.yml",
+                "repos: {}\n\
+                 manifest:\n  \
+                   url: \"\"\n  \
+                   composefile:\n    \
+                     - dest: CLAUDE.md\n      \
+                       parts:\n        \
+                         - src: SHARED.md\n",
+            ),
+        ],
+    );
+
+    // THE MIDDLE LAYER, also bare, and it uses THE SAME FILENAME as base and
+    // as the root decoy. Same name across all three is deliberate: it is what
+    // makes a wrong resolution produce wrong CONTENT rather than no content.
+    let standards = repo(
+        root,
+        "standards",
+        &[
+            ("SHARED.md", "FROM STANDARDS"),
+            (
+                "gripspace.yml",
+                &format!(
+                    "repos: {{}}\n\
+                     gripspaces:\n  \
+                       - url: {}\n\
+                     manifest:\n  \
+                       url: \"\"\n  \
+                       composefile:\n    \
+                         - dest: CLAUDE.md\n      \
+                           parts:\n        \
+                             - src: SHARED.md\n",
+                    base.display()
+                ),
+            ),
+        ],
+    );
+
+    // THE ROOT, carrying a DECOY at the manifest-relative path the ancestors'
+    // bare parts USED to resolve to.
+    let top = repo(
+        root,
+        "top",
+        &[
+            ("SHARED.md", "DECOY FROM ROOT MANIFEST"),
+            ("TOP.md", "FROM TOP"),
+            (
+                "gripspace.yml",
+                &format!(
+                    "repos: {{}}\n\
+                     gripspaces:\n  \
+                       - url: {}\n\
+                     manifest:\n  \
+                       url: \"\"\n  \
+                       composefile:\n    \
+                         - dest: CLAUDE.md\n      \
+                           parts:\n        \
+                             - src: TOP.md\n",
+                    standards.display()
+                ),
+            ),
+        ],
+    );
+
+    let ws = TempDir::new().unwrap();
+    let init = Command::cargo_bin("gr")
+        .unwrap()
+        .args(["init", top.to_str().unwrap()])
+        .current_dir(ws.path())
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "PRECONDITION FAILED: gr init did not succeed, so anything below is a \
+         fact about the harness rather than about gr.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr),
+    );
+    let workspace = ws.path().join("workspace");
+
+    let sync = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+
+    // PRECONDITION: gripspace resolution must not have degraded to a warning.
+    // Without this, a fixture mistake reads as a feature failure — resolution
+    // failure currently warns while sync still reports success.
+    let stderr = String::from_utf8_lossy(&sync.stderr);
+    let stdout = String::from_utf8_lossy(&sync.stdout);
+    assert!(
+        !stdout.contains("Gripspace resolution failed")
+            && !stderr.contains("Gripspace resolution failed"),
+        "PRECONDITION FAILED: gripspace resolution failed, so this test is \
+         about the fixture rather than about composition.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // PRECONDITION: every layer materialized, or "missing content" would just
+    // mean "the layer was never fetched".
+    for layer in ["base", "standards"] {
+        assert!(
+            workspace.join(".gitgrip/spaces").join(layer).is_dir(),
+            "PRECONDITION FAILED: gripspace '{layer}' did not materialize"
+        );
+    }
+
+    let composed_path = workspace.join("CLAUDE.md");
+    assert!(
+        composed_path.is_file(),
+        "no composed file was produced at all.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let composed = std::fs::read_to_string(&composed_path).unwrap();
+
+    // THE CARRY: ancestors' composefiles reached the merge.
+    assert!(
+        composed.contains("FROM BASE"),
+        "the deepest ancestor's composefile was dropped.\ngot:\n{composed}"
+    );
+    assert!(
+        composed.contains("FROM STANDARDS"),
+        "the middle layer's composefile was dropped.\ngot:\n{composed}"
+    );
+    assert!(
+        composed.contains("FROM TOP"),
+        "the root's own part is missing"
+    );
+
+    // THE REBASE: a bare part resolved against the layer that WROTE it, not
+    // against the root manifest. This is what the decoy exists to catch.
+    assert!(
+        !composed.contains("DECOY"),
+        "a bare part from an included gripspace resolved against the ROOT \
+         manifest and picked up the decoy.\ngot:\n{composed}"
+    );
+
+    // THE ORDER: ancestors first, local last, checked at this same boundary.
+    let base_at = composed.find("FROM BASE").unwrap();
+    let std_at = composed.find("FROM STANDARDS").unwrap();
+    let top_at = composed.find("FROM TOP").unwrap();
+    assert!(
+        base_at < std_at && std_at < top_at,
+        "layers are not ancestors-first.\ngot:\n{composed}"
+    );
+}

--- a/tests/manifest_input_warnings.rs
+++ b/tests/manifest_input_warnings.rs
@@ -1,0 +1,287 @@
+//! Command-level witnesses for manifest input that would otherwise be discarded
+//! in silence.
+//!
+//! *** WHY THESE ARE NOT UNIT TESTS, WHICH IS THE WHOLE POINT. ***
+//!
+//! The first attempt at covering this shipped four unit tests against
+//! `Manifest::unknown_top_level_keys`. Review blocked it: every one exercised
+//! the HELPER, none drove `filter_repos` with a bad URL, and none proved the
+//! warning reaches STDERR through a real command. So a revert to a silent
+//! `filter_map`, or a warning quietly moved back to stdout where `--json`
+//! consumers would swallow it, left all four GREEN.
+//!
+//! The author had just counted call sites to find the right chokepoint
+//! (`parse_raw`, not `load`) and then tested the helper anyway. VERIFYING WHERE
+//! YOUR CODE GOES AND VERIFYING THROUGH WHERE IT GOES ARE TWO DIFFERENT ACTS,
+//! and the second is easier to skip because the first felt like diligence.
+//!
+//! So these drive the real binary, and assert on the STREAM as well as the
+//! text, because the routing is half the contract: a correctness warning on
+//! stdout is swallowed by redirection and corrupts `--json`.
+
+use assert_cmd::Command;
+use std::path::Path;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A bare origin carrying a manifest on `main` and one content branch `api`.
+///
+/// Returns (tempdir, file:// url of the bare repo).
+fn origin_with_manifest(manifest_body: &str) -> (TempDir, String) {
+    let temp = TempDir::new().unwrap();
+    let bare = temp.path().join("origin.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    git(temp.path(), &["init", "-q", "--bare", "origin.git"]);
+    let url = format!("file://{}", bare.display());
+
+    let work = temp.path().join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    git(&work, &["init", "-q"]);
+    git(&work, &["remote", "add", "origin", bare.to_str().unwrap()]);
+
+    // content branch
+    git(&work, &["checkout", "-q", "--orphan", "api"]);
+    std::fs::write(work.join("API.md"), "api\n").unwrap();
+    git(&work, &["add", "-A"]);
+    git(&work, &["commit", "-qm", "api"]);
+    git(&work, &["push", "-q", "origin", "api"]);
+
+    // manifest branch
+    git(&work, &["checkout", "-q", "--orphan", "main"]);
+    let _ = StdCommand::new("git")
+        .args(["rm", "-rqf", "."])
+        .current_dir(&work)
+        .output();
+    std::fs::write(work.join("PROJECT.md"), "project\n").unwrap();
+    std::fs::write(
+        work.join("gripspace.yml"),
+        manifest_body.replace("__URL__", &url),
+    )
+    .unwrap();
+    git(&work, &["add", "-A"]);
+    git(&work, &["commit", "-qm", "manifest"]);
+    git(&work, &["push", "-qf", "origin", "main"]);
+
+    (temp, url)
+}
+
+/// `gr init <url>` then `gr sync` inside the created workspace. Returns sync's output.
+fn init_then_sync(url: &str, extra: &[&str]) -> (TempDir, std::process::Output) {
+    let ws = TempDir::new().unwrap();
+    let init = Command::cargo_bin("gr")
+        .unwrap()
+        .args(["init", url])
+        .current_dir(ws.path())
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "PRECONDITION FAILED: gr init did not succeed, so anything below is a \
+         fact about the harness rather than about gr.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr),
+    );
+    let workspace = ws.path().join("workspace");
+    assert!(
+        workspace.is_dir(),
+        "PRECONDITION FAILED: gr init created no workspace/ directory"
+    );
+
+    let mut args = vec!["sync"];
+    args.extend_from_slice(extra);
+    let out = Command::cargo_bin("gr")
+        .unwrap()
+        .args(&args)
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    (ws, out)
+}
+
+const VALID_MANIFEST: &str = r#"version: 2
+repos:
+  api: { url: "__URL__", path: ./api, revision: api }
+"#;
+
+/// A bare filesystem path instead of a `file://` URL. `gr init` clones from it
+/// happily; `parse_git_url` cannot read it, so `filter_repos` used to drop the
+/// repo without a word and every downstream count printed zero, styled as
+/// success. That silence produced a defect report against repo registration,
+/// which was never broken.
+const UNPARSEABLE_URL_MANIFEST: &str = r#"version: 2
+repos:
+  api: { url: "/tmp/definitely-not-a-url/origin.git", path: ./api, revision: api }
+"#;
+
+/// `composefile` at the TOP level. It belongs under `manifest:`, serde discards
+/// unknown keys in silence, and the block vanishes at exit 0.
+const MISPLACED_KEY_MANIFEST: &str = r#"version: 2
+repos:
+  api: { url: "__URL__", path: ./api, revision: api }
+composefile:
+  - dest: CLAUDE.md
+    parts:
+      - src: PROJECT.md
+"#;
+
+#[test]
+fn sync_names_a_repo_it_could_not_resolve_and_says_so_on_stderr() {
+    let (_origin, url) = origin_with_manifest(UNPARSEABLE_URL_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // THE REPO, so the user knows which declaration was ignored.
+    assert!(
+        stderr.contains("api"),
+        "stderr must name the dropped repo.\nstderr: {stderr}"
+    );
+    // THE REASON, because "excluded" without a cause is not actionable.
+    assert!(
+        stderr.contains("could not be parsed"),
+        "stderr must give the reason.\nstderr: {stderr}"
+    );
+    // THE REMEDY, which is the whole difference between a warning and a fix.
+    assert!(
+        stderr.contains("file://"),
+        "stderr must point at the remedy.\nstderr: {stderr}"
+    );
+    // AND THE ROUTING IS HALF THE CONTRACT. On stdout this warning is swallowed
+    // by redirection and corrupts --json; that is why the stream is asserted
+    // rather than just the text.
+    assert!(
+        !stdout.contains("could not be parsed"),
+        "the warning must not be on stdout.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn sync_names_a_misplaced_manifest_key_and_says_where_it_belongs() {
+    let (_origin, url) = origin_with_manifest(MISPLACED_KEY_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stderr.contains("composefile"),
+        "stderr must name the ignored key.\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("manifest.composefile"),
+        "misplacement is the common case, so the warning must name where the \
+         key belongs.\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("manifest.composefile"),
+        "the warning must not be on stdout.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn a_valid_manifest_warns_on_neither_stream() {
+    // *** THE CONTROL THAT MATTERS MOST. ***
+    //
+    // A warning that fires on valid input is worse than no warning, because it
+    // trains readers to ignore the channel -- which is the defect being fixed,
+    // one layer up. Without this, both tests above would still pass on an
+    // implementation that warned about everything.
+    let (_origin, url) = origin_with_manifest(VALID_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &[]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "a valid manifest must sync cleanly.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("IGNORED"),
+        "valid manifest produced an unknown-key warning.\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("EXCLUDED"),
+        "valid manifest produced a dropped-repo warning.\nstderr: {stderr}"
+    );
+    // Positive half: the repo really did resolve, so the silence above is a
+    // clean run rather than a run that did nothing.
+    assert!(
+        stdout.contains("api") || stdout.contains("1 repositor"),
+        "the valid repo should appear in normal output.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn a_warning_never_enters_the_json_stdout_stream() {
+    // MY contract, narrowly: whatever else is on stdout, the warning is not.
+    // That is the half this change owns, and it is asserted in --json mode
+    // because that is where stdout pollution actually costs a consumer.
+    let (_origin, url) = origin_with_manifest(UNPARSEABLE_URL_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &["--json"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // PRECONDITION: the warning actually fired, or this asserts nothing.
+    assert!(
+        stderr.contains("EXCLUDED"),
+        "the warning did not fire, so this test proves nothing.\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.contains("EXCLUDED") && !stdout.contains("could not be parsed"),
+        "the warning leaked into --json stdout.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+#[ignore = "PRE-EXISTING defect, not introduced here; see the body. Un-ignore \
+            when gr's warning/success output is routed off stdout."]
+fn json_stdout_should_be_parseable_json_and_currently_is_not() {
+    // *** A DEFECT THIS TEST FOUND, RECORDED RATHER THAN HIDDEN. ***
+    //
+    // `gr sync --json` prints a human success line BEFORE the JSON document:
+    //
+    //     ✓ Applied 0 link(s)
+    //     { "success": true, ... }
+    //
+    // so stdout is not parseable JSON and every machine consumer of `--json`
+    // is already broken. This is INDEPENDENT of the warning change in this
+    // branch -- it reproduces without any manifest defect at all -- and it is
+    // an instance of the same root cause: `Output` writes through `println!`,
+    // at ~124 call sites across the tree, so every "warning" and success line
+    // lands on stdout.
+    //
+    // Deliberately NOT fixed here. Moving 124 call sites off stdout changes
+    // observable output everywhere and is its own change with its own gate;
+    // folding it into a manifest-parsing fix would make both unreviewable.
+    //
+    // Left as an ignored test rather than a comment because a comment is not
+    // runnable and cannot tell you when it stops being true. Un-ignore it and
+    // it becomes the acceptance criterion for that change.
+    let (_origin, url) = origin_with_manifest(VALID_MANIFEST);
+    let (_ws, out) = init_then_sync(&url, &["--json"]);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    serde_json::from_str::<serde_json::Value>(stdout.trim()).unwrap_or_else(|e| {
+        panic!("--json stdout is not parseable JSON ({e}).\nstdout: {stdout}")
+    });
+}


### PR DESCRIPTION
Promotes `dev` to `main` for the 1.1.0 release, via throwaway branch `promote/v1.1.0` per the standing promotion pattern (`dev` is never the PR head).

Payload: layered composition (#872), multi-revision gripspace coexistence (#869), manifest input surfacing (#868), and the 1.1.0 version bump (#876).

Merge method: merge commit. After merge: `dev` fast-forward sync from `main`, then tag `v1.1.0` on the promoted tip; the GitHub release and crates.io publish are created by CI on the tag.

Premium boundary: grip is OSS (workspace orchestration); this promotion carries no premium content.
