### PR TITLE
fix(link): verify gripspace pins before applying

### DIFF
--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -225,6 +225,19 @@ fn is_commit_id_like(rev: &str) -> bool {
     rev.len() >= 4 && rev.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
+/// Resolve a hexadecimal object-id prefix without interpreting it as a ref name.
+///
+/// `revparse_single` gives refs precedence, so an all-hex tag deleted from
+/// origin could otherwise resolve through the stale local tag and be mistaken
+/// for an immutable commit pin. The object database answers the narrower
+/// question this branch asks and rejects ambiguous prefixes itself.
+fn commit_from_id_prefix(repo: &git2::Repository, rev: &str) -> anyhow::Result<git2::Oid> {
+    let prefix = git2::Oid::from_str(rev)?;
+    let oid = repo.odb()?.exists_prefix(prefix, rev.len())?;
+    repo.find_commit(oid)?;
+    Ok(oid)
+}
+
 /// Refuse a manual apply when a gripspace is not at its configured revision.
 ///
 /// A successful local composition proves that the files are internally
@@ -281,14 +294,11 @@ fn ensure_gripspace_sources_current(
             let pinned_oid = if let Some(tag_oid) = remote_tag_commit(&repo, &rev)? {
                 tag_oid
             } else if is_commit_id_like(&rev) {
-                repo.revparse_single(&rev)
-                    .and_then(|object| object.peel_to_commit())
-                    .map(|commit| commit.id())
-                    .map_err(|error| {
-                        CliOutcomeError::refusal(format!(
-                            "Cannot verify gripspace source '{name}' at configured commit '{rev}': {error}"
-                        ))
-                    })?
+                commit_from_id_prefix(&repo, &rev).map_err(|error| {
+                    CliOutcomeError::refusal(format!(
+                        "Cannot verify gripspace source '{name}' at configured commit id '{rev}': {error}. Use a longer commit id if the prefix is ambiguous, or correct the configured revision."
+                    ))
+                })?
             } else {
                 return Err(CliOutcomeError::refusal(format!(
                     "Cannot verify gripspace source '{name}' at configured revision '{rev}' against origin. Run `gr sync` before `gr link --apply`."

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -12,6 +12,7 @@ use crate::files::{process_composefiles, resolve_file_source};
 use crate::git::{fetch_remote, path_exists};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Check if a source path contains glob characters (`*`, `?`, `[`).
 fn is_glob_pattern(src: &str) -> bool {
@@ -176,13 +177,62 @@ fn referenced_gripspaces(manifest: &Manifest) -> BTreeSet<String> {
     names
 }
 
-/// Refuse a manual apply when a branch-backed gripspace is behind upstream.
+/// Resolve a named tag from the remote itself, without trusting the local tag.
+///
+/// A normal fetch deliberately refuses to move an existing local tag. Using
+/// `revparse_single(rev)` after that fetch therefore compares HEAD with the
+/// same stale local ref and can certify old content as current. `ls-remote`
+/// observes the upstream ref directly and handles both lightweight and
+/// annotated tags; the peeled commit wins when both rows are present.
+fn remote_tag_commit(repo: &git2::Repository, rev: &str) -> anyhow::Result<Option<git2::Oid>> {
+    let workdir = repo
+        .workdir()
+        .ok_or_else(|| anyhow::anyhow!("Gripspace source has no working directory"))?;
+    let tag_ref = format!("refs/tags/{rev}");
+    let peeled_ref = format!("{tag_ref}^{{}}");
+    let output = Command::new("git")
+        .args(["ls-remote", "--tags", "origin", &tag_ref, &peeled_ref])
+        .current_dir(workdir)
+        .output()
+        .map_err(|error| anyhow::anyhow!("Cannot inspect origin tag '{rev}': {error}"))?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "Cannot inspect origin tag '{}': {}",
+            rev,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let mut direct = None;
+    let mut peeled = None;
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Some((oid, reference)) = line.split_once(char::is_whitespace) else {
+            continue;
+        };
+        let parsed = git2::Oid::from_str(oid.trim()).map_err(|error| {
+            anyhow::anyhow!("Origin returned an invalid object id for tag '{rev}': {error}")
+        })?;
+        match reference.trim() {
+            value if value == peeled_ref => peeled = Some(parsed),
+            value if value == tag_ref => direct = Some(parsed),
+            _ => {}
+        }
+    }
+    Ok(peeled.or(direct))
+}
+
+fn is_full_commit_id(rev: &str) -> bool {
+    rev.len() == 40 && rev.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// Refuse a manual apply when a gripspace is not at its configured revision.
 ///
 /// A successful local composition proves that the files are internally
 /// usable. It does not prove that the source clone is current. Fetch first,
-/// then compare graph position. A detached HEAD is accepted only when the
-/// materializer recorded an explicit tag or commit revision and HEAD still
-/// resolves to that pin. Detachment by itself is not evidence of a pin.
+/// then compare both branch identity and graph position. An attached HEAD must
+/// still be on the configured branch. A detached HEAD is accepted only when
+/// the materializer recorded an explicit tag or commit revision and HEAD still
+/// resolves to that pin. Neither attachment nor detachment proves provenance.
 fn ensure_gripspace_sources_current(
     workspace_root: &Path,
     manifest: &Manifest,
@@ -228,15 +278,23 @@ fn ensure_gripspace_sources_current(
                 .into());
             }
 
-            let pinned_oid = repo
-                .revparse_single(&rev)
-                .and_then(|object| object.peel_to_commit())
-                .map(|commit| commit.id())
-                .map_err(|error| {
-                    CliOutcomeError::refusal(format!(
-                        "Cannot verify gripspace source '{name}' at configured revision '{rev}': {error}"
-                    ))
-                })?;
+            let pinned_oid = if let Some(tag_oid) = remote_tag_commit(&repo, &rev)? {
+                tag_oid
+            } else if is_full_commit_id(&rev) {
+                repo.revparse_single(&rev)
+                    .and_then(|object| object.peel_to_commit())
+                    .map(|commit| commit.id())
+                    .map_err(|error| {
+                        CliOutcomeError::refusal(format!(
+                            "Cannot verify gripspace source '{name}' at configured commit '{rev}': {error}"
+                        ))
+                    })?
+            } else {
+                return Err(CliOutcomeError::refusal(format!(
+                    "Cannot verify gripspace source '{name}' at configured revision '{rev}' against origin. Run `gr sync` before `gr link --apply`."
+                ))
+                .into());
+            };
             if pinned_oid != local_oid {
                 return Err(CliOutcomeError::refusal(format!(
                     "Gripspace source '{name}' does not match configured revision '{rev}'. Run `gr sync` before `gr link --apply`."
@@ -250,6 +308,20 @@ fn ensure_gripspace_sources_current(
             .shorthand()
             .ok_or_else(|| anyhow::anyhow!("Cannot identify branch for gripspace source '{name}'"))?
             .to_string();
+
+        let requested_rev = requested_gripspace_revision(&path).map_err(|error| {
+            CliOutcomeError::refusal(format!(
+                "Cannot verify gripspace source '{name}' on branch '{branch}': {error}"
+            ))
+        })?;
+        if let Some(rev) = requested_rev {
+            if rev != branch {
+                return Err(CliOutcomeError::refusal(format!(
+                    "Gripspace source '{name}' is on branch '{branch}', configured revision '{rev}'. Run `gr sync` before `gr link --apply`."
+                ))
+                .into());
+            }
+        }
 
         let remote_ref = format!("refs/remotes/origin/{branch}");
         let remote_oid = repo

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -221,8 +221,8 @@ fn remote_tag_commit(repo: &git2::Repository, rev: &str) -> anyhow::Result<Optio
     Ok(peeled.or(direct))
 }
 
-fn is_full_commit_id(rev: &str) -> bool {
-    rev.len() == 40 && rev.bytes().all(|byte| byte.is_ascii_hexdigit())
+fn is_commit_id_like(rev: &str) -> bool {
+    rev.len() >= 4 && rev.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 /// Refuse a manual apply when a gripspace is not at its configured revision.
@@ -280,7 +280,7 @@ fn ensure_gripspace_sources_current(
 
             let pinned_oid = if let Some(tag_oid) = remote_tag_commit(&repo, &rev)? {
                 tag_oid
-            } else if is_full_commit_id(&rev) {
+            } else if is_commit_id_like(&rev) {
                 repo.revparse_single(&rev)
                     .and_then(|object| object.peel_to_commit())
                     .map(|commit| commit.id())

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -596,7 +596,11 @@ pub async fn dispatch_command(
             .await?;
         }
         Some(Commands::Link { status, apply }) => {
-            let ctx = load_workspace_context(quiet, verbose, json)?;
+            // Manual apply is a verification path, not a materialization path.
+            // Resolve included manifests from the clones exactly as they sit so
+            // a detached source cannot be silently reattached before link's
+            // freshness guard observes it. Status retains the historical loader.
+            let ctx = load_workspace_context_with_materialization(quiet, verbose, json, !apply)?;
             crate::cli::commands::link::run_link(
                 &ctx.workspace_root,
                 &ctx.manifest,
@@ -1038,7 +1042,9 @@ pub async fn dispatch_command(
 /// `.griptree` many levels up eclipse a `.gitgrip` or checkout one level
 /// down, because the griptree pass never stopped climbing to give the nearer
 /// marker a chance).
-fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest::Manifest)> {
+fn load_gripspace(
+    materialize_gripspaces: bool,
+) -> anyhow::Result<(std::path::PathBuf, crate::core::manifest::Manifest)> {
     let current = std::env::current_dir()?;
     let mut search_path = current;
     loop {
@@ -1047,7 +1053,7 @@ fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest
             if let Ok(pointer) =
                 crate::core::griptree::GriptreePointer::load(&griptree_pointer_path)
             {
-                return load_from_griptree(&search_path, &pointer);
+                return load_from_griptree(&search_path, &pointer, materialize_gripspaces);
             }
         }
 
@@ -1079,7 +1085,7 @@ fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest
             {
                 let content = std::fs::read_to_string(&manifest_path)?;
                 let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
-                resolve_gripspace_includes(&mut manifest, &search_path);
+                resolve_gripspace_includes(&mut manifest, &search_path, materialize_gripspaces)?;
                 return Ok((search_path, manifest));
             }
         }
@@ -1089,7 +1095,7 @@ fn load_gripspace() -> anyhow::Result<(std::path::PathBuf, crate::core::manifest
         {
             let content = std::fs::read_to_string(repo_yaml)?;
             let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
-            resolve_gripspace_includes(&mut manifest, &search_path);
+            resolve_gripspace_includes(&mut manifest, &search_path, materialize_gripspaces)?;
             return Ok((search_path, manifest));
         }
 
@@ -1117,7 +1123,16 @@ fn load_workspace_context(
     verbose: bool,
     json: bool,
 ) -> anyhow::Result<WorkspaceContext> {
-    let (workspace_root, manifest) = load_gripspace()?;
+    load_workspace_context_with_materialization(quiet, verbose, json, true)
+}
+
+fn load_workspace_context_with_materialization(
+    quiet: bool,
+    verbose: bool,
+    json: bool,
+    materialize_gripspaces: bool,
+) -> anyhow::Result<WorkspaceContext> {
+    let (workspace_root, manifest) = load_gripspace(materialize_gripspaces)?;
     Ok(WorkspaceContext::new(
         workspace_root,
         manifest,
@@ -1131,6 +1146,7 @@ fn load_workspace_context(
 fn load_from_griptree(
     griptree_path: &std::path::Path,
     pointer: &crate::core::griptree::GriptreePointer,
+    materialize_gripspaces: bool,
 ) -> anyhow::Result<(std::path::PathBuf, crate::core::manifest::Manifest)> {
     let griptree_manifest_path =
         crate::core::manifest_paths::resolve_gripspace_manifest_path(griptree_path);
@@ -1152,7 +1168,7 @@ fn load_from_griptree(
     };
 
     let mut manifest = crate::core::manifest::Manifest::parse(&content)?;
-    resolve_gripspace_includes(&mut manifest, griptree_path);
+    resolve_gripspace_includes(&mut manifest, griptree_path, materialize_gripspaces)?;
     Ok((griptree_path.to_path_buf(), manifest))
 }
 
@@ -1160,9 +1176,15 @@ fn load_from_griptree(
 fn resolve_gripspace_includes(
     manifest: &mut crate::core::manifest::Manifest,
     workspace_root: &std::path::Path,
-) {
+    materialize_gripspaces: bool,
+) -> anyhow::Result<()> {
     let spaces_dir = crate::core::manifest_paths::spaces_dir(workspace_root);
     if spaces_dir.exists() {
-        let _ = crate::core::gripspace::resolve_all_gripspaces(manifest, &spaces_dir);
+        if materialize_gripspaces {
+            let _ = crate::core::gripspace::resolve_all_gripspaces(manifest, &spaces_dir);
+        } else {
+            crate::core::gripspace::resolve_existing_gripspaces(manifest, &spaces_dir)?;
+        }
     }
+    Ok(())
 }

--- a/src/core/gripspace.rs
+++ b/src/core/gripspace.rs
@@ -386,6 +386,55 @@ pub fn ensure_gripspace(
     Ok(gripspace_path)
 }
 
+/// Locate an already-materialized gripspace without changing its checkout.
+///
+/// Manual link application must inspect the source state the operator actually
+/// has. Calling [`ensure_gripspace`] while loading that command can run
+/// `checkout -B` and erase a detached-HEAD premise before the freshness guard
+/// sees it. Prefer the recorded URL + revision identity. If provenance is
+/// missing, a unique same-remote clone is still returned so the guard can
+/// refuse it explicitly rather than resolution hiding the source altogether.
+fn existing_gripspace(
+    spaces_dir: &Path,
+    config: &GripspaceConfig,
+) -> Result<PathBuf, ManifestError> {
+    let entries = std::fs::read_dir(spaces_dir).map_err(|error| {
+        ManifestError::GripspaceError(format!(
+            "Cannot inspect materialized gripspaces at '{}': {error}. Run `gr sync` before applying links.",
+            spaces_dir.display()
+        ))
+    })?;
+
+    let mut same_remote = Vec::new();
+    let mut exact = Vec::new();
+    for entry in entries {
+        let path = entry
+            .map_err(|error| ManifestError::GripspaceError(error.to_string()))?
+            .path();
+        if !path.is_dir() || !is_same_remote(&path, &config.url) {
+            continue;
+        }
+        let recorded_matches = match (requested_gripspace_revision(&path), config.rev.as_deref()) {
+            (Ok(Some(recorded)), Some(requested)) => recorded == requested,
+            (Ok(None), None) => true,
+            _ => false,
+        };
+        if recorded_matches {
+            exact.push(path.clone());
+        }
+        same_remote.push(path);
+    }
+
+    match (exact.as_slice(), same_remote.as_slice()) {
+        ([path], _) => Ok(path.clone()),
+        ([], [path]) => Ok(path.clone()),
+        _ => Err(ManifestError::GripspaceError(format!(
+            "Cannot identify one existing gripspace for '{}'. Run `gr sync` before applying links.",
+            config.url
+        ))),
+    }
+}
+
 /// Update a gripspace by fetching and pulling latest.
 pub fn update_gripspace(
     gripspace_path: &Path,
@@ -400,7 +449,11 @@ pub fn update_gripspace(
 
     // Fetch from origin
     let output = Command::new("git")
-        .args(["fetch", "origin"])
+        // Managed gripspace clones treat the manifest's named tag as upstream
+        // authority. A plain fetch leaves a moved local tag untouched, so the
+        // subsequent checkout resolves the stale tag and `gr sync` cannot
+        // satisfy the recovery path named by the link freshness refusal.
+        .args(["fetch", "--force", "--tags", "origin"])
         .current_dir(gripspace_path)
         .output()
         .map_err(|e| ManifestError::GripspaceError(format!("Failed to fetch gripspace: {}", e)))?;
@@ -627,6 +680,26 @@ pub fn resolve_all_gripspaces(
     manifest: &mut Manifest,
     spaces_dir: &Path,
 ) -> Result<(), ManifestError> {
+    resolve_all_gripspaces_with_materialization(manifest, spaces_dir, true)
+}
+
+/// Resolve included manifests from existing clones without changing HEAD.
+///
+/// This is the manual-link preflight form. It deliberately refuses a missing
+/// or ambiguous clone instead of cloning, fetching, checking out, or recording
+/// revision metadata while merely deciding whether an apply is safe.
+pub fn resolve_existing_gripspaces(
+    manifest: &mut Manifest,
+    spaces_dir: &Path,
+) -> Result<(), ManifestError> {
+    resolve_all_gripspaces_with_materialization(manifest, spaces_dir, false)
+}
+
+fn resolve_all_gripspaces_with_materialization(
+    manifest: &mut Manifest,
+    spaces_dir: &Path,
+    materialize: bool,
+) -> Result<(), ManifestError> {
     let gripspaces = match manifest.gripspaces.take() {
         Some(gs) if !gs.is_empty() => gs,
         _ => return Ok(()),
@@ -652,6 +725,7 @@ pub fn resolve_all_gripspaces(
             &mut active_stack,
             &mut resolved,
             0,
+            materialize,
             &mut merged_repos,
             &mut merged_scripts,
             &mut merged_env,
@@ -866,6 +940,7 @@ fn resolve_gripspace_recursive(
     active_stack: &mut HashSet<String>,
     resolved: &mut HashSet<String>,
     depth: usize,
+    materialize: bool,
     merged_repos: &mut HashMap<String, crate::core::manifest::RepoConfig>,
     merged_scripts: &mut HashMap<String, crate::core::manifest::WorkspaceScript>,
     merged_env: &mut HashMap<String, String>,
@@ -901,10 +976,24 @@ fn resolve_gripspace_recursive(
         )));
     }
 
-    let gripspace_path = ensure_gripspace(spaces_dir, config)?;
-    // Resolve the actual directory name (may differ from `name` due to reserved
-    // name suffixing or multi-rev disambiguation)
-    let dir_name = resolve_space_name(&config.url, config.rev.as_deref(), spaces_dir)?;
+    let gripspace_path = if materialize {
+        ensure_gripspace(spaces_dir, config)?
+    } else {
+        existing_gripspace(spaces_dir, config)?
+    };
+    // Use the directory we actually opened. In read-only mode a detached source
+    // may no longer satisfy revision-derived allocation heuristics, and asking
+    // those heuristics again would select a different path and erase the premise.
+    let dir_name = gripspace_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            ManifestError::GripspaceError(format!(
+                "Cannot identify gripspace directory for '{}'",
+                gripspace_path.display()
+            ))
+        })?
+        .to_string();
 
     // Load the gripspace's manifest
     let Some(manifest_path) = manifest_paths::resolve_manifest_file_in_dir(&gripspace_path) else {
@@ -933,7 +1022,9 @@ fn resolve_gripspace_recursive(
     if let Some(ref nested_gripspaces) = gs_manifest.gripspaces {
         for nested_config in nested_gripspaces {
             // Clone the nested gripspace if it doesn't exist yet
-            ensure_gripspace(spaces_dir, nested_config)?;
+            if materialize {
+                ensure_gripspace(spaces_dir, nested_config)?;
+            }
 
             resolve_gripspace_recursive(
                 nested_config,
@@ -941,6 +1032,7 @@ fn resolve_gripspace_recursive(
                 active_stack,
                 resolved,
                 depth + 1,
+                materialize,
                 merged_repos,
                 merged_scripts,
                 merged_env,

--- a/tests/link_apply_detached_freshness.rs
+++ b/tests/link_apply_detached_freshness.rs
@@ -295,8 +295,7 @@ fn link_apply_refuses_a_detached_source_with_an_unresolvable_named_revision() {
     );
 }
 
-#[test]
-fn control_explicit_full_sha_pin_is_accepted() {
+fn assert_explicit_sha_pin_is_accepted(pin_len: usize) {
     // Build with rev = the source's initial commit SHA.
     let t = TempDir::new().unwrap();
     let root = t.path().to_path_buf();
@@ -308,7 +307,8 @@ fn control_explicit_full_sha_pin_is_accepted() {
             ("gripspace.yml", "version: 2\nrepos: {}\n"),
         ],
     );
-    let pin = git(&source, &["rev-parse", "HEAD"]);
+    let full_pin = git(&source, &["rev-parse", "HEAD"]);
+    let pin = &full_pin[..pin_len];
     let dummy = repo(&root, "dummy-repo", &[("README.md", "d\n")]);
     let manifest = repo(
         &root,
@@ -372,7 +372,7 @@ repos:
         String::from_utf8_lossy(&sync.stderr)
     );
     let space = workspace.join(".gitgrip/spaces/source-space");
-    eprintln!("[A3] recorded: {}", recorded(&space));
+    eprintln!("[A3/{pin_len}] recorded: {}", recorded(&space));
     assert!(
         git(&space, &["branch", "--show-current"]).is_empty(),
         "SHA pin must be detached"
@@ -382,8 +382,18 @@ repos:
     git(&source, &["add", "-A"]);
     git(&source, &["commit", "-qm", "advance"]);
     let (code, diag) = apply(&workspace);
-    eprintln!("[A3] exit={:?}\n{}", code, diag);
+    eprintln!("[A3/{pin_len}] exit={:?}\n{}", code, diag);
     assert_eq!(code, Some(0), "A3 control must be ACCEPTED: {diag}");
+}
+
+#[test]
+fn control_explicit_full_sha_pin_is_accepted() {
+    assert_explicit_sha_pin_is_accepted(40);
+}
+
+#[test]
+fn explicit_short_sha_pin_is_accepted() {
+    assert_explicit_sha_pin_is_accepted(8);
 }
 
 #[test]

--- a/tests/link_apply_detached_freshness.rs
+++ b/tests/link_apply_detached_freshness.rs
@@ -51,6 +51,13 @@ struct Fx {
 
 /// Build a workspace whose gripspace source is materialized at `rev`.
 fn setup(rev: &str) -> Fx {
+    setup_with_source(rev, |_| {})
+}
+
+fn setup_with_source<F>(rev: &str, prepare_source: F) -> Fx
+where
+    F: FnOnce(&Path),
+{
     let t = TempDir::new().unwrap();
     let root = t.path().to_path_buf();
     let source = repo(
@@ -61,6 +68,7 @@ fn setup(rev: &str) -> Fx {
             ("gripspace.yml", "version: 2\nrepos: {}\n"),
         ],
     );
+    prepare_source(&source);
     let dummy = repo(&root, "dummy-repo", &[("README.md", "d\n")]);
     let manifest = repo(
         &root,
@@ -295,6 +303,27 @@ fn link_apply_refuses_a_detached_source_with_an_unresolvable_named_revision() {
     );
 }
 
+#[test]
+fn an_unresolvable_all_hex_commit_prefix_names_an_operator_remedy() {
+    let fx = setup("main");
+    git(
+        &fx.space,
+        &[
+            "config",
+            "gitgrip.requestedGripspaceRev",
+            "0000000000000000000000000000000000000000",
+        ],
+    );
+    git(&fx.space, &["checkout", "--detach", "HEAD"]);
+    let (code, diag) = apply(&fx.workspace);
+    assert_eq!(code, Some(2), "unresolvable commit prefix must refuse");
+    assert!(
+        diag.contains("Use a longer commit id if the prefix is ambiguous")
+            && diag.contains("correct the configured revision"),
+        "diagnostic must name remedies that can change the result: {diag}"
+    );
+}
+
 fn assert_explicit_sha_pin_is_accepted(pin_len: usize) {
     // Build with rev = the source's initial commit SHA.
     let t = TempDir::new().unwrap();
@@ -398,79 +427,12 @@ fn explicit_short_sha_pin_is_accepted() {
 
 #[test]
 fn moved_tag_is_refused_until_sync_updates_the_managed_clone() {
-    let t = TempDir::new().unwrap();
-    let root = t.path().to_path_buf();
-    let source = repo(
-        &root,
-        "source-space",
-        &[
-            ("SECTION.md", "v1\n"),
-            ("gripspace.yml", "version: 2\nrepos: {}\n"),
-        ],
-    );
-    git(&source, &["tag", "release"]);
-    let dummy = repo(&root, "dummy-repo", &[("README.md", "d\n")]);
-    let manifest = repo(
-        &root,
-        "workspace-manifest",
-        &[(
-            "gripspace.yml",
-            &format!(
-                r#"version: 2
-gripspaces:
-  - url: "{}"
-    rev: release
-manifest:
-  url: "{}"
-  revision: main
-  composefile:
-    - dest: OUT.md
-      parts:
-        - gripspace: source-space
-          src: SECTION.md
-repos:
-  dummy-repo:
-    url: "{}"
-    path: ./dummy-repo
-    revision: main
-"#,
-                source.display(),
-                root.join("workspace-manifest").display(),
-                dummy.display()
-            ),
-        )],
-    );
-    let workspace = root.join("workspace");
-    let init = Command::cargo_bin("gr")
-        .unwrap()
-        .args([
-            "init",
-            manifest.to_str().unwrap(),
-            "--path",
-            workspace.to_str().unwrap(),
-            "--no-interactive",
-        ])
-        .output()
-        .unwrap();
-    assert!(
-        init.status.success(),
-        "init: {}{}",
-        String::from_utf8_lossy(&init.stdout),
-        String::from_utf8_lossy(&init.stderr)
-    );
-    let sync = Command::cargo_bin("gr")
-        .unwrap()
-        .arg("sync")
-        .current_dir(&workspace)
-        .output()
-        .unwrap();
-    assert!(
-        sync.status.success(),
-        "sync: {}{}",
-        String::from_utf8_lossy(&sync.stdout),
-        String::from_utf8_lossy(&sync.stderr)
-    );
-    let space = workspace.join(".gitgrip/spaces/source-space");
+    let fx = setup_with_source("release", |source| {
+        git(source, &["tag", "release"]);
+    });
+    let source = &fx.source;
+    let workspace = &fx.workspace;
+    let space = &fx.space;
     eprintln!("[A4] recorded: {}", recorded(&space));
     let before = git(&space, &["rev-parse", "HEAD"]);
     // Upstream moves the tag to new content.
@@ -520,5 +482,36 @@ repos:
         std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
         "v2-MOVED-TAG\n",
         "recovered apply must compose the upstream tag content"
+    );
+}
+
+#[test]
+fn an_all_hex_tag_deleted_from_origin_is_not_reinterpreted_as_a_commit_prefix() {
+    let fx = setup_with_source("cafe", |source| {
+        git(source, &["tag", "cafe"]);
+    });
+    let before = git(&fx.space, &["rev-parse", "HEAD"]);
+    assert_eq!(
+        git(&fx.space, &["rev-parse", "cafe"]),
+        before,
+        "fixture: the managed clone must retain its local tag"
+    );
+
+    git(&fx.source, &["tag", "-d", "cafe"]);
+    let (code, diag) = apply(&fx.workspace);
+    assert_eq!(
+        code,
+        Some(2),
+        "a tag absent from origin must not certify through its stale local ref: {diag}"
+    );
+    assert_eq!(
+        git(&fx.space, &["rev-parse", "HEAD"]),
+        before,
+        "refusal must not move the managed clone"
+    );
+    assert_eq!(
+        std::fs::read_to_string(fx.workspace.join("OUT.md")).unwrap(),
+        "v1\n",
+        "refusal must not compose again from the stale local tag"
     );
 }

--- a/tests/link_apply_detached_freshness.rs
+++ b/tests/link_apply_detached_freshness.rs
@@ -1,0 +1,514 @@
+//! End-to-end witnesses for detached gripspace freshness through the `gr` binary.
+//!
+//! These start above manifest resolution because that caller used to erase the
+//! detached premise before the freshness guard could inspect it.
+
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = StdCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {:?} in {}: {}",
+        args,
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn repo(root: &Path, name: &str, files: &[(&str, &str)]) -> PathBuf {
+    let dir = root.join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    git(&dir, &["init", "-q", "-b", "main"]);
+    git(&dir, &["config", "user.email", "t@e.com"]);
+    git(&dir, &["config", "user.name", "t"]);
+    for (p, b) in files {
+        let full = dir.join(p);
+        if let Some(par) = full.parent() {
+            std::fs::create_dir_all(par).unwrap();
+        }
+        std::fs::write(full, b).unwrap();
+    }
+    git(&dir, &["add", "-A"]);
+    git(&dir, &["commit", "-qm", "initial"]);
+    dir
+}
+
+struct Fx {
+    _t: TempDir,
+    source: PathBuf,
+    workspace: PathBuf,
+    space: PathBuf,
+}
+
+/// Build a workspace whose gripspace source is materialized at `rev`.
+fn setup(rev: &str) -> Fx {
+    let t = TempDir::new().unwrap();
+    let root = t.path().to_path_buf();
+    let source = repo(
+        &root,
+        "source-space",
+        &[
+            ("SECTION.md", "v1\n"),
+            ("gripspace.yml", "version: 2\nrepos: {}\n"),
+        ],
+    );
+    let dummy = repo(&root, "dummy-repo", &[("README.md", "d\n")]);
+    let manifest = repo(
+        &root,
+        "workspace-manifest",
+        &[(
+            "gripspace.yml",
+            &format!(
+                r#"version: 2
+gripspaces:
+  - url: "{}"
+    rev: {}
+manifest:
+  url: "{}"
+  revision: main
+  composefile:
+    - dest: OUT.md
+      parts:
+        - gripspace: source-space
+          src: SECTION.md
+repos:
+  dummy-repo:
+    url: "{}"
+    path: ./dummy-repo
+    revision: main
+"#,
+                source.display(),
+                rev,
+                root.join("workspace-manifest").display(),
+                dummy.display()
+            ),
+        )],
+    );
+
+    let workspace = root.join("workspace");
+    let init = Command::cargo_bin("gr")
+        .unwrap()
+        .args([
+            "init",
+            manifest.to_str().unwrap(),
+            "--path",
+            workspace.to_str().unwrap(),
+            "--no-interactive",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "init: {}{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let sync = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    assert!(
+        sync.status.success(),
+        "baseline sync: {}{}",
+        String::from_utf8_lossy(&sync.stdout),
+        String::from_utf8_lossy(&sync.stderr)
+    );
+    let space = workspace.join(".gitgrip/spaces/source-space");
+    Fx {
+        _t: t,
+        source,
+        workspace,
+        space,
+    }
+}
+
+fn apply(ws: &Path) -> (Option<i32>, String) {
+    let o = Command::cargo_bin("gr")
+        .unwrap()
+        .args(["link", "--apply"])
+        .current_dir(ws)
+        .output()
+        .unwrap();
+    (
+        o.status.code(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        ),
+    )
+}
+
+fn run_sync(ws: &Path) -> (Option<i32>, String) {
+    let o = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(ws)
+        .output()
+        .unwrap();
+    (
+        o.status.code(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&o.stdout),
+            String::from_utf8_lossy(&o.stderr)
+        ),
+    )
+}
+
+fn recorded(space: &Path) -> String {
+    let o = StdCommand::new("git")
+        .args(["config", "--get", "gitgrip.requestedGripspaceRev"])
+        .current_dir(space)
+        .output()
+        .unwrap();
+    format!(
+        "exit={:?} value={:?}",
+        o.status.code(),
+        String::from_utf8_lossy(&o.stdout).trim()
+    )
+}
+
+#[test]
+fn link_apply_refuses_an_attached_source_on_the_wrong_configured_branch() {
+    let fx = setup("main");
+    assert_eq!(
+        std::fs::read_to_string(fx.workspace.join("OUT.md")).unwrap(),
+        "v1\n",
+        "precondition: the workspace starts from configured main"
+    );
+    git(&fx.source, &["branch", "scratch", "HEAD"]);
+    git(&fx.space, &["checkout", "-qb", "scratch"]);
+
+    std::fs::write(fx.source.join("SECTION.md"), "v2\n").unwrap();
+    git(&fx.source, &["add", "-A"]);
+    git(&fx.source, &["commit", "-qm", "advance main"]);
+
+    let (code, diag) = apply(&fx.workspace);
+    assert_eq!(code, Some(2), "wrong attached branch must refuse: {diag}");
+    assert!(
+        diag.contains("is on branch 'scratch', configured revision 'main'"),
+        "wrong-branch diagnostic: {diag}"
+    );
+    assert_eq!(
+        git(&fx.space, &["branch", "--show-current"]),
+        "scratch",
+        "refusal must not silently reattach the source"
+    );
+    assert_eq!(
+        std::fs::read_to_string(fx.workspace.join("OUT.md")).unwrap(),
+        "v1\n",
+        "refusal must not compose stale content"
+    );
+}
+
+#[test]
+fn control_attached_source_on_the_configured_current_branch_is_accepted() {
+    let fx = setup("main");
+    assert_eq!(
+        git(&fx.space, &["branch", "--show-current"]),
+        "main",
+        "precondition: attached to configured main"
+    );
+
+    let (code, diag) = apply(&fx.workspace);
+    assert_eq!(code, Some(0), "current configured branch must pass: {diag}");
+    assert_eq!(
+        std::fs::read_to_string(fx.workspace.join("OUT.md")).unwrap(),
+        "v1\n"
+    );
+}
+
+#[test]
+fn link_apply_refuses_a_branch_configured_source_that_is_detached() {
+    let fx = setup("main");
+    eprintln!("[A1] recorded after sync: {}", recorded(&fx.space));
+    assert!(
+        git(&fx.space, &["branch", "--show-current"]) == "main",
+        "precondition: attached to main"
+    );
+    git(&fx.space, &["checkout", "--detach", "HEAD"]);
+    assert!(
+        git(&fx.space, &["branch", "--show-current"]).is_empty(),
+        "precondition: detached"
+    );
+    let (code, diag) = apply(&fx.workspace);
+    eprintln!("[A1] exit={:?}\n{}", code, diag);
+    assert_eq!(code, Some(2), "A1 must refuse");
+    assert!(
+        diag.contains("detached from configured branch"),
+        "A1 diagnostic: {diag}"
+    );
+    assert!(
+        git(&fx.space, &["branch", "--show-current"]).is_empty(),
+        "refusal must not silently reattach the source"
+    );
+}
+
+#[test]
+fn link_apply_refuses_a_detached_source_without_recorded_provenance() {
+    let fx = setup("main");
+    git(
+        &fx.space,
+        &["config", "--unset", "gitgrip.requestedGripspaceRev"],
+    );
+    eprintln!("[A2a] recorded after unset: {}", recorded(&fx.space));
+    git(&fx.space, &["checkout", "--detach", "HEAD"]);
+    let (code, diag) = apply(&fx.workspace);
+    eprintln!("[A2a] exit={:?}\n{}", code, diag);
+    assert_eq!(code, Some(2), "A2a must refuse");
+    assert!(
+        diag.contains("provenance is unavailable"),
+        "A2a diagnostic: {diag}"
+    );
+}
+
+#[test]
+fn link_apply_refuses_a_detached_source_with_an_unresolvable_named_revision() {
+    let fx = setup("main");
+    git(
+        &fx.space,
+        &[
+            "config",
+            "gitgrip.requestedGripspaceRev",
+            "v9.9.9-does-not-exist",
+        ],
+    );
+    git(&fx.space, &["checkout", "--detach", "HEAD"]);
+    let (code, diag) = apply(&fx.workspace);
+    eprintln!("[A2b] exit={:?}\n{}", code, diag);
+    assert_eq!(code, Some(2), "A2b must refuse");
+    assert!(
+        diag.contains("configured revision"),
+        "A2b diagnostic: {diag}"
+    );
+}
+
+#[test]
+fn control_explicit_full_sha_pin_is_accepted() {
+    // Build with rev = the source's initial commit SHA.
+    let t = TempDir::new().unwrap();
+    let root = t.path().to_path_buf();
+    let source = repo(
+        &root,
+        "source-space",
+        &[
+            ("SECTION.md", "v1\n"),
+            ("gripspace.yml", "version: 2\nrepos: {}\n"),
+        ],
+    );
+    let pin = git(&source, &["rev-parse", "HEAD"]);
+    let dummy = repo(&root, "dummy-repo", &[("README.md", "d\n")]);
+    let manifest = repo(
+        &root,
+        "workspace-manifest",
+        &[(
+            "gripspace.yml",
+            &format!(
+                r#"version: 2
+gripspaces:
+  - url: "{}"
+    rev: {}
+manifest:
+  url: "{}"
+  revision: main
+  composefile:
+    - dest: OUT.md
+      parts:
+        - gripspace: source-space
+          src: SECTION.md
+repos:
+  dummy-repo:
+    url: "{}"
+    path: ./dummy-repo
+    revision: main
+"#,
+                source.display(),
+                pin,
+                root.join("workspace-manifest").display(),
+                dummy.display()
+            ),
+        )],
+    );
+    let workspace = root.join("workspace");
+    let init = Command::cargo_bin("gr")
+        .unwrap()
+        .args([
+            "init",
+            manifest.to_str().unwrap(),
+            "--path",
+            workspace.to_str().unwrap(),
+            "--no-interactive",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "init: {}{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let sync = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    assert!(
+        sync.status.success(),
+        "sync: {}{}",
+        String::from_utf8_lossy(&sync.stdout),
+        String::from_utf8_lossy(&sync.stderr)
+    );
+    let space = workspace.join(".gitgrip/spaces/source-space");
+    eprintln!("[A3] recorded: {}", recorded(&space));
+    assert!(
+        git(&space, &["branch", "--show-current"]).is_empty(),
+        "SHA pin must be detached"
+    );
+    // Advance upstream: an immutable commit pin is NOT stale by definition.
+    std::fs::write(source.join("SECTION.md"), "v2\n").unwrap();
+    git(&source, &["add", "-A"]);
+    git(&source, &["commit", "-qm", "advance"]);
+    let (code, diag) = apply(&workspace);
+    eprintln!("[A3] exit={:?}\n{}", code, diag);
+    assert_eq!(code, Some(0), "A3 control must be ACCEPTED: {diag}");
+}
+
+#[test]
+fn moved_tag_is_refused_until_sync_updates_the_managed_clone() {
+    let t = TempDir::new().unwrap();
+    let root = t.path().to_path_buf();
+    let source = repo(
+        &root,
+        "source-space",
+        &[
+            ("SECTION.md", "v1\n"),
+            ("gripspace.yml", "version: 2\nrepos: {}\n"),
+        ],
+    );
+    git(&source, &["tag", "release"]);
+    let dummy = repo(&root, "dummy-repo", &[("README.md", "d\n")]);
+    let manifest = repo(
+        &root,
+        "workspace-manifest",
+        &[(
+            "gripspace.yml",
+            &format!(
+                r#"version: 2
+gripspaces:
+  - url: "{}"
+    rev: release
+manifest:
+  url: "{}"
+  revision: main
+  composefile:
+    - dest: OUT.md
+      parts:
+        - gripspace: source-space
+          src: SECTION.md
+repos:
+  dummy-repo:
+    url: "{}"
+    path: ./dummy-repo
+    revision: main
+"#,
+                source.display(),
+                root.join("workspace-manifest").display(),
+                dummy.display()
+            ),
+        )],
+    );
+    let workspace = root.join("workspace");
+    let init = Command::cargo_bin("gr")
+        .unwrap()
+        .args([
+            "init",
+            manifest.to_str().unwrap(),
+            "--path",
+            workspace.to_str().unwrap(),
+            "--no-interactive",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "init: {}{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let sync = Command::cargo_bin("gr")
+        .unwrap()
+        .arg("sync")
+        .current_dir(&workspace)
+        .output()
+        .unwrap();
+    assert!(
+        sync.status.success(),
+        "sync: {}{}",
+        String::from_utf8_lossy(&sync.stdout),
+        String::from_utf8_lossy(&sync.stderr)
+    );
+    let space = workspace.join(".gitgrip/spaces/source-space");
+    eprintln!("[A4] recorded: {}", recorded(&space));
+    let before = git(&space, &["rev-parse", "HEAD"]);
+    // Upstream moves the tag to new content.
+    std::fs::write(source.join("SECTION.md"), "v2-MOVED-TAG\n").unwrap();
+    git(&source, &["add", "-A"]);
+    git(&source, &["commit", "-qm", "advance"]);
+    git(&source, &["tag", "-f", "release"]);
+    let upstream = git(&source, &["rev-parse", "release"]);
+    assert_ne!(before, upstream, "fixture: tag must have moved");
+    let (code, diag) = apply(&workspace);
+    let after = git(&space, &["rev-parse", "HEAD"]);
+    let out = std::fs::read_to_string(workspace.join("OUT.md")).unwrap_or_default();
+    eprintln!("[A4] local_before={before} upstream_tag={upstream} local_after={after}");
+    eprintln!("[A4] exit={:?} OUT.md={:?}\n{}", code, out, diag);
+    eprintln!(
+        "[A4] local tag after fetch: {}",
+        git(&space, &["rev-parse", "release"])
+    );
+    assert_eq!(code, Some(2), "moved upstream tag must refuse: {diag}");
+    assert!(
+        diag.contains("does not match configured revision 'release'"),
+        "moved-tag diagnostic: {diag}"
+    );
+    assert_eq!(after, before, "refusal must not move the managed clone");
+    assert_eq!(out, "v1\n", "refusal must not compose stale content again");
+
+    let (sync_code, sync_diag) = run_sync(&workspace);
+    assert_eq!(sync_code, Some(0), "gr sync must recover: {sync_diag}");
+    assert_eq!(
+        git(&space, &["rev-parse", "HEAD"]),
+        upstream,
+        "sync must materialize the moved upstream tag"
+    );
+    assert_eq!(
+        git(&space, &["rev-parse", "release"]),
+        upstream,
+        "sync must force-update the managed local tag"
+    );
+
+    let (apply_code, apply_diag) = apply(&workspace);
+    assert_eq!(
+        apply_code,
+        Some(0),
+        "apply after recovery must succeed: {apply_diag}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("OUT.md")).unwrap(),
+        "v2-MOVED-TAG\n",
+        "recovered apply must compose the upstream tag content"
+    );
+}


### PR DESCRIPTION
## Summary

- Resolve included gripspaces from their existing checkouts during `gr link --apply`, so manifest loading cannot silently reattach a detached source before the freshness guard inspects it.
- Refuse an attached managed clone when its current branch differs from the configured revision, before comparing that branch with its own remote-tracking ref.
- Compare named tag pins with the tag advertised by `origin`, then make `gr sync` force-update managed tags so the recovery path reaches the same upstream object.
- Resolve hexadecimal commit-id abbreviations directly against the local object database after the origin-tag check, so a stale all-hex local ref cannot masquerade as an immutable commit pin.
- Refuse unresolved or ambiguous commit-id prefixes with remedies that can change the result.
- Exercise the behavior through the `gr` binary for a wrong attached branch, the matching attached-branch control, branch-configured detachment, missing and unresolvable provenance, full and abbreviated immutable commit pins, moved tags, and a deleted all-hex tag retained only by the managed clone.

## Verification

- `rustfmt --edition 2021 --check src/cli/commands/link.rs src/cli/dispatch.rs src/core/gripspace.rs tests/link_apply_detached_freshness.rs`
- `cargo test --test link_apply_detached_freshness -- --test-threads=1` (10 passed)
- `cargo test` (exit 0)
- Mutation: removing the configured-revision comparison makes the wrong-attached-branch witness accept and compose stale content while the matching-branch control remains green.
- Mutation: restoring preflight materialization makes the three detached-source witnesses fail while the controls remain green.
- Mutation: resolving the tag from the local clone makes the moved-tag refusal witness fail.
- Mutation: restoring a plain tag fetch preserves the refusal but makes the `gr sync` recovery witness fail.
- Mutation: resolving a commit-id prefix through ref-aware revision parsing makes only the deleted all-hex tag witness fail (1 failed, 9 passed).
- Mutation: requiring a full 40-character commit id makes only the abbreviated-pin witness fail (1 failed, 9 passed).
- Mutation: returning the bare object-database error removes the actionable remedy and makes only the operator-remedy witness fail (1 failed, 9 passed).

Ref #891 — closes at promotion.