### PR TITLE
feat(gr2): add native add, commit, and push verbs

### DIFF
--- a/gr2/python_cli/add.py
+++ b/gr2/python_cli/add.py
@@ -1,0 +1,51 @@
+"""Native single-repository staging for the Python gr2 CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .gitops import git
+
+
+class AddError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class AddResult:
+    requested_paths: tuple[str, ...]
+    staged_files: tuple[str, ...]
+
+
+def stage_files(repo: Path, paths: list[str]) -> AddResult:
+    """Stage only the requested pathspecs and report their observed index rows.
+
+    ``git add --all`` is deliberate. A deleted tracked path does not exist on
+    disk, so a filesystem existence precheck turns a valid deletion into a
+    false "missing" error. Git's index is the authority for pathspec validity.
+    """
+    if not paths:
+        raise AddError("at least one path is required")
+
+    requested = tuple(paths)
+    try:
+        staged = git(repo, "add", "--all", "--", *requested)
+    except OSError as exc:
+        raise AddError(f"failed to launch git add in {repo}: {exc}") from exc
+    if staged.returncode != 0:
+        detail = (staged.stderr or staged.stdout).strip()
+        raise AddError(detail or f"git add failed with exit {staged.returncode}")
+
+    try:
+        observed = git(repo, "diff", "--cached", "--name-only", "-z", "--", *requested)
+    except OSError as exc:
+        raise AddError(
+            f"git add succeeded but staged-path evidence was unavailable: {exc}"
+        ) from exc
+    if observed.returncode != 0:
+        detail = (observed.stderr or observed.stdout).strip()
+        raise AddError(detail or "git add succeeded but staged-path evidence was unavailable")
+
+    staged_files = tuple(sorted(name for name in observed.stdout.split("\0") if name))
+    return AddResult(requested_paths=requested, staged_files=staged_files)

--- a/gr2/python_cli/app.py
+++ b/gr2/python_cli/app.py
@@ -12,9 +12,12 @@ import typer
 from gr2.prototypes import lane_workspace_prototype as lane_proto
 from gr2.prototypes import repo_maintenance_prototype as repo_proto
 
+from . import add as add_ops
 from . import branch as branch_ops
+from . import commit as commit_ops
 from . import execops, failures, migration, spec_apply, syncops
 from . import pr as pr_ops
+from . import push as push_ops
 from .events import EventType, emit_after_outcome
 from .gitops import (
     branch_exists,
@@ -572,6 +575,82 @@ def branch_cmd(
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
     typer.echo(f"Switched to branch '{name}'")
+
+
+@app.command("add")
+def add_cmd(
+    paths: list[str] = typer.Argument(..., help="Paths or pathspecs to stage"),
+    repo_path: Path | None = typer.Option(
+        None,
+        "--repo-path",
+        help="Repo to operate on (defaults to cwd; gr2 verbs are single-repo)",
+    ),
+) -> None:
+    """Stage paths in one repository, including tracked deletions."""
+    target = (repo_path or Path.cwd()).resolve()
+    try:
+        result = add_ops.stage_files(target, paths)
+    except add_ops.AddError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    if result.staged_files:
+        typer.echo(f"Staged {len(result.staged_files)} path(s): {', '.join(result.staged_files)}")
+    else:
+        typer.echo("No changes staged for the requested paths")
+
+
+@app.command("commit")
+def commit_cmd(
+    message: str = typer.Option(..., "--message", "-m", help="Commit message"),
+    amend: bool = typer.Option(False, "--amend", help="Amend the current commit"),
+    repo_path: Path | None = typer.Option(
+        None,
+        "--repo-path",
+        help="Repo to operate on (defaults to cwd; gr2 verbs are single-repo)",
+    ),
+) -> None:
+    """Create or amend one commit from the staged index."""
+    target = (repo_path or Path.cwd()).resolve()
+    try:
+        receipt = commit_ops.create_commit(target, message, amend=amend)
+    except commit_ops.CommitError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    action = "Amended" if receipt.amended else "Committed"
+    typer.echo(f"{action} {receipt.commit_sha}")
+
+
+@app.command("push")
+def push_cmd(
+    remote: str | None = typer.Option(None, "--remote", help="Configured remote to push"),
+    set_upstream: bool = typer.Option(False, "--set-upstream", "-u"),
+    force_with_lease: bool = typer.Option(
+        False,
+        "--force-with-lease",
+        help="Replace the remote ref only if its observed value still matches",
+    ),
+    repo_path: Path | None = typer.Option(
+        None,
+        "--repo-path",
+        help="Repo to operate on (defaults to cwd; gr2 verbs are single-repo)",
+    ),
+) -> None:
+    """Push one branch and verify its immutable remote commit."""
+    target = (repo_path or Path.cwd()).resolve()
+    try:
+        receipt = push_ops.push_current_branch(
+            target,
+            remote=remote,
+            set_upstream=set_upstream,
+            force_with_lease=force_with_lease,
+        )
+    except push_ops.PushError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(
+        f"Pushed {receipt.branch} to {receipt.remote} at {receipt.remote_sha} "
+        "(remote ref verified)"
+    )
 
 
 @exec_app.command("status")

--- a/gr2/python_cli/commit.py
+++ b/gr2/python_cli/commit.py
@@ -1,0 +1,83 @@
+"""Native single-repository commit creation for the Python gr2 CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .gitops import git
+
+
+class CommitError(Exception):
+    pass
+
+
+class NothingToCommitError(CommitError):
+    pass
+
+
+@dataclass(frozen=True)
+class CommitReceipt:
+    commit_sha: str
+    message: str
+    amended: bool
+
+
+def _head_sha(repo: Path, *, required: bool) -> str | None:
+    try:
+        result = git(repo, "rev-parse", "--verify", "HEAD")
+    except OSError as exc:
+        raise CommitError(f"failed to resolve HEAD in {repo}: {exc}") from exc
+    sha = result.stdout.strip() if result.returncode == 0 else ""
+    if required and not sha:
+        raise CommitError("git commit succeeded but the resulting HEAD could not be verified")
+    return sha or None
+
+
+def _staged_changes_exist(repo: Path) -> bool:
+    try:
+        probe = git(repo, "diff", "--cached", "--quiet", "--exit-code")
+    except OSError as exc:
+        raise CommitError(f"failed to inspect the staged index in {repo}: {exc}") from exc
+    if probe.returncode == 0:
+        return False
+    if probe.returncode == 1:
+        return True
+    detail = (probe.stderr or probe.stdout).strip()
+    raise CommitError(detail or f"staged-index probe failed with exit {probe.returncode}")
+
+
+def create_commit(repo: Path, message: str, *, amend: bool = False) -> CommitReceipt:
+    """Create a commit and return the immutable commit ID observed afterward.
+
+    A normal commit first asks the index whether a staged diff exists. It never
+    classifies "nothing to commit" by localized or version-dependent prose.
+    Amend is allowed without a new staged diff because changing only the prior
+    commit message is a valid amend operation.
+    """
+    if not message:
+        raise CommitError("commit message must not be empty")
+    if not amend and not _staged_changes_exist(repo):
+        raise NothingToCommitError("no staged changes to commit")
+
+    head_before = _head_sha(repo, required=False)
+
+    args = ["commit"]
+    if amend:
+        args.append("--amend")
+    args.extend(["-m", message])
+    try:
+        committed = git(repo, *args)
+    except OSError as exc:
+        raise CommitError(f"failed to launch git commit in {repo}: {exc}") from exc
+    if committed.returncode != 0:
+        detail = (committed.stderr or committed.stdout).strip()
+        raise CommitError(detail or f"git commit failed with exit {committed.returncode}")
+
+    commit_sha = _head_sha(repo, required=True)
+    assert commit_sha is not None
+    if commit_sha == head_before:
+        raise CommitError(
+            f"git commit returned success but HEAD did not advance from {head_before}"
+        )
+    return CommitReceipt(commit_sha=commit_sha, message=message, amended=amend)

--- a/gr2/python_cli/push.py
+++ b/gr2/python_cli/push.py
@@ -1,0 +1,155 @@
+"""Native single-repository push with explicit remote and arrival evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .gitops import git
+
+
+class PushError(Exception):
+    pass
+
+
+class PushEvidenceError(PushError):
+    """The push was acknowledged, but its remote result cannot be verified."""
+
+
+@dataclass(frozen=True)
+class PushReceipt:
+    remote: str
+    branch: str
+    local_sha: str
+    remote_sha: str
+    set_upstream: bool
+    force_with_lease: bool
+
+
+def _current_branch(repo: Path) -> str:
+    try:
+        result = git(repo, "branch", "--show-current")
+    except OSError as exc:
+        raise PushError(f"failed to determine the current branch in {repo}: {exc}") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise PushError(detail or "failed to determine the current branch")
+    branch = result.stdout.strip()
+    if not branch:
+        raise PushError("cannot push from detached HEAD")
+    return branch
+
+
+def _remote_names(repo: Path) -> tuple[str, ...]:
+    try:
+        result = git(repo, "remote")
+    except OSError as exc:
+        raise PushError(f"failed to enumerate remotes in {repo}: {exc}") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise PushError(detail or "failed to enumerate git remotes")
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _select_remote(repo: Path, branch: str, explicit: str | None) -> str:
+    remotes = _remote_names(repo)
+    if explicit is not None:
+        if explicit not in remotes:
+            raise PushError(f"remote '{explicit}' is not configured in {repo}")
+        return explicit
+
+    for key in (f"branch.{branch}.pushRemote", "remote.pushDefault", f"branch.{branch}.remote"):
+        try:
+            configured = git(repo, "config", "--get", key)
+        except OSError as exc:
+            raise PushError(f"failed to inspect configured push destination {key}: {exc}") from exc
+        if configured.returncode == 0 and configured.stdout.strip():
+            remote = configured.stdout.strip()
+            if remote not in remotes:
+                raise PushError(f"{key} names unavailable remote '{remote}'")
+            return remote
+        if configured.returncode not in {0, 1}:
+            detail = (configured.stderr or configured.stdout).strip()
+            raise PushError(detail or f"failed to inspect configured push destination {key}")
+
+    if len(remotes) == 1:
+        return remotes[0]
+    if not remotes:
+        raise PushError("no git remote is configured; pass --remote after adding one")
+    raise PushError(
+        f"multiple remotes are configured ({', '.join(remotes)}); pass --remote or configure the branch upstream"
+    )
+
+
+def _head_sha(repo: Path) -> str:
+    try:
+        result = git(repo, "rev-parse", "--verify", "HEAD")
+    except OSError as exc:
+        raise PushError(f"failed to resolve HEAD in {repo}: {exc}") from exc
+    sha = result.stdout.strip() if result.returncode == 0 else ""
+    if not sha:
+        raise PushError("cannot push because HEAD is not a commit")
+    return sha
+
+
+def _remote_branch_sha(repo: Path, remote: str, branch: str) -> str:
+    ref = f"refs/heads/{branch}"
+    try:
+        result = git(repo, "ls-remote", "--heads", remote, ref)
+    except OSError as exc:
+        raise PushEvidenceError(
+            f"push was acknowledged but remote receipt evidence was unavailable: {exc}"
+        ) from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise PushEvidenceError(
+            detail or "push was acknowledged but the remote branch could not be queried"
+        )
+    rows = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    matches = [parts[0] for parts in rows if len(parts) == 2 and parts[1] == ref]
+    if len(matches) != 1:
+        raise PushEvidenceError(
+            f"push was acknowledged but remote '{remote}' did not provide exactly one receipt for {ref}"
+        )
+    return matches[0]
+
+
+def push_current_branch(
+    repo: Path,
+    *,
+    remote: str | None = None,
+    set_upstream: bool = False,
+    force_with_lease: bool = False,
+) -> PushReceipt:
+    """Push the current branch and verify that the remote ref equals HEAD."""
+    branch = _current_branch(repo)
+    selected_remote = _select_remote(repo, branch, remote)
+    local_sha = _head_sha(repo)
+
+    args = ["push"]
+    if set_upstream:
+        args.append("--set-upstream")
+    if force_with_lease:
+        args.append("--force-with-lease")
+    args.extend([selected_remote, branch])
+    try:
+        pushed = git(repo, *args)
+    except OSError as exc:
+        raise PushError(f"failed to launch git push in {repo}: {exc}") from exc
+    if pushed.returncode != 0:
+        detail = (pushed.stderr or pushed.stdout).strip()
+        raise PushError(detail or f"git push failed with exit {pushed.returncode}")
+
+    remote_sha = _remote_branch_sha(repo, selected_remote, branch)
+    if remote_sha != local_sha:
+        raise PushEvidenceError(
+            f"push was acknowledged but remote {selected_remote}/{branch} is {remote_sha}, expected {local_sha}"
+        )
+    return PushReceipt(
+        remote=selected_remote,
+        branch=branch,
+        local_sha=local_sha,
+        remote_sha=remote_sha,
+        set_upstream=set_upstream,
+        force_with_lease=force_with_lease,
+    )

--- a/gr2/tests/test_add.py
+++ b/gr2/tests/test_add.py
@@ -106,3 +106,24 @@ def test_add_cli_defaults_to_the_cwd_repository_only(
     assert result.exit_code == 0, result.output
     assert _cached_names(repo_a) == ["new.txt"]
     assert _cached_names(repo_b) == []
+
+
+def test_add_cli_honors_explicit_repo_path_over_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli.app import app
+
+    cwd_repo = _init_repo(tmp_path / "cwd")
+    requested_repo = _init_repo(tmp_path / "requested")
+    (cwd_repo / "new.txt").write_text("cwd\n")
+    (requested_repo / "new.txt").write_text("requested\n")
+    monkeypatch.chdir(cwd_repo)
+
+    result = CliRunner().invoke(
+        app,
+        ["add", "--repo-path", str(requested_repo), "new.txt"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _cached_names(cwd_repo) == []
+    assert _cached_names(requested_repo) == ["new.txt"]

--- a/gr2/tests/test_add.py
+++ b/gr2/tests/test_add.py
@@ -1,0 +1,108 @@
+"""Executable contract for the native single-repository ``gr2 add`` verb."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir()
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Test")
+    _git(path, "config", "user.email", "test@example.com")
+    (path / "keep.txt").write_text("before\n")
+    (path / "delete.txt").write_text("delete me\n")
+    _git(path, "add", ".")
+    _git(path, "commit", "-m", "initial")
+    return path
+
+
+def _cached_names(repo: Path) -> list[str]:
+    output = _git(repo, "diff", "--cached", "--name-only", "-z").stdout
+    return [name for name in output.split("\0") if name]
+
+
+def test_stage_files_stages_added_modified_and_deleted_paths(tmp_path: Path) -> None:
+    from gr2.python_cli.add import stage_files
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "keep.txt").write_text("after\n")
+    (repo / "delete.txt").unlink()
+    (repo / "new.txt").write_text("new\n")
+
+    result = stage_files(repo, ["keep.txt", "delete.txt", "new.txt"])
+
+    assert result.staged_files == ("delete.txt", "keep.txt", "new.txt")
+    assert _cached_names(repo) == ["delete.txt", "keep.txt", "new.txt"]
+
+
+def test_deleted_path_is_staged_instead_of_misclassified_as_missing(tmp_path: Path) -> None:
+    from gr2.python_cli.add import stage_files
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "delete.txt").unlink()
+
+    result = stage_files(repo, ["delete.txt"])
+
+    assert result.staged_files == ("delete.txt",)
+    assert (
+        _git(repo, "diff", "--cached", "--diff-filter=D", "--name-only").stdout.strip()
+        == "delete.txt"
+    )
+
+
+def test_never_existing_path_refuses_without_touching_the_index(tmp_path: Path) -> None:
+    from gr2.python_cli.add import AddError, stage_files
+
+    repo = _init_repo(tmp_path / "repo")
+
+    with pytest.raises(AddError):
+        stage_files(repo, ["never-existed.txt"])
+
+    assert _cached_names(repo) == []
+
+
+def test_result_is_scoped_to_requested_paths_not_the_whole_index(tmp_path: Path) -> None:
+    from gr2.python_cli.add import stage_files
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "keep.txt").write_text("already staged\n")
+    _git(repo, "add", "keep.txt")
+    (repo / "new.txt").write_text("requested\n")
+
+    result = stage_files(repo, ["new.txt"])
+
+    assert result.staged_files == ("new.txt",)
+    assert _cached_names(repo) == ["keep.txt", "new.txt"]
+
+
+def test_add_cli_defaults_to_the_cwd_repository_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli.app import app
+
+    repo_a = _init_repo(tmp_path / "a")
+    repo_b = _init_repo(tmp_path / "b")
+    (repo_a / "new.txt").write_text("a\n")
+    (repo_b / "new.txt").write_text("b\n")
+    monkeypatch.chdir(repo_a)
+
+    result = CliRunner().invoke(app, ["add", "new.txt"])
+
+    assert result.exit_code == 0, result.output
+    assert _cached_names(repo_a) == ["new.txt"]
+    assert _cached_names(repo_b) == []

--- a/gr2/tests/test_commit.py
+++ b/gr2/tests/test_commit.py
@@ -135,3 +135,49 @@ def test_commit_cli_defaults_to_the_cwd_repository_only(
     assert result.exit_code == 0, result.output
     assert _git(repo_a, "show", "-s", "--format=%s", "HEAD").stdout.strip() == "cwd only"
     assert _git(repo_b, "rev-parse", "HEAD").stdout.strip() == before_b
+
+
+def test_commit_cli_honors_explicit_repo_path_over_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli.app import app
+
+    cwd_repo = _init_repo(tmp_path / "cwd")
+    requested_repo = _init_repo(tmp_path / "requested")
+    for repo in (cwd_repo, requested_repo):
+        (repo / "tracked.txt").write_text("changed\n")
+        _git(repo, "add", "tracked.txt")
+    cwd_head = _git(cwd_repo, "rev-parse", "HEAD").stdout.strip()
+    monkeypatch.chdir(cwd_repo)
+
+    result = CliRunner().invoke(
+        app,
+        ["commit", "--repo-path", str(requested_repo), "-m", "requested only"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _git(cwd_repo, "rev-parse", "HEAD").stdout.strip() == cwd_head
+    assert (
+        _git(requested_repo, "show", "-s", "--format=%s", "HEAD").stdout.strip()
+        == "requested only"
+    )
+
+
+def test_commit_cli_threads_amend_without_new_staged_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli.app import app
+
+    repo = _init_repo(tmp_path / "repo")
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        ["commit", "--repo-path", str(repo), "--amend", "-m", "amended through cli"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        _git(repo, "show", "-s", "--format=%s", "HEAD").stdout.strip()
+        == "amended through cli"
+    )

--- a/gr2/tests/test_commit.py
+++ b/gr2/tests/test_commit.py
@@ -1,0 +1,137 @@
+"""Executable contract for the native single-repository ``gr2 commit`` verb."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir()
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Test")
+    _git(path, "config", "user.email", "test@example.com")
+    (path / "tracked.txt").write_text("initial\n")
+    _git(path, "add", ".")
+    _git(path, "commit", "-m", "initial")
+    return path
+
+
+def test_create_commit_returns_the_commit_it_actually_created(tmp_path: Path) -> None:
+    from gr2.python_cli.commit import create_commit
+
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "tracked.txt").write_text("changed\n")
+    _git(repo, "add", "tracked.txt")
+
+    receipt = create_commit(repo, "native commit")
+
+    actual_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert receipt.commit_sha == actual_head
+    assert receipt.message == "native commit"
+    assert _git(repo, "show", "-s", "--format=%s", "HEAD").stdout.strip() == "native commit"
+
+
+def test_no_staged_changes_refuses_structurally_before_commit(tmp_path: Path) -> None:
+    from gr2.python_cli.commit import NothingToCommitError, create_commit
+
+    repo = _init_repo(tmp_path / "repo")
+    head_before = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    with pytest.raises(NothingToCommitError):
+        create_commit(repo, "must not exist")
+
+    assert _git(repo, "rev-parse", "HEAD").stdout.strip() == head_before
+
+
+def test_commit_outcome_uses_exit_status_not_command_prose(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli import commit as commit_ops
+
+    repo = _init_repo(tmp_path / "repo")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_git(_repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[:3] == ("diff", "--cached", "--quiet"):
+            return subprocess.CompletedProcess(["git", *args], 1, "", "nothing to commit")
+        if args[0] == "commit":
+            return subprocess.CompletedProcess(["git", *args], 0, "", "nothing to commit")
+        if args == ("rev-parse", "--verify", "HEAD"):
+            sha = "b" * 40 if calls.count(args) == 1 else "a" * 40
+            return subprocess.CompletedProcess(["git", *args], 0, sha + "\n", "")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(commit_ops, "git", fake_git)
+
+    receipt = commit_ops.create_commit(repo, "status wins")
+
+    assert receipt.commit_sha == "a" * 40
+    assert any(args[0] == "commit" for args in calls)
+
+
+def test_acknowledged_commit_without_a_new_head_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli import commit as commit_ops
+
+    repo = _init_repo(tmp_path / "repo")
+
+    def fake_git(_repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ("diff", "--cached", "--quiet"):
+            return subprocess.CompletedProcess(["git", *args], 1, "", "")
+        if args[0] == "commit":
+            return subprocess.CompletedProcess(["git", *args], 0, "", "")
+        if args == ("rev-parse", "--verify", "HEAD"):
+            return subprocess.CompletedProcess(["git", *args], 0, "a" * 40 + "\n", "")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(commit_ops, "git", fake_git)
+
+    with pytest.raises(commit_ops.CommitError, match="HEAD did not advance"):
+        commit_ops.create_commit(repo, "no fruit")
+
+
+def test_amend_without_new_staged_changes_is_allowed(tmp_path: Path) -> None:
+    from gr2.python_cli.commit import create_commit
+
+    repo = _init_repo(tmp_path / "repo")
+
+    receipt = create_commit(repo, "amended message", amend=True)
+
+    assert receipt.amended is True
+    assert _git(repo, "show", "-s", "--format=%s", "HEAD").stdout.strip() == "amended message"
+
+
+def test_commit_cli_defaults_to_the_cwd_repository_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli.app import app
+
+    repo_a = _init_repo(tmp_path / "a")
+    repo_b = _init_repo(tmp_path / "b")
+    for repo in (repo_a, repo_b):
+        (repo / "tracked.txt").write_text("changed\n")
+        _git(repo, "add", "tracked.txt")
+    before_b = _git(repo_b, "rev-parse", "HEAD").stdout.strip()
+    monkeypatch.chdir(repo_a)
+
+    result = CliRunner().invoke(app, ["commit", "-m", "cwd only"])
+
+    assert result.exit_code == 0, result.output
+    assert _git(repo_a, "show", "-s", "--format=%s", "HEAD").stdout.strip() == "cwd only"
+    assert _git(repo_b, "rev-parse", "HEAD").stdout.strip() == before_b

--- a/gr2/tests/test_push.py
+++ b/gr2/tests/test_push.py
@@ -226,3 +226,68 @@ def test_cli_exposes_force_with_lease_but_never_raw_force(tmp_path: Path) -> Non
     assert safe.exit_code == 0, safe.output
     assert unsafe.exit_code != 0
     assert "No such option: --force" in unsafe.output
+    assert _git(repo, "config", "--get", "branch.main.remote").stdout.strip() == "upstream"
+
+
+def test_push_cli_honors_explicit_repo_path_and_remote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli.app import app
+
+    repo = _init_repo(tmp_path / "repo")
+    one = _bare(tmp_path / "one.git")
+    two = _bare(tmp_path / "two.git")
+    _git(repo, "remote", "add", "one", str(one))
+    _git(repo, "remote", "add", "two", str(two))
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        ["push", "--repo-path", str(repo), "--remote", "two"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _git(two, "rev-parse", "refs/heads/main").stdout.strip() == _git(
+        repo, "rev-parse", "HEAD"
+    ).stdout.strip()
+    assert _git(one, "show-ref", "--verify", "refs/heads/main", check=False).returncode != 0
+
+
+def test_push_cli_threads_force_with_lease_when_remote_has_advanced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli.app import app
+    from gr2.python_cli.push import push_current_branch
+
+    repo = _init_repo(tmp_path / "repo")
+    remote = _bare(tmp_path / "remote.git")
+    _git(repo, "remote", "add", "upstream", str(remote))
+    push_current_branch(repo, set_upstream=True)
+
+    local_sha = _commit(repo, "local divergence")
+    other = tmp_path / "other"
+    subprocess.run(
+        ["git", "clone", str(remote), str(other)], check=True, capture_output=True, text=True
+    )
+    _git(other, "config", "user.name", "Other")
+    _git(other, "config", "user.email", "other@example.com")
+    remote_advanced = _commit(other, "remote advance")
+    _git(other, "push", "origin", "main")
+    _git(repo, "fetch", "upstream", "main")
+    assert _git(repo, "rev-parse", "upstream/main").stdout.strip() == remote_advanced
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "push",
+            "--repo-path",
+            str(repo),
+            "--remote",
+            "upstream",
+            "--force-with-lease",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _git(remote, "rev-parse", "refs/heads/main").stdout.strip() == local_sha

--- a/gr2/tests/test_push.py
+++ b/gr2/tests/test_push.py
@@ -1,0 +1,228 @@
+"""Executable contract for the native single-repository ``gr2 push`` verb."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir()
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.name", "Test")
+    _git(path, "config", "user.email", "test@example.com")
+    (path / "tracked.txt").write_text("initial\n")
+    _git(path, "add", ".")
+    _git(path, "commit", "-m", "initial")
+    return path
+
+
+def _bare(path: Path) -> Path:
+    subprocess.run(["git", "init", "--bare", str(path)], check=True, capture_output=True, text=True)
+    return path
+
+
+def _commit(repo: Path, text: str) -> str:
+    (repo / "tracked.txt").write_text(text + "\n")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-m", text)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_push_uses_the_configured_non_origin_remote_and_verifies_arrival(tmp_path: Path) -> None:
+    from gr2.python_cli.push import push_current_branch
+
+    repo = _init_repo(tmp_path / "repo")
+    remote = _bare(tmp_path / "remote.git")
+    _git(repo, "remote", "add", "upstream", str(remote))
+
+    receipt = push_current_branch(repo, set_upstream=True)
+
+    remote_head = _git(remote, "rev-parse", "refs/heads/main").stdout.strip()
+    assert receipt.remote == "upstream"
+    assert receipt.branch == "main"
+    assert receipt.local_sha == remote_head
+    assert receipt.remote_sha == remote_head
+    assert _git(repo, "config", "--get", "branch.main.remote").stdout.strip() == "upstream"
+
+
+def test_multiple_remotes_without_a_configured_or_explicit_choice_refuse(tmp_path: Path) -> None:
+    from gr2.python_cli.push import PushError, push_current_branch
+
+    repo = _init_repo(tmp_path / "repo")
+    _git(repo, "remote", "add", "one", str(_bare(tmp_path / "one.git")))
+    _git(repo, "remote", "add", "two", str(_bare(tmp_path / "two.git")))
+
+    with pytest.raises(PushError, match="multiple remotes"):
+        push_current_branch(repo)
+
+
+def test_branch_push_remote_takes_precedence_over_fetch_remote(tmp_path: Path) -> None:
+    from gr2.python_cli.push import push_current_branch
+
+    repo = _init_repo(tmp_path / "repo")
+    fetcher = _bare(tmp_path / "fetcher.git")
+    pusher = _bare(tmp_path / "pusher.git")
+    _git(repo, "remote", "add", "fetcher", str(fetcher))
+    _git(repo, "remote", "add", "pusher", str(pusher))
+    _git(repo, "config", "branch.main.remote", "fetcher")
+    _git(repo, "config", "branch.main.pushRemote", "pusher")
+
+    receipt = push_current_branch(repo)
+
+    assert receipt.remote == "pusher"
+    assert _git(pusher, "rev-parse", "refs/heads/main").stdout.strip() == receipt.local_sha
+    assert _git(fetcher, "show-ref", "--verify", "refs/heads/main", check=False).returncode != 0
+
+
+def test_explicit_remote_selects_one_of_multiple_remotes(tmp_path: Path) -> None:
+    from gr2.python_cli.push import push_current_branch
+
+    repo = _init_repo(tmp_path / "repo")
+    one = _bare(tmp_path / "one.git")
+    two = _bare(tmp_path / "two.git")
+    _git(repo, "remote", "add", "one", str(one))
+    _git(repo, "remote", "add", "two", str(two))
+
+    receipt = push_current_branch(repo, remote="two")
+
+    assert receipt.remote == "two"
+    assert _git(two, "rev-parse", "refs/heads/main").stdout.strip() == receipt.local_sha
+    assert _git(one, "show-ref", "--verify", "refs/heads/main", check=False).returncode != 0
+
+
+def test_detached_head_refuses_before_any_push(tmp_path: Path) -> None:
+    from gr2.python_cli.push import PushError, push_current_branch
+
+    repo = _init_repo(tmp_path / "repo")
+    remote = _bare(tmp_path / "remote.git")
+    _git(repo, "remote", "add", "upstream", str(remote))
+    _git(repo, "checkout", "--detach", "HEAD")
+
+    with pytest.raises(PushError, match="detached HEAD"):
+        push_current_branch(repo)
+
+    assert _git(remote, "show-ref", "--verify", "refs/heads/main", check=False).returncode != 0
+
+
+def test_divergent_push_refuses_without_rewriting_the_remote(tmp_path: Path) -> None:
+    from gr2.python_cli.push import PushError, push_current_branch
+
+    repo = _init_repo(tmp_path / "repo")
+    remote = _bare(tmp_path / "remote.git")
+    _git(repo, "remote", "add", "upstream", str(remote))
+    push_current_branch(repo, set_upstream=True)
+
+    other = tmp_path / "other"
+    subprocess.run(
+        ["git", "clone", str(remote), str(other)], check=True, capture_output=True, text=True
+    )
+    _git(other, "config", "user.name", "Other")
+    _git(other, "config", "user.email", "other@example.com")
+    remote_advanced = _commit(other, "remote advance")
+    _git(other, "push", "origin", "main")
+
+    _commit(repo, "local divergence")
+    with pytest.raises(PushError):
+        push_current_branch(repo)
+
+    assert _git(remote, "rev-parse", "refs/heads/main").stdout.strip() == remote_advanced
+
+
+def test_acknowledged_push_without_matching_receipt_evidence_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli import push as push_ops
+
+    repo = _init_repo(tmp_path / "repo")
+
+    def fake_git(_repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        if args == ("branch", "--show-current"):
+            return subprocess.CompletedProcess(["git", *args], 0, "main\n", "")
+        if args[:2] == ("config", "--get"):
+            if args[2] == "branch.main.remote":
+                return subprocess.CompletedProcess(["git", *args], 0, "upstream\n", "")
+            return subprocess.CompletedProcess(["git", *args], 1, "", "")
+        if args == ("remote",):
+            return subprocess.CompletedProcess(["git", *args], 0, "upstream\n", "")
+        if args == ("rev-parse", "--verify", "HEAD"):
+            return subprocess.CompletedProcess(["git", *args], 0, "a" * 40 + "\n", "")
+        if args[:2] == ("push", "upstream"):
+            return subprocess.CompletedProcess(["git", *args], 0, "", "")
+        if args[:3] == ("ls-remote", "--heads", "upstream"):
+            return subprocess.CompletedProcess(["git", *args], 0, "", "")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(push_ops, "git", fake_git)
+
+    with pytest.raises(push_ops.PushEvidenceError, match="did not provide"):
+        push_ops.push_current_branch(repo)
+
+
+def test_force_with_lease_is_threaded_to_git_without_raw_force(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gr2.python_cli import push as push_ops
+
+    repo = _init_repo(tmp_path / "repo")
+    push_args: tuple[str, ...] | None = None
+
+    def fake_git(_repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        nonlocal push_args
+        if args == ("branch", "--show-current"):
+            return subprocess.CompletedProcess(["git", *args], 0, "main\n", "")
+        if args == ("remote",):
+            return subprocess.CompletedProcess(["git", *args], 0, "upstream\n", "")
+        if args[:2] == ("config", "--get"):
+            if args[2] == "branch.main.remote":
+                return subprocess.CompletedProcess(["git", *args], 0, "upstream\n", "")
+            return subprocess.CompletedProcess(["git", *args], 1, "", "")
+        if args == ("rev-parse", "--verify", "HEAD"):
+            return subprocess.CompletedProcess(["git", *args], 0, "a" * 40 + "\n", "")
+        if args[0] == "push":
+            push_args = args
+            return subprocess.CompletedProcess(["git", *args], 0, "", "")
+        if args[:3] == ("ls-remote", "--heads", "upstream"):
+            row = "a" * 40 + "\trefs/heads/main\n"
+            return subprocess.CompletedProcess(["git", *args], 0, row, "")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(push_ops, "git", fake_git)
+
+    push_ops.push_current_branch(repo, force_with_lease=True)
+
+    assert push_args is not None
+    assert "--force-with-lease" in push_args
+    assert "--force" not in push_args
+
+
+def test_cli_exposes_force_with_lease_but_never_raw_force(tmp_path: Path) -> None:
+    from gr2.python_cli.app import app
+
+    repo = _init_repo(tmp_path / "repo")
+    remote = _bare(tmp_path / "remote.git")
+    _git(repo, "remote", "add", "upstream", str(remote))
+    runner = CliRunner()
+
+    safe = runner.invoke(
+        app,
+        ["push", "--repo-path", str(repo), "--set-upstream", "--force-with-lease"],
+    )
+    unsafe = runner.invoke(app, ["push", "--repo-path", str(repo), "--force"])
+
+    assert safe.exit_code == 0, safe.output
+    assert unsafe.exit_code != 0
+    assert "No such option: --force" in unsafe.output


### PR DESCRIPTION
## Summary

- add native single-repository `add`, `commit`, and `push` commands to the Python gr2 CLI
- return observed staged paths, the resulting commit SHA, and remote-arrival evidence instead of inferring success from command exit alone
- refuse empty commits, ambiguous remotes, detached pushes, and pushes whose remote result cannot be verified
- bind CLI option forwarding with observable repository, remote-selection, upstream, amend, and lease outcomes

## Verification

- `python3 -m pytest -q gr2/tests/test_add.py gr2/tests/test_commit.py gr2/tests/test_push.py`
- 25 passed on 2026-08-17 at `1592c3e9aacbf04e8bc929f088985a9d2de18054`
- under the full focused suite, ignoring explicit repository paths makes three CLI witnesses fail
- under the full focused suite, dropping push option forwarding makes three CLI witnesses fail
- under the full focused suite, dropping amend forwarding makes one CLI witness fail

_Correction: the previous verification text said the repository-path mutation caused two failures. A full-suite rerun showed three because the amend witness also depends on the explicit repository path._

Premium boundary: core OSS repository workflow primitives.