### PR TITLE
fix: make PR merge refusals observable

### DIFF
--- a/src/cli/commands/pr/merge.rs
+++ b/src/cli/commands/pr/merge.rs
@@ -1,9 +1,13 @@
 //! PR merge command implementation
 
 use super::create::has_commits_ahead;
+use crate::cli::outcome::CliOutcomeError;
 use crate::cli::output::Output;
 use crate::core::manifest::Manifest;
-use crate::core::repo::{get_manifest_repo_info, require_explicit_multi_repo_scope, RepoInfo};
+use crate::core::repo::{
+    get_manifest_repo_info, require_explicit_multi_repo_scope, validate_repo_filters_known,
+    RepoInfo,
+};
 use crate::git::{get_current_branch, open_repo, path_exists};
 use crate::platform::traits::{HostingPlatform, PlatformError};
 use crate::platform::{get_platform_adapter, CheckState, MergeMethod, StatusCheckResult};
@@ -240,6 +244,9 @@ pub async fn run_pr_merge(
     manifest: &Manifest,
     opts: &MergeOptions<'_>,
 ) -> anyhow::Result<()> {
+    validate_repo_filters_known(manifest, opts.repo_filter.as_deref())
+        .map_err(|error| CliOutcomeError::refusal(error.to_string()))?;
+
     if !opts.json {
         Output::header("Merging pull requests...");
         println!();
@@ -660,7 +667,7 @@ pub async fn run_pr_merge(
                 .collect::<Vec<_>>()
                 .join("|")
         );
-        return Ok(());
+        return Err(CliOutcomeError::reported_refusal("merge refused by readiness gate").into());
     }
 
     // Auto-merge flow: enable auto-merge and return early

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod args;
 pub mod commands;
 pub mod context;
 pub mod dispatch;
+pub mod outcome;
 pub mod output;
 pub mod output_sink;
 pub mod repo_iter;

--- a/src/cli/outcome.rs
+++ b/src/cli/outcome.rs
@@ -1,0 +1,103 @@
+//! Process-level outcome classification for CLI commands.
+//!
+//! `anyhow::Result` distinguishes success from failure, but not a command that
+//! was operationally unable to run from one that deliberately refused an act.
+//! Callers need that distinction without parsing rendered prose.
+
+use thiserror::Error;
+
+/// Exit code used when the command understood the request but refused the act.
+pub const EXIT_REFUSED: u8 = 2;
+
+/// An error whose process status and rendering behavior are part of the CLI contract.
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct CliOutcomeError {
+    exit_code: u8,
+    already_reported: bool,
+    message: String,
+}
+
+impl CliOutcomeError {
+    /// Refuse before any command-specific diagnostic has been rendered.
+    pub fn refusal(message: impl Into<String>) -> Self {
+        Self {
+            exit_code: EXIT_REFUSED,
+            already_reported: false,
+            message: message.into(),
+        }
+    }
+
+    /// Refuse after the command has already rendered the actionable diagnostic.
+    pub fn reported_refusal(message: impl Into<String>) -> Self {
+        Self {
+            exit_code: EXIT_REFUSED,
+            already_reported: true,
+            message: message.into(),
+        }
+    }
+
+    pub fn exit_code(&self) -> u8 {
+        self.exit_code
+    }
+
+    pub fn already_reported(&self) -> bool {
+        self.already_reported
+    }
+}
+
+/// Resolve the process code without requiring callers to know concrete error types.
+pub fn exit_code_for_error(error: &anyhow::Error) -> u8 {
+    error
+        .downcast_ref::<CliOutcomeError>()
+        .map(CliOutcomeError::exit_code)
+        .unwrap_or(1)
+}
+
+/// Whether the command already printed the diagnostic that explains this failure.
+pub fn error_was_reported(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<CliOutcomeError>()
+        .map(CliOutcomeError::already_reported)
+        .unwrap_or(false)
+}
+
+/// Render an unreported error with the same Debug shape used by the previous
+/// `Result<(), anyhow::Error>` process entry point.
+pub fn render_unreported_error(error: &anyhow::Error) -> String {
+    format!("Error: {error:?}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refusal_is_distinct_from_operational_failure() {
+        let refused = anyhow::Error::from(CliOutcomeError::refusal("not ready"));
+        let operational = anyhow::anyhow!("network failed");
+
+        assert_eq!(exit_code_for_error(&refused), EXIT_REFUSED);
+        assert_eq!(exit_code_for_error(&operational), 1);
+    }
+
+    #[test]
+    fn only_reported_refusals_suppress_duplicate_rendering() {
+        let pending = anyhow::Error::from(CliOutcomeError::refusal("bad selector"));
+        let rendered = anyhow::Error::from(CliOutcomeError::reported_refusal("not ready"));
+
+        assert!(!error_was_reported(&pending));
+        assert!(error_was_reported(&rendered));
+    }
+
+    #[test]
+    fn unreported_errors_keep_the_prior_debug_chain_shape() {
+        let error = anyhow::anyhow!("inner failure").context("outer context");
+        let rendered = render_unreported_error(&error);
+
+        assert!(
+            rendered.starts_with("Error: outer context\n\nCaused by:\n    inner failure"),
+            "unexpected rendering: {rendered:?}"
+        );
+    }
+}

--- a/src/core/repo.rs
+++ b/src/core/repo.rs
@@ -374,9 +374,35 @@ pub fn validate_repo_filters_known(
         .map(|name| format!("'{}'", name))
         .collect::<Vec<_>>()
         .join(", ");
+    let mut suggestions = missing
+        .iter()
+        .flat_map(|filter| {
+            manifest.repos.iter().filter_map(|(manifest_name, config)| {
+                let matches_remote_name = config
+                    .url
+                    .as_deref()
+                    .and_then(parse_git_url)
+                    .is_some_and(|parsed| parsed.repo == filter.as_str());
+                let matches_path_name = std::path::Path::new(&config.path)
+                    .file_name()
+                    .is_some_and(|name| name == std::ffi::OsStr::new(filter.as_str()));
+
+                (matches_remote_name || matches_path_name)
+                    .then(|| format!("'{}' ({})", manifest_name, config.path))
+            })
+        })
+        .collect::<Vec<_>>();
+    suggestions.sort();
+    suggestions.dedup();
+    let suggestion = if suggestions.is_empty() {
+        String::new()
+    } else {
+        format!(" Did you mean {}?", suggestions.join(" or "))
+    };
     anyhow::bail!(
-        "repo filter {} not found in local manifest. If it was added upstream, run `gr sync --repo manifest` or plain `gr sync` first, then retry.",
-        names
+        "repo filter {} not found in local manifest.{} If it was added upstream, run `gr sync --repo manifest` or plain `gr sync` first, then retry.",
+        names,
+        suggestion
     );
 }
 
@@ -1286,6 +1312,55 @@ repos:
         assert!(
             require_explicit_multi_repo_scope(&matched, false, true, "edit", |s| s.to_string())
                 .is_ok()
+        );
+    }
+
+    #[test]
+    fn unknown_manifest_name_suggests_the_matching_remote_repo_name() {
+        let manifest = Manifest::parse(
+            r#"
+repos:
+  synapt:
+    url: https://github.com/example/recall.git
+    path: ./synapt
+"#,
+        )
+        .unwrap();
+
+        let err = validate_repo_filters_known(&manifest, Some(&["recall".to_string()]))
+            .expect_err("a remote repository name is not a manifest selector");
+
+        assert!(
+            err.to_string()
+                .contains("Did you mean 'synapt' (./synapt)?"),
+            "the refusal should bridge from the remote name to the manifest selector: {err}"
+        );
+    }
+
+    #[test]
+    fn remote_name_hint_lists_every_matching_manifest_key_deterministically() {
+        let manifest = Manifest::parse(
+            r#"
+repos:
+  grip-next:
+    url: https://github.com/example/grip.git
+    path: ./next
+    revision: next
+  grip-stable:
+    url: https://github.com/example/grip.git
+    path: ./stable
+    revision: stable
+"#,
+        )
+        .unwrap();
+
+        let err = validate_repo_filters_known(&manifest, Some(&["grip".to_string()]))
+            .expect_err("a remote repository name is not a manifest selector");
+
+        assert!(
+            err.to_string()
+                .contains("Did you mean 'grip-next' (./next) or 'grip-stable' (./stable)?"),
+            "every matching manifest key should be listed in stable order: {err}"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,11 @@
 
 use clap::Parser;
 use gitgrip::cli::args::Cli;
+use gitgrip::cli::outcome::{error_was_reported, exit_code_for_error, render_unreported_error};
+use std::process::ExitCode;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> ExitCode {
     let cli = Cli::parse();
 
     // Initialize tracing — `--verbose` enables debug logging for gitgrip
@@ -23,5 +25,13 @@ async fn main() -> anyhow::Result<()> {
     let verbose = cli.verbose;
     let json = cli.json;
 
-    gitgrip::cli::dispatch::dispatch_command(cli.command, quiet, verbose, json).await
+    match gitgrip::cli::dispatch::dispatch_command(cli.command, quiet, verbose, json).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            if !error_was_reported(&error) {
+                eprintln!("{}", render_unreported_error(&error));
+            }
+            ExitCode::from(exit_code_for_error(&error))
+        }
+    }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -252,6 +252,45 @@ fn test_checkout_add_errors_when_filters_match_no_repos() {
 }
 
 #[test]
+fn test_pr_merge_unknown_repo_is_a_process_level_refusal() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("pr")
+        .arg("merge")
+        .arg("--repo")
+        .arg("missing")
+        .arg("--method")
+        .arg("merge")
+        .arg("--yes")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "repo filter 'missing' not found in local manifest",
+        ));
+}
+
+#[test]
+fn test_pr_merge_known_repo_with_no_open_pr_is_still_success() {
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+
+    let mut cmd = Command::cargo_bin("gr").unwrap();
+    cmd.current_dir(&ws.workspace_root)
+        .arg("pr")
+        .arg("merge")
+        .arg("--repo")
+        .arg("app")
+        .arg("--method")
+        .arg("merge")
+        .arg("--yes")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No open PRs found"))
+        .stdout(predicate::str::contains("Repositories checked: 1"));
+}
+
+#[test]
 fn test_checkout_add_rejects_create_and_base_flags() {
     let ws = WorkspaceBuilder::new().add_repo("app").build();
 

--- a/tests/test_pr_merge.rs
+++ b/tests/test_pr_merge.rs
@@ -431,10 +431,11 @@ async fn test_pr_merge_repo_filter_excludes_non_target() {
 }
 
 // ── Repo Filter: No Matching Repos ────────────────────────────
-// When --repo names a repo that doesn't exist, all repos are filtered out.
+// An explicit selector names something the caller believes exists. Empty is
+// therefore a refusal, not a successful operation over an empty set.
 
 #[tokio::test]
-async fn test_pr_merge_repo_filter_no_match_finds_no_prs() {
+async fn test_pr_merge_repo_filter_no_match_is_a_usage_refusal() {
     let ws = WorkspaceBuilder::new().add_repo("app").build();
 
     let manifest = ws.load_manifest();
@@ -463,10 +464,11 @@ async fn test_pr_merge_repo_filter_no_match_finds_no_prs() {
     )
     .await;
 
+    let err = result.expect_err("an unknown explicit --repo selector must fail");
+    assert_eq!(gitgrip::cli::outcome::exit_code_for_error(&err), 2);
     assert!(
-        result.is_ok(),
-        "repo filter with no matches should succeed with 'no PRs found': {:?}",
-        result.err()
+        err.to_string().contains("nonexistent"),
+        "the refusal must name the selector that matched nothing: {err}"
     );
 }
 
@@ -825,10 +827,11 @@ async fn test_skip_gate_approval_does_not_also_waive_checks() {
     )
     .await;
 
-    assert!(
-        result.is_ok(),
-        "should report, not error: {:?}",
-        result.err()
+    let err = result.expect_err("a live readiness gate must refuse the merge");
+    assert_eq!(
+        gitgrip::cli::outcome::exit_code_for_error(&err),
+        2,
+        "readiness refusal must be distinguishable from operational failure"
     );
 
     let requests = server.received_requests().await.unwrap();
@@ -838,6 +841,72 @@ async fn test_skip_gate_approval_does_not_also_waive_checks() {
             .any(|r| r.method == Method::PUT && r.url.path().ends_with("/merge")),
         "checks were still running and only `approval` was waived — no merge must be sent. \
          If this fires, --skip-gate is behaving as a blanket --force."
+    );
+}
+
+#[tokio::test]
+async fn test_readiness_refusal_reaches_the_process_exit_status() {
+    let (server, _adapter) = setup_github_mock().await;
+
+    let ws = WorkspaceBuilder::new().add_repo("app").build();
+    let mut manifest = ws.load_manifest();
+
+    git_helpers::create_branch(&ws.repo_path("app"), "feat/test");
+    git_helpers::commit_file(
+        &ws.repo_path("app"),
+        "feature.txt",
+        "feature",
+        "Add feature",
+    );
+
+    point_repo_at_mock(&mut manifest, "app", &server);
+    let manifest_yaml = serde_yaml::to_string(&manifest).unwrap();
+    std::fs::write(
+        ws.workspace_root.join(".gitgrip/spaces/main/gripspace.yml"),
+        manifest_yaml,
+    )
+    .unwrap();
+
+    mock_list_prs(&server, vec![(42, "feat/test")]).await;
+    mock_get_pr(&server, 42, "open", false).await;
+    mock_pr_reviews(&server, 42, vec![("COMMENTED", "alice")]).await;
+    mock_check_runs(&server, "feat/test", vec![("CI", "in_progress", None)]).await;
+    mock_merge_pr(&server, 42, true).await;
+
+    let output = tokio::process::Command::new(assert_cmd::cargo::cargo_bin!("gr"))
+        .current_dir(&ws.workspace_root)
+        .env("GITHUB_TOKEN", "test")
+        .args([
+            "pr",
+            "merge",
+            "--skip-gate",
+            "approval",
+            "--method",
+            "merge",
+            "--yes",
+        ])
+        .output()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "readiness refusal must survive dispatch and main; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("Error: merge refused"),
+        "main must not append a generic error after the command rendered the actionable refusal"
+    );
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.method == Method::PUT && r.url.path().ends_with("/merge")),
+        "a refusal with exit 2 must still send no merge request"
     );
 }
 


### PR DESCRIPTION
## Summary

- validate explicit `gr pr merge --repo` selectors before PR discovery, including deterministic hints that list every matching manifest alias
- return exit 2 when a readiness gate deliberately refuses a merge, while preserving exit 1 for operational failures
- keep a valid selection with no open PRs as exit 0, preserve the existing Debug-chain stderr shape, and avoid duplicating an actionable refusal already rendered by the command

## Verification

- `RUST_BACKTRACE=1 cargo test -q` passes on the committed head, matching the repository CI environment
- focused PR-merge tests: 15 passed, 1 ignored
- CLI integration tests: 24 passed
- born-red witnesses covered the unknown selector, the readiness refusal, the remote-name hint, and complete sorted hints for multiple aliases of one remote
- removing selector validation, restoring readiness-path success, or changing the refusal code from 2 to 1 independently makes its matching witness fail
- the stderr-shape witness passes with backtraces both disabled and enabled, while changing Debug rendering to alternate Display makes it fail

## Boundary

This changes only the public CLI outcome contract and its tests. It contains no identity, organization, entitlement, private-repository, or premium architecture behavior.

Ref #884 — closes at promotion

Ref #885 — closes at promotion

Contributes to #886, which remains open for the other verbs.