### PR TITLE
feat(gr2): Prototype 1 propagation daemon on one declared managed replica

### DIFF
--- a/gr2/docs/HOOK-EVENT-CONTRACT.md
+++ b/gr2/docs/HOOK-EVENT-CONTRACT.md
@@ -197,6 +197,20 @@ and `lease.force_broken` (which fires when a live lease is broken with
 | `workspace.materialized` | `gr2 workspace materialize` or `gr2 apply` | `{repos: [{repo, first_materialize: bool}]}` |
 | `workspace.file_projected` | File link/copy applied | `{repo, kind, src, dest}` |
 
+#### Propagation
+
+| Type | Trigger | Payload |
+|------|---------|---------|
+| `propagation.receipt` | The propagation daemon (`gr2/prototypes/propagation_daemon.py`) completed one operation against its declared managed replica, in any terminal state (acknowledged, refused, partial, unverifiable) | `{summary, state, pending_id, operation_id, source_rev, expected_base, after, replayed, receipt_path}` |
+
+`propagation.receipt` is emitted once per operation; a tick that finds the cursor
+already at the source revision is not an operation and emits nothing. `summary` is
+the one-line notification a channel consumer relays verbatim. `receipt_path` is the
+full path of the receipt file the daemon wrote, an explicit exception to the
+relative-path rule in 3.3: the receipt store lives under the daemon's declared
+`state_dir`, which is not a workspace file and may sit outside `workspace_root`.
+`after` is `null` when the operation did not reach `applied`.
+
 ### 3.3 Payload Conventions
 
 - All paths in payloads are relative to `workspace_root`, never absolute.
@@ -471,6 +485,9 @@ class EventType(str, Enum):
     # Workspace operations
     WORKSPACE_MATERIALIZED = "workspace.materialized"
     WORKSPACE_FILE_PROJECTED = "workspace.file_projected"
+
+    # Propagation (one event per receipt from the propagation daemon)
+    PROPAGATION_RECEIPT = "propagation.receipt"
 ```
 
 ### 7.3 Implementation Location

--- a/gr2/prototypes/propagation_daemon.py
+++ b/gr2/prototypes/propagation_daemon.py
@@ -31,7 +31,16 @@ The git environment is a declared choice. Tests run isolated from the host's
 configuration (the Prototype 0 default); a real private remote needs the host's
 credential helper, so a declaration may say ``"git_env": "inherit"``. The daemon never
 creates a commit (fast-forward only), so inheriting the host configuration does not
-invoke signing.
+invoke signing. In both modes ``GIT_TERMINAL_PROMPT=0`` is set: a daemon never answers
+a prompt, so a missing credential fails the tick instead of hanging the loop on a tty.
+A tick whose git call fails is printed as ``propagation tick-failed`` and counted, and
+the loop continues; the next tick replays whatever the machine left pending.
+
+The first dogfood run found the inherit seam the hard way: the machine collapsed an
+explicit empty environment into its isolated default because ``{}`` is falsy, so the
+clone that ``ensure_replica`` made with the host's credentials was followed by an
+``ls-remote`` that prompted for a username. The machine now distinguishes ``None``
+from ``{}`` and the seam is witnessed at both ends.
 """
 
 from __future__ import annotations
@@ -57,6 +66,7 @@ from gr2.prototypes.propagation_state_machine import (
     Policy,
     Propagator,
     Receipt,
+    SourceUnobservable,
     State,
 )
 from gr2.python_cli.events import EventType, emit
@@ -104,7 +114,11 @@ class Declaration:
 
     @property
     def git_env(self) -> dict[str, str]:
-        return {} if self.git_env_mode == "inherit" else dict(_ISOLATED_GIT_ENV)
+        # A daemon never answers a prompt: in both modes a missing credential must fail
+        # the git call (and the tick) rather than hang the loop on a tty. "inherit" carries
+        # ONLY that override, so the host's credential helper and config are in force.
+        base = {} if self.git_env_mode == "inherit" else dict(_ISOLATED_GIT_ENV)
+        return {**base, "GIT_TERMINAL_PROMPT": "0"}
 
     def destination(self) -> Destination:
         return Destination(
@@ -410,8 +424,27 @@ def tick(declaration: Declaration, propagator: Propagator) -> TickResult:
 class LoopStats:
     ticks: int = 0
     operations: int = 0
+    failures: int = 0
     by_state: dict[str, int] = field(default_factory=dict)
     last: TickResult | None = None
+
+
+_TICK_FAILURES = (SourceUnobservable, subprocess.CalledProcessError, OSError)
+
+
+def _git_failure_line(exc: BaseException) -> str:
+    if isinstance(exc, SourceUnobservable):
+        return str(exc)
+    if isinstance(exc, subprocess.CalledProcessError):
+        argv = (
+            " ".join(str(part) for part in exc.cmd)
+            if isinstance(exc.cmd, list | tuple)
+            else exc.cmd
+        )
+        stderr = (exc.stderr or "").strip().splitlines()
+        tail = stderr[-1] if stderr else ""
+        return f"git exited {exc.returncode} ({argv}): {tail}"
+    return f"{type(exc).__name__}: {exc}"
 
 
 def run_loop(
@@ -424,6 +457,14 @@ def run_loop(
 ) -> LoopStats:
     """Tick until ``stop()`` says so (or once). Every tick prints exactly one line.
 
+    A tick whose git call fails (the source unobservable, a credential refused, the mirror
+    fetch interrupted) is printed and counted and the loop goes on: nothing about the
+    declaration changed, and whatever the machine left pending is replayed on the next
+    tick, which is the machine's own kill-and-replay contract. The machine names the first
+    of those ``SourceUnobservable``, raised before any state is touched; the others arrive
+    as ``CalledProcessError`` / ``OSError`` from its git calls. Any other exception is a
+    defect in this module and propagates.
+
     ``out`` defaults to the stdout in force at CALL time, not at import time, so a caller
     that redirects stdout (a test, a wrapper, a supervisor) gets the lines.
     """
@@ -432,14 +473,27 @@ def run_loop(
     propagator = make_propagator(declaration)
     stats = LoopStats()
     while True:
-        result = tick(declaration, propagator)
-        stats.ticks += 1
-        stats.last = result
-        if result.receipt is not None:
-            stats.operations += 1
-            key = str(result.receipt.state)
-            stats.by_state[key] = stats.by_state.get(key, 0) + 1
-        print(f"{result.observed_at} {result.summary}", file=stream, flush=True)
+        observed_at = datetime.now(UTC).isoformat()
+        try:
+            result = tick(declaration, propagator)
+        except _TICK_FAILURES as exc:
+            stats.ticks += 1
+            stats.failures += 1
+            print(
+                f"{observed_at} propagation tick-failed: {declaration.destination_id} "
+                f"{_git_failure_line(exc)}; this tick left no receipt, the next tick "
+                f"replays whatever the machine left pending",
+                file=stream,
+                flush=True,
+            )
+        else:
+            stats.ticks += 1
+            stats.last = result
+            if result.receipt is not None:
+                stats.operations += 1
+                key = str(result.receipt.state)
+                stats.by_state[key] = stats.by_state.get(key, 0) + 1
+            print(f"{result.observed_at} {result.summary}", file=stream, flush=True)
         if once or (stop is not None and stop()):
             return stats
         sleep(declaration.interval_seconds)

--- a/gr2/prototypes/propagation_daemon.py
+++ b/gr2/prototypes/propagation_daemon.py
@@ -61,6 +61,7 @@ from gr2.prototypes.propagation_state_machine import (
     Coordinate,
     Destination,
     DestinationKind,
+    DestinationUnreadable,
     Direction,
     Operation,
     Policy,
@@ -429,12 +430,24 @@ class LoopStats:
     last: TickResult | None = None
 
 
-_TICK_FAILURES = (SourceUnobservable, subprocess.CalledProcessError, OSError)
+# Every way a tick can fail on the environment rather than on this module, derived from
+# the machine's raise sites: the source cannot be observed (before any state is touched),
+# the destination cannot be read (at observe, plan, or verify, each a point the machine
+# replays from), or a git call failed / could not be spawned. DestinationUnreadable WRAPS
+# the last two, so catching them without it would let the wrapped form escape.
+_TICK_FAILURES = (
+    SourceUnobservable,
+    DestinationUnreadable,
+    subprocess.CalledProcessError,
+    OSError,
+)
 
 
 def _git_failure_line(exc: BaseException) -> str:
     if isinstance(exc, SourceUnobservable):
         return str(exc)
+    if isinstance(exc, DestinationUnreadable):
+        return f"destination unreadable: {exc}"
     if isinstance(exc, subprocess.CalledProcessError):
         argv = (
             " ".join(str(part) for part in exc.cmd)
@@ -457,13 +470,18 @@ def run_loop(
 ) -> LoopStats:
     """Tick until ``stop()`` says so (or once). Every tick prints exactly one line.
 
-    A tick whose git call fails (the source unobservable, a credential refused, the mirror
-    fetch interrupted) is printed and counted and the loop goes on: nothing about the
-    declaration changed, and whatever the machine left pending is replayed on the next
-    tick, which is the machine's own kill-and-replay contract. The machine names the first
-    of those ``SourceUnobservable``, raised before any state is touched; the others arrive
-    as ``CalledProcessError`` / ``OSError`` from its git calls. Any other exception is a
-    defect in this module and propagates.
+    A tick that fails on the environment (the source unobservable, the destination
+    unreadable because the checkout went away or a volume unmounted, a credential refused,
+    the mirror fetch interrupted) is printed and counted and the loop goes on: nothing
+    about the declaration changed, and whatever the machine left pending is replayed on
+    the next tick, which is the machine's own kill-and-replay contract. The machine names
+    the first two ``SourceUnobservable`` (raised before any state is touched) and
+    ``DestinationUnreadable`` (raised at observe, plan, or verify, each a replay point);
+    the rest arrive as ``CalledProcessError`` / ``OSError`` from its git calls. What
+    propagates, by design: ``JournalInconsistent`` and ``LookupError`` from the machine (a
+    journal that cannot account for its own cursor is corrupted sink state, and guessing
+    would hide it), ``DeclarationMismatch`` from ``ensure_replica`` at startup, and any
+    defect in this module.
 
     ``out`` defaults to the stdout in force at CALL time, not at import time, so a caller
     that redirects stdout (a test, a wrapper, a supervisor) gets the lines.

--- a/gr2/prototypes/propagation_daemon.py
+++ b/gr2/prototypes/propagation_daemon.py
@@ -1,0 +1,467 @@
+"""Prototype 1 of the propagation daemon: ONE declared managed replica, a real source.
+
+Prototype 0 (``propagation_state_machine``) proved the state contract on synthetic
+repositories. This module runs that same machine on a loop against a single destination
+that a declaration names as a managed replica, so the daemon can watch a real canonical
+upstream, fetch, plan, apply, verify, acknowledge, and leave a neutral receipt behind
+for every operation it ran. Nothing here grants the daemon authority over an authoring
+clone: the declaration can only name a replica, and the machine's own gates (direction,
+base unmoved, clean, fast-forward) refuse everything the declaration cannot vouch for.
+
+What one tick does, in order:
+
+1. observe the source with ``git ls-remote``; if the cursor already names the source
+   revision there is no operation, no receipt, and nothing is written;
+2. otherwise drive the machine once and take its receipt, whatever its state --
+   a refusal is a receipt too, because "I did not apply and here is why" is the
+   only honest thing a replica manager can say about a destination it refused;
+3. write the receipt as its own JSON file, with the per-state latency derived from
+   the receipt's own transition timestamps rather than from a stopwatch around
+   the call, so the numbers describe what the journal describes;
+4. emit one ``propagation.receipt`` event on the gr2 outbox carrying the receipt's
+   one-line summary. The design names a one-line channel notification; this module
+   writes that line to the outbox and to stdout and knows no channel, so the
+   prototype depends on nothing outside ``gr2``.
+
+Success for Prototype 1 is measured latency plus exact receipts, not the absence of an
+exception. Every receipt names the exact source and destination revisions, and every
+latency figure is recomputable from the receipt that carries it.
+
+The git environment is a declared choice. Tests run isolated from the host's
+configuration (the Prototype 0 default); a real private remote needs the host's
+credential helper, so a declaration may say ``"git_env": "inherit"``. The daemon never
+creates a commit (fast-forward only), so inheriting the host configuration does not
+invoke signing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TextIO
+
+from gr2.prototypes.propagation_state_machine import (
+    Coordinate,
+    Destination,
+    DestinationKind,
+    Direction,
+    Operation,
+    Policy,
+    Propagator,
+    Receipt,
+    State,
+)
+from gr2.python_cli.events import EventType, emit
+
+_ISOLATED_GIT_ENV = {
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_NOSYSTEM": "1",
+}
+
+ACTOR = "propagation-daemon"
+
+
+class DeclarationError(ValueError):
+    """The declaration does not describe exactly one managed replica."""
+
+
+class DeclarationMismatch(RuntimeError):
+    """The destination path exists and is not the declared replica."""
+
+
+@dataclass(frozen=True)
+class Declaration:
+    """Exactly one managed replica of one branch of one source.
+
+    Every field is opaque to the machine except ``branch`` (what ls-remote asks for) and
+    ``destination_path`` (where the replica lives). ``kind`` is carried so a reader of the
+    declaration can see the only value it may hold; ``load_declaration`` refuses any other.
+    """
+
+    source_url: str
+    branch: str
+    destination_id: str
+    destination_path: Path
+    state_dir: Path
+    outbox_root: Path
+    coordinate: Coordinate
+    interval_seconds: float
+    policy_hash: str
+    git_env_mode: str = "isolated"
+    kind: DestinationKind = DestinationKind.REPLICA
+
+    @property
+    def receipts_dir(self) -> Path:
+        return self.state_dir / "receipts"
+
+    @property
+    def git_env(self) -> dict[str, str]:
+        return {} if self.git_env_mode == "inherit" else dict(_ISOLATED_GIT_ENV)
+
+    def destination(self) -> Destination:
+        return Destination(
+            destination_id=self.destination_id, path=self.destination_path, kind=self.kind
+        )
+
+    def policy(self) -> Policy:
+        # downward only: the one direction a managed replica can be the destination of
+        return Policy(policy_hash=self.policy_hash, allowed_directions=frozenset({Direction.DOWN}))
+
+
+_REQUIRED = (
+    "source_url",
+    "branch",
+    "destination_id",
+    "destination_path",
+    "state_dir",
+    "outbox_root",
+    "coordinate",
+)
+
+
+def declaration_from_dict(data: dict[str, object]) -> Declaration:
+    missing = [key for key in _REQUIRED if key not in data]
+    if missing:
+        raise DeclarationError(f"declaration is missing {missing}")
+    kind = str(data.get("kind", DestinationKind.REPLICA))
+    if kind != str(DestinationKind.REPLICA):
+        # the one thing this daemon must never be told to do: an authoring clone is not
+        # a destination it may drive, and that is decided here, before any git call
+        raise DeclarationError(f"this daemon drives managed replicas only; declared kind={kind!r}")
+    git_env_mode = str(data.get("git_env", "isolated"))
+    if git_env_mode not in {"isolated", "inherit"}:
+        raise DeclarationError(f"git_env must be 'isolated' or 'inherit', got {git_env_mode!r}")
+    coord = data["coordinate"]
+    if not isinstance(coord, dict):
+        raise DeclarationError("coordinate must be an object")
+    for key in ("source", "layer", "artifact_class"):
+        if key not in coord:
+            raise DeclarationError(f"coordinate is missing {key!r}")
+    interval = float(data.get("interval_seconds", 30.0))
+    if interval <= 0:
+        raise DeclarationError("interval_seconds must be positive")
+    destination_id = str(data["destination_id"])
+    coordinate = Coordinate(
+        source=str(coord["source"]),
+        destination=destination_id,
+        layer=str(coord["layer"]),
+        direction=Direction.DOWN,
+        operation=Operation.APPLY,
+        artifact_class=str(coord["artifact_class"]),
+    )
+    return Declaration(
+        source_url=str(data["source_url"]),
+        branch=str(data["branch"]),
+        destination_id=destination_id,
+        destination_path=Path(str(data["destination_path"])).expanduser(),
+        state_dir=Path(str(data["state_dir"])).expanduser(),
+        outbox_root=Path(str(data["outbox_root"])).expanduser(),
+        coordinate=coordinate,
+        interval_seconds=interval,
+        policy_hash=str(data.get("policy_hash", "prototype-1-downward-only")),
+        git_env_mode=git_env_mode,
+    )
+
+
+def load_declaration(path: Path) -> Declaration:
+    with path.open() as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise DeclarationError("declaration must be a JSON object")
+    return declaration_from_dict(data)
+
+
+# --------------------------------------------------------------------------- replica
+
+
+def _git(repo: Path, *args: str, env: dict[str, str]) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env},
+    )
+    return proc.stdout.strip()
+
+
+def ensure_replica(declaration: Declaration) -> Path:
+    """Make the declared replica exist, or refuse to treat what is there as the replica.
+
+    Absent: clone the declared branch of the declared source, single-branch, so the only
+    thing at that path is what the declaration says. Present: it must be a git checkout
+    whose ``origin`` is the declared source and whose current branch is the declared
+    branch; anything else is refused here, before the machine ever reads it, because the
+    alternative is a daemon fast-forwarding a clone that happens to sit at the path.
+    """
+    path = declaration.destination_path
+    env = declaration.git_env
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "-q",
+                "--branch",
+                declaration.branch,
+                "--single-branch",
+                declaration.source_url,
+                str(path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, **env},
+        )
+        return path
+    try:
+        origin = _git(path, "remote", "get-url", "origin", env=env)
+        branch = _git(path, "rev-parse", "--abbrev-ref", "HEAD", env=env)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        raise DeclarationMismatch(f"{path} exists and is not a git checkout: {exc}") from exc
+    if origin != declaration.source_url:
+        raise DeclarationMismatch(
+            f"{path} has origin {origin!r}, declaration names {declaration.source_url!r}"
+        )
+    if branch != declaration.branch:
+        raise DeclarationMismatch(
+            f"{path} is on {branch!r}, declaration names {declaration.branch!r}"
+        )
+    return path
+
+
+# --------------------------------------------------------------------------- ticks
+
+
+@dataclass(frozen=True)
+class TickResult:
+    observed_at: str
+    source_rev: str
+    cursor_before: str | None
+    receipt: Receipt | None
+    receipt_path: Path | None
+    latency_seconds: dict[str, float] | None
+    summary: str
+
+    @property
+    def was_operation(self) -> bool:
+        return self.receipt is not None
+
+
+def _parse_ts(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def latency_from_receipt(receipt: Receipt) -> dict[str, float]:
+    """Per-state latency derived from the receipt's own transition timestamps.
+
+    Keys are ``<from>-><to>`` for each consecutive pair and ``total`` from the first to
+    the last transition. A replayed receipt carries the ORIGINAL transitions, so its
+    latency describes the run that did the work, not the replay that found it.
+    """
+    transitions = receipt.transitions
+    out: dict[str, float] = {}
+    for previous, current in zip(transitions, transitions[1:], strict=False):
+        delta = (_parse_ts(current.timestamp) - _parse_ts(previous.timestamp)).total_seconds()
+        out[f"{previous.state}->{current.state}"] = round(delta, 6)
+    if transitions:
+        total = (
+            _parse_ts(transitions[-1].timestamp) - _parse_ts(transitions[0].timestamp)
+        ).total_seconds()
+        out["total"] = round(total, 6)
+    return out
+
+
+def _short(rev: str | None) -> str:
+    return (rev or "-")[:12]
+
+
+def summarize(receipt: Receipt, latency: dict[str, float]) -> str:
+    """The one line a channel reader needs: what, where, which revisions, how long."""
+    landed = _short(receipt.after) if receipt.after else "unchanged"
+    head = (
+        f"propagation {receipt.state}: {receipt.coordinate.destination} "
+        f"at {_short(receipt.expected_base)} -> {landed}, intended {_short(receipt.source_rev)} "
+        f"(source {receipt.coordinate.source}, attempt {receipt.attempt}"
+    )
+    if receipt.replayed:
+        head += ", replayed"
+    head += f", total {latency.get('total', 0.0):.3f}s)"
+    if receipt.state is State.REFUSED and receipt.refusal_reason:
+        head += f" refused: {receipt.refusal_reason}"
+    return head
+
+
+def write_receipt(
+    declaration: Declaration, receipt: Receipt, latency: dict[str, float], observed_at: str
+) -> Path:
+    declaration.receipts_dir.mkdir(parents=True, exist_ok=True)
+    stamp = observed_at.replace(":", "").replace("+00:00", "Z")
+    name = f"{stamp}-{receipt.pending_id[:12]}-{receipt.state}.json"
+    path = declaration.receipts_dir / name
+    payload = {
+        "daemon": ACTOR,
+        "declaration": {
+            "source_url": declaration.source_url,
+            "branch": declaration.branch,
+            "destination_id": declaration.destination_id,
+            "destination_path": str(declaration.destination_path),
+        },
+        "observed_at": observed_at,
+        "latency_seconds": latency,
+        "receipt": receipt.as_dict(),
+    }
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    os.replace(tmp, path)
+    return path
+
+
+def notify(declaration: Declaration, receipt: Receipt, summary: str, receipt_path: Path) -> None:
+    emit(
+        EventType.PROPAGATION_RECEIPT,
+        declaration.outbox_root,
+        ACTOR,
+        declaration.destination_id,
+        {
+            "summary": summary,
+            "state": str(receipt.state),
+            "pending_id": receipt.pending_id,
+            "operation_id": receipt.operation_id,
+            "source_rev": receipt.source_rev,
+            "expected_base": receipt.expected_base,
+            "after": receipt.after,
+            "replayed": receipt.replayed,
+            "receipt_path": str(receipt_path),
+        },
+    )
+
+
+def make_propagator(declaration: Declaration) -> Propagator:
+    # The machine only ever stringifies ``source_remote`` (ls-remote, fetch), so a URL
+    # passes through as-is. It must NOT be wrapped in Path: Path collapses the "//" of a
+    # URL scheme and the source would silently become a relative directory.
+    return Propagator(
+        source_remote=declaration.source_url,  # type: ignore[arg-type]
+        branch=declaration.branch,
+        state_dir=declaration.state_dir,
+        policy=declaration.policy(),
+        git_env=declaration.git_env,
+    )
+
+
+def tick(declaration: Declaration, propagator: Propagator) -> TickResult:
+    observed_at = datetime.now(UTC).isoformat()
+    coordinate = declaration.coordinate
+    observation = propagator.observe_source(coordinate)
+    if not observation.is_new:
+        return TickResult(
+            observed_at=observed_at,
+            source_rev=observation.source_rev,
+            cursor_before=observation.cursor,
+            receipt=None,
+            receipt_path=None,
+            latency_seconds=None,
+            summary=(
+                f"propagation current: {declaration.destination_id} cursor already at "
+                f"{_short(observation.source_rev)}; not an operation"
+            ),
+        )
+    receipt = propagator.run(coordinate, declaration.destination())
+    if receipt is None:
+        # the source moved between observe and run, back to the cursor; nothing to do
+        return TickResult(
+            observed_at=observed_at,
+            source_rev=observation.source_rev,
+            cursor_before=observation.cursor,
+            receipt=None,
+            receipt_path=None,
+            latency_seconds=None,
+            summary=(
+                f"propagation current: {declaration.destination_id} source returned to the "
+                f"cursor between observe and run; not an operation"
+            ),
+        )
+    latency = latency_from_receipt(receipt)
+    summary = summarize(receipt, latency)
+    receipt_path = write_receipt(declaration, receipt, latency, observed_at)
+    notify(declaration, receipt, summary, receipt_path)
+    return TickResult(
+        observed_at=observed_at,
+        source_rev=observation.source_rev,
+        cursor_before=observation.cursor,
+        receipt=receipt,
+        receipt_path=receipt_path,
+        latency_seconds=latency,
+        summary=summary,
+    )
+
+
+@dataclass
+class LoopStats:
+    ticks: int = 0
+    operations: int = 0
+    by_state: dict[str, int] = field(default_factory=dict)
+    last: TickResult | None = None
+
+
+def run_loop(
+    declaration: Declaration,
+    *,
+    once: bool = False,
+    stop: Callable[[], bool] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    out: TextIO | None = None,
+) -> LoopStats:
+    """Tick until ``stop()`` says so (or once). Every tick prints exactly one line.
+
+    ``out`` defaults to the stdout in force at CALL time, not at import time, so a caller
+    that redirects stdout (a test, a wrapper, a supervisor) gets the lines.
+    """
+    stream = out if out is not None else sys.stdout
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    stats = LoopStats()
+    while True:
+        result = tick(declaration, propagator)
+        stats.ticks += 1
+        stats.last = result
+        if result.receipt is not None:
+            stats.operations += 1
+            key = str(result.receipt.state)
+            stats.by_state[key] = stats.by_state.get(key, 0) + 1
+        print(f"{result.observed_at} {result.summary}", file=stream, flush=True)
+        if once or (stop is not None and stop()):
+            return stats
+        sleep(declaration.interval_seconds)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--declaration", required=True, type=Path)
+    parser.add_argument("--once", action="store_true", help="one tick, then exit")
+    parser.add_argument(
+        "--interval", type=float, default=None, help="override the declared interval"
+    )
+    args = parser.parse_args(argv)
+    declaration = load_declaration(args.declaration)
+    if args.interval is not None:
+        declaration = replace(declaration, interval_seconds=float(args.interval))
+    try:
+        run_loop(declaration, once=args.once)
+    except KeyboardInterrupt:
+        print("propagation daemon: stopped", flush=True)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through main() in tests
+    sys.exit(main())

--- a/gr2/prototypes/propagation_daemon.py
+++ b/gr2/prototypes/propagation_daemon.py
@@ -379,6 +379,12 @@ def tick(declaration: Declaration, propagator: Propagator) -> TickResult:
     coordinate = declaration.coordinate
     observation = propagator.observe_source(coordinate)
     if not observation.is_new:
+        # Not an operation, but not a shortcut past the machine either: it must account
+        # for a cursor that sits at the source revision, and it raises JournalInconsistent
+        # for one the journal never acknowledged. An earlier version of this tick returned
+        # here without asking, and "current; not an operation" would have hidden corrupted
+        # sink state on every tick forever. Found by the witness, not by the dogfood.
+        propagator.run(coordinate, declaration.destination(), observation=observation)
         return TickResult(
             observed_at=observed_at,
             source_rev=observation.source_rev,
@@ -391,9 +397,10 @@ def tick(declaration: Declaration, propagator: Propagator) -> TickResult:
                 f"{_short(observation.source_rev)}; not an operation"
             ),
         )
-    receipt = propagator.run(coordinate, declaration.destination())
+    receipt = propagator.run(coordinate, declaration.destination(), observation=observation)
     if receipt is None:
-        # the source moved between observe and run, back to the cursor; nothing to do
+        # the machine's contract allows None for "not new"; with the observation shared it
+        # cannot answer that here, but a None is still not an operation and writes nothing
         return TickResult(
             observed_at=observed_at,
             source_rev=observation.source_rev,

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -102,6 +102,15 @@ class DestinationUnreadable(RuntimeError):
     """A read against the destination returned an error instead of an answer."""
 
 
+class SourceUnobservable(RuntimeError):
+    """``git ls-remote`` against the source failed or advertised no such branch.
+
+    Raised before any cursor, journal, or destination state is touched, so a caller that
+    loops (a daemon) can count it and try again on its next tick with nothing to repair.
+    A ``RuntimeError`` subclass, so a caller that caught the bare class still does.
+    """
+
+
 class Direction(StrEnum):
     DOWN = "down"
     UP = "up"
@@ -536,7 +545,9 @@ class Propagator:
         self.policy = policy
         self.kill_after = kill_after
         self.after_apply_verb = after_apply_verb
-        self.git_env = git_env or _ISOLATED_GIT_ENV
+        # None means "the default, isolated from the host"; an explicit {} means "inherit the
+        # host environment" and must not collapse into the default because it is falsy
+        self.git_env = _ISOLATED_GIT_ENV if git_env is None else git_env
         self.journal = Journal(state_dir)
         self.mirror = state_dir / "mirror.git"
 
@@ -550,8 +561,11 @@ class Propagator:
             env={**os.environ, **self.git_env},
         )
         if out.returncode != 0 or not out.stdout.strip():
-            raise RuntimeError(
-                f"source {self.source_remote} has no branch {self.branch}: {out.stderr.strip()}"
+            stderr = out.stderr.strip().splitlines()
+            tail = stderr[-1] if stderr else "no output"
+            raise SourceUnobservable(
+                f"git ls-remote exited {out.returncode} for {self.source_remote} "
+                f"refs/heads/{self.branch}: {tail}"
             )
         source_rev = out.stdout.split()[0]
         return Observation(source_rev=source_rev, cursor=cursor, is_new=(source_rev != cursor))

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -594,18 +594,33 @@ class Propagator:
 
     # -- driver
 
-    def run(self, coordinate: Coordinate, destination: Destination) -> Receipt | None:
+    def run(
+        self,
+        coordinate: Coordinate,
+        destination: Destination,
+        observation: Observation | None = None,
+    ) -> Receipt | None:
         """Drive one coordinate. ``None`` means no new source revision: not an operation.
 
-        Raises if the cursor sits at a revision the journal never acknowledged.
+        Raises ``JournalInconsistent`` if the cursor sits at a revision the journal never
+        acknowledged. A caller that has already observed the source this tick may pass
+        its ``observation`` so the source is not asked twice; the cursor check runs on it
+        all the same, because "nothing new" is exactly the answer that would hide a
+        corrupted sink state, whoever observed.
         """
-        return self._run(coordinate, destination, report_current=False)
+        return self._run(coordinate, destination, report_current=False, observation=observation)
 
     def _run(
-        self, coordinate: Coordinate, destination: Destination, *, report_current: bool
+        self,
+        coordinate: Coordinate,
+        destination: Destination,
+        *,
+        report_current: bool,
+        observation: Observation | None = None,
     ) -> Receipt | None:
         key = coordinate.key()
-        observation = self.observe_source(coordinate)
+        if observation is None:
+            observation = self.observe_source(coordinate)
         if not observation.is_new:
             # The cursor is AT the source revision, which only happens after an
             # acknowledgement at that revision; _terminal_receipt RAISES if the

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -102,6 +102,14 @@ class DestinationUnreadable(RuntimeError):
     """A read against the destination returned an error instead of an answer."""
 
 
+class JournalInconsistent(RuntimeError):
+    """The cursor names a revision the journal cannot account for.
+
+    A corrupted sink state: the prototype says so and stops rather than guessing an
+    outcome. Raised deliberately and left to propagate by every caller, by name.
+    """
+
+
 class SourceUnobservable(RuntimeError):
     """``git ls-remote`` against the source failed or advertised no such branch.
 
@@ -658,7 +666,7 @@ class Propagator:
         if not attempts or attempts[-1][-1].state is not State.ACKNOWLEDGED:
             # A cursor at a revision the journal never acknowledged is a corrupted
             # sink state, and the prototype says so rather than guessing an outcome.
-            raise RuntimeError(
+            raise JournalInconsistent(
                 f"cursor for {coordinate.destination} is at {source_rev} but the journal "
                 "carries no acknowledged attempt at that revision"
             )
@@ -1192,6 +1200,7 @@ __all__ = [
     "Destination",
     "DestinationKind",
     "DestinationUnreadable",
+    "JournalInconsistent",
     "Direction",
     "GateResult",
     "Journal",

--- a/gr2/python_cli/events.py
+++ b/gr2/python_cli/events.py
@@ -84,6 +84,10 @@ class EventType(str, Enum):
     WORKSPACE_MATERIALIZED = "workspace.materialized"
     WORKSPACE_FILE_PROJECTED = "workspace.file_projected"
 
+    # one event per propagation receipt: the daemon's notification line, carried on the
+    # outbox so a consumer can relay it without the daemon knowing any channel
+    PROPAGATION_RECEIPT = "propagation.receipt"
+
 
 def _outbox_path(workspace_root: Path) -> Path:
     return workspace_root / ".grip" / "events" / "outbox.jsonl"

--- a/gr2/tests/test_events.py
+++ b/gr2/tests/test_events.py
@@ -81,8 +81,9 @@ class TestEventTypeEnum:
 
     def test_total_count(self):
         from gr2.python_cli.events import EventType
-        # 5 lane + 4 lease + 4 hook + 7 PR + 8 sync + 3 exec + 2 recovery + 2 workspace = 35
-        assert len(EventType) == 35
+        # 5 lane + 4 lease + 4 hook + 7 PR + 8 sync + 3 exec + 2 recovery + 2 workspace
+        # + 1 propagation = 36
+        assert len(EventType) == 36
 
 
 # ---------------------------------------------------------------------------

--- a/gr2/tests/test_propagation_daemon.py
+++ b/gr2/tests/test_propagation_daemon.py
@@ -1,0 +1,685 @@
+"""Prototype 1: the propagation daemon, proven on a synthetic source and a declared replica.
+
+Everything here runs under ``tmp_path``: one bare "source" remote with a config-like file
+on ``main``, an authoring clone that pushes changes to it, and a replica path that the
+declaration names. No real workspace, remote, or authoring clone is touched.
+
+What the tests prove, each as its own witness:
+
+* a declaration names exactly one managed replica; an authoring kind, an unknown git
+  environment, a non-positive interval, or a missing field is refused before any git call
+* ``ensure_replica`` clones the declared branch when the path is absent, accepts the path
+  it declared, and refuses a checkout whose origin or branch differ, or a non-git directory
+* the first tick on a fresh replica acknowledges without running the verb (the replica
+  was born at the source revision); a tick with no new revision is not an operation and
+  writes nothing; a pushed change is applied on the next tick with exact revisions
+* every receipt that is an operation is written as its own JSON file and announced as one
+  ``propagation.receipt`` event on the outbox; a refusal is a receipt too, and the refused
+  destination is left untouched
+* the latency figures in a written receipt are recomputable from that receipt's own
+  transition timestamps
+* ``run_loop`` ticks once under ``once``, stops when told, sleeps the declared interval,
+  and prints exactly one line per tick
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from gr2.prototypes.propagation_daemon import (
+    ACTOR,
+    Declaration,
+    DeclarationError,
+    DeclarationMismatch,
+    declaration_from_dict,
+    ensure_replica,
+    latency_from_receipt,
+    load_declaration,
+    main,
+    make_propagator,
+    run_loop,
+    summarize,
+    tick,
+)
+from gr2.prototypes.propagation_state_machine import (
+    DestinationKind,
+    Direction,
+    Operation,
+    State,
+)
+from gr2.python_cli.events import EventType
+
+# Commits in the synthetic repositories must not depend on, or touch, the machine's
+# global git configuration (signing keys, hooks paths, identities).
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "prototype",
+    "GIT_AUTHOR_EMAIL": "prototype@example.invalid",
+    "GIT_COMMITTER_NAME": "prototype",
+    "GIT_COMMITTER_EMAIL": "prototype@example.invalid",
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_NOSYSTEM": "1",
+}
+
+
+def git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    return proc.stdout.strip()
+
+
+def _run(*args: str) -> None:
+    subprocess.run(
+        list(args), check=True, capture_output=True, text=True, env={**os.environ, **_GIT_ENV}
+    )
+
+
+def snapshot(repo: Path) -> dict[str, str]:
+    """Everything an 'untouched' claim is about: refs, HEAD, index+worktree state, bytes."""
+    return {
+        "refs": git(repo, "for-each-ref"),
+        "head": git(repo, "rev-parse", "HEAD"),
+        "porcelain": git(repo, "status", "--porcelain"),
+        "canon": (repo / "canon.md").read_text(),
+        "reflog": git(repo, "reflog", "show", "--format=%gs", "HEAD"),
+    }
+
+
+@dataclass
+class Synthetic:
+    remote: Path
+    author: Path
+    base: str
+    root: Path
+
+    def push_change(self, text: str) -> str:
+        (self.author / "canon.md").write_text(text)
+        git(self.author, "add", "canon.md")
+        git(self.author, "commit", "-q", "-m", f"canon: {text.strip()[:40]}")
+        git(self.author, "push", "-q", "origin", "main")
+        return git(self.author, "rev-parse", "HEAD")
+
+
+def _bare_with_one_commit(root: Path, name: str, text: str) -> tuple[Path, Path, str]:
+    remote = root / f"{name}.git"
+    _run("git", "init", "-q", "--bare", "--initial-branch=main", str(remote))
+    author = root / f"{name}-author"
+    _run("git", "clone", "-q", str(remote), str(author))
+    git(author, "switch", "-q", "-c", "main")
+    (author / "canon.md").write_text(text)
+    git(author, "add", "canon.md")
+    git(author, "commit", "-q", "-m", text.strip())
+    git(author, "push", "-q", "-u", "origin", "main")
+    return remote, author, git(author, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def synthetic(tmp_path: Path) -> Synthetic:
+    remote, author, base = _bare_with_one_commit(tmp_path, "source", "canon v1\n")
+    return Synthetic(remote=remote, author=author, base=base, root=tmp_path)
+
+
+def declaration_dict(syn: Synthetic, **overrides: object) -> dict[str, object]:
+    data: dict[str, object] = {
+        "source_url": str(syn.remote),
+        "branch": "main",
+        "destination_id": "config-main-replica",
+        "destination_path": str(syn.root / "replicas" / "config-main"),
+        "state_dir": str(syn.root / "propagation" / "config-main"),
+        "outbox_root": str(syn.root / "workspace"),
+        "coordinate": {
+            "source": "synthetic/source",
+            "layer": "config",
+            "artifact_class": "config-tree",
+        },
+        "interval_seconds": 7.5,
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.fixture
+def declaration(synthetic: Synthetic) -> Declaration:
+    return declaration_from_dict(declaration_dict(synthetic))
+
+
+def outbox_events(root: Path) -> list[dict[str, object]]:
+    outbox = root / ".grip" / "events" / "outbox.jsonl"
+    if not outbox.exists():
+        return []
+    return [json.loads(line) for line in outbox.read_text().splitlines() if line.strip()]
+
+
+def receipt_files(decl: Declaration) -> list[Path]:
+    if not decl.receipts_dir.exists():
+        return []
+    return sorted(p for p in decl.receipts_dir.iterdir() if p.suffix == ".json")
+
+
+def applied_observation(receipt) -> dict[str, object]:
+    applied = [t for t in receipt.transitions if t.state is State.APPLIED]
+    assert len(applied) == 1, [t.state for t in receipt.transitions]
+    return applied[0].observation
+
+
+# ----------------------------------------------------------------------- declaration
+
+
+def test_declaration_builds_a_downward_apply_coordinate_for_one_managed_replica(
+    synthetic: Synthetic,
+) -> None:
+    decl = declaration_from_dict(declaration_dict(synthetic))
+    assert decl.source_url == str(synthetic.remote)
+    assert decl.branch == "main"
+    assert decl.kind is DestinationKind.REPLICA
+    assert decl.destination().kind is DestinationKind.REPLICA
+    assert decl.destination().destination_id == "config-main-replica"
+    assert decl.coordinate.destination == "config-main-replica"
+    assert decl.coordinate.direction is Direction.DOWN
+    assert decl.coordinate.operation is Operation.APPLY
+    assert decl.coordinate.source == "synthetic/source"
+    assert decl.coordinate.layer == "config"
+    assert decl.coordinate.artifact_class == "config-tree"
+    assert decl.interval_seconds == 7.5
+    assert decl.policy().allowed_directions == frozenset({Direction.DOWN})
+    assert decl.receipts_dir == decl.state_dir / "receipts"
+    # the default git environment is isolated from the host; "inherit" is the opt-in
+    assert decl.git_env_mode == "isolated"
+    assert decl.git_env["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert decl.git_env["GIT_CONFIG_NOSYSTEM"] == "1"
+    inherit = declaration_from_dict(declaration_dict(synthetic, git_env="inherit"))
+    assert inherit.git_env == {}
+
+
+def test_declaration_defaults_interval_and_policy_hash_when_absent(synthetic: Synthetic) -> None:
+    data = declaration_dict(synthetic)
+    del data["interval_seconds"]
+    decl = declaration_from_dict(data)
+    assert decl.interval_seconds == 30.0
+    assert decl.policy_hash == "prototype-1-downward-only"
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["source_url", "branch", "destination_id", "destination_path", "state_dir", "outbox_root"],
+)
+def test_declaration_refuses_a_missing_field_by_name(synthetic: Synthetic, missing: str) -> None:
+    data = declaration_dict(synthetic)
+    del data[missing]
+    with pytest.raises(DeclarationError, match=missing):
+        declaration_from_dict(data)
+
+
+def test_declaration_refuses_a_missing_or_incomplete_coordinate(synthetic: Synthetic) -> None:
+    data = declaration_dict(synthetic)
+    del data["coordinate"]
+    with pytest.raises(DeclarationError, match="coordinate"):
+        declaration_from_dict(data)
+    with pytest.raises(DeclarationError, match="coordinate must be an object"):
+        declaration_from_dict(declaration_dict(synthetic, coordinate="synthetic/source"))
+    partial = {"source": "synthetic/source", "layer": "config"}
+    with pytest.raises(DeclarationError, match="artifact_class"):
+        declaration_from_dict(declaration_dict(synthetic, coordinate=partial))
+
+
+@pytest.mark.parametrize("kind", ["authoring", "mirror", ""])
+def test_declaration_refuses_any_kind_but_replica_before_any_git_call(
+    synthetic: Synthetic, kind: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # if the refusal happened after a git call, this would raise something else first
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: pytest.fail("git was invoked for a refused kind")
+    )
+    with pytest.raises(DeclarationError, match="managed replicas only"):
+        declaration_from_dict(declaration_dict(synthetic, kind=kind))
+
+
+def test_declaration_accepts_the_replica_kind_spelled_out(synthetic: Synthetic) -> None:
+    decl = declaration_from_dict(declaration_dict(synthetic, kind="replica"))
+    assert decl.kind is DestinationKind.REPLICA
+
+
+def test_declaration_refuses_an_unknown_git_environment(synthetic: Synthetic) -> None:
+    with pytest.raises(DeclarationError, match="git_env must be"):
+        declaration_from_dict(declaration_dict(synthetic, git_env="host"))
+
+
+@pytest.mark.parametrize("interval", [0, -1, -0.5])
+def test_declaration_refuses_a_non_positive_interval(synthetic: Synthetic, interval: float) -> None:
+    with pytest.raises(DeclarationError, match="interval_seconds must be positive"):
+        declaration_from_dict(declaration_dict(synthetic, interval_seconds=interval))
+
+
+def test_load_declaration_reads_a_json_object_and_refuses_anything_else(
+    synthetic: Synthetic, tmp_path: Path
+) -> None:
+    path = tmp_path / "declaration.json"
+    path.write_text(json.dumps(declaration_dict(synthetic)))
+    decl = load_declaration(path)
+    assert decl.destination_id == "config-main-replica"
+    assert decl.destination_path == synthetic.root / "replicas" / "config-main"
+    path.write_text(json.dumps([declaration_dict(synthetic)]))
+    with pytest.raises(DeclarationError, match="JSON object"):
+        load_declaration(path)
+
+
+def test_make_propagator_passes_the_source_url_through_as_the_exact_string(
+    synthetic: Synthetic,
+) -> None:
+    # a Path would collapse the "//" of a URL scheme into "/" and the source would
+    # silently become a relative directory; the machine only ever stringifies it
+    url = "https://example.invalid/org/config.git"
+    decl = declaration_from_dict(declaration_dict(synthetic, source_url=url))
+    propagator = make_propagator(decl)
+    assert str(propagator.source_remote) == url
+    assert "//" in str(propagator.source_remote)
+    assert propagator.branch == "main"
+    assert propagator.state_dir == decl.state_dir
+    assert propagator.policy == decl.policy()
+    assert propagator.git_env == decl.git_env
+
+
+# ----------------------------------------------------------------------- ensure_replica
+
+
+def test_ensure_replica_clones_the_declared_branch_single_branch_when_absent(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    # a second branch on the source makes --single-branch load-bearing: without it the
+    # clone would carry refs/remotes/origin/scratch too, and the assertion below would fail
+    git(synthetic.author, "push", "-q", "origin", "main:refs/heads/scratch")
+    assert not declaration.destination_path.exists()
+    path = ensure_replica(declaration)
+    assert path == declaration.destination_path
+    assert git(path, "remote", "get-url", "origin") == str(synthetic.remote)
+    assert git(path, "rev-parse", "--abbrev-ref", "HEAD") == "main"
+    assert git(path, "rev-parse", "HEAD") == synthetic.base
+    assert (path / "canon.md").read_text() == "canon v1\n"
+    tracking = git(path, "for-each-ref", "--format=%(refname)", "refs/remotes/").splitlines()
+    assert tracking == ["refs/remotes/origin/main"]
+
+
+def test_ensure_replica_accepts_the_path_it_declared_and_leaves_it_untouched(
+    declaration: Declaration,
+) -> None:
+    ensure_replica(declaration)
+    before = snapshot(declaration.destination_path)
+    assert ensure_replica(declaration) == declaration.destination_path
+    assert snapshot(declaration.destination_path) == before
+
+
+def test_ensure_replica_refuses_a_checkout_whose_origin_is_not_the_declared_source(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    other, _, _ = _bare_with_one_commit(synthetic.root, "other", "other v1\n")
+    declaration.destination_path.parent.mkdir(parents=True)
+    _run("git", "clone", "-q", str(other), str(declaration.destination_path))
+    before = snapshot(declaration.destination_path)
+    with pytest.raises(DeclarationMismatch, match="has origin"):
+        ensure_replica(declaration)
+    assert snapshot(declaration.destination_path) == before
+
+
+def test_ensure_replica_refuses_a_checkout_on_another_branch(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    ensure_replica(declaration)
+    git(declaration.destination_path, "switch", "-q", "-c", "scratch")
+    before = snapshot(declaration.destination_path)
+    with pytest.raises(DeclarationMismatch, match="is on 'scratch'"):
+        ensure_replica(declaration)
+    assert snapshot(declaration.destination_path) == before
+
+
+def test_ensure_replica_refuses_a_path_that_is_not_a_git_checkout(
+    declaration: Declaration,
+) -> None:
+    declaration.destination_path.mkdir(parents=True)
+    (declaration.destination_path / "canon.md").write_text("not a clone\n")
+    with pytest.raises(DeclarationMismatch, match="not a git checkout"):
+        ensure_replica(declaration)
+    assert (declaration.destination_path / "canon.md").read_text() == "not a clone\n"
+    assert not (declaration.destination_path / ".git").exists()
+
+
+# ----------------------------------------------------------------------- ticks
+
+
+def test_first_tick_on_a_fresh_replica_acknowledges_without_running_the_verb(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    result = tick(declaration, propagator)
+    assert result.was_operation
+    assert result.cursor_before is None
+    assert result.source_rev == synthetic.base
+    receipt = result.receipt
+    assert receipt is not None
+    assert receipt.state is State.ACKNOWLEDGED
+    assert receipt.attempt == 1
+    assert receipt.replayed is False
+    assert receipt.source_rev == synthetic.base
+    assert receipt.expected_base == synthetic.base
+    assert receipt.after == synthetic.base
+    # the replica was born at the source revision: the read-back established it, no verb
+    assert applied_observation(receipt)["verb_ran_now"] is False
+    assert git(declaration.destination_path, "rev-parse", "HEAD") == synthetic.base
+    # one receipt file, one outbox event, one summary carried by both
+    files = receipt_files(declaration)
+    assert files == [result.receipt_path]
+    assert files[0].name.endswith(f"-{receipt.pending_id[:12]}-acknowledged.json")
+    events = outbox_events(declaration.outbox_root)
+    assert [e["type"] for e in events] == [EventType.PROPAGATION_RECEIPT.value]
+    event = events[0]
+    assert event["actor"] == ACTOR
+    assert event["owner_unit"] == declaration.destination_id
+    assert event["summary"] == result.summary
+    assert event["state"] == "acknowledged"
+    assert event["pending_id"] == receipt.pending_id
+    assert event["operation_id"] == receipt.operation_id
+    assert event["source_rev"] == synthetic.base
+    assert event["expected_base"] == synthetic.base
+    assert event["after"] == synthetic.base
+    assert event["replayed"] is False
+    assert event["receipt_path"] == str(result.receipt_path)
+    assert result.summary.startswith("propagation acknowledged: config-main-replica at ")
+    assert "attempt 1" in result.summary
+
+
+def test_a_tick_with_no_new_revision_is_not_an_operation_and_writes_nothing(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    first = tick(declaration, propagator)
+    assert first.was_operation
+    files_before = receipt_files(declaration)
+    events_before = outbox_events(declaration.outbox_root)
+    before = snapshot(declaration.destination_path)
+    second = tick(declaration, propagator)
+    assert not second.was_operation
+    assert second.receipt is None
+    assert second.receipt_path is None
+    assert second.latency_seconds is None
+    assert second.cursor_before == synthetic.base
+    assert second.source_rev == synthetic.base
+    assert "not an operation" in second.summary
+    assert "cursor already at" in second.summary
+    assert receipt_files(declaration) == files_before
+    assert outbox_events(declaration.outbox_root) == events_before
+    assert snapshot(declaration.destination_path) == before
+
+
+def test_a_pushed_change_is_applied_on_the_next_tick_with_exact_revisions(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    tick(declaration, propagator)
+    new = synthetic.push_change("canon v2\n")
+    assert new != synthetic.base
+    result = tick(declaration, propagator)
+    assert result.was_operation
+    assert result.cursor_before == synthetic.base
+    assert result.source_rev == new
+    receipt = result.receipt
+    assert receipt is not None
+    assert receipt.state is State.ACKNOWLEDGED
+    assert receipt.attempt == 1
+    assert receipt.replayed is False
+    assert receipt.source_rev == new
+    assert receipt.expected_base == synthetic.base
+    assert receipt.after == new
+    assert applied_observation(receipt)["verb_ran_now"] is True
+    assert git(declaration.destination_path, "rev-parse", "HEAD") == new
+    assert (declaration.destination_path / "canon.md").read_text() == "canon v2\n"
+    assert git(declaration.destination_path, "status", "--porcelain") == ""
+    # exact revisions in the one line a channel reader sees
+    assert f"at {synthetic.base[:12]} -> {new[:12]}, intended {new[:12]}" in result.summary
+    assert "(source synthetic/source, attempt 1, total " in result.summary
+    # a second receipt file and a second outbox event, each naming the new revision
+    files = receipt_files(declaration)
+    assert len(files) == 2
+    assert result.receipt_path in files
+    events = outbox_events(declaration.outbox_root)
+    assert len(events) == 2
+    assert events[1]["source_rev"] == new
+    assert events[1]["expected_base"] == synthetic.base
+    assert events[1]["after"] == new
+    assert events[1]["state"] == "acknowledged"
+    # and the tick after that is current again: nothing written, nothing emitted
+    third = tick(declaration, propagator)
+    assert not third.was_operation
+    assert third.cursor_before == new
+    assert receipt_files(declaration) == files
+    assert outbox_events(declaration.outbox_root) == events
+
+
+def test_written_receipt_round_trips_and_its_latency_is_recomputable_from_itself(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    tick(declaration, propagator)
+    new = synthetic.push_change("canon v2\n")
+    result = tick(declaration, propagator)
+    assert result.receipt is not None and result.receipt_path is not None
+    payload = json.loads(result.receipt_path.read_text())
+    assert set(payload) == {"daemon", "declaration", "observed_at", "latency_seconds", "receipt"}
+    assert payload["daemon"] == ACTOR
+    assert payload["declaration"] == {
+        "source_url": str(synthetic.remote),
+        "branch": "main",
+        "destination_id": "config-main-replica",
+        "destination_path": str(declaration.destination_path),
+    }
+    assert payload["observed_at"] == result.observed_at
+    assert payload["receipt"] == result.receipt.as_dict()
+    assert payload["receipt"]["state"] == "acknowledged"
+    assert payload["receipt"]["source_rev"] == new
+    assert payload["receipt"]["after"] == new
+    # the latency the daemon reports is the latency the module derives from the receipt
+    assert payload["latency_seconds"] == result.latency_seconds
+    assert result.latency_seconds == latency_from_receipt(result.receipt)
+    # and it is recomputable by a reader who has ONLY the written file
+    transitions = payload["receipt"]["transitions"]
+    states = [t["state"] for t in transitions]
+    assert states == ["observed", "fetched", "planned", "applied", "verified", "acknowledged"]
+    stamps = [datetime.fromisoformat(t["timestamp"]) for t in transitions]
+    recomputed = {
+        f"{a['state']}->{b['state']}": round((tb - ta).total_seconds(), 6)
+        for (a, ta), (b, tb) in zip(
+            zip(transitions, stamps, strict=True),
+            zip(transitions[1:], stamps[1:], strict=True),
+            strict=False,
+        )
+    }
+    recomputed["total"] = round((stamps[-1] - stamps[0]).total_seconds(), 6)
+    assert payload["latency_seconds"] == recomputed
+    assert set(recomputed) == {
+        "observed->fetched",
+        "fetched->planned",
+        "planned->applied",
+        "applied->verified",
+        "verified->acknowledged",
+        "total",
+    }
+    assert all(value >= 0 for value in recomputed.values())
+    assert recomputed["total"] == pytest.approx(
+        sum(v for k, v in recomputed.items() if k != "total"), abs=1e-5
+    )
+
+
+def test_a_dirty_replica_is_refused_with_a_receipt_left_untouched_then_applies_once_clean(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    tick(declaration, propagator)
+    (declaration.destination_path / "canon.md").write_text("local edit on the replica\n")
+    new = synthetic.push_change("canon v2\n")
+    before = snapshot(declaration.destination_path)
+    refused = tick(declaration, propagator)
+    assert refused.was_operation
+    receipt = refused.receipt
+    assert receipt is not None
+    assert receipt.state is State.REFUSED
+    assert receipt.attempt == 1
+    assert receipt.after is None
+    assert receipt.refusal_reason is not None
+    assert receipt.refusal_reason.startswith("destination.clean:")
+    assert "refused: destination.clean:" in refused.summary
+    assert "-> unchanged" in refused.summary
+    # refused means untouched: refs, HEAD, worktree bytes, reflog all as before
+    assert snapshot(declaration.destination_path) == before
+    # and a refusal is a receipt too: written and announced
+    files = receipt_files(declaration)
+    assert refused.receipt_path in files
+    assert refused.receipt_path.name.endswith("-refused.json")
+    events = outbox_events(declaration.outbox_root)
+    assert events[-1]["state"] == "refused"
+    assert events[-1]["after"] is None
+    assert events[-1]["source_rev"] == new
+    # clean up, and the next tick is a NEW attempt at the same revision, not a replay
+    git(declaration.destination_path, "checkout", "--", "canon.md")
+    applied = tick(declaration, propagator)
+    assert applied.receipt is not None
+    assert applied.receipt.state is State.ACKNOWLEDGED
+    assert applied.receipt.attempt == 2
+    assert applied.receipt.replayed is False
+    assert applied.receipt.after == new
+    assert git(declaration.destination_path, "rev-parse", "HEAD") == new
+    assert "attempt 2" in applied.summary
+    assert len(receipt_files(declaration)) == len(files) + 1
+    assert outbox_events(declaration.outbox_root)[-1]["state"] == "acknowledged"
+
+
+def test_tick_writes_and_announces_nothing_when_the_machine_returns_none(
+    declaration: Declaration, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # the only way to reach this branch is a race (the source moved back to the cursor
+    # between observe and run), so the machine's answer is forced here; the claim under
+    # test is the daemon's: no receipt, no file, no event
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    monkeypatch.setattr(propagator, "run", lambda coordinate, destination: None)
+    result = tick(declaration, propagator)
+    assert not result.was_operation
+    assert result.receipt_path is None
+    assert "source returned to the cursor" in result.summary
+    assert receipt_files(declaration) == []
+    assert outbox_events(declaration.outbox_root) == []
+
+
+def test_summarize_names_state_destination_revisions_attempt_and_total(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    tick(declaration, propagator)
+    new = synthetic.push_change("canon v2\n")
+    receipt = tick(declaration, propagator).receipt
+    assert receipt is not None
+    line = summarize(receipt, {"total": 1.23456})
+    assert line == (
+        f"propagation acknowledged: config-main-replica at {synthetic.base[:12]} -> {new[:12]}, "
+        f"intended {new[:12]} (source synthetic/source, attempt 1, total 1.235s)"
+    )
+    # a replayed receipt says so, and a missing total reads as 0.000s rather than failing
+    from dataclasses import replace
+
+    replayed = replace(receipt, replayed=True)
+    assert summarize(replayed, {}).endswith(
+        "(source synthetic/source, attempt 1, replayed, total 0.000s)"
+    )
+
+
+# ----------------------------------------------------------------------- loop + CLI
+
+
+def test_run_loop_once_ensures_the_replica_ticks_once_and_prints_exactly_one_line(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    out = io.StringIO()
+    assert not declaration.destination_path.exists()
+    stats = run_loop(
+        declaration, once=True, sleep=lambda s: pytest.fail("slept under once"), out=out
+    )
+    assert declaration.destination_path.exists()
+    assert stats.ticks == 1
+    assert stats.operations == 1
+    assert stats.by_state == {"acknowledged": 1}
+    assert stats.last is not None and stats.last.was_operation
+    lines = out.getvalue().splitlines()
+    assert len(lines) == 1
+    assert lines[0] == f"{stats.last.observed_at} {stats.last.summary}"
+
+
+def test_run_loop_stops_when_told_and_sleeps_the_declared_interval_between_ticks(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    out = io.StringIO()
+    slept: list[float] = []
+    ticks_seen = {"n": 0}
+
+    def stop() -> bool:
+        ticks_seen["n"] += 1
+        return ticks_seen["n"] >= 3
+
+    stats = run_loop(declaration, stop=stop, sleep=slept.append, out=out)
+    assert stats.ticks == 3
+    assert stats.operations == 1  # the first tick; the next two found the cursor current
+    assert stats.by_state == {"acknowledged": 1}
+    assert slept == [7.5, 7.5]
+    lines = out.getvalue().splitlines()
+    assert len(lines) == 3
+    assert "propagation acknowledged" in lines[0]
+    assert all("not an operation" in line for line in lines[1:])
+
+
+def test_main_once_runs_a_single_tick_from_a_declaration_file(
+    synthetic: Synthetic, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "declaration.json"
+    path.write_text(json.dumps(declaration_dict(synthetic)))
+    decl = load_declaration(path)
+    assert main(["--declaration", str(path), "--once"]) == 0
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+    assert len(lines) == 1
+    assert "propagation acknowledged: config-main-replica" in lines[0]
+    assert len(receipt_files(decl)) == 1
+    assert [e["type"] for e in outbox_events(decl.outbox_root)] == ["propagation.receipt"]
+
+
+def test_main_interval_override_replaces_the_declared_interval(
+    synthetic: Synthetic, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "declaration.json"
+    path.write_text(json.dumps(declaration_dict(synthetic)))
+    seen: dict[str, object] = {}
+
+    def fake_run_loop(declaration: Declaration, *, once: bool = False, **_: object):
+        seen["interval"] = declaration.interval_seconds
+        seen["once"] = once
+        return None
+
+    import gr2.prototypes.propagation_daemon as daemon
+
+    monkeypatch.setattr(daemon, "run_loop", fake_run_loop)
+    assert main(["--declaration", str(path), "--once", "--interval", "2.5"]) == 0
+    assert seen == {"interval": 2.5, "once": True}
+    assert main(["--declaration", str(path)]) == 0
+    assert seen == {"interval": 7.5, "once": False}

--- a/gr2/tests/test_propagation_daemon.py
+++ b/gr2/tests/test_propagation_daemon.py
@@ -20,6 +20,9 @@ What the tests prove, each as its own witness:
   transition timestamps
 * ``run_loop`` ticks once under ``once``, stops when told, sleeps the declared interval,
   and prints exactly one line per tick
+* a tick that fails on the environment (the source moved away, the destination checkout
+  removed mid-loop) is printed as ``tick-failed`` and counted, the loop goes on, and the
+  next loop over a restored environment completes the operation
 """
 
 from __future__ import annotations
@@ -27,6 +30,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
@@ -674,6 +678,49 @@ def test_a_tick_whose_git_call_fails_is_printed_counted_and_the_loop_goes_on(
     assert recovered.failures == 0
     assert recovered.operations == 1
     assert recovered.by_state == {"acknowledged": 1}
+
+
+def test_a_tick_whose_destination_vanished_is_printed_counted_and_the_loop_goes_on(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    # the replica exists and ensure_replica has accepted it when the loop starts; the
+    # checkout goes away AFTER the first tick (a removed directory, an unmounted volume),
+    # and a new source revision makes every later tick an operation that must read it
+    out = io.StringIO()
+    slept: list[float] = []
+    calls = {"n": 0}
+
+    def stop() -> bool:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            shutil.rmtree(declaration.destination_path)
+            synthetic.push_change("canon v2\n")
+            return False
+        return calls["n"] >= 3
+
+    stats = run_loop(declaration, stop=stop, sleep=slept.append, out=out)
+    assert stats.ticks == 3
+    assert stats.operations == 1  # the first tick, acknowledged before the checkout vanished
+    assert stats.failures == 2
+    assert stats.by_state == {"acknowledged": 1}
+    assert slept == [7.5, 7.5]
+    lines = out.getvalue().splitlines()
+    assert len(lines) == 3
+    assert "propagation acknowledged: config-main-replica" in lines[0]
+    for line in lines[1:]:
+        assert "propagation tick-failed: config-main-replica destination unreadable:" in line
+        assert "config-main-replica:" in line  # the machine names the destination it could not read
+    assert len(receipt_files(declaration)) == 1
+    assert len(outbox_events(declaration.outbox_root)) == 1
+    # recovery: a fresh loop re-ensures the replica (absent path -> clone at the source
+    # revision) and the pending operation completes as an ordinary acknowledgement
+    recovered = run_loop(declaration, once=True, sleep=slept.append, out=io.StringIO())
+    assert recovered.failures == 0
+    assert recovered.operations == 1
+    assert recovered.by_state == {"acknowledged": 1}
+    assert git(declaration.destination_path, "rev-parse", "HEAD") == git(
+        synthetic.author, "rev-parse", "HEAD"
+    )
 
 
 def test_run_loop_stops_when_told_and_sleeps_the_declared_interval_between_ticks(

--- a/gr2/tests/test_propagation_daemon.py
+++ b/gr2/tests/test_propagation_daemon.py
@@ -198,8 +198,12 @@ def test_declaration_builds_a_downward_apply_coordinate_for_one_managed_replica(
     assert decl.git_env_mode == "isolated"
     assert decl.git_env["GIT_CONFIG_GLOBAL"] == os.devnull
     assert decl.git_env["GIT_CONFIG_NOSYSTEM"] == "1"
+    # a daemon never answers a prompt, in either mode
+    assert decl.git_env["GIT_TERMINAL_PROMPT"] == "0"
     inherit = declaration_from_dict(declaration_dict(synthetic, git_env="inherit"))
-    assert inherit.git_env == {}
+    # inherit carries ONLY the prompt override: the host's config and credential helper
+    # stay in force, which is the whole point of declaring it for a private remote
+    assert inherit.git_env == {"GIT_TERMINAL_PROMPT": "0"}
 
 
 def test_declaration_defaults_interval_and_policy_hash_when_absent(synthetic: Synthetic) -> None:
@@ -288,6 +292,12 @@ def test_make_propagator_passes_the_source_url_through_as_the_exact_string(
     assert propagator.state_dir == decl.state_dir
     assert propagator.policy == decl.policy()
     assert propagator.git_env == decl.git_env
+    assert "GIT_CONFIG_GLOBAL" in propagator.git_env  # isolated by default
+    # and the inherit mode reaches the machine as inherit: the host config is NOT masked
+    # (the first dogfood run lost the credential helper here and hung on a username prompt)
+    inherit = make_propagator(declaration_from_dict(declaration_dict(synthetic, git_env="inherit")))
+    assert inherit.git_env == {"GIT_TERMINAL_PROMPT": "0"}
+    assert "GIT_CONFIG_GLOBAL" not in inherit.git_env
 
 
 # ----------------------------------------------------------------------- ensure_replica
@@ -625,6 +635,45 @@ def test_run_loop_once_ensures_the_replica_ticks_once_and_prints_exactly_one_lin
     lines = out.getvalue().splitlines()
     assert len(lines) == 1
     assert lines[0] == f"{stats.last.observed_at} {stats.last.summary}"
+
+
+def test_a_tick_whose_git_call_fails_is_printed_counted_and_the_loop_goes_on(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    ensure_replica(declaration)
+    # take the source away: the replica still names it as origin, so ensure_replica accepts
+    # the path, and the first git call of the tick (ls-remote) fails
+    moved = synthetic.remote.with_name("source.git.moved")
+    synthetic.remote.rename(moved)
+    out = io.StringIO()
+    slept: list[float] = []
+    seen = {"n": 0}
+
+    def stop() -> bool:
+        seen["n"] += 1
+        return seen["n"] >= 2
+
+    stats = run_loop(declaration, stop=stop, sleep=slept.append, out=out)
+    assert stats.ticks == 2
+    assert stats.failures == 2
+    assert stats.operations == 0
+    assert stats.by_state == {}
+    assert stats.last is None
+    assert slept == [7.5]  # it kept going after the first failure
+    lines = out.getvalue().splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        assert "propagation tick-failed: config-main-replica git ls-remote exited" in line
+        assert "ls-remote" in line
+        assert "this tick left no receipt" in line
+    assert receipt_files(declaration) == []
+    assert outbox_events(declaration.outbox_root) == []
+    # put the source back: the very next tick is an ordinary operation, nothing to repair
+    moved.rename(synthetic.remote)
+    recovered = run_loop(declaration, once=True, sleep=slept.append, out=io.StringIO())
+    assert recovered.failures == 0
+    assert recovered.operations == 1
+    assert recovered.by_state == {"acknowledged": 1}
 
 
 def test_run_loop_stops_when_told_and_sleeps_the_declared_interval_between_ticks(

--- a/gr2/tests/test_propagation_daemon.py
+++ b/gr2/tests/test_propagation_daemon.py
@@ -23,6 +23,9 @@ What the tests prove, each as its own witness:
 * a tick that fails on the environment (the source moved away, the destination checkout
   removed mid-loop) is printed as ``tick-failed`` and counted, the loop goes on, and the
   next loop over a restored environment completes the operation
+* what the loop says propagates does propagate: a corrupted cursor (``JournalInconsistent``)
+  leaves the loop by name with no tick line and no receipt, and ``LookupError`` or a bare
+  ``RuntimeError`` from a tick is not swallowed either
 """
 
 from __future__ import annotations
@@ -55,6 +58,8 @@ from gr2.prototypes.propagation_daemon import (
 from gr2.prototypes.propagation_state_machine import (
     DestinationKind,
     Direction,
+    Journal,
+    JournalInconsistent,
     Operation,
     State,
 )
@@ -583,12 +588,12 @@ def test_a_dirty_replica_is_refused_with_a_receipt_left_untouched_then_applies_o
 def test_tick_writes_and_announces_nothing_when_the_machine_returns_none(
     declaration: Declaration, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # the only way to reach this branch is a race (the source moved back to the cursor
-    # between observe and run), so the machine's answer is forced here; the claim under
-    # test is the daemon's: no receipt, no file, no event
+    # the machine's contract allows None ("not new"); since the daemon now hands the
+    # machine its own observation that answer cannot arise on this path, so it is forced
+    # here; the claim under test is the daemon's: no receipt, no file, no event
     ensure_replica(declaration)
     propagator = make_propagator(declaration)
-    monkeypatch.setattr(propagator, "run", lambda coordinate, destination: None)
+    monkeypatch.setattr(propagator, "run", lambda coordinate, destination, observation=None: None)
     result = tick(declaration, propagator)
     assert not result.was_operation
     assert result.receipt_path is None
@@ -721,6 +726,69 @@ def test_a_tick_whose_destination_vanished_is_printed_counted_and_the_loop_goes_
     assert git(declaration.destination_path, "rev-parse", "HEAD") == git(
         synthetic.author, "rev-parse", "HEAD"
     )
+
+
+def test_a_corrupted_cursor_propagates_out_of_the_loop_by_name_instead_of_retrying_forever(
+    synthetic: Synthetic, declaration: Declaration
+) -> None:
+    # The one state the journal can never produce on its own: a cursor AT the source
+    # revision with no acknowledged attempt behind it. The machine names it
+    # JournalInconsistent and the loop must NOT treat it as an environmental failure: a
+    # daemon that swallowed it would print tick-failed forever over corrupted sink state
+    # and nobody would learn. Found unwitnessed in review (widening the catch list to
+    # RuntimeError kept the suite green), so this is the witness.
+    ensure_replica(declaration)
+    propagator = make_propagator(declaration)
+    Journal(declaration.state_dir).advance_cursor(
+        declaration.coordinate.key(), synthetic.base, pending_id="forged"
+    )
+    out = io.StringIO()
+    with pytest.raises(JournalInconsistent, match="no acknowledged attempt"):
+        run_loop(declaration, once=True, sleep=lambda _s: None, out=out)
+    assert out.getvalue() == ""  # no tick line: the loop did not survive it
+    assert receipt_files(declaration) == []
+    assert outbox_events(declaration.outbox_root) == []
+    # and the same with the propagator handed in through tick() directly
+    with pytest.raises(JournalInconsistent):
+        tick(declaration, propagator)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pytest.param(LookupError("no transitions journaled"), id="LookupError"),
+        pytest.param(RuntimeError("a defect in the daemon"), id="bare-RuntimeError"),
+        pytest.param(ValueError("a defect in the daemon"), id="ValueError"),
+    ],
+)
+def test_the_loop_does_not_swallow_what_it_says_propagates(
+    declaration: Declaration, monkeypatch: pytest.MonkeyPatch, exc: BaseException
+) -> None:
+    # The docstring lists what propagates by design; this pins the list from the other
+    # side. A "hardening" edit that widened _TICK_FAILURES to RuntimeError or LookupError
+    # would turn a corrupted-journal halt into an infinite retry, silently.
+    import gr2.prototypes.propagation_daemon as daemon_module
+
+    calls = {"n": 0}
+
+    def exploding_tick(decl, propagator):  # noqa: ANN001 - signature of daemon.tick
+        calls["n"] += 1
+        raise exc
+
+    monkeypatch.setattr(daemon_module, "tick", exploding_tick)
+    out = io.StringIO()
+    # the stop predicate is BOUNDED so that a loop which wrongly swallows the exception
+    # terminates and fails here, instead of spinning forever and hanging the suite
+    rounds = {"n": 0}
+
+    def stop_after_three() -> bool:
+        rounds["n"] += 1
+        return rounds["n"] >= 3
+
+    with pytest.raises(type(exc)):
+        run_loop(declaration, stop=stop_after_three, sleep=lambda _s: None, out=out)
+    assert calls["n"] == 1  # it did not go round again
+    assert out.getvalue() == ""
 
 
 def test_run_loop_stops_when_told_and_sleeps_the_declared_interval_between_ticks(

--- a/gr2/tests/test_propagation_state_machine.py
+++ b/gr2/tests/test_propagation_state_machine.py
@@ -669,6 +669,25 @@ def test_run_all_with_no_declared_targets_is_none(synthetic: Synthetic) -> None:
     assert propagator(synthetic).run_all([]) is None
 
 
+def test_an_explicit_empty_git_env_is_inherit_and_not_the_isolated_default(
+    synthetic: Synthetic,
+) -> None:
+    # None asks for the default (isolated from the host); {} asks to inherit the host
+    # environment. {} is falsy, so an `or` would silently turn inherit into isolated and a
+    # caller that needs the host's credential helper would lose it without any error.
+    assert "GIT_CONFIG_GLOBAL" in propagator(synthetic).git_env
+    assert propagator(synthetic, git_env=None).git_env == propagator(synthetic).git_env
+    assert propagator(synthetic, git_env={}).git_env == {}
+    explicit = {"GIT_TERMINAL_PROMPT": "0"}
+    assert propagator(synthetic, git_env=explicit).git_env == explicit
+    # and the inherit form still drives the machine: a change is applied under {} as well
+    dest = replica(synthetic, "replica")
+    new = synthetic.push_change("canon v2\n")
+    receipt = propagator(synthetic, git_env={}).run(coordinate(dest.destination_id), dest)
+    assert receipt is not None and receipt.state is State.ACKNOWLEDGED
+    assert git(dest.path, "rev-parse", "HEAD") == new
+
+
 def test_all_destinations_verifying_is_acknowledged_not_partial(synthetic: Synthetic) -> None:
     a = replica(synthetic, "replica-a")
     b = replica(synthetic, "replica-b")

--- a/gr2/tests/test_propagation_state_machine.py
+++ b/gr2/tests/test_propagation_state_machine.py
@@ -43,6 +43,7 @@ from gr2.prototypes.propagation_state_machine import (
     DestinationKind,
     Direction,
     Journal,
+    JournalInconsistent,
     Operation,
     Policy,
     Propagator,
@@ -646,9 +647,9 @@ def test_a_cursor_the_journal_never_acknowledged_is_a_corrupted_sink_state_and_r
     Journal(synthetic.state_dir).advance_cursor(coord.key(), new, pending_id="forged")
     before = snapshot(dest.path)
 
-    with pytest.raises(RuntimeError, match="no acknowledged attempt"):
+    with pytest.raises(JournalInconsistent, match="no acknowledged attempt"):
         propagator(synthetic).run_all([(coord, dest)])
-    with pytest.raises(RuntimeError, match="no acknowledged attempt"):
+    with pytest.raises(JournalInconsistent, match="no acknowledged attempt"):
         propagator(synthetic).run(coord, dest)
     assert snapshot(dest.path) == before, "a refusal to guess must not touch the destination"
 


### PR DESCRIPTION
## What

Prototype 1 of the propagation daemon: the Prototype 0 state machine (#889) run on a loop against ONE destination that a declaration names as a managed replica of one branch of one source. This is the step before the daemon is allowed near a real clone, and it is built so the declaration cannot give it more than that.

`gr2/prototypes/propagation_daemon.py`:

- **Declaration** names exactly one managed replica (`source_url`, `branch`, `destination_id`, `destination_path`, `state_dir`, `outbox_root`, a coordinate, an interval). `kind` may only be `replica`; an authoring kind, an unknown git environment, a non-positive interval, or a missing field is refused before any git call. The policy is fixed to downward-only, the one direction a managed replica can be the destination of.
- **`ensure_replica`** clones the declared branch single-branch when the path is absent; when the path exists it must be a git checkout whose `origin` is the declared source and whose current branch is the declared branch, otherwise it is refused before the machine ever reads it (a daemon must not fast-forward a clone that merely sits at the path). A non-git directory is refused too.
- **One tick**: observe the source with `git ls-remote`; if the cursor already names the source revision there is no operation, no receipt, and nothing is written. Otherwise drive the machine once and take its receipt, whatever its state — a refusal is a receipt too — write it as its own JSON file with per-state latency derived from the receipt's own transition timestamps (not a stopwatch around the call), and emit one `propagation.receipt` event on the gr2 outbox carrying the one-line summary. The daemon writes that line to the outbox and to stdout and knows no channel, so the prototype depends on nothing outside `gr2`.
- **Git environment is a declared choice**: isolated from the host configuration by default (the Prototype 0 default); `"git_env": "inherit"` for a real private remote that needs the host's credential helper. The daemon never creates a commit, so inheriting does not invoke signing. **In both modes `GIT_TERMINAL_PROMPT=0` is set**: a daemon never answers a prompt, so a missing credential fails the tick instead of hanging the loop on a tty.
- **A tick that fails on the environment is printed and counted, and the loop goes on.** `run_loop` catches `SourceUnobservable` (the machine's new name for a failed or empty `ls-remote`, raised before any state is touched), `DestinationUnreadable` (the machine's wrapper for a failed destination read, raised at observe, plan, or verify, each a point it replays from), `CalledProcessError`, and `OSError`; the catch list is derived from the machine's raise sites reachable from a tick and says so in a comment. It prints one `propagation tick-failed` line, increments `LoopStats.failures`, and continues; the next tick replays whatever the machine left pending, which is the machine's own kill-and-replay contract. What propagates, by design and by name: `JournalInconsistent` and `LookupError` from the machine (a journal that cannot account for its own cursor is corrupted sink state), `DeclarationMismatch` from `ensure_replica` at startup, and any defect in the daemon module — and that claim is witnessed from the other side (a forged cursor leaves `run_loop` by name with nothing written; `LookupError`, a bare `RuntimeError`, and `ValueError` from a tick are not swallowed).
- **The not-new path asks the machine too.** The tick observes the source once and hands that observation to `Propagator.run` on both paths (new: the operation; not new: the machine's cursor check, which raises `JournalInconsistent` for a cursor the journal never acknowledged). An earlier version of the tick returned "current; not an operation" without asking, so the machine's corrupted-sink check never ran on the daemon path and would have hidden corrupted sink state on every tick forever; the witness for the escape claim found it.
- **`run_loop` / CLI**: one printed line per tick, `--once`, `--interval` override; stdout is resolved at call time so a redirecting caller gets the lines.

`gr2/prototypes/propagation_state_machine.py` (Prototype 0) gets two small changes the first dogfood run demanded: `Propagator` now distinguishes `git_env=None` (the isolated default) from an explicit `{}` (inherit the host environment), where it previously collapsed the falsy `{}` into the default, so the daemon's inherit mode silently lost the host's credential helper and `ls-remote` prompted for a username; and a failed or empty `ls-remote` raises `SourceUnobservable` (a `RuntimeError` subclass, so any caller of the bare class still catches it) instead of a bare `RuntimeError`, so a looping caller can recognise it by name. A third small change names the machine's one deliberate escape: a cursor at a revision the journal never acknowledged raises `JournalInconsistent` (also a `RuntimeError` subclass) instead of a bare `RuntimeError`, so an escape that is meant is distinguishable from one that is not at any catch site. A fourth: `Propagator.run` takes an optional `observation`, so a caller that already observed the source this tick can hand it over instead of asking the source twice; the cursor check runs on it all the same, because "nothing new" is exactly the answer that would hide a corrupted sink state, whoever observed.

`gr2/python_cli/events.py` gains `EventType.PROPAGATION_RECEIPT`; `gr2/docs/HOOK-EVENT-CONTRACT.md` documents it in the 3.2 taxonomy and the 7.2 enum listing, with `receipt_path` declared as an explicit exception to the relative-path rule (the receipt store is daemon state under the declared `state_dir`, not a workspace file); the exhaustive `EventType` count test moves from 35 to 36.

`gr2/tests/test_propagation_daemon.py` builds a bare source remote, an authoring clone, and a declared replica path, and proves, each as its own witness:

- the declaration builds a downward `apply` coordinate for the declared replica; each required field, a missing or incomplete coordinate, any kind but `replica` (with `subprocess.run` patched to fail the test if git were invoked), an unknown `git_env`, and a non-positive interval are refused by name
- `ensure_replica` clones the declared branch single-branch when absent (the source carries a second branch, so `--single-branch` is load-bearing), accepts and leaves untouched the path it declared, and refuses a checkout with another origin, a checkout on another branch, and a non-git directory, each left untouched
- the first tick on a fresh replica acknowledges without running the verb (the replica was born at the source revision; `verb_ran_now` is false in the applied transition), writes one receipt file, and emits one `propagation.receipt` event whose fields name the exact revisions and carry the same summary line
- a tick with no new revision is not an operation: no receipt, no file, no event, replica untouched
- a pushed change is applied on the next tick with `verb_ran_now` true, the replica's HEAD and worktree advanced, a second receipt file and a second event naming the new revision, and the tick after that is current again
- the written receipt round-trips (`daemon`, `declaration`, `observed_at`, `latency_seconds`, `receipt`) and its latency is recomputed by a reader holding ONLY the file, from the receipt's own transitions (`observed->fetched` … `verified->acknowledged`, `total`), equal to what the daemon wrote
- a dirty replica is refused with a receipt (`destination.clean`), written and announced, and left byte-for-byte untouched; after cleanup the next tick is attempt 2, not a replay
- when the machine answers `None` (the source moved back to the cursor between observe and run; forced, since it is a race), nothing is written and nothing is emitted
- `run_loop` under `--once` ensures the replica, ticks once, and prints exactly one line; under a stop predicate it sleeps the declared interval between ticks and the second and third ticks are not operations; `main` runs one tick from a declaration file and applies `--interval` over the declared value
- both git environment modes carry `GIT_TERMINAL_PROMPT=0`, and inherit carries ONLY that override; `make_propagator` hands the machine inherit as inherit (asserted at the propagator seam, where the first dogfood run lost it)
- with the source moved away after the replica exists, two ticks fail with `propagation tick-failed … git ls-remote exited …` lines, `failures == 2`, no operation, no receipt file, no event, and the loop kept going (the declared interval was slept once between them); with the source put back the very next tick is an ordinary acknowledged operation, nothing to repair
- in `test_propagation_state_machine.py`: an explicit `{}` is inherit and not the isolated default (`None` and the default are identical, `{}` is empty, an explicit mapping is passed through), and a change is applied under `{}` as well
- with the replica accepted at loop start and then REMOVED after the first tick (a deleted checkout, an unmounted volume) while a new source revision makes every later tick an operation that must read it, the first tick acknowledges and the next two fail with `propagation tick-failed … destination unreadable: …` lines naming the destination, `failures == 2`, `operations == 1`, one receipt file and one event only, the declared interval slept between ticks; a fresh loop re-ensures the replica (absent path → clone) and the operation completes as an ordinary acknowledgement with the replica's HEAD at the new source revision
- in `test_propagation_state_machine.py`: the corrupted-cursor escape is `JournalInconsistent` by name (still matching the `RuntimeError` witnesses)
- a forged cursor (advanced to the source revision with no acknowledged attempt) makes `run_loop` raise `JournalInconsistent` by name with no tick line, no receipt file, and no event, and `tick` raises the same; and with `tick` replaced by one that raises `LookupError`, a bare `RuntimeError`, or `ValueError`, `run_loop` raises that exception after exactly one call (the stop predicate is bounded so a loop that wrongly swallowed it would fail rather than hang)

## Evidence (RAN)

- `python3 -m pytest gr2/tests/test_propagation_daemon.py gr2/tests/test_propagation_state_machine.py`: 83 passed, 1 xfailed (41 daemon + 42 machine; Python 3.13.2, pytest 9.0.2); the module under test resolved to the repository file via the root conftest, confirmed by the control that a bare interpreter resolves `gr2` to an installed snapshot that does not contain the daemon module at all
- `ruff check` clean on the daemon module and its test under the project config; `ruff format` applied to the two new files only; the four pre-existing findings in `events.py` (UP042, UP017 ×3) are on `dev` and untouched here
- mutation run over the daemon module, nine rows, each row asserting its anchor applied (count == 1) and the suite run to a verdict (a missing summary is an instrument failure, never "survived"), the module restored from a saved copy and hash-verified after every row: the not-new early return dropped killed exactly the not-an-operation witness (the machine's own `None` keeps the no-write property, so the distinguishing observable is the summary); the origin check removed killed exactly the other-origin witness; the branch check removed killed exactly the other-branch witness; `--single-branch` dropped killed exactly the clone witness; the kind check removed killed exactly the three kind refusals; `notify()` skipped killed exactly the four witnesses that read the outbox; the atomic rename skipped killed exactly the five witnesses that read a receipt file; `total` dropped from the latency killed exactly the round-trip witness; `UP` allowed alongside `DOWN` killed exactly the declaration witness
- four further mutations for the second commit, same discipline (anchor count == 1, suite to a verdict, restore from a saved copy with pre/post hashes printed and equal): restoring the machine's `or` killed exactly the `{}`-is-inherit witness; dropping `GIT_TERMINAL_PROMPT` from both modes killed exactly the declaration witness and the propagator-seam witness; removing `SourceUnobservable` from the loop's catch list killed exactly the tick-failure witness; raising the bare `RuntimeError` again from `observe_source_at` killed exactly the same tick-failure witness from the machine's side
- two more for the third commit, same discipline: dropping `DestinationUnreadable` from the loop's catch list killed exactly the vanished-destination witness (the loop crashes on the second tick, as the second reviewer of this branch first demonstrated); raising the bare `RuntimeError` again for the corrupted cursor killed exactly the corrupted-cursor witness. Six rows in the second run, each restored from a saved copy with equal pre/post hashes, baseline and final both green
- two more for the fourth commit, run as one eight-row table with the six above (each row still killing exactly its witnesses; the named-escape row now also kills the daemon-side corrupted-cursor witness): restoring the not-new shortcut (the machine never asked to account for the cursor) killed exactly the corrupted-cursor loop witness; widening the catch list to also swallow `RuntimeError` and `LookupError` (the "harden the daemon" edit the second reviewer tried against the previous head, which left that suite green) killed exactly the corrupted-cursor loop witness and the `LookupError` / bare-`RuntimeError` cases, with the `ValueError` case green as the control. Restores hash-equal, baseline and final 83 green
- the whole `gr2/tests` tree at this head: 967 passed, 1 xfailed, 5 failed; the same 5 (two in `test_event_log_integrity.py`, one each in `test_gr2_packaging.py`, `test_sprint21_sync_platform.py`, `test_workspace_edit_lease_cap.py`) fail identically on `origin/dev` at the base commit, so they are pre-existing and untouched here

## Not in scope

- the dogfood run's results against a real source (its first attempt is what found the inherit seam fixed here; the measured latency and receipts are reported separately once the run completes on this code)
- more than one destination per declaration, any transport, and any policy content beyond the fixed downward direction
- relaying the outbox line to a channel (a consumer's job; the daemon knows no channel)

Premium boundary: grip is OSS; this is local git mechanics over opaque identifiers and carries no identity, org, or policy content.
