### PR TITLE
fix(link): refuse stale gripspace sources

### DIFF
--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -2,12 +2,15 @@
 //!
 //! Manages copyfile and linkfile entries.
 
+use crate::cli::outcome::CliOutcomeError;
 use crate::cli::output::Output;
+use crate::core::gripspace::requested_gripspace_revision;
 use crate::core::manifest::Manifest;
 use crate::core::manifest_paths;
 use crate::core::repo::RepoInfo;
 use crate::files::{process_composefiles, resolve_file_source};
-use crate::git::path_exists;
+use crate::git::{fetch_remote, path_exists};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 /// Check if a source path contains glob characters (`*`, `?`, `[`).
@@ -118,10 +121,157 @@ pub fn run_link(
     if status {
         show_link_status(workspace_root, manifest, json)?;
     } else if apply {
+        ensure_gripspace_sources_current(workspace_root, manifest)?;
         apply_links(workspace_root, manifest, false)?;
     } else {
         // Default: show status
         show_link_status(workspace_root, manifest, json)?;
+    }
+
+    Ok(())
+}
+
+/// Names of gripspace clones whose bytes can reach a manual link application.
+///
+/// Resolution rewrites inherited composefile parts to their materialized
+/// directory name. Copyfile and linkfile sources retain the explicit
+/// `gripspace:<name>:<path>` spelling. Collect both forms so the freshness
+/// check and the writer cover the same source classes.
+fn referenced_gripspaces(manifest: &Manifest) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    let Some(config) = &manifest.manifest else {
+        return names;
+    };
+
+    for source in config
+        .copyfile
+        .iter()
+        .flatten()
+        .map(|entry| entry.src.as_str())
+        .chain(
+            config
+                .linkfile
+                .iter()
+                .flatten()
+                .map(|entry| entry.src.as_str()),
+        )
+    {
+        if let Some(rest) = source.strip_prefix("gripspace:") {
+            if let Some((name, _)) = rest.split_once(':') {
+                names.insert(name.to_string());
+            }
+        }
+    }
+
+    for name in config
+        .composefile
+        .iter()
+        .flatten()
+        .flat_map(|compose| &compose.parts)
+        .filter_map(|part| part.gripspace.as_ref())
+    {
+        names.insert(name.clone());
+    }
+
+    names
+}
+
+/// Refuse a manual apply when a branch-backed gripspace is behind upstream.
+///
+/// A successful local composition proves that the files are internally
+/// usable. It does not prove that the source clone is current. Fetch first,
+/// then compare graph position. A detached HEAD is accepted only when the
+/// materializer recorded an explicit tag or commit revision and HEAD still
+/// resolves to that pin. Detachment by itself is not evidence of a pin.
+fn ensure_gripspace_sources_current(
+    workspace_root: &Path,
+    manifest: &Manifest,
+) -> anyhow::Result<()> {
+    let spaces_dir = manifest_paths::spaces_dir(workspace_root);
+
+    for name in referenced_gripspaces(manifest) {
+        let path = spaces_dir.join(&name);
+        let repo = git2::Repository::open(&path).map_err(|error| {
+            anyhow::anyhow!(
+                "Cannot verify gripspace source '{}' at {}: {}",
+                name,
+                path.display(),
+                error
+            )
+        })?;
+        fetch_remote(&repo, "origin").map_err(|error| {
+            anyhow::anyhow!("Cannot verify gripspace source '{name}' against origin: {error}")
+        })?;
+
+        let head = repo.head()?;
+        let local_oid = head
+            .target()
+            .ok_or_else(|| anyhow::anyhow!("Cannot resolve HEAD for gripspace source '{name}'"))?;
+        if !head.is_branch() {
+            let requested_rev = requested_gripspace_revision(&path).map_err(|error| {
+                CliOutcomeError::refusal(format!(
+                    "Cannot verify detached gripspace source '{name}': {error}"
+                ))
+            })?;
+            let Some(rev) = requested_rev else {
+                return Err(CliOutcomeError::refusal(format!(
+                    "Gripspace source '{name}' is unexpectedly detached without an explicit revision pin. Run `gr sync` before `gr link --apply`."
+                ))
+                .into());
+            };
+
+            let remote_branch = format!("refs/remotes/origin/{rev}");
+            if repo.find_reference(&remote_branch).is_ok() {
+                return Err(CliOutcomeError::refusal(format!(
+                    "Gripspace source '{name}' is detached from configured branch '{rev}'. Run `gr sync` before `gr link --apply`."
+                ))
+                .into());
+            }
+
+            let pinned_oid = repo
+                .revparse_single(&rev)
+                .and_then(|object| object.peel_to_commit())
+                .map(|commit| commit.id())
+                .map_err(|error| {
+                    CliOutcomeError::refusal(format!(
+                        "Cannot verify gripspace source '{name}' at configured revision '{rev}': {error}"
+                    ))
+                })?;
+            if pinned_oid != local_oid {
+                return Err(CliOutcomeError::refusal(format!(
+                    "Gripspace source '{name}' does not match configured revision '{rev}'. Run `gr sync` before `gr link --apply`."
+                ))
+                .into());
+            }
+            continue;
+        }
+
+        let branch = head
+            .shorthand()
+            .ok_or_else(|| anyhow::anyhow!("Cannot identify branch for gripspace source '{name}'"))?
+            .to_string();
+
+        let remote_ref = format!("refs/remotes/origin/{branch}");
+        let remote_oid = repo
+            .find_reference(&remote_ref)
+            .and_then(|reference| {
+                reference
+                    .target()
+                    .ok_or_else(|| git2::Error::from_str(&format!("{remote_ref} has no target")))
+            })
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "Cannot verify gripspace source '{name}' against origin/{branch}: {error}"
+                )
+            })?;
+        let (_, behind) = repo.graph_ahead_behind(local_oid, remote_oid)?;
+
+        if behind > 0 {
+            return Err(CliOutcomeError::refusal(format!(
+                "Gripspace source '{name}' is behind origin/{branch} by {behind} commit(s). Run `gr sync` before `gr link --apply`."
+            ))
+            .into());
+        }
     }
 
     Ok(())
@@ -774,11 +924,44 @@ pub fn apply_links(workspace_root: &Path, manifest: &Manifest, quiet: bool) -> a
 mod tests {
     use super::*;
     use crate::core::manifest::{
-        CloneStrategy, CopyFileConfig, LinkFileConfig, ManifestRepoConfig, ManifestSettings,
-        MergeStrategy, RepoConfig,
+        CloneStrategy, CopyFileConfig, GripspaceConfig, LinkFileConfig, ManifestRepoConfig,
+        ManifestSettings, MergeStrategy, RepoConfig,
     };
     use std::collections::HashMap;
+    use std::process::Command as GitCommand;
     use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) -> String {
+        let output = GitCommand::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?} failed in {}: {}",
+            dir.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn source_repo(path: &Path) -> String {
+        std::fs::create_dir_all(path).unwrap();
+        git(path, &["init", "-q", "-b", "main"]);
+        git(path, &["config", "user.email", "test@example.com"]);
+        git(path, &["config", "user.name", "test"]);
+        std::fs::write(path.join("SOURCE.md"), "version one\n").unwrap();
+        git(path, &["add", "SOURCE.md"]);
+        git(path, &["commit", "-qm", "initial"]);
+        git(path, &["rev-parse", "HEAD"])
+    }
+
+    fn advance_source(path: &Path) {
+        std::fs::write(path.join("SOURCE.md"), "version two\n").unwrap();
+        git(path, &["add", "SOURCE.md"]);
+        git(path, &["commit", "-qm", "advance"]);
+    }
 
     fn create_test_manifest(
         copyfiles: Option<Vec<CopyFileConfig>>,
@@ -823,6 +1006,90 @@ mod tests {
             },
             workspace: None,
         }
+    }
+
+    #[test]
+    fn freshness_sources_cover_every_gripspace_backed_link_shape() {
+        let manifest = Manifest::parse_raw(
+            r#"
+version: 2
+repos: {}
+manifest:
+  url: ""
+  copyfile:
+    - src: gripspace:copy-space:file.txt
+      dest: copy.txt
+    - src: local.txt
+      dest: local-copy.txt
+  linkfile:
+    - src: gripspace:link-space:file.txt
+      dest: link.txt
+  composefile:
+    - dest: composed.txt
+      parts:
+        - gripspace: compose-space
+          src: file.txt
+        - gripspace: copy-space
+          src: another.txt
+        - src: local.txt
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            referenced_gripspaces(&manifest),
+            BTreeSet::from([
+                "compose-space".to_string(),
+                "copy-space".to_string(),
+                "link-space".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn detached_source_requires_recorded_pin_provenance() {
+        let fixture = TempDir::new().unwrap();
+        let workspace = fixture.path().join("workspace");
+        let spaces = manifest_paths::spaces_dir(&workspace);
+        std::fs::create_dir_all(&spaces).unwrap();
+        let origin = fixture.path().join("source-space");
+        let pinned_sha = source_repo(&origin);
+
+        let unpinned = GripspaceConfig {
+            url: origin.display().to_string(),
+            rev: None,
+        };
+        let clone = crate::core::gripspace::ensure_gripspace(&spaces, &unpinned).unwrap();
+        git(&clone, &["checkout", "--detach", "HEAD"]);
+        assert!(git(&clone, &["branch", "--show-current"]).is_empty());
+        advance_source(&origin);
+
+        let manifest = Manifest::parse_raw(
+            r#"
+version: 2
+repos: {}
+manifest:
+  url: ""
+  copyfile:
+    - src: gripspace:source-space:SOURCE.md
+      dest: OUTPUT.md
+"#,
+        )
+        .unwrap();
+        let error = ensure_gripspace_sources_current(&workspace, &manifest).unwrap_err();
+        let diagnostic = error.to_string();
+        assert!(diagnostic.contains("unexpectedly detached"), "{diagnostic}");
+        assert!(diagnostic.contains("gr sync"), "{diagnostic}");
+
+        // Positive control: the same detached object is accepted when the
+        // materializer records that exact commit as the requested revision.
+        let pinned = GripspaceConfig {
+            url: origin.display().to_string(),
+            rev: Some(pinned_sha),
+        };
+        let pinned_clone = crate::core::gripspace::ensure_gripspace(&spaces, &pinned).unwrap();
+        assert!(git(&pinned_clone, &["branch", "--show-current"]).is_empty());
+        ensure_gripspace_sources_current(&workspace, &manifest).unwrap();
     }
 
     #[test]

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -25,6 +25,53 @@ use std::process::Command;
 /// Maximum depth for recursive gripspace includes
 const MAX_GRIPSPACE_DEPTH: usize = 5;
 
+/// Local git-config key recording the revision contract used to materialize a
+/// gripspace clone. An empty value means the manifest omitted `rev` and the
+/// clone is expected to remain branch-backed.
+const REQUESTED_REV_CONFIG_KEY: &str = "gitgrip.requestedGripspaceRev";
+
+fn record_requested_revision(
+    gripspace_path: &Path,
+    rev: Option<&str>,
+) -> Result<(), ManifestError> {
+    let repo = git2::Repository::open(gripspace_path).map_err(|error| {
+        ManifestError::GripspaceError(format!(
+            "Failed to open gripspace revision metadata: {error}"
+        ))
+    })?;
+    repo.config()
+        .and_then(|mut config| config.set_str(REQUESTED_REV_CONFIG_KEY, rev.unwrap_or("")))
+        .map_err(|error| {
+            ManifestError::GripspaceError(format!(
+                "Failed to record gripspace revision metadata: {error}"
+            ))
+        })
+}
+
+/// Revision contract recorded when this gripspace was resolved.
+///
+/// `Ok(None)` is a recorded rev-less, branch-backed source. A missing key is
+/// an error rather than an implicit pin because absence cannot prove why a
+/// detached checkout exists.
+pub fn requested_gripspace_revision(
+    gripspace_path: &Path,
+) -> Result<Option<String>, ManifestError> {
+    let repo = git2::Repository::open(gripspace_path).map_err(|error| {
+        ManifestError::GripspaceError(format!(
+            "Failed to open gripspace revision metadata: {error}"
+        ))
+    })?;
+    let value = repo
+        .config()
+        .and_then(|config| config.get_string(REQUESTED_REV_CONFIG_KEY))
+        .map_err(|error| {
+            ManifestError::GripspaceError(format!(
+                "Gripspace revision provenance is unavailable: {error}. Run `gr sync` before applying links."
+            ))
+        })?;
+    Ok((!value.is_empty()).then_some(value))
+}
+
 /// Extract a gripspace name from its URL.
 ///
 /// Takes the last path component without `.git` suffix.
@@ -311,6 +358,7 @@ pub fn ensure_gripspace(
         if let Some(ref rev) = config.rev {
             checkout_rev(&gripspace_path, rev)?;
         }
+        record_requested_revision(&gripspace_path, config.rev.as_deref())?;
         return Ok(gripspace_path);
     }
 
@@ -332,6 +380,8 @@ pub fn ensure_gripspace(
     if let Some(ref rev) = config.rev {
         checkout_rev(&gripspace_path, rev)?;
     }
+
+    record_requested_revision(&gripspace_path, config.rev.as_deref())?;
 
     Ok(gripspace_path)
 }
@@ -386,6 +436,8 @@ pub fn update_gripspace(
             )));
         }
     }
+
+    record_requested_revision(gripspace_path, config.rev.as_deref())?;
 
     Ok(())
 }

--- a/tests/link_apply_freshness.rs
+++ b/tests/link_apply_freshness.rs
@@ -1,0 +1,228 @@
+//! `gr link --apply` must not certify stale gripspace-derived output.
+//!
+//! The command composes from clones under `.gitgrip/spaces`. A valid local
+//! file proves only that composition can run. It does not prove that the clone
+//! still reflects its upstream. This test advances the upstream after a known
+//! current baseline and requires the manual apply path to refuse before it
+//! rewrites the destination from stale bytes.
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed in {}: {}",
+        args,
+        dir.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn repo(root: &Path, name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let dir = root.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    git(&dir, &["init", "-q", "-b", "main"]);
+    git(&dir, &["config", "user.email", "test@example.com"]);
+    git(&dir, &["config", "user.name", "test"]);
+    for (path, body) in files {
+        let full = dir.join(path);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(full, body).unwrap();
+    }
+    git(&dir, &["add", "-A"]);
+    git(&dir, &["commit", "-qm", "initial"]);
+    dir
+}
+
+fn advance(repo: &Path, body: &str) -> String {
+    std::fs::write(repo.join("SECTION.md"), body).unwrap();
+    git(repo, &["add", "SECTION.md"]);
+    git(repo, &["commit", "-qm", "advance source"]);
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+#[test]
+fn link_apply_refuses_a_gripspace_source_that_is_behind_upstream() {
+    let fixture = TempDir::new().unwrap();
+    let root = fixture.path();
+
+    let source = repo(
+        root,
+        "source-space",
+        &[
+            ("SECTION.md", "version-one-content\n"),
+            ("gripspace.yml", "version: 2\nrepos: {}\n"),
+        ],
+    );
+    let dummy = repo(root, "dummy-repo", &[("README.md", "dummy\n")]);
+    let manifest = repo(
+        root,
+        "workspace-manifest",
+        &[(
+            "gripspace.yml",
+            &format!(
+                r#"version: 2
+gripspaces:
+  - url: "{}"
+    rev: main
+manifest:
+  url: "{}"
+  revision: main
+  composefile:
+    - dest: OUT.md
+      parts:
+        - gripspace: source-space
+          src: SECTION.md
+repos:
+  dummy-repo:
+    url: "{}"
+    path: ./dummy-repo
+    revision: main
+"#,
+                source.display(),
+                root.join("workspace-manifest").display(),
+                dummy.display(),
+            ),
+        )],
+    );
+
+    let workspace = root.join("workspace");
+    let init = Command::cargo_bin("gr")
+        .unwrap()
+        .args([
+            "init",
+            manifest.to_str().unwrap(),
+            "--path",
+            workspace.to_str().unwrap(),
+            "--no-interactive",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "init precondition failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // Establish a known-current composition through the same sync path the
+    // issue uses before advancing the source. `gr init` currently treats a
+    // link-application failure as a warning, so its zero exit alone is not a
+    // sufficient fixture precondition.
+    let baseline_sync = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    assert!(
+        baseline_sync.status.success(),
+        "baseline sync precondition failed:\nmanifest={}\nstdout={}\nstderr={}",
+        std::fs::read_to_string(workspace.join(".gitgrip/spaces/main/gripspace.yml"))
+            .unwrap_or_else(|error| format!("<unreadable: {error}>")),
+        String::from_utf8_lossy(&baseline_sync.stdout),
+        String::from_utf8_lossy(&baseline_sync.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("OUT.md")).unwrap_or_else(|error| {
+            panic!(
+                "baseline composition did not produce OUT.md: {error}\nstdout={}\nstderr={}",
+                String::from_utf8_lossy(&baseline_sync.stdout),
+                String::from_utf8_lossy(&baseline_sync.stderr)
+            )
+        }),
+        "version-one-content\n"
+    );
+
+    advance(&source, "version-two-content\n");
+    let sync = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    assert!(
+        sync.status.success(),
+        "sync precondition failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&sync.stdout),
+        String::from_utf8_lossy(&sync.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
+        "version-two-content\n"
+    );
+
+    let upstream_head = advance(&source, "version-three-content\n");
+    let local_head = git(
+        &workspace.join(".gitgrip/spaces/source-space"),
+        &["rev-parse", "HEAD"],
+    );
+    assert_ne!(
+        local_head, upstream_head,
+        "fixture must be stale before apply"
+    );
+
+    let apply = Command::cargo_bin("gr")
+        .unwrap()
+        .args(["link", "--apply"])
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    assert_eq!(
+        apply.status.code(),
+        Some(2),
+        "a stale source must be a deliberate refusal, not success:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let diagnostic = format!(
+        "{}{}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    assert!(
+        diagnostic.contains("source-space"),
+        "diagnostic must name the stale source"
+    );
+    assert!(
+        diagnostic.contains("gr sync"),
+        "diagnostic must state the recovery path"
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
+        "version-two-content\n",
+        "refusal must happen before stale bytes rewrite the destination"
+    );
+
+    // Positive control: after the named recovery path, the same command runs
+    // and the destination reflects the advanced source.
+    let sync = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    assert!(sync.status.success());
+    let apply = Command::cargo_bin("gr")
+        .unwrap()
+        .args(["link", "--apply"])
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    assert!(apply.status.success());
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
+        "version-three-content\n"
+    );
+}


### PR DESCRIPTION
> **Correction after merge (2026-08-19):** The detached-source guarantee below is narrower than the CLI behavior. `gr link --apply` verifies attached branch sources, but manifest resolution can reattach a branch-configured detached source before the freshness guard observes it. A named tag pin is also compared with the local tag, which can remain stale after the upstream tag moves. The detached branch and moved-tag paths are not fixed by this PR. Follow-up: #891.

## Summary

- verify every branch-backed gripspace source before manual link application
- refuse before writing when a referenced source is behind upstream
- record the requested revision at materialization and update
- accept detached HEAD only when it matches an explicit tag or commit pin
- refuse rev-less or branch-configured detachment and name `gr sync` as recovery

Manual `gr link --apply` previously proved that local source files were composable, not that the source checkouts were current. This change measures upstream freshness and refuses an unverifiable detached state before any link write.

## Verification

- full `cargo test` suite passed
- the stale-source end-to-end witness passes after `gr sync`
- removing manual preflight makes the stale-source witness fail by applying stale content with exit 0
- restoring the unconditional detached-HEAD bypass makes the provenance witness fail
- the same detached commit passes when materialized through an explicit SHA pin
- removing composefile enumeration makes the source-shape and stale-source witnesses fail

## Boundary

The stale-source refusal is limited to manual `gr link --apply`. `gr sync` now records revision provenance during materialization and update, while retaining its existing link-application behavior.

Ref #883 — closes at promotion.
