### PR TITLE
fix(gr2): a torn journal line stops being fatal, and stops eating its neighbour

### DIFF
--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -102,6 +102,19 @@ class DestinationUnreadable(RuntimeError):
     """A read against the destination returned an error instead of an answer."""
 
 
+@dataclass(frozen=True)
+class MalformedLine:
+    """A journal line that could not be parsed, kept so a drop is never silent.
+
+    ``index`` counts lines in the file, blank ones included, so it names the line a
+    reader would count to by hand.
+    """
+
+    index: int
+    excerpt: str
+    reason: str
+
+
 class JournalInconsistent(RuntimeError):
     """The cursor names a revision the journal cannot account for.
 
@@ -371,23 +384,93 @@ class Journal:
         self.state_dir = state_dir
         self.path = state_dir / "journal.jsonl"
         self.cursors_dir = state_dir / "cursors"
+        # Rows are cached against the file's (size, mtime_ns) because Prototype 1 asks
+        # the machine to account for an observation on EVERY tick, including idle ones,
+        # which moved this parse from once-per-change to once-per-tick. The Propagator
+        # is built once per loop and holds one Journal, so the cache spans ticks.
+        #
+        # LIMITATION, stated rather than assumed away: an in-place mutation that changes
+        # neither size nor mtime_ns is not detected. The append-only writer never
+        # produces that state, and the next real append invalidates the entry — but a
+        # cache sitting on a corruption-detection path should name what it cannot see.
+        self._cache_key: tuple[int, int] | None = None
+        self._cached_rows: list[dict[str, object]] = []
+        self._malformed: tuple[MalformedLine, ...] = ()
+
+    @property
+    def malformed_lines(self) -> tuple[MalformedLine, ...]:
+        """Lines the last read could not parse. Empty is the ordinary answer."""
+        return self._malformed
 
     # -- rows
 
     def _rows(self) -> list[dict[str, object]]:
-        if not self.path.exists():
+        """Every readable row, oldest first. Unreadable lines are dropped and counted.
+
+        A kill between ``_write``'s write and its fsync leaves a partial line, so an
+        unparseable line is an ordinary consequence of the writer being killed — not
+        evidence of corruption, and not a reason to refuse. Raising here would exit the
+        daemon on its first tick and on every restart after it, because the loop lets
+        anything outside its named failure list propagate.
+
+        Position does NOT discriminate cause. A tear is trailing only until the daemon
+        restarts and appends again, after which the same orphan sits mid-file with intact
+        rows on both sides. The question that does discriminate is whether the CURSOR can
+        still be accounted for, and ``replay`` already asks it and already raises
+        ``JournalInconsistent`` by name. Dropping a line here lets that check be the one
+        that decides, instead of a bare ``ValueError`` from this parse pre-empting it.
+
+        Returned rows are shared with the cache and must be treated as read-only; every
+        consumer in this module filters or copies rather than mutating.
+        """
+        try:
+            stat = self.path.stat()
+        except (FileNotFoundError, NotADirectoryError):
+            self._cache_key, self._cached_rows, self._malformed = None, [], ()
             return []
+
+        key = (stat.st_size, stat.st_mtime_ns)
+        if key == self._cache_key:
+            return self._cached_rows
+
         rows: list[dict[str, object]] = []
-        for line in self.path.read_text().splitlines():
-            line = line.strip()
+        malformed: list[MalformedLine] = []
+        for index, raw in enumerate(self.path.read_text().splitlines()):
+            line = raw.strip()
             if not line:
                 continue
-            rows.append(json.loads(line))
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                malformed.append(
+                    MalformedLine(index=index, excerpt=line[:120], reason=str(exc))
+                )
+        self._cache_key, self._cached_rows, self._malformed = key, rows, tuple(malformed)
         return rows
 
     def _write(self, row: dict[str, object]) -> None:
+        """Append one row, terminating a torn remnant first.
+
+        Without the repair, appending onto a partial line GLUES this row to it, and the
+        tear costs two rows instead of one: the interrupted write, and the next write,
+        which was itself correct and fsynced. Terminating first confines the damage to
+        the line that was actually interrupted.
+
+        Two writers racing can at worst both terminate, leaving a blank line, which
+        ``_rows`` already skips.
+        """
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        unterminated = False
+        try:
+            with self.path.open("rb") as probe:
+                if probe.seek(0, os.SEEK_END):
+                    probe.seek(-1, os.SEEK_END)
+                    unterminated = probe.read(1) != b"\n"
+        except FileNotFoundError:
+            pass
         with self.path.open("a") as handle:
+            if unterminated:
+                handle.write("\n")
             handle.write(json.dumps(row, separators=(",", ":")) + "\n")
             handle.flush()
             os.fsync(handle.fileno())
@@ -1216,6 +1299,7 @@ __all__ = [
     "DestinationKind",
     "DestinationUnreadable",
     "JournalInconsistent",
+    "MalformedLine",
     "Direction",
     "GateResult",
     "Journal",

--- a/gr2/tests/test_propagation_state_machine.py
+++ b/gr2/tests/test_propagation_state_machine.py
@@ -883,3 +883,108 @@ def test_outbox_event_survives_a_consumer_that_fails_after_reading(tmp_path: Pat
     again = _offered_types(workspace)
     if again != ["sync.completed"]:
         raise EventLost(f"offered once, then lost: second read returned {again!r}")
+
+
+# -- grip#893: a torn journal line must not be fatal, and must not eat its neighbour
+#
+# The writer appends and fsyncs, so a kill between the write and the fsync leaves
+# a partial trailing line. Three witnesses, each for a distinct failure:
+#
+#   W1  the tear must not destroy the NEXT row (measured on the filed issue: with
+#       no newline repair the following append glues onto the remnant, so a row
+#       that was written correctly and fsynced becomes unreadable)
+#   W2  reading a torn journal must not raise; the intact prefix still answers
+#   W3  an idle tick must not re-parse a journal that has not changed
+#
+# W1 is the one the issue does not contain and is the reason the position rule in
+# it does not hold: after a restart append the malformed line is no longer last.
+
+
+def _tear(journal: Journal, partial: str = '{"kind": "not-final') -> None:
+    """Leave a partial trailing line, exactly as a kill between write and fsync does."""
+    with journal.path.open("a") as handle:
+        handle.write(partial)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def test_a_torn_line_does_not_swallow_the_row_written_after_it(tmp_path: Path) -> None:
+    """W1. The append after a tear must not glue onto the remnant.
+
+    Without a newline repair the file becomes ``…{"n": 3, "no{"n": 4}`` — row 4 was
+    written correctly and fsynced, and is unreadable because row 3 died mid-line.
+    A tear may cost the interrupted write; it must never cost the next one.
+    """
+    journal = Journal(tmp_path / "state")
+    journal._write({"n": 1})
+    journal._write({"n": 2})
+    _tear(journal)
+
+    journal._write({"n": 4})
+
+    rows = journal._rows()
+    assert {r.get("n") for r in rows} == {1, 2, 4}, (
+        "the row written after the tear must survive it; "
+        f"file was {journal.path.read_text()!r}"
+    )
+
+
+def test_a_torn_trailing_line_is_skipped_and_reported_not_raised(tmp_path: Path) -> None:
+    """W2. Reading a torn journal answers from the intact prefix and says what it dropped.
+
+    The daemon lets anything outside its named failure list propagate, so a bare
+    ``JSONDecodeError`` out of the parse exits the loop on the first tick and on
+    every restart after it. The intact prefix is still a truthful answer.
+    """
+    journal = Journal(tmp_path / "state")
+    journal._write({"n": 1})
+    journal._write({"n": 2})
+    _tear(journal)
+
+    rows = journal._rows()
+
+    assert [r.get("n") for r in rows] == [1, 2]
+    assert len(journal.malformed_lines) == 1, "the drop must be counted, not silent"
+    assert journal.malformed_lines[0].index == 2
+
+
+def test_an_unchanged_journal_is_not_reparsed_on_the_next_tick(tmp_path: Path) -> None:
+    """W3. Prototype 1 consults the machine on every tick, including idle ones.
+
+    That is correct — a corrupted sink behind an unchanged source must not read as
+    healthy — but it moved the whole-file parse from once-per-change to once-per-
+    tick. An unchanged file must cost nothing to re-read; a changed one must not
+    be served from a stale cache.
+    """
+    journal = Journal(tmp_path / "state")
+    journal._write({"n": 1})
+    journal._write({"n": 2})
+
+    parsed: list[str] = []
+    real_loads = json.loads
+
+    def counting_loads(payload, *args, **kwargs):  # type: ignore[no-untyped-def]
+        parsed.append(payload)
+        return real_loads(payload, *args, **kwargs)
+
+    import gr2.prototypes.propagation_state_machine as module
+
+    original = module.json.loads
+    module.json.loads = counting_loads
+    try:
+        first = journal._rows()
+        after_first = len(parsed)
+        second = journal._rows()
+        after_second = len(parsed)
+
+        journal._write({"n": 3})
+        third = journal._rows()
+        after_third = len(parsed)
+    finally:
+        module.json.loads = original
+
+    assert after_first == 2, "the first read parses the file"
+    assert after_second == after_first, "an unchanged journal must not be re-parsed"
+    assert first == second
+    assert after_third > after_second, "a changed journal must not be served stale"
+    assert [r.get("n") for r in third] == [1, 2, 3]


### PR DESCRIPTION
The journal writer appends and fsyncs, so a kill between the two leaves a partial line. Three consequences, each with its own witness.

**A tear used to cost two rows, not one.** Appending onto an unterminated line glues the new row to the remnant, so a row that was serialized correctly and fsynced becomes unreadable. `_write` now terminates a remnant first, confining the damage to the line actually interrupted. This is the half the issue did not contain, and it is the reason the issue's discriminator does not hold.

**`_rows` raised a bare `JSONDecodeError` on any unparseable line.** The daemon lets anything outside its named failure list propagate, so one bad moment exited the loop on its first tick and on every restart after it. Unparseable lines are now dropped and counted, and `MalformedLine` keeps the drop from being silent.

**The drop is unconditional rather than trailing-only, because position does not discriminate cause.** A tear is trailing only until the daemon restarts and appends again, after which the same orphan sits mid-file with intact rows on both sides — so a position rule would raise on the writer's own crash-then-restart signature. The question that does discriminate is whether the cursor can still be accounted for, and `replay` already asks it and already raises `JournalInconsistent` by name. Dropping here lets that check decide instead of being pre-empted by a parse error. Skipping is safe because the acknowledgement row is written before the cursor advances, so a torn acknowledgement leaves the operation unacknowledged and it is redone idempotently.

**Idle ticks no longer re-parse the file.** Prototype 1 asks the machine to account for an observation on every tick, which moved this parse from once-per-change to once-per-tick. Rows are cached against `(size, mtime_ns)`; the `Propagator` is built once per loop and holds one `Journal`, so the cache spans ticks — verified rather than assumed, since a cache that never hits in production would be a green over a non-fix. The one state it cannot see, an in-place mutation changing neither size nor mtime_ns, is named in the code rather than assumed away.

## Verification

86 passed, 1 xfailed — up from 83 by exactly the three witnesses added, so nothing was lost or silently skipped.

Each guard is mutation-proven, and each mutation was restored byte-exact:

| Mutation | Kills |
|---|---|
| remove the newline repair | W1 only |
| restore the bare `json.loads` | W1 and W2 |
| disable the cache | W3 only |

The second killing two is a real dependency rather than a stray: W1 asserts on the rows that survive, so without the skip guard its torn orphan still raises. The guards compose, and that is reported rather than presented as three tidy isolations.

Ref #893 — closes at promotion.

Premium boundary: grip is OSS because this is local workspace state machinery — journal durability and read caching — with no identity, org, or entitlement semantics.
