### PR TITLE
feat(gr2): propagation state machine prototype on synthetic repos

### DIFF
--- a/gr2/prototypes/README.md
+++ b/gr2/prototypes/README.md
@@ -406,3 +406,43 @@ This keeps the cache discussion grounded in evidence:
 - cache remains the optimization
 - the prototype should tell us whether the optimization is material enough to
   justify building it into `apply`
+
+## Propagation State Machine (Prototype 0)
+
+Before any daemon is allowed to move changes between workspaces, the state
+contract for one propagation is proven on synthetic repositories:
+
+```bash
+python3 -m pytest gr2/tests/test_propagation_state_machine.py -q
+```
+
+`gr2/prototypes/propagation_state_machine.py` drives one change through
+`observed -> fetched -> planned -> applied -> verified -> acknowledged`, with
+`refused`, `partial`, and `unverifiable` reachable from any of them. Every
+transition names the observation that established it, and every receipt names
+the exact source and destination revisions. Everything it carries is an opaque
+identifier; it holds no notion of agent or workspace identity and no policy
+content (the allowed directions are a required input with no default).
+
+The tests build a bare source remote and three destinations (a clean replica, a
+dirty authoring clone, an authoring clone that is ahead of the source) and
+prove, each as its own witness:
+
+- killing the sink between each pair of states and replaying applies the change
+  exactly once (measured from the destination's own reflog and the journal)
+- the cursor advances only on `acknowledged`
+- a moved expected base refuses with the observed base in the receipt; nothing
+  is merged, forced, or retried against the new base
+- a dirty or diverged authoring clone is refused and left byte-for-byte
+  untouched (refs, HEAD, index, worktree, reflog)
+- a destination that cannot be read back after the apply verb is recorded as
+  `unverifiable`, never collapsed into `refused` or `applied`, and resolves on
+  replay
+- an acknowledged operation replays as a no-op returning the original outcome;
+  a refused one starts a new attempt, because a refusal describes a moment
+
+It is also the home of a born-red witness for the existing event outbox:
+`read_events()` advances the consumer cursor before the caller performs its
+effect, so a consumer that fails after reading loses the event. The test is
+marked `xfail(strict=True)` and turns the marker into a failure the moment
+acknowledgment moves after the effect.

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -1,0 +1,1141 @@
+"""Prototype 0: a propagation state machine over git repositories.
+
+This prototype proves the state contract for moving one change from a source
+repository to one or more destination clones, before any daemon is allowed near
+a real authoring clone. It is deliberately neutral: every identifier it carries
+(source, destination, layer, artifact class, policy hash) is an opaque string
+the caller resolves; the machine interprets none of them and holds no notion of
+who an agent or a workspace is.
+
+The one rule the contract enforces:
+
+    Every state transition names the observation that establishes it, and that
+    observation must be capable of returning a different answer.
+
+States, in order, each with the observation that establishes it:
+
+    observed      a source change was detected at a named revision
+    fetched       the object is present in the sink's mirror and its digest was
+                  recomputed from the object itself
+    planned       a plan exists, bound to the destination base it was computed
+                  against, with every gate recorded individually
+    applied       the destination itself reports the intended revision (read
+                  back from the destination, never from the verb's exit status)
+    verified      the declared postcondition was checked by name and holds
+    acknowledged  the source cursor advances, only now
+
+and three more reachable from any of them:
+
+    refused       a named refusal condition fired, and which one is recorded
+    partial       some declared targets verified and others did not, both listed
+    unverifiable  the effect may or may not have happened and no observation
+                  available to the sink can tell; never collapsed into either
+                  neighbour, because one invites a double apply and the other
+                  invites work on an effect that may not exist
+
+Idempotency and compare-and-swap:
+
+* every operation has an id derived from (coordinate, source revision, expected
+  base, digest); the journal is keyed so a replay resumes the same operation
+* every destination transition is compare-and-swap on the expected base; a
+  moved base refuses and reports what was observed, it never merges or forces
+* the apply step tolerates exactly one benign discrepancy: a destination that
+  already reports the intended revision is recorded as applied without running
+  the verb again, which is how a sink killed mid-apply replays without applying
+  twice
+
+Replay rules the journal implements:
+
+* an acknowledged operation replays as a no-op returning the original outcome
+* a refused operation is terminal for that attempt only: a later run at the same
+  source revision starts a new attempt, because a refusal describes a moment
+  (a dirty worktree, a moved base) and the author may have changed it
+* anything else resumes from the last recorded state without skipping a state
+
+Everything under ``state_dir`` belongs to the sink: ``journal.jsonl`` (append
+only, one row per transition or note, fsynced), ``cursors/`` (one small file per
+coordinate, written only on acknowledged), and ``mirror.git`` (a bare mirror the
+sink fetches into, so destinations are read but never written before apply).
+
+Fault injection for tests: ``kill_after`` raises :class:`SinkKilled` right after
+the named state is journaled (or right after the apply verb ran, before the read
+back, with ``KILL_AFTER_APPLY_VERB``); ``after_apply_verb`` runs a callable
+between the verb and the read back so a destination can be made unreadable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+KILL_AFTER_APPLY_VERB = "apply-verb"
+
+_GATE_IDS = (
+    "policy.direction",
+    "destination.base-unmoved",
+    "destination.clean",
+    "destination.fast-forward",
+)
+_POSTCONDITION = "head-is-intended-after-and-tree-matches-digest"
+
+# The prototype runs git without the user's global or system configuration so
+# that signing, hook paths, and identity settings on the host cannot reach the
+# synthetic repositories. Callers may pass their own environment.
+_ISOLATED_GIT_ENV = {
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_NOSYSTEM": "1",
+}
+
+
+class SinkKilled(RuntimeError):
+    """The sink process died at a fault-injection point."""
+
+
+class DestinationUnreadable(RuntimeError):
+    """A read against the destination returned an error instead of an answer."""
+
+
+class Direction(StrEnum):
+    DOWN = "down"
+    UP = "up"
+    ACROSS = "across"
+
+
+class Operation(StrEnum):
+    APPLY = "apply"
+    CONTRIBUTE = "contribute"
+    OBSERVE = "observe"
+
+
+class DestinationKind(StrEnum):
+    REPLICA = "replica"
+    AUTHORING = "authoring"
+
+
+class State(StrEnum):
+    OBSERVED = "observed"
+    FETCHED = "fetched"
+    PLANNED = "planned"
+    APPLIED = "applied"
+    VERIFIED = "verified"
+    ACKNOWLEDGED = "acknowledged"
+    REFUSED = "refused"
+    PARTIAL = "partial"
+    UNVERIFIABLE = "unverifiable"
+
+
+_ORDERED = (
+    State.OBSERVED,
+    State.FETCHED,
+    State.PLANNED,
+    State.APPLIED,
+    State.VERIFIED,
+    State.ACKNOWLEDGED,
+)
+
+
+@dataclass(frozen=True)
+class Coordinate:
+    source: str
+    destination: str
+    layer: str
+    direction: Direction
+    operation: Operation
+    artifact_class: str
+
+    def key(self) -> str:
+        return "|".join(
+            (
+                self.source,
+                self.destination,
+                self.layer,
+                str(self.direction),
+                str(self.operation),
+                self.artifact_class,
+            )
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "source": self.source,
+            "destination": self.destination,
+            "layer": self.layer,
+            "direction": str(self.direction),
+            "operation": str(self.operation),
+            "artifact_class": self.artifact_class,
+        }
+
+
+@dataclass(frozen=True)
+class Destination:
+    destination_id: str
+    path: Path
+    kind: DestinationKind
+
+
+@dataclass(frozen=True)
+class Policy:
+    """Opaque policy inputs. The caller resolves them; the machine only applies them.
+
+    ``allowed_directions`` has no default on purpose: a permissive default would
+    be the decision, whoever wrote it.
+    """
+
+    policy_hash: str
+    allowed_directions: frozenset[Direction]
+
+
+@dataclass(frozen=True)
+class GateResult:
+    gate_id: str
+    result: str
+    detail: str
+    result_hash: str
+
+    def as_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Transition:
+    state: State
+    observation: dict[str, object]
+    timestamp: str
+    operation_id: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "state": str(self.state),
+            "observation": self.observation,
+            "timestamp": self.timestamp,
+            "operation_id": self.operation_id,
+        }
+
+
+@dataclass(frozen=True)
+class Observation:
+    source_rev: str
+    cursor: str | None
+    is_new: bool
+
+
+@dataclass(frozen=True)
+class Receipt:
+    pending_id: str
+    attempt: int
+    operation_id: str | None
+    coordinate: Coordinate
+    source_rev: str
+    expected_base: str
+    observed_base: str | None
+    after: str | None
+    digest: str | None
+    plan_hash: str | None
+    policy_hash: str
+    gate_results: tuple[GateResult, ...]
+    state: State
+    postcondition_checked: str | None
+    postcondition_holds: bool | None
+    timestamp: str
+    refusal_reason: str | None
+    detail: str
+    transitions: tuple[Transition, ...]
+    replayed: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "pending_id": self.pending_id,
+            "attempt": self.attempt,
+            "operation_id": self.operation_id,
+            "coordinate": self.coordinate.as_dict(),
+            "source_rev": self.source_rev,
+            "expected_base": self.expected_base,
+            "observed_base": self.observed_base,
+            "after": self.after,
+            "digest": self.digest,
+            "plan_hash": self.plan_hash,
+            "policy_hash": self.policy_hash,
+            "gate_results": [g.as_dict() for g in self.gate_results],
+            "state": str(self.state),
+            "postcondition_checked": self.postcondition_checked,
+            "postcondition_holds": self.postcondition_holds,
+            "timestamp": self.timestamp,
+            "refusal_reason": self.refusal_reason,
+            "detail": self.detail,
+            "transitions": [t.as_dict() for t in self.transitions],
+            "replayed": self.replayed,
+        }
+
+
+@dataclass(frozen=True)
+class PlanOutcome:
+    state: State
+    reached: tuple[str, ...]
+    not_reached: tuple[tuple[str, str], ...]
+    receipts: tuple[Receipt, ...]
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _sha256_json(obj: object) -> str:
+    return hashlib.sha256(
+        json.dumps(obj, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def operation_id_for(coordinate_key: str, source_rev: str, expected_base: str, digest: str) -> str:
+    return _sha256_json(
+        {
+            "coordinate": coordinate_key,
+            "source_rev": source_rev,
+            "expected_base": expected_base,
+            "digest": digest,
+        }
+    )
+
+
+def pending_id_for(coordinate_key: str, source_rev: str, attempt: int) -> str:
+    return _sha256_json(
+        {"coordinate": coordinate_key, "source_rev": source_rev, "attempt": attempt}
+    )
+
+
+def _git(repo: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or _ISOLATED_GIT_ENV)},
+    )
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, proc.args, proc.stdout, proc.stderr)
+    return proc.stdout.strip()
+
+
+def tree_digest(repo: Path, rev: str, env: dict[str, str] | None = None) -> str:
+    """The content digest of a revision: its tree id, recomputed from the object store."""
+    return _git(repo, "rev-parse", f"{rev}^{{tree}}", env=env)
+
+
+# --------------------------------------------------------------------------- journal
+
+
+class Journal:
+    """Append-only record of transitions and notes, plus per-coordinate cursors."""
+
+    def __init__(self, state_dir: Path) -> None:
+        self.state_dir = state_dir
+        self.path = state_dir / "journal.jsonl"
+        self.cursors_dir = state_dir / "cursors"
+
+    # -- rows
+
+    def _rows(self) -> list[dict[str, object]]:
+        if not self.path.exists():
+            return []
+        rows: list[dict[str, object]] = []
+        for line in self.path.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+        return rows
+
+    def _write(self, row: dict[str, object]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a") as handle:
+            handle.write(json.dumps(row, separators=(",", ":")) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def append(
+        self,
+        *,
+        pending_id: str,
+        attempt: int,
+        operation_id: str | None,
+        coordinate_key: str,
+        source_rev: str,
+        state: State,
+        observation: dict[str, object],
+    ) -> Transition:
+        transition = Transition(
+            state=state, observation=observation, timestamp=_now(), operation_id=operation_id
+        )
+        self._write(
+            {
+                "kind": "transition",
+                "pending_id": pending_id,
+                "attempt": attempt,
+                "operation_id": operation_id,
+                "coordinate_key": coordinate_key,
+                "source_rev": source_rev,
+                **transition.as_dict(),
+            }
+        )
+        return transition
+
+    def note(
+        self,
+        *,
+        pending_id: str,
+        attempt: int,
+        coordinate_key: str,
+        source_rev: str,
+        note: str,
+        data: dict[str, object] | None = None,
+    ) -> None:
+        self._write(
+            {
+                "kind": "note",
+                "pending_id": pending_id,
+                "attempt": attempt,
+                "coordinate_key": coordinate_key,
+                "source_rev": source_rev,
+                "note": note,
+                "data": data or {},
+                "timestamp": _now(),
+            }
+        )
+
+    def rows_for(self, coordinate_key: str, source_rev: str) -> list[dict[str, object]]:
+        return [
+            r
+            for r in self._rows()
+            if r.get("coordinate_key") == coordinate_key and r.get("source_rev") == source_rev
+        ]
+
+    def find(self, coordinate_key: str, source_rev: str) -> list[list[Transition]]:
+        """Every attempt at (coordinate, source revision), oldest first, each as its transitions."""
+        attempts: dict[int, list[Transition]] = {}
+        for row in self.rows_for(coordinate_key, source_rev):
+            if row.get("kind") != "transition":
+                continue
+            attempts.setdefault(int(row["attempt"]), []).append(
+                Transition(
+                    state=State(str(row["state"])),
+                    observation=dict(row["observation"]),  # type: ignore[arg-type]
+                    timestamp=str(row["timestamp"]),
+                    operation_id=row.get("operation_id"),  # type: ignore[arg-type]
+                )
+            )
+        return [attempts[k] for k in sorted(attempts)]
+
+    def notes(self, coordinate_key: str, source_rev: str, note: str) -> int:
+        return sum(
+            1
+            for r in self.rows_for(coordinate_key, source_rev)
+            if r.get("kind") == "note" and r.get("note") == note
+        )
+
+    # -- cursors
+
+    def cursor_path(self, coordinate_key: str) -> Path:
+        return self.cursors_dir / (hashlib.sha256(coordinate_key.encode()).hexdigest() + ".json")
+
+    def cursor(self, coordinate_key: str) -> str | None:
+        path = self.cursor_path(coordinate_key)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+        value = data.get("source_rev")
+        return str(value) if value else None
+
+    def advance_cursor(self, coordinate_key: str, source_rev: str, pending_id: str) -> None:
+        self.cursors_dir.mkdir(parents=True, exist_ok=True)
+        path = self.cursor_path(coordinate_key)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(
+                {
+                    "coordinate_key": coordinate_key,
+                    "source_rev": source_rev,
+                    "pending_id": pending_id,
+                    "advanced_at": _now(),
+                },
+                indent=2,
+            )
+        )
+        with tmp.open("rb") as handle:
+            os.fsync(handle.fileno())
+        tmp.rename(path)
+
+
+# ------------------------------------------------------------------------ the machine
+
+
+@dataclass
+class _Op:
+    """The in-flight operation, reconstructed from the journal on resume."""
+
+    coordinate: Coordinate
+    destination: Destination
+    source_rev: str
+    attempt: int
+    pending_id: str
+    previous_cursor: str | None
+    expected_base: str | None = None
+    digest: str | None = None
+    operation_id: str | None = None
+    observed_base: str | None = None
+    intended_after: str | None = None
+    plan_hash: str | None = None
+    gate_results: tuple[GateResult, ...] = ()
+    transitions: list[Transition] = field(default_factory=list)
+
+    @property
+    def key(self) -> str:
+        return self.coordinate.key()
+
+
+class Propagator:
+    def __init__(
+        self,
+        source_remote: Path,
+        branch: str,
+        state_dir: Path,
+        policy: Policy,
+        *,
+        kill_after: State | str | None = None,
+        after_apply_verb: Callable[[], None] | None = None,
+        git_env: dict[str, str] | None = None,
+    ) -> None:
+        self.source_remote = source_remote
+        self.branch = branch
+        self.state_dir = state_dir
+        self.policy = policy
+        self.kill_after = kill_after
+        self.after_apply_verb = after_apply_verb
+        self.git_env = git_env or _ISOLATED_GIT_ENV
+        self.journal = Journal(state_dir)
+        self.mirror = state_dir / "mirror.git"
+
+    # -- observation of the source
+
+    def observe_source_at(self, cursor: str | None) -> Observation:
+        out = subprocess.run(
+            ["git", "ls-remote", str(self.source_remote), f"refs/heads/{self.branch}"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, **self.git_env},
+        )
+        if out.returncode != 0 or not out.stdout.strip():
+            raise RuntimeError(
+                f"source {self.source_remote} has no branch {self.branch}: {out.stderr.strip()}"
+            )
+        source_rev = out.stdout.split()[0]
+        return Observation(source_rev=source_rev, cursor=cursor, is_new=(source_rev != cursor))
+
+    def observe_source(self, coordinate: Coordinate) -> Observation:
+        return self.observe_source_at(self.journal.cursor(coordinate.key()))
+
+    # -- destination reads (never writes before apply)
+
+    def read_head(self, destination: Destination) -> str:
+        try:
+            return _git(destination.path, "rev-parse", "HEAD", env=self.git_env)
+        except (subprocess.CalledProcessError, OSError) as exc:
+            raise DestinationUnreadable(f"{destination.destination_id}: {exc}") from exc
+
+    def _porcelain(self, destination: Destination) -> str:
+        return _git(destination.path, "status", "--porcelain", env=self.git_env)
+
+    # -- driver
+
+    def run(self, coordinate: Coordinate, destination: Destination) -> Receipt | None:
+        key = coordinate.key()
+        observation = self.observe_source(coordinate)
+        if not observation.is_new:
+            return None
+        source_rev = observation.source_rev
+
+        attempts = self.journal.find(key, source_rev)
+        if attempts:
+            last = attempts[-1]
+            last_state = last[-1].state
+            if last_state is State.ACKNOWLEDGED:
+                # terminal: the original outcome, no verb, and the cursor repaired if it lagged
+                attempt = len(attempts)
+                pending_id = pending_id_for(key, source_rev, attempt)
+                self.journal.note(
+                    pending_id=pending_id,
+                    attempt=attempt,
+                    coordinate_key=key,
+                    source_rev=source_rev,
+                    note="replayed-terminal",
+                    data={"state": str(last_state)},
+                )
+                self.journal.advance_cursor(key, source_rev, pending_id)
+                return self._receipt(coordinate, source_rev, attempt, replayed=True)
+            if last_state is State.REFUSED:
+                op = self._fresh(
+                    coordinate,
+                    destination,
+                    source_rev,
+                    observation.cursor,
+                    attempt=len(attempts) + 1,
+                )
+            else:
+                op = self._resume(
+                    coordinate,
+                    destination,
+                    source_rev,
+                    observation.cursor,
+                    attempt=len(attempts),
+                    transitions=last,
+                )
+        else:
+            op = self._fresh(coordinate, destination, source_rev, observation.cursor, attempt=1)
+
+        self._drive(op)
+        return self._receipt(coordinate, source_rev, op.attempt, replayed=False)
+
+    def run_all(self, targets: Iterable[tuple[Coordinate, Destination]]) -> PlanOutcome | None:
+        receipts: list[Receipt] = []
+        for coordinate, destination in targets:
+            receipt = self.run(coordinate, destination)
+            if receipt is not None:
+                receipts.append(receipt)
+        if not receipts:
+            return None
+        reached = tuple(r.coordinate.destination for r in receipts if r.state is State.ACKNOWLEDGED)
+        not_reached = tuple(
+            (r.coordinate.destination, r.refusal_reason or r.detail or f"state={r.state}")
+            for r in receipts
+            if r.state is not State.ACKNOWLEDGED
+        )
+        if not not_reached:
+            state = State.ACKNOWLEDGED
+        elif not reached:
+            state = State.REFUSED
+        else:
+            state = State.PARTIAL
+        return PlanOutcome(
+            state=state, reached=reached, not_reached=not_reached, receipts=tuple(receipts)
+        )
+
+    # -- attempt construction
+
+    def _fresh(
+        self,
+        coordinate: Coordinate,
+        destination: Destination,
+        source_rev: str,
+        cursor: str | None,
+        *,
+        attempt: int,
+    ) -> _Op:
+        return _Op(
+            coordinate=coordinate,
+            destination=destination,
+            source_rev=source_rev,
+            attempt=attempt,
+            pending_id=pending_id_for(coordinate.key(), source_rev, attempt),
+            previous_cursor=cursor,
+        )
+
+    def _resume(
+        self,
+        coordinate: Coordinate,
+        destination: Destination,
+        source_rev: str,
+        cursor: str | None,
+        *,
+        attempt: int,
+        transitions: list[Transition],
+    ) -> _Op:
+        op = self._fresh(coordinate, destination, source_rev, cursor, attempt=attempt)
+        op.transitions = list(transitions)
+        for t in transitions:
+            obs = t.observation
+            if t.state is State.OBSERVED:
+                op.expected_base = str(obs["expected_base"])
+            elif t.state is State.FETCHED:
+                op.digest = str(obs["digest"])
+                op.operation_id = t.operation_id
+            elif t.state is State.PLANNED:
+                op.observed_base = str(obs["observed_base"])
+                op.intended_after = str(obs["intended_after"])
+                op.plan_hash = str(obs["plan_hash"])
+                op.gate_results = tuple(
+                    GateResult(**g)
+                    for g in obs["gate_results"]  # type: ignore[arg-type]
+                )
+        return op
+
+    # -- the state machine
+
+    def _drive(self, op: _Op) -> None:
+        last = op.transitions[-1].state if op.transitions else None
+        if last is None:
+            self._observe(op)
+            last = State.OBSERVED
+        if last is State.OBSERVED:
+            self._fetch(op)
+            last = State.FETCHED
+        if last is State.FETCHED:
+            if not self._plan(op):
+                return  # refused at plan; journaled
+            last = State.PLANNED
+        if last in (State.PLANNED, State.UNVERIFIABLE):
+            if not self._apply(op):
+                return  # refused or unverifiable; journaled
+            last = State.APPLIED
+        if last is State.APPLIED:
+            if not self._verify(op):
+                return  # postcondition did not hold; journaled as a note, state stays applied
+            last = State.VERIFIED
+        if last is State.VERIFIED:
+            self._acknowledge(op)
+
+    def _record(self, op: _Op, state: State, observation: dict[str, object]) -> None:
+        transition = self.journal.append(
+            pending_id=op.pending_id,
+            attempt=op.attempt,
+            operation_id=op.operation_id,
+            coordinate_key=op.key,
+            source_rev=op.source_rev,
+            state=state,
+            observation=observation,
+        )
+        op.transitions.append(transition)
+        if self.kill_after == state:
+            raise SinkKilled(f"killed after {state}")
+
+    def _note(self, op: _Op, note: str, data: dict[str, object] | None = None) -> None:
+        self.journal.note(
+            pending_id=op.pending_id,
+            attempt=op.attempt,
+            coordinate_key=op.key,
+            source_rev=op.source_rev,
+            note=note,
+            data=data,
+        )
+
+    def _observe(self, op: _Op) -> None:
+        op.expected_base = self.read_head(op.destination)
+        self._record(
+            op,
+            State.OBSERVED,
+            {
+                "source_rev": op.source_rev,
+                "source_branch": self.branch,
+                "previous_cursor": op.previous_cursor,
+                "expected_base": op.expected_base,
+                "established_by": (
+                    "ls-remote on the source reported a revision the cursor did not name"
+                ),
+            },
+        )
+
+    def _fetch(self, op: _Op) -> None:
+        if not self.mirror.exists():
+            self.mirror.parent.mkdir(parents=True, exist_ok=True)
+            subprocess.run(
+                ["git", "init", "-q", "--bare", str(self.mirror)],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, **self.git_env},
+            )
+        _git(
+            self.mirror,
+            "fetch",
+            "-q",
+            str(self.source_remote),
+            f"+refs/heads/{self.branch}:refs/remotes/source/{self.branch}",
+            env=self.git_env,
+        )
+        # presence is asserted against the object itself, not the fetch's exit status
+        _git(self.mirror, "cat-file", "-e", f"{op.source_rev}^{{commit}}", env=self.git_env)
+        op.digest = tree_digest(self.mirror, op.source_rev, env=self.git_env)
+        assert op.expected_base is not None
+        op.operation_id = operation_id_for(op.key, op.source_rev, op.expected_base, op.digest)
+        self._record(
+            op,
+            State.FETCHED,
+            {
+                "digest": op.digest,
+                "mirror": str(self.mirror),
+                "established_by": (
+                    "cat-file -e on the mirror and the tree id recomputed from the object"
+                ),
+            },
+        )
+
+    def _gate(self, gate_id: str, passed: bool, detail: str) -> GateResult:
+        result = "pass" if passed else "fail"
+        return GateResult(
+            gate_id=gate_id,
+            result=result,
+            detail=detail,
+            result_hash=_sha256_json({"gate": gate_id, "result": result, "detail": detail}),
+        )
+
+    def _plan(self, op: _Op) -> bool:
+        assert op.expected_base is not None and op.digest is not None
+        gates: list[GateResult] = []
+
+        allowed = op.coordinate.direction in self.policy.allowed_directions
+        gates.append(
+            self._gate(
+                "policy.direction",
+                allowed,
+                f"direction={op.coordinate.direction} "
+                f"allowed={sorted(str(d) for d in self.policy.allowed_directions)}",
+            )
+        )
+
+        op.observed_base = self.read_head(op.destination)
+        gates.append(
+            self._gate(
+                "destination.base-unmoved",
+                op.observed_base == op.expected_base,
+                f"expected_base={op.expected_base} observed_base={op.observed_base}",
+            )
+        )
+
+        porcelain = self._porcelain(op.destination)
+        gates.append(
+            self._gate(
+                "destination.clean",
+                porcelain == "",
+                "worktree and index clean"
+                if porcelain == ""
+                else f"dirty: {len(porcelain.splitlines())} path(s)",
+            )
+        )
+
+        # the destination's HEAD is fetched INTO the mirror (a read of the destination),
+        # so ahead/behind is computed in the sink's own store
+        observed_tag = hashlib.sha256(op.destination.destination_id.encode()).hexdigest()[:16]
+        observed_ref = f"refs/observed/{observed_tag}"
+        _git(
+            self.mirror,
+            "fetch",
+            "-q",
+            str(op.destination.path),
+            f"+HEAD:{observed_ref}",
+            env=self.git_env,
+        )
+        counts = _git(
+            self.mirror,
+            "rev-list",
+            "--left-right",
+            "--count",
+            f"{op.source_rev}...{observed_ref}",
+            env=self.git_env,
+        )
+        behind_s, ahead_s = counts.split()
+        behind, ahead = int(behind_s), int(ahead_s)
+        gates.append(
+            self._gate(
+                "destination.fast-forward",
+                ahead == 0,
+                f"ahead={ahead} behind={behind} (destination relative to source revision)",
+            )
+        )
+
+        op.intended_after = op.source_rev
+        op.gate_results = tuple(gates)
+        op.plan_hash = _sha256_json(
+            {
+                "operation_id": op.operation_id,
+                "intended_after": op.intended_after,
+                "policy_hash": self.policy.policy_hash,
+                "gates": [g.gate_id for g in gates],
+                "destination_kind": str(op.destination.kind),
+            }
+        )
+        self._record(
+            op,
+            State.PLANNED,
+            {
+                "observed_base": op.observed_base,
+                "intended_after": op.intended_after,
+                "plan_hash": op.plan_hash,
+                "policy_hash": self.policy.policy_hash,
+                "gate_results": [g.as_dict() for g in gates],
+                "established_by": (
+                    "every gate evaluated and recorded individually against the destination "
+                    "as read now"
+                ),
+            },
+        )
+        failed = [g for g in gates if g.result == "fail"]
+        if failed:
+            first = failed[0]
+            self._record(
+                op,
+                State.REFUSED,
+                {
+                    "refusal_reason": f"{first.gate_id}: {first.detail}",
+                    "failed_gates": [g.gate_id for g in failed],
+                    "observed_base": op.observed_base,
+                },
+            )
+            return False
+        return True
+
+    def _apply(self, op: _Op) -> bool:
+        assert op.expected_base is not None and op.intended_after is not None
+        try:
+            head = self.read_head(op.destination)
+        except DestinationUnreadable as exc:
+            # nothing has been done to the destination yet, so this is a named refusal
+            self._record(
+                op,
+                State.REFUSED,
+                {"refusal_reason": f"destination.unreadable: {exc}", "observed_base": None},
+            )
+            return False
+
+        if head == op.intended_after:
+            # the verb landed in an earlier life of this sink; do not run it again
+            self._record(
+                op,
+                State.APPLIED,
+                {
+                    "after": head,
+                    "observed_base": head,
+                    "verb_ran_now": False,
+                    "established_by": (
+                        "read-back found the intended revision already at the destination"
+                    ),
+                },
+            )
+            return True
+        if head != op.expected_base:
+            self._record(
+                op,
+                State.REFUSED,
+                {
+                    "refusal_reason": (
+                        f"expected_base moved: expected {op.expected_base}, observed {head}"
+                    ),
+                    "observed_base": head,
+                },
+            )
+            return False
+
+        self._note(
+            op, "apply-verb-started", {"expected_base": head, "intended_after": op.intended_after}
+        )
+        _git(
+            op.destination.path,
+            "fetch",
+            "-q",
+            str(self.mirror),
+            f"refs/remotes/source/{self.branch}",
+            env=self.git_env,
+        )
+        _git(op.destination.path, "merge", "-q", "--ff-only", op.intended_after, env=self.git_env)
+        if self.after_apply_verb is not None:
+            self.after_apply_verb()
+        if self.kill_after == KILL_AFTER_APPLY_VERB:
+            raise SinkKilled("killed after the apply verb, before the read back")
+
+        try:
+            after = self.read_head(op.destination)
+        except DestinationUnreadable as exc:
+            self._record(
+                op,
+                State.UNVERIFIABLE,
+                {
+                    "detail": (
+                        f"the apply verb returned but the destination could not be read back: {exc}"
+                    ),
+                    "observed_base": None,
+                },
+            )
+            return False
+
+        if after != op.intended_after:
+            self._record(
+                op,
+                State.REFUSED,
+                {
+                    "refusal_reason": (
+                        f"destination.apply-mismatch: verb returned but destination reports {after}"
+                    ),
+                    "observed_base": after,
+                },
+            )
+            return False
+
+        self._record(
+            op,
+            State.APPLIED,
+            {
+                "after": after,
+                "observed_base": head,
+                "verb_ran_now": True,
+                "established_by": (
+                    "rev-parse HEAD on the destination after the verb reports the intended revision"
+                ),
+            },
+        )
+        return True
+
+    def _verify(self, op: _Op) -> bool:
+        assert op.intended_after is not None and op.digest is not None
+        head = self.read_head(op.destination)
+        tree = tree_digest(op.destination.path, head, env=self.git_env)
+        porcelain = self._porcelain(op.destination)
+        holds = head == op.intended_after and tree == op.digest and porcelain == ""
+        detail = f"head={head} tree={tree} clean={porcelain == ''}"
+        if not holds:
+            self._note(
+                op, "postcondition-failed", {"postcondition": _POSTCONDITION, "detail": detail}
+            )
+            return False
+        self._record(
+            op,
+            State.VERIFIED,
+            {
+                "postcondition_checked": _POSTCONDITION,
+                "holds": True,
+                "detail": detail,
+                "established_by": "the named postcondition re-read from the destination",
+            },
+        )
+        return True
+
+    def _acknowledge(self, op: _Op) -> None:
+        # the journal row is the acknowledgment; the cursor is derived from it and
+        # repaired from it on replay, so the row is written first
+        self._record(
+            op,
+            State.ACKNOWLEDGED,
+            {"cursor": op.source_rev, "established_by": "verified was recorded for this operation"},
+        )
+        self.journal.advance_cursor(op.key, op.source_rev, op.pending_id)
+
+    # -- receipts
+
+    def _receipt(
+        self, coordinate: Coordinate, source_rev: str, attempt: int, *, replayed: bool
+    ) -> Receipt:
+        key = coordinate.key()
+        # rows are read in journal order: a note and a later transition about the same
+        # fact resolve to whichever came last, never to whichever kind is handled last
+        rows = [r for r in self.journal.rows_for(key, source_rev) if int(r["attempt"]) == attempt]
+        transitions: list[Transition] = []
+
+        expected_base = ""
+        observed_base: str | None = None
+        after: str | None = None
+        digest: str | None = None
+        operation_id: str | None = None
+        plan_hash: str | None = None
+        gate_results: tuple[GateResult, ...] = ()
+        postcondition_checked: str | None = None
+        postcondition_holds: bool | None = None
+        refusal_reason: str | None = None
+        detail = ""
+
+        for row in rows:
+            if row.get("kind") == "note":
+                if row.get("note") == "postcondition-failed":
+                    data = row.get("data") or {}
+                    postcondition_checked = str(data.get("postcondition", _POSTCONDITION))  # type: ignore[union-attr]
+                    postcondition_holds = False
+                    detail = str(data.get("detail", ""))  # type: ignore[union-attr]
+                continue
+            t = Transition(
+                state=State(str(row["state"])),
+                observation=dict(row["observation"]),  # type: ignore[arg-type]
+                timestamp=str(row["timestamp"]),
+                operation_id=row.get("operation_id"),  # type: ignore[arg-type]
+            )
+            transitions.append(t)
+            obs = t.observation
+            if t.state is State.OBSERVED:
+                expected_base = str(obs["expected_base"])
+            elif t.state is State.FETCHED:
+                digest = str(obs["digest"])
+                operation_id = t.operation_id
+            elif t.state is State.PLANNED:
+                observed_base = str(obs["observed_base"])
+                plan_hash = str(obs["plan_hash"])
+                gate_results = tuple(GateResult(**g) for g in obs["gate_results"])  # type: ignore[arg-type]
+            elif t.state is State.APPLIED:
+                after = str(obs["after"])
+                observed_base = str(obs["observed_base"])
+            elif t.state is State.VERIFIED:
+                postcondition_checked = str(obs["postcondition_checked"])
+                postcondition_holds = True
+                detail = str(obs.get("detail", ""))
+            elif t.state is State.REFUSED:
+                refusal_reason = str(obs["refusal_reason"])
+                if obs.get("observed_base") is not None:
+                    observed_base = str(obs["observed_base"])
+            elif t.state is State.UNVERIFIABLE:
+                detail = str(obs["detail"])
+
+        if not transitions:
+            raise LookupError(
+                f"no transitions journaled for attempt {attempt} of {key} @ {source_rev}"
+            )
+        state = transitions[-1].state
+        return Receipt(
+            pending_id=pending_id_for(key, source_rev, attempt),
+            attempt=attempt,
+            operation_id=operation_id,
+            coordinate=coordinate,
+            source_rev=source_rev,
+            expected_base=expected_base,
+            observed_base=observed_base,
+            after=after,
+            digest=digest,
+            plan_hash=plan_hash,
+            policy_hash=self.policy.policy_hash,
+            gate_results=gate_results,
+            state=state,
+            postcondition_checked=postcondition_checked,
+            postcondition_holds=postcondition_holds,
+            timestamp=transitions[-1].timestamp,
+            refusal_reason=refusal_reason,
+            detail=detail,
+            transitions=tuple(transitions),
+            replayed=replayed,
+        )
+
+
+__all__ = [
+    "KILL_AFTER_APPLY_VERB",
+    "Coordinate",
+    "Destination",
+    "DestinationKind",
+    "DestinationUnreadable",
+    "Direction",
+    "GateResult",
+    "Journal",
+    "Observation",
+    "Operation",
+    "PlanOutcome",
+    "Policy",
+    "Propagator",
+    "Receipt",
+    "SinkKilled",
+    "State",
+    "Transition",
+    "operation_id_for",
+    "pending_id_for",
+    "tree_digest",
+]

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -573,10 +573,23 @@ class Propagator:
     # -- driver
 
     def run(self, coordinate: Coordinate, destination: Destination) -> Receipt | None:
+        """Drive one coordinate. ``None`` means no new source revision: not an operation."""
+        return self._run(coordinate, destination, report_current=False)
+
+    def _run(
+        self, coordinate: Coordinate, destination: Destination, *, report_current: bool
+    ) -> Receipt | None:
         key = coordinate.key()
         observation = self.observe_source(coordinate)
         if not observation.is_new:
-            return None
+            if not report_current:
+                return None
+            # The cursor is AT the source revision, which only happens after an
+            # acknowledgement at that revision. For an aggregate the target was
+            # declared and already reached; report the terminal outcome rather
+            # than dropping the target, because a dropped target is
+            # indistinguishable from one that was never part of the invocation.
+            return self._terminal_receipt(coordinate, observation.source_rev)
         source_rev = observation.source_rev
 
         attempts = self.journal.find(key, source_rev)
@@ -620,10 +633,32 @@ class Propagator:
         self._drive(op)
         return self._receipt(coordinate, source_rev, op.attempt, replayed=False)
 
+    def _terminal_receipt(self, coordinate: Coordinate, source_rev: str) -> Receipt:
+        """The original outcome for a coordinate whose cursor is already at ``source_rev``."""
+        attempts = self.journal.find(coordinate.key(), source_rev)
+        if not attempts or attempts[-1][-1].state is not State.ACKNOWLEDGED:
+            # A cursor at a revision the journal never acknowledged is a corrupted
+            # sink state, and the prototype says so rather than guessing an outcome.
+            raise RuntimeError(
+                f"cursor for {coordinate.destination} is at {source_rev} but the journal "
+                "carries no acknowledged attempt at that revision"
+            )
+        return self._receipt(coordinate, source_rev, len(attempts), replayed=True)
+
     def run_all(self, targets: Iterable[tuple[Coordinate, Destination]]) -> PlanOutcome | None:
+        """Drive every declared target and classify the aggregate.
+
+        A declared target whose cursor is already at the source revision was reached
+        by an earlier invocation; it is reported as reached with its terminal receipt
+        (``replayed=True``), never dropped. Dropping it would reclassify a replayed
+        ``partial`` as ``refused``, which is what the first cut did (found in review):
+        the aggregate must distinguish "already reached" from "not part of this
+        invocation", and the only way to do that is to keep reporting it.
+        ``None`` only when no targets were declared.
+        """
         receipts: list[Receipt] = []
         for coordinate, destination in targets:
-            receipt = self.run(coordinate, destination)
+            receipt = self._run(coordinate, destination, report_current=True)
             if receipt is not None:
                 receipts.append(receipt)
         if not receipts:

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -573,7 +573,10 @@ class Propagator:
     # -- driver
 
     def run(self, coordinate: Coordinate, destination: Destination) -> Receipt | None:
-        """Drive one coordinate. ``None`` means no new source revision: not an operation."""
+        """Drive one coordinate. ``None`` means no new source revision: not an operation.
+
+        Raises if the cursor sits at a revision the journal never acknowledged.
+        """
         return self._run(coordinate, destination, report_current=False)
 
     def _run(
@@ -582,14 +585,16 @@ class Propagator:
         key = coordinate.key()
         observation = self.observe_source(coordinate)
         if not observation.is_new:
-            if not report_current:
-                return None
             # The cursor is AT the source revision, which only happens after an
-            # acknowledgement at that revision. For an aggregate the target was
-            # declared and already reached; report the terminal outcome rather
-            # than dropping the target, because a dropped target is
-            # indistinguishable from one that was never part of the invocation.
-            return self._terminal_receipt(coordinate, observation.source_rev)
+            # acknowledgement at that revision; _terminal_receipt RAISES if the
+            # journal carries no such acknowledgement, on both paths, because a
+            # cursor the journal cannot account for is a corrupted sink state and
+            # "nothing new" is exactly the answer that would hide it. For an
+            # aggregate the target was declared and already reached; report the
+            # terminal outcome rather than dropping the target, because a dropped
+            # target is indistinguishable from one never part of the invocation.
+            terminal = self._terminal_receipt(coordinate, observation.source_rev)
+            return terminal if report_current else None
         source_rev = observation.source_rev
 
         attempts = self.journal.find(key, source_rev)

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -151,15 +151,30 @@ class Coordinate:
     artifact_class: str
 
     def key(self) -> str:
-        return "|".join(
-            (
-                self.source,
-                self.destination,
-                self.layer,
-                str(self.direction),
-                str(self.operation),
-                self.artifact_class,
-            )
+        """Canonical, injective key: the JSON of ``as_dict()`` with sorted keys.
+
+        The fields are OPAQUE identifiers, so no delimiter can be assumed absent
+        from them. A ``"|".join`` made ``("source|dest", "target", ...)`` and
+        ``("source", "dest|target", ...)`` the same key, and the key names the
+        journal rows and the cursor file, so two coordinates would have shared
+        replay state (found in review of the first cut). JSON string encoding
+        escapes every byte that could be mistaken for structure, so the key
+        round-trips: ``json.loads(key) == as_dict()``. Distinct coordinates
+        therefore cannot collide, and the witness asserts the round-trip rather
+        than any particular pair.
+        """
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_key(cls, key: str) -> Coordinate:
+        data = json.loads(key)
+        return cls(
+            source=str(data["source"]),
+            destination=str(data["destination"]),
+            layer=str(data["layer"]),
+            direction=Direction(str(data["direction"])),
+            operation=Operation(str(data["operation"])),
+            artifact_class=str(data["artifact_class"]),
         )
 
     def as_dict(self) -> dict[str, str]:

--- a/gr2/tests/test_propagation_state_machine.py
+++ b/gr2/tests/test_propagation_state_machine.py
@@ -1,0 +1,660 @@
+"""Prototype 0: the propagation state machine, proven on synthetic git repositories.
+
+Everything here runs against throwaway repositories under ``tmp_path``. No real
+workspace, remote, or authoring clone is touched. The synthetic topology is:
+
+* one bare "source" remote with a config-like file on ``main``
+* three destinations: a clean managed replica, a dirty authoring clone, and an
+  authoring clone that is ahead of (and behind) the source
+
+What the tests prove, each as its own witness:
+
+* one change walks observed -> fetched -> planned -> applied -> verified ->
+  acknowledged, and every receipt names exact source and destination revisions
+* killing the sink between each pair of states and replaying applies the change
+  exactly once, with the cursor advancing only on acknowledged
+* a moved expected base refuses (compare-and-swap) and the receipt carries the
+  observed base; nothing is merged or forced
+* a dirty authoring clone and a diverged authoring clone are refused and left
+  byte-for-byte untouched
+* a destination that cannot be read back after the apply verb is recorded as
+  ``unverifiable`` (never collapsed into refused or applied) and resolves on replay
+* some destinations verifying while others refuse is ``partial``, both sides
+  enumerated
+* the born-red witness for the outbox: a consumer that fails after reading an
+  event loses that event for good, because the cursor advances before the effect
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from gr2.prototypes.propagation_state_machine import (
+    KILL_AFTER_APPLY_VERB,
+    Coordinate,
+    Destination,
+    DestinationKind,
+    Direction,
+    Journal,
+    Operation,
+    Policy,
+    Propagator,
+    SinkKilled,
+    State,
+    tree_digest,
+)
+from gr2.python_cli.events import EventType, emit, read_events
+
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+# Commits in the synthetic repositories must not depend on, or touch, the
+# machine's global git configuration (signing keys, hooks paths, identities).
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "prototype",
+    "GIT_AUTHOR_EMAIL": "prototype@example.invalid",
+    "GIT_COMMITTER_NAME": "prototype",
+    "GIT_COMMITTER_EMAIL": "prototype@example.invalid",
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_NOSYSTEM": "1",
+}
+
+
+def git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    return proc.stdout.strip()
+
+
+def head_moves(repo: Path) -> int:
+    """How many times HEAD has moved since the clone (reflog entries minus the clone)."""
+    lines = git(repo, "reflog", "show", "--format=%gs", "HEAD").splitlines()
+    return len(lines) - 1
+
+
+def snapshot(repo: Path) -> dict[str, str]:
+    """Everything an 'untouched' claim is about: refs, HEAD, index+worktree state, bytes."""
+    return {
+        "refs": git(repo, "for-each-ref"),
+        "head": git(repo, "rev-parse", "HEAD"),
+        "porcelain": git(repo, "status", "--porcelain"),
+        "canon": (repo / "canon.md").read_text(),
+        "reflog": git(repo, "reflog", "show", "--format=%gs", "HEAD"),
+    }
+
+
+@dataclass
+class Synthetic:
+    remote: Path
+    author: Path
+    base: str
+    state_dir: Path
+    root: Path
+
+    def push_change(self, text: str) -> str:
+        (self.author / "canon.md").write_text(text)
+        git(self.author, "add", "canon.md")
+        git(self.author, "commit", "-q", "-m", f"canon: {text.strip()[:40]}")
+        git(self.author, "push", "-q", "origin", "main")
+        return git(self.author, "rev-parse", "HEAD")
+
+    def clone(self, name: str) -> Path:
+        path = self.root / name
+        subprocess.run(
+            ["git", "clone", "-q", str(self.remote), str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, **_GIT_ENV},
+        )
+        return path
+
+
+@pytest.fixture
+def synthetic(tmp_path: Path) -> Synthetic:
+    remote = tmp_path / "source.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "--initial-branch=main", str(remote)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    author = tmp_path / "author"
+    subprocess.run(
+        ["git", "clone", "-q", str(remote), str(author)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    git(author, "switch", "-q", "-c", "main")
+    (author / "canon.md").write_text("canon v1\n")
+    git(author, "add", "canon.md")
+    git(author, "commit", "-q", "-m", "canon v1")
+    git(author, "push", "-q", "-u", "origin", "main")
+    base = git(author, "rev-parse", "HEAD")
+    state_dir = tmp_path / "sink-state"
+    return Synthetic(remote=remote, author=author, base=base, state_dir=state_dir, root=tmp_path)
+
+
+POLICY = Policy(policy_hash="policy-prototype-0", allowed_directions=frozenset({Direction.DOWN}))
+
+
+def coordinate(destination_id: str, direction: Direction = Direction.DOWN) -> Coordinate:
+    return Coordinate(
+        source="source-0",
+        destination=destination_id,
+        layer="layer-0",
+        direction=direction,
+        operation=Operation.APPLY,
+        artifact_class="class-0",
+    )
+
+
+def replica(syn: Synthetic, name: str = "replica") -> Destination:
+    return Destination(destination_id=name, path=syn.clone(name), kind=DestinationKind.REPLICA)
+
+
+def authoring(syn: Synthetic, name: str = "authoring") -> Destination:
+    return Destination(destination_id=name, path=syn.clone(name), kind=DestinationKind.AUTHORING)
+
+
+def propagator(syn: Synthetic, **kwargs) -> Propagator:
+    return Propagator(
+        source_remote=syn.remote, branch="main", state_dir=syn.state_dir, policy=POLICY, **kwargs
+    )
+
+
+# --------------------------------------------------------------------------- happy path
+
+
+def test_one_change_reaches_acknowledged_and_names_exact_revisions(synthetic: Synthetic) -> None:
+    dest = replica(synthetic)
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+
+    receipt = propagator(synthetic).run(coord, dest)
+
+    assert receipt is not None
+    assert receipt.state is State.ACKNOWLEDGED
+    assert [t.state for t in receipt.transitions] == [
+        State.OBSERVED,
+        State.FETCHED,
+        State.PLANNED,
+        State.APPLIED,
+        State.VERIFIED,
+        State.ACKNOWLEDGED,
+    ]
+    # exact revisions, never prefixes
+    assert receipt.source_rev == new and _SHA.match(receipt.source_rev)
+    assert receipt.expected_base == synthetic.base
+    assert receipt.observed_base == synthetic.base
+    assert receipt.after == new
+    assert receipt.operation_id is not None and len(receipt.operation_id) == 64
+    assert receipt.digest == git(dest.path, "rev-parse", f"{new}^{{tree}}")
+    # the destination really moved, read back from the destination itself
+    assert git(dest.path, "rev-parse", "HEAD") == new
+    assert (dest.path / "canon.md").read_text() == "canon v2\n"
+    assert head_moves(dest.path) == 1
+    # gate results are individual, each with a hash; the postcondition is named
+    assert {g.gate_id for g in receipt.gate_results} == {
+        "policy.direction",
+        "destination.base-unmoved",
+        "destination.clean",
+        "destination.fast-forward",
+    }
+    assert all(g.result == "pass" and len(g.result_hash) == 64 for g in receipt.gate_results)
+    assert receipt.postcondition_checked == "head-is-intended-after-and-tree-matches-digest"
+    assert receipt.postcondition_holds is True
+    assert receipt.refusal_reason is None
+    # the cursor advanced, and only because acknowledged was reached
+    assert Journal(synthetic.state_dir).cursor(coord.key()) == new
+    # the receipt is a plain, JSON-serialisable record
+    json.dumps(receipt.as_dict())
+
+
+def test_no_new_source_revision_is_not_an_operation(synthetic: Synthetic) -> None:
+    dest = replica(synthetic)
+    synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    sink = propagator(synthetic)
+    assert sink.run(coord, dest) is not None
+    journal_lines = Journal(synthetic.state_dir).path.read_text()
+    before = snapshot(dest.path)
+
+    assert sink.run(coord, dest) is None
+
+    assert snapshot(dest.path) == before
+    assert Journal(synthetic.state_dir).path.read_text() == journal_lines
+
+
+def test_observe_control_rereads_at_a_known_revision_and_reports_nothing(
+    synthetic: Synthetic,
+) -> None:
+    new = synthetic.push_change("canon v2\n")
+    sink = propagator(synthetic)
+    fresh = sink.observe_source_at(cursor=None)
+    assert fresh.source_rev == new and fresh.is_new is True
+    # the control: the same read, at a cursor that already names the revision
+    assert sink.observe_source_at(cursor=new).is_new is False
+    # and at a cursor known to predate it, the change IS reported
+    assert sink.observe_source_at(cursor=synthetic.base).is_new is True
+
+
+def test_fetched_digest_control_known_different_object_mismatches(synthetic: Synthetic) -> None:
+    dest = replica(synthetic)
+    new = synthetic.push_change("canon v2\n")
+    receipt = propagator(synthetic).run(coordinate(dest.destination_id), dest)
+    assert receipt is not None and receipt.digest is not None
+    mirror = synthetic.state_dir / "mirror.git"
+    assert tree_digest(mirror, new) == receipt.digest
+    # the discriminating control: a known-different object recomputes to a different digest
+    assert tree_digest(mirror, synthetic.base) != receipt.digest
+
+
+# ------------------------------------------------------------------ kill + replay
+
+
+@pytest.mark.parametrize(
+    "kill_after",
+    [
+        State.OBSERVED,
+        State.FETCHED,
+        State.PLANNED,
+        KILL_AFTER_APPLY_VERB,
+        State.APPLIED,
+        State.VERIFIED,
+    ],
+)
+def test_kill_between_states_then_replay_applies_exactly_once(
+    synthetic: Synthetic, kill_after
+) -> None:
+    dest = replica(synthetic)
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+
+    with pytest.raises(SinkKilled):
+        propagator(synthetic, kill_after=kill_after).run(coord, dest)
+
+    journal = Journal(synthetic.state_dir)
+    attempts = journal.find(coord.key(), new)
+    assert len(attempts) == 1
+    recorded = [t.state for t in attempts[0]]
+    expected_last = State.PLANNED if kill_after == KILL_AFTER_APPLY_VERB else kill_after
+    assert recorded[-1] is expected_last
+    # the cursor never advances before acknowledged, whatever state the sink died in
+    assert journal.cursor(coord.key()) is None
+    verb_ran_before_kill = kill_after in (KILL_AFTER_APPLY_VERB, State.APPLIED, State.VERIFIED)
+    assert git(dest.path, "rev-parse", "HEAD") == (new if verb_ran_before_kill else synthetic.base)
+
+    receipt = propagator(synthetic).run(coord, dest)
+
+    assert receipt is not None and receipt.state is State.ACKNOWLEDGED
+    assert receipt.replayed is False  # it was resumed, not a terminal no-op
+    assert receipt.after == new and git(dest.path, "rev-parse", "HEAD") == new
+    assert journal.cursor(coord.key()) == new
+    # exactly one apply, measured two ways: the destination's own reflog and the journal
+    assert head_moves(dest.path) == 1
+    assert journal.notes(coord.key(), new, "apply-verb-started") == 1
+    # one attempt, states strictly in order, no state skipped
+    (transitions,) = journal.find(coord.key(), new)
+    states = [t.state for t in transitions]
+    assert states == [
+        State.OBSERVED,
+        State.FETCHED,
+        State.PLANNED,
+        State.APPLIED,
+        State.VERIFIED,
+        State.ACKNOWLEDGED,
+    ]
+
+
+def test_replay_of_an_acknowledged_operation_is_a_no_op_returning_the_original_outcome(
+    synthetic: Synthetic,
+) -> None:
+    dest = replica(synthetic)
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    first = propagator(synthetic).run(coord, dest)
+    assert first is not None and first.state is State.ACKNOWLEDGED
+    # lose the cursor store (the kind of thing that happens); the journal still knows
+    cursor_file = Journal(synthetic.state_dir).cursor_path(coord.key())
+    cursor_file.unlink()
+    before = snapshot(dest.path)
+
+    again = propagator(synthetic).run(coord, dest)
+
+    assert again is not None
+    assert again.replayed is True
+    assert again.state is State.ACKNOWLEDGED
+    assert again.operation_id == first.operation_id
+    assert again.after == first.after == new
+    assert snapshot(dest.path) == before  # no verb ran against the destination
+    assert head_moves(dest.path) == 1
+
+
+def test_kill_after_acknowledged_row_before_cursor_replays_as_terminal_and_repairs_cursor(
+    synthetic: Synthetic,
+) -> None:
+    # the acknowledged row is written before the cursor advances, so the journal is
+    # the source of truth and the cursor is derived from it; a death in between must
+    # not re-run anything and must leave the cursor repaired afterwards
+    dest = replica(synthetic)
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    with pytest.raises(SinkKilled):
+        propagator(synthetic, kill_after=State.ACKNOWLEDGED).run(coord, dest)
+    journal = Journal(synthetic.state_dir)
+    (transitions,) = journal.find(coord.key(), new)
+    assert transitions[-1].state is State.ACKNOWLEDGED
+    assert journal.cursor(coord.key()) is None
+    before = snapshot(dest.path)
+
+    receipt = propagator(synthetic).run(coord, dest)
+
+    assert receipt is not None and receipt.replayed is True
+    assert receipt.state is State.ACKNOWLEDGED
+    assert journal.cursor(coord.key()) == new
+    assert snapshot(dest.path) == before
+    assert head_moves(dest.path) == 1
+    # and now the source has nothing new for this coordinate
+    assert propagator(synthetic).run(coord, dest) is None
+
+
+# ---------------------------------------------------------------- refusals
+
+
+def test_moved_expected_base_refuses_and_reports_observed_base(synthetic: Synthetic) -> None:
+    dest = replica(synthetic)
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    with pytest.raises(SinkKilled):
+        propagator(synthetic, kill_after=State.PLANNED).run(coord, dest)
+    # between plan and apply, the destination moves
+    (dest.path / "canon.md").write_text("local edit committed\n")
+    git(dest.path, "commit", "-q", "-am", "local")
+    moved = git(dest.path, "rev-parse", "HEAD")
+    assert moved != synthetic.base
+
+    receipt = propagator(synthetic).run(coord, dest)
+
+    assert receipt is not None
+    assert receipt.state is State.REFUSED
+    assert receipt.expected_base == synthetic.base
+    assert receipt.observed_base == moved
+    assert receipt.refusal_reason is not None and "expected_base" in receipt.refusal_reason
+    assert receipt.after is None
+    # not merged, not forced, not retried against the new base
+    assert git(dest.path, "rev-parse", "HEAD") == moved
+    assert (dest.path / "canon.md").read_text() == "local edit committed\n"
+    assert Journal(synthetic.state_dir).cursor(coord.key()) is None
+    assert Journal(synthetic.state_dir).notes(coord.key(), new, "apply-verb-started") == 0
+
+
+def test_dirty_authoring_clone_is_refused_and_untouched(synthetic: Synthetic) -> None:
+    dest = authoring(synthetic)
+    (dest.path / "canon.md").write_text("uncommitted authoring in progress\n")
+    (dest.path / "scratch.txt").write_text("untracked\n")
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    before = snapshot(dest.path)
+
+    receipt = propagator(synthetic).run(coord, dest)
+
+    assert receipt is not None and receipt.state is State.REFUSED
+    assert receipt.source_rev == new and receipt.expected_base == synthetic.base
+    failed = {g.gate_id: g for g in receipt.gate_results if g.result == "fail"}
+    assert "destination.clean" in failed
+    assert receipt.refusal_reason is not None and receipt.refusal_reason.startswith(
+        "destination.clean"
+    )
+    # gates are recorded individually, including the ones that passed
+    assert {g.gate_id for g in receipt.gate_results} >= {"policy.direction", "destination.clean"}
+    # untouched means untouched: refs, HEAD, index/worktree, bytes, reflog
+    assert snapshot(dest.path) == before
+    assert (dest.path / "scratch.txt").read_text() == "untracked\n"
+
+
+def test_diverged_authoring_clone_is_refused_with_counts_and_untouched(
+    synthetic: Synthetic,
+) -> None:
+    dest = authoring(synthetic)
+    (dest.path / "canon.md").write_text("local canon branch\n")
+    git(dest.path, "commit", "-q", "-am", "local authoring commit")
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    before = snapshot(dest.path)
+
+    receipt = propagator(synthetic).run(coord, dest)
+
+    assert receipt is not None and receipt.state is State.REFUSED
+    failed = {g.gate_id: g for g in receipt.gate_results if g.result == "fail"}
+    assert "destination.fast-forward" in failed
+    assert "ahead=1" in failed["destination.fast-forward"].detail
+    assert "behind=1" in failed["destination.fast-forward"].detail
+    assert receipt.source_rev == new
+    assert receipt.observed_base == before["head"]
+    assert snapshot(dest.path) == before
+
+
+def test_direction_outside_policy_is_refused_at_plan_and_destination_untouched(
+    synthetic: Synthetic,
+) -> None:
+    dest = replica(synthetic)
+    synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id, direction=Direction.UP)
+    before = snapshot(dest.path)
+
+    receipt = propagator(synthetic).run(coord, dest)
+
+    assert receipt is not None and receipt.state is State.REFUSED
+    assert [t.state for t in receipt.transitions][-2:] == [State.PLANNED, State.REFUSED]
+    assert receipt.refusal_reason is not None and receipt.refusal_reason.startswith(
+        "policy.direction"
+    )
+    assert snapshot(dest.path) == before
+
+
+def test_refused_then_cleaned_is_a_new_attempt_not_a_replayed_refusal(synthetic: Synthetic) -> None:
+    dest = authoring(synthetic)
+    (dest.path / "canon.md").write_text("uncommitted\n")
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    first = propagator(synthetic).run(coord, dest)
+    assert first is not None and first.state is State.REFUSED
+    # the author cleans up; the same source revision at the same base is now applicable
+    git(dest.path, "checkout", "--", "canon.md")
+
+    second = propagator(synthetic).run(coord, dest)
+
+    assert second is not None and second.state is State.ACKNOWLEDGED
+    assert second.replayed is False
+    assert second.after == new
+    attempts = Journal(synthetic.state_dir).find(coord.key(), new)
+    assert len(attempts) == 2
+    assert [t.state for t in attempts[0]][-1] is State.REFUSED
+    assert [t.state for t in attempts[1]][-1] is State.ACKNOWLEDGED
+
+
+# ---------------------------------------------------------- verification + unverifiable
+
+
+def test_verified_postcondition_mutation_fails_the_check_and_blocks_acknowledgement(
+    synthetic: Synthetic,
+) -> None:
+    dest = replica(synthetic)
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    with pytest.raises(SinkKilled):
+        propagator(synthetic, kill_after=State.APPLIED).run(coord, dest)
+    assert git(dest.path, "rev-parse", "HEAD") == new
+    # mutate the postcondition: the worktree no longer matches the applied tree
+    (dest.path / "canon.md").write_text("mutated after apply\n")
+
+    receipt = propagator(synthetic).run(coord, dest)
+
+    assert receipt is not None
+    assert receipt.state is State.APPLIED  # the highest state actually established
+    assert receipt.postcondition_checked == "head-is-intended-after-and-tree-matches-digest"
+    assert receipt.postcondition_holds is False
+    assert Journal(synthetic.state_dir).cursor(coord.key()) is None
+    assert [t.state for t in receipt.transitions][-1] is State.APPLIED
+    # the control: undo the mutation and the same check verifies
+    (dest.path / "canon.md").write_text("canon v2\n")
+    control = propagator(synthetic).run(coord, dest)
+    assert control is not None and control.state is State.ACKNOWLEDGED
+    assert control.postcondition_holds is True
+
+
+def test_unreadable_destination_after_apply_is_unverifiable_and_resolves_on_replay(
+    synthetic: Synthetic,
+) -> None:
+    dest = replica(synthetic)
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    hidden = dest.path.with_name("replica-hidden")
+
+    def hide_destination() -> None:
+        dest.path.rename(hidden)
+
+    receipt = propagator(synthetic, after_apply_verb=hide_destination).run(coord, dest)
+
+    assert receipt is not None
+    assert receipt.state is State.UNVERIFIABLE
+    assert receipt.refusal_reason is None  # not refused
+    assert receipt.after is None  # not applied either; nobody read it back
+    assert "read back" in receipt.detail
+    assert Journal(synthetic.state_dir).cursor(coord.key()) is None
+    assert [t.state for t in receipt.transitions][-2:] == [State.PLANNED, State.UNVERIFIABLE]
+
+    hidden.rename(dest.path)
+    resolved = propagator(synthetic).run(coord, dest)
+
+    assert resolved is not None and resolved.state is State.ACKNOWLEDGED
+    assert resolved.after == new
+    assert head_moves(dest.path) == 1
+    assert Journal(synthetic.state_dir).notes(coord.key(), new, "apply-verb-started") == 1
+    assert [t.state for t in resolved.transitions] == [
+        State.OBSERVED,
+        State.FETCHED,
+        State.PLANNED,
+        State.UNVERIFIABLE,
+        State.APPLIED,
+        State.VERIFIED,
+        State.ACKNOWLEDGED,
+    ]
+
+
+# ------------------------------------------------------------------- partial
+
+
+def test_mixed_destinations_are_partial_with_both_sides_enumerated(synthetic: Synthetic) -> None:
+    clean = replica(synthetic, "replica")
+    dirty = authoring(synthetic, "dirty-authoring")
+    (dirty.path / "canon.md").write_text("uncommitted\n")
+    ahead = authoring(synthetic, "ahead-authoring")
+    (ahead.path / "canon.md").write_text("local\n")
+    git(ahead.path, "commit", "-q", "-am", "local")
+    new = synthetic.push_change("canon v2\n")
+    targets = [(coordinate(d.destination_id), d) for d in (clean, dirty, ahead)]
+
+    outcome = propagator(synthetic).run_all(targets)
+
+    assert outcome.state is State.PARTIAL
+    assert outcome.reached == ("replica",)
+    assert {d for d, _reason in outcome.not_reached} == {"dirty-authoring", "ahead-authoring"}
+    reasons = dict(outcome.not_reached)
+    assert reasons["dirty-authoring"].startswith("destination.clean")
+    assert reasons["ahead-authoring"].startswith("destination.fast-forward")
+    # every receipt, reached or not, names exact revisions
+    for receipt in outcome.receipts:
+        assert _SHA.match(receipt.source_rev) and receipt.source_rev == new
+        assert _SHA.match(receipt.expected_base)
+        assert receipt.observed_base is not None and _SHA.match(receipt.observed_base)
+    assert git(clean.path, "rev-parse", "HEAD") == new
+    assert git(dirty.path, "rev-parse", "HEAD") == synthetic.base
+    assert (dirty.path / "canon.md").read_text() == "uncommitted\n"
+
+
+def test_all_destinations_verifying_is_acknowledged_not_partial(synthetic: Synthetic) -> None:
+    a = replica(synthetic, "replica-a")
+    b = replica(synthetic, "replica-b")
+    synthetic.push_change("canon v2\n")
+    outcome = propagator(synthetic).run_all(
+        [(coordinate(a.destination_id), a), (coordinate(b.destination_id), b)]
+    )
+    assert outcome.state is State.ACKNOWLEDGED
+    assert set(outcome.reached) == {"replica-a", "replica-b"}
+    assert outcome.not_reached == ()
+
+
+# ------------------------------------------------- operation identity
+
+
+def test_operation_id_binds_coordinate_source_base_and_digest(synthetic: Synthetic) -> None:
+    a = replica(synthetic, "replica-a")
+    b = replica(synthetic, "replica-b")
+    new = synthetic.push_change("canon v2\n")
+    ra = propagator(synthetic).run(coordinate(a.destination_id), a)
+    rb = propagator(synthetic).run(coordinate(b.destination_id), b)
+    assert ra is not None and rb is not None
+    # same source revision, same base, same digest: the coordinate differs, so the id differs
+    assert ra.operation_id != rb.operation_id
+    expected = hashlib.sha256(
+        json.dumps(
+            {
+                "coordinate": coordinate(a.destination_id).key(),
+                "source_rev": new,
+                "expected_base": synthetic.base,
+                "digest": ra.digest,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    assert ra.operation_id == expected
+
+
+# ---------------------------------------------------- born-red outbox witness
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "outbox consumers lose events: read_events() advances the cursor before the "
+        "caller performs its effect, so a consumer that fails after reading never sees "
+        "the event again. This witness turns green only when acknowledgment moves "
+        "after the effect; strict=True forces the marker off at that moment."
+    ),
+)
+def test_outbox_event_survives_a_consumer_that_fails_after_reading(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    emit(
+        EventType.SYNC_COMPLETED,
+        workspace,
+        actor="sink",
+        owner_unit="unit-0",
+        payload={"detail": "one"},
+    )
+
+    with pytest.raises(RuntimeError):
+        offered = read_events(workspace, "propagation-consumer")
+        assert [e["type"] for e in offered] == ["sync.completed"]
+        raise RuntimeError("effect failed after the read")
+
+    # the contract a propagation consumer needs: an event whose effect did not happen
+    # is offered again
+    assert [e["type"] for e in read_events(workspace, "propagation-consumer")] == ["sync.completed"]

--- a/gr2/tests/test_propagation_state_machine.py
+++ b/gr2/tests/test_propagation_state_machine.py
@@ -588,6 +588,55 @@ def test_mixed_destinations_are_partial_with_both_sides_enumerated(synthetic: Sy
     assert (dirty.path / "canon.md").read_text() == "uncommitted\n"
 
 
+def test_replaying_a_partial_outcome_keeps_the_reached_target_and_stays_partial(
+    synthetic: Synthetic,
+) -> None:
+    # Found in review: the first cut's run_all dropped a declared target whose cursor
+    # was already at the source revision (run() returns None for "nothing new"), so a
+    # replayed partial reclassified itself as REFUSED with reached=() -- the
+    # aggregate could not tell "already reached" from "not part of this invocation".
+    clean = replica(synthetic, "replica")
+    dirty = authoring(synthetic, "dirty-authoring")
+    (dirty.path / "canon.md").write_text("uncommitted\n")
+    new = synthetic.push_change("canon v2\n")
+    targets = [(coordinate(d.destination_id), d) for d in (clean, dirty)]
+
+    first = propagator(synthetic).run_all(targets)
+    assert first is not None and first.state is State.PARTIAL
+    assert first.reached == ("replica",)
+    assert [d for d, _ in first.not_reached] == ["dirty-authoring"]
+    assert head_moves(clean.path) == 1
+
+    # Replay with nothing changed: the SAME classification, the reached target is
+    # still enumerated (as a replayed terminal receipt), and it is not applied again.
+    second = propagator(synthetic).run_all(targets)
+    assert second is not None and second.state is State.PARTIAL, second
+    assert second.reached == ("replica",)
+    assert [d for d, _ in second.not_reached] == ["dirty-authoring"]
+    by_dest = {r.coordinate.destination: r for r in second.receipts}
+    assert by_dest["replica"].replayed is True
+    assert by_dest["replica"].state is State.ACKNOWLEDGED
+    assert by_dest["replica"].after == new
+    assert by_dest["dirty-authoring"].replayed is False  # a refusal starts a new attempt
+    assert by_dest["dirty-authoring"].attempt == 2
+    assert head_moves(clean.path) == 1, "the reached target must not be applied twice"
+
+    # The author cleans up: the refused target is reached on a fresh attempt and the
+    # aggregate becomes ACKNOWLEDGED with BOTH targets enumerated as reached.
+    git(dirty.path, "checkout", "--", "canon.md")
+    third = propagator(synthetic).run_all(targets)
+    assert third is not None and third.state is State.ACKNOWLEDGED, third
+    assert set(third.reached) == {"replica", "dirty-authoring"}
+    assert third.not_reached == ()
+    assert git(dirty.path, "rev-parse", "HEAD") == new
+    assert head_moves(clean.path) == 1
+
+
+def test_run_all_with_no_declared_targets_is_none(synthetic: Synthetic) -> None:
+    synthetic.push_change("canon v2\n")
+    assert propagator(synthetic).run_all([]) is None
+
+
 def test_all_destinations_verifying_is_acknowledged_not_partial(synthetic: Synthetic) -> None:
     a = replica(synthetic, "replica-a")
     b = replica(synthetic, "replica-b")
@@ -715,13 +764,49 @@ def test_distinct_coordinates_never_share_cursor_or_journal_rows(tmp_path: Path)
 # ---------------------------------------------------- born-red outbox witness
 
 
+class EventLost(AssertionError):
+    """Raised ONLY by the survival check below; the xfail is constrained to it.
+
+    ``xfail(strict=True)`` alone accepts ANY failure in the marked test, so a
+    premise that broke -- no event emitted, nothing offered on the first read --
+    would satisfy the marker forever while its reason text kept claiming cursor
+    loss (found in review: replacing the first read's result with ``[]`` still
+    reported the same expected xfail). With ``raises=EventLost`` a premise
+    failure is a plain AssertionError, which is NOT the expected type, so it is
+    reported as a real failure; only the final survival check can satisfy the
+    marker, and only by raising this class explicitly.
+    """
+
+
+def _offered_types(workspace: Path) -> list[str]:
+    return [e["type"] for e in read_events(workspace, "propagation-consumer")]
+
+
+def test_outbox_offers_an_emitted_event_to_a_fresh_consumer(tmp_path: Path) -> None:
+    # The PREMISE of the born-red witness, as its own ordinary test: an emitted
+    # event is offered on the first read. If this goes red the outbox regressed
+    # upstream of the cursor question and the witness below is not about that.
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    emit(
+        EventType.SYNC_COMPLETED,
+        workspace,
+        actor="sink",
+        owner_unit="unit-0",
+        payload={"detail": "one"},
+    )
+    assert _offered_types(workspace) == ["sync.completed"]
+
+
 @pytest.mark.xfail(
     strict=True,
+    raises=EventLost,
     reason=(
         "outbox consumers lose events: read_events() advances the cursor before the "
         "caller performs its effect, so a consumer that fails after reading never sees "
         "the event again. This witness turns green only when acknowledgment moves "
-        "after the effect; strict=True forces the marker off at that moment."
+        "after the effect; strict=True forces the marker off at that moment, and "
+        "raises=EventLost keeps every premise failure outside the expected envelope."
     ),
 )
 def test_outbox_event_survives_a_consumer_that_fails_after_reading(tmp_path: Path) -> None:
@@ -735,11 +820,14 @@ def test_outbox_event_survives_a_consumer_that_fails_after_reading(tmp_path: Pat
         payload={"detail": "one"},
     )
 
+    # PREMISE (plain asserts: a failure here is a FAILURE, not the expected xfail)
     with pytest.raises(RuntimeError):
-        offered = read_events(workspace, "propagation-consumer")
-        assert [e["type"] for e in offered] == ["sync.completed"]
+        offered = _offered_types(workspace)
+        assert offered == ["sync.completed"], f"premise: nothing offered, got {offered!r}"
         raise RuntimeError("effect failed after the read")
 
-    # the contract a propagation consumer needs: an event whose effect did not happen
-    # is offered again
-    assert [e["type"] for e in read_events(workspace, "propagation-consumer")] == ["sync.completed"]
+    # SURVIVAL CHECK, the only statement allowed to satisfy the marker: an event
+    # whose effect did not happen is offered again
+    again = _offered_types(workspace)
+    if again != ["sync.completed"]:
+        raise EventLost(f"offered once, then lost: second read returned {again!r}")

--- a/gr2/tests/test_propagation_state_machine.py
+++ b/gr2/tests/test_propagation_state_machine.py
@@ -627,6 +627,91 @@ def test_operation_id_binds_coordinate_source_base_and_digest(synthetic: Synthet
     assert ra.operation_id == expected
 
 
+# ------------------------------------------------ coordinate key is injective
+
+
+def _coord(**overrides: object) -> Coordinate:
+    base: dict[str, object] = {
+        "source": "source",
+        "destination": "target",
+        "layer": "layer",
+        "direction": Direction.DOWN,
+        "operation": Operation.APPLY,
+        "artifact_class": "class",
+    }
+    return Coordinate(**{**base, **overrides})  # type: ignore[arg-type]
+
+
+def _joined_with_pipes(c: Coordinate) -> str:
+    """The scheme the first cut used, kept here ONLY as the control."""
+    return "|".join(
+        (c.source, c.destination, c.layer, str(c.direction), str(c.operation), c.artifact_class)
+    )
+
+
+# Every pair below is two DISTINCT coordinates whose fields, joined with "|",
+# produced ONE key on the first cut. The first pair is the reviewer's exact
+# discriminator; the second shifts the byte across the source/destination/layer
+# boundaries in one move; the third shows the enum fields are not a fence either,
+# because an opaque field may itself contain the enum words.
+_COLLIDING_ON_THE_OLD_SCHEME = [
+    (_coord(source="source|dest"), _coord(destination="dest|target")),
+    (_coord(layer="layer|down"), _coord(source="source|target", destination="layer", layer="down")),
+    (
+        _coord(artifact_class="class|down|apply|z"),
+        _coord(layer="layer|down|apply|class", artifact_class="z"),
+    ),
+]
+
+# Bytes JSON itself uses for structure, in the opaque fields: these never collided
+# under the old scheme, so they carry no control; they exist to show the new
+# encoding escapes them and round-trips regardless.
+_JSON_STRUCTURE_BYTES = [
+    _coord(source='a","destination":"b'),
+    _coord(source="a\\"),
+    _coord(source="a\\\\"),
+    _coord(destination='{"source":"x"}'),
+    _coord(layer="|", artifact_class="|"),
+]
+
+
+@pytest.mark.parametrize("left,right", _COLLIDING_ON_THE_OLD_SCHEME)
+def test_distinct_coordinates_never_share_a_key(left: Coordinate, right: Coordinate) -> None:
+    assert left != right, "the pair must be two different coordinates or it proves nothing"
+    # Control first: the pair MUST collide under the old scheme, or the witness is
+    # not discriminating and a green here would say nothing about the fix.
+    assert _joined_with_pipes(left) == _joined_with_pipes(right)
+    assert left.key() != right.key()
+
+
+@pytest.mark.parametrize(
+    "coord",
+    [c for pair in _COLLIDING_ON_THE_OLD_SCHEME for c in pair] + _JSON_STRUCTURE_BYTES,
+)
+def test_coordinate_key_round_trips_so_injectivity_is_structural(coord: Coordinate) -> None:
+    # Injectivity is asserted as a ROUND TRIP, not as "this pair differs": if every
+    # key decodes back to the coordinate that produced it, no two coordinates can
+    # share one, whatever bytes the opaque fields carry.
+    assert Coordinate.from_key(coord.key()) == coord
+    assert json.loads(coord.key()) == coord.as_dict()
+
+
+def test_distinct_coordinates_never_share_cursor_or_journal_rows(tmp_path: Path) -> None:
+    # The consequence the review named: the key names the cursor file and the journal
+    # rows, so a shared key is shared replay state. Advance one; the other is untouched.
+    left, right = _COLLIDING_ON_THE_OLD_SCHEME[0]
+    journal = Journal(tmp_path / "state")
+    assert journal.cursor_path(left.key()) != journal.cursor_path(right.key())
+    journal.advance_cursor(left.key(), "a" * 40, pending_id="p")
+    assert journal.cursor(left.key()) == "a" * 40
+    assert journal.cursor(right.key()) is None
+    journal.note(
+        pending_id="p", attempt=1, coordinate_key=left.key(), source_rev="a" * 40, note="only-left"
+    )
+    assert journal.notes(left.key(), "a" * 40, "only-left") == 1
+    assert journal.notes(right.key(), "a" * 40, "only-left") == 0
+
+
 # ---------------------------------------------------- born-red outbox witness
 
 

--- a/gr2/tests/test_propagation_state_machine.py
+++ b/gr2/tests/test_propagation_state_machine.py
@@ -632,6 +632,38 @@ def test_replaying_a_partial_outcome_keeps_the_reached_target_and_stays_partial(
     assert head_moves(clean.path) == 1
 
 
+def test_a_cursor_the_journal_never_acknowledged_is_a_corrupted_sink_state_and_raises(
+    synthetic: Synthetic,
+) -> None:
+    # Found in review: the "corrupted sink state" branch was unwitnessed, so a silent
+    # `return None` in its place kept the whole file green while dropping a declared
+    # target from the aggregate -- the same outcome class the previous fix closed.
+    dest = replica(synthetic, "replica")
+    new = synthetic.push_change("canon v2\n")
+    coord = coordinate(dest.destination_id)
+    # Forge the one state the journal can never produce: a cursor AT the source
+    # revision with no acknowledged attempt behind it.
+    Journal(synthetic.state_dir).advance_cursor(coord.key(), new, pending_id="forged")
+    before = snapshot(dest.path)
+
+    with pytest.raises(RuntimeError, match="no acknowledged attempt"):
+        propagator(synthetic).run_all([(coord, dest)])
+    with pytest.raises(RuntimeError, match="no acknowledged attempt"):
+        propagator(synthetic).run(coord, dest)
+    assert snapshot(dest.path) == before, "a refusal to guess must not touch the destination"
+
+    # Control: a cursor the journal DID acknowledge is the ordinary current state --
+    # run() reports nothing new and run_all reports the target as already reached.
+    healthy = replica(synthetic, "healthy")
+    hcoord = coordinate(healthy.destination_id)
+    first = propagator(synthetic).run(hcoord, healthy)
+    assert first is not None and first.state is State.ACKNOWLEDGED
+    assert propagator(synthetic).run(hcoord, healthy) is None
+    again = propagator(synthetic).run_all([(hcoord, healthy)])
+    assert again is not None and again.state is State.ACKNOWLEDGED
+    assert again.reached == ("healthy",) and again.receipts[0].replayed is True
+
+
 def test_run_all_with_no_declared_targets_is_none(synthetic: Synthetic) -> None:
     synthetic.push_change("canon v2\n")
     assert propagator(synthetic).run_all([]) is None


### PR DESCRIPTION
## What

A prototype of the propagation state contract, proven on synthetic git repositories before any daemon is allowed near a real clone.

`gr2/prototypes/propagation_state_machine.py` drives one change through `observed -> fetched -> planned -> applied -> verified -> acknowledged`, with `refused`, `partial`, and `unverifiable` reachable from any state. Every transition names the observation that established it; every receipt names the exact source and destination revisions; all identifiers are opaque (no agent or workspace identity and no policy content; the allowed directions are a required input with no default). `applied` is read back from the destination, never from the verb's exit status; `unverifiable` is a first-class state and is never collapsed into either neighbour.

`gr2/tests/test_propagation_state_machine.py` builds a bare source remote and three destinations (clean replica, dirty authoring clone, diverged authoring clone) and proves, each as its own witness:

- killing the sink between each pair of states and replaying applies the change exactly once, measured from the destination's own reflog and from the journal
- the cursor advances only on `acknowledged`; a death between the acknowledged row and the cursor write replays as a terminal no-op and repairs the cursor
- a moved expected base refuses (compare-and-swap) with the observed base in the receipt; nothing is merged, forced, or retried against the new base
- a dirty authoring clone and a diverged authoring clone (`ahead=1 behind=1` in the gate detail) are refused and left byte-for-byte untouched: refs, HEAD, index, worktree, reflog
- a destination that cannot be read back after the apply verb is `unverifiable`, and resolves to `applied -> verified -> acknowledged` on replay without running the verb again
- some destinations verifying while others refuse is `partial`, both sides enumerated with reasons; replaying that partial with nothing changed stays `partial`, the already-reached target is enumerated as a replayed terminal receipt and not applied twice, and once the author clears the refusal the aggregate is `acknowledged` with both reached
- an acknowledged operation replays as a no-op returning the original outcome; a refused one starts a new attempt, because a refusal describes a moment
- a direction outside the declared policy is refused at plan with the destination untouched
- the operation id binds (coordinate, source revision, expected base, digest)
- the coordinate key is injective over its opaque fields: every key round-trips to the coordinate that produced it, across the field boundaries and across the bytes JSON itself uses for structure, and two coordinates that collided under the first cut's key do not share a cursor file or a journal row
- a cursor sitting at the source revision with no acknowledged journal attempt behind it is a corrupted sink state: both `run()` and `run_all()` raise naming the missing acknowledgement and leave the destination byte-for-byte untouched, while an acknowledged cursor is the ordinary current state (`None` from `run()`, an already-reached replayed receipt from `run_all()`)

It also carries a born-red witness for the existing event outbox: `read_events()` advances the consumer cursor before the caller performs its effect, so a consumer that fails after reading loses the event for good. The test is `xfail(strict=True, raises=EventLost)`: the marker fails the suite the moment acknowledgment moves after the effect, and only the final survival check can satisfy it, because every premise assertion is a plain `assert` (not the expected type) and is reported as a real failure. The premise, that an emitted event is offered on the first read, is also its own ordinary test.

## What the first cut got wrong

Found in review of the previous revision: the key that names journal rows and cursor files joined the six coordinate fields with `|`. The fields are opaque, so no delimiter can be assumed absent from them, and the reviewer proved it — `(source="source|dest", destination="target")` and `(source="source", destination="dest|target")` produced one key, so two distinct coordinates would have shared replay state, against the prototype's own opaque-identifier contract. The key is now the canonical JSON of the coordinate (sorted keys, compact separators — the same encoding the operation id already uses) and `Coordinate.from_key` decodes it, so injectivity is structural and the witness asserts it as a round-trip rather than as "this pair differs". Each collision pair asserts its own control first, that the old scheme did collide on it. The fix is its own commit on top of the reviewed first cut, so the delta can be read on its own.

## What the second review found

Two reporting defects, both fixed as their own commit on top of the reviewed ones so the delta reads alone:

- **`run_all` dropped already-reached targets on replay.** `run()` returns `None` for "no new source revision" (not an operation; that contract stands), and `run_all` took `None` to mean "not part of this invocation", so a replayed `partial` reclassified itself as `refused` with `reached=()`. The aggregate now drives each declared target through a path that, when the cursor is already at the source revision, returns the terminal receipt from the journal (`replayed=True`) instead of `None`; a cursor at a revision the journal never acknowledged raises rather than guessing (witnessed in the next revision, see below). Witnessed across three invocations (partial → partial with the reached target enumerated and not re-applied, reflog held at 1 → acknowledged with both reached after the author cleans up), plus an empty-targets control.
- **The outbox xfail accepted any failure.** A strict xfail marks a test expected to fail for any reason, so a broken premise (nothing offered on the first read) satisfied the marker while the reason text kept claiming cursor loss. The marker is now constrained with `raises=EventLost`, raised only by the survival check.

## What the third review found

The corrupted-cursor refusal above was promised and unwitnessed: the reviewer replaced the `RuntimeError` with a silent `return None` and the whole file stayed green. A silent `None` there is the exact outcome class the second fix closed (a declared target dropped from the aggregate), now over a corrupted sink state instead of a healthy one. Fixed as its own commit: the check now runs on both driver paths, so `run()` no longer reports "nothing new" over a cursor the journal never acknowledged, and the witness forges that state (cursor advanced with no journal rows), asserts both entry points raise with the missing-acknowledgement detail, asserts the destination is untouched, and carries a healthy control.

## Evidence (RAN)

- `python3 -m pytest gr2/tests/test_propagation_state_machine.py`: 41 passed, 1 xfailed (the strict born-red witness), Python 3.13.2, pytest 9.0.2; the module under test printed as the repository file, not an installed copy
- `ruff check` clean under the project config (E/F/I/UP, 100 columns); `ruff format` applied to the two new files only
- mutation run over the whole test file, fifteen rows, each row asserting its anchor applied (count == 1) before running and the module restored and hash-verified against the pre-mutation bytes after: cursor-advance-at-applied killed 2; compare-and-swap removed killed 1; idempotent landing removed killed 2; postcondition ignores tree and cleanliness killed 1; unverifiable collapsed into refused killed 1; clean gate always passes killed 3; fast-forward gate always passes killed 2; refused treated as terminal killed 1; direction gate always passes killed 1; observe never reports new killed 22; key restored to the `|` join killed exactly the three collision pairs, the eleven round-trips, and the cursor-and-journal isolation witness, with the 22 original tests staying green; `run_all` restored to the first cut's `run()` killed exactly the partial-replay witness; the outbox witness's own first read returning `[]` reds the premise test and reports the witness as FAILED rather than xfailed; an outbox that offers the event again reports XPASS(strict) as a failure, which is the marker-off signal the witness exists to give; the corrupted-cursor raise replaced by `return None` killed exactly the new witness and nothing else (these four restored from a saved copy and hash-verified, since `git checkout --` on an uncommitted tree restores HEAD rather than the fix)
- the whole `gr2/tests` tree, re-run at this head: 925 passed, 1 xfailed, 5 failed; the same 5 (two in `test_event_log_integrity.py`, one each in `test_gr2_packaging.py`, `test_sprint21_sync_platform.py`, `test_workspace_edit_lease_cap.py`) fail identically on a clean worktree of `origin/dev` at the base commit without this branch, so they are pre-existing and untouched here; the previous two revisions' bodies carried the first measured count (921) forward without re-running the whole tree, which was stale by the tests those revisions added

## Not in scope

- fixing the outbox cursor ordering (a consumer-contract change; its own PR)
- any daemon, transport, latency budget, or policy content; direction policy is an opaque input here

Premium boundary: grip is OSS; this is local git mechanics over opaque identifiers and carries no identity, org, or policy content.
