### PR TITLE
feat(gr2): Prototype 2 contribution protocol — canonical destinations, lease-guarded up, sets, retire refusal, append surfaces

### DIFF
--- a/gr2/prototypes/contribution_protocol.py
+++ b/gr2/prototypes/contribution_protocol.py
@@ -283,6 +283,23 @@ def _now() -> str:
     return datetime.now(UTC).isoformat(timespec="microseconds")
 
 
+def state_latencies(receipt: Receipt) -> list[tuple[str, float]]:
+    """Per-state latency from the receipt's OWN timestamps, in seconds.
+
+    Each row is ``(state, seconds since the previous transition)``; the first row is
+    ``(state, 0.0)``. A measurement, not a witness: the receipts already carry the
+    timestamps, so the number comes from the artifact and not from a stopwatch around
+    it. Printed so a daemon's ``up`` budget can start from data.
+    """
+    rows: list[tuple[str, float]] = []
+    previous: datetime | None = None
+    for t in receipt.transitions:
+        at = datetime.fromisoformat(t.timestamp)
+        rows.append((str(t.state), 0.0 if previous is None else (at - previous).total_seconds()))
+        previous = at
+    return rows
+
+
 class ContributionSet:
     """Several contributions that must land together: prepare all, land in order, report."""
 
@@ -526,4 +543,5 @@ __all__ = [
     "SetReceipt",
     "Subspace",
     "WriteMode",
+    "state_latencies",
 ]

--- a/gr2/prototypes/contribution_protocol.py
+++ b/gr2/prototypes/contribution_protocol.py
@@ -1,0 +1,529 @@
+"""Prototype 2: the contribution protocol around the propagation state machine.
+
+The machine (``propagation_state_machine``) lands ONE contribution on a canonical
+remote by compare-and-swap. This module is the protocol that decides WHICH owner a
+change is proposed to, lands SEVERAL contributions that must go together, refuses
+to RETIRE a workspace that still holds open contributions, and gives declared
+append-only surfaces the one behaviour they are allowed that everything else is
+not: two writers, both land, neither replans.
+
+Everything here is neutral: layer refs, destination ids, and surface names are
+opaque strings the caller resolves. The module holds no notion of who an agent or
+an org is, and who MAY contribute where is a policy it is handed, never derives.
+
+Four pieces, each the smallest shape that its witness needs:
+
+``ResolvedManifest`` / ``ResolvedEntry``
+    Ownership is a RECORDED fact, never a guess over path shape. Every resolved
+    entry carries ``declared_by`` (the layer whose declaration put it in the
+    workspace), ``overridden_by`` (the layer whose override currently governs it,
+    if any) and ``write_mode`` (``own`` / ``contribute`` / ``append`` / ``read``).
+    ``owner()`` is ``overridden_by or declared_by``; ``classify()`` answers, for a
+    path, whether a change is local authoring, a contribution (and to whom), an
+    append, or refused. Two layers declaring the same entry without an override is
+    a NAMED collision at resolution, not a silent precedence.
+
+    Today's resolver FLATTENS this information away (it merges repos by name and
+    records no provenance), so this dataclass is the specification of the field
+    the resolver must grow, and the witnesses run against the stub.
+
+``ContributionSet``
+    Several contributions that must land together land in DECLARED ORDER with one
+    receipt per member and one set receipt naming what landed — all-or-REPORT,
+    not all-or-nothing. ``prepare()`` drives every member through its gates and
+    stops before any verb (``stop_after=PLANNED``); if any member refuses there,
+    nothing has landed and the set reports it. ``land()`` then resumes each member
+    in order and STOPS at the first member that does not reach acknowledged,
+    leaving earlier members landed (git history is forward-only; a rollback would
+    be a new forward operation, never an un-push) and naming the landed, the
+    refusing, and the not-attempted members in the set receipt.
+
+``Subspace``
+    A workspace that holds contributions. ``retire()`` REFUSES while any of its
+    contributions is not terminal — not acknowledged and not explicitly
+    abandoned — and lists their operation ids. ``abandon()`` writes an
+    ``abandoned`` note to the contribution's own journal, so a workspace can never
+    be retired with a change that simply evaporates.
+
+``AppendSurface``
+    A declared append-only file: one guarded append point (an exclusive lock held
+    across write + flush + fsync), each record numbered in arrival order. Two
+    writers both land; no expected base exists because the operation commutes.
+    This is commutative BY DECLARATION, never inferred from the shape of a change,
+    and it is a file-level surface: a git-tracked path is never an append surface
+    to this protocol, because landing two appends there would require merging on
+    an author's behalf.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+from gr2.prototypes.propagation_state_machine import (
+    Coordinate,
+    Destination,
+    Propagator,
+    Receipt,
+    State,
+)
+
+ABANDONED_NOTE = "abandoned"
+
+
+class WriteMode(StrEnum):
+    OWN = "own"
+    CONTRIBUTE = "contribute"
+    APPEND = "append"
+    READ = "read"
+
+
+class ResolutionCollision(ValueError):
+    """Two layers declared the same entry and neither said ``override``.
+
+    Named and refused at resolution; never resolved by precedence silently.
+    """
+
+
+@dataclass(frozen=True)
+class ResolvedEntry:
+    """One surface of a materialized workspace, with its provenance recorded."""
+
+    name: str
+    path: str
+    declared_by: str
+    overridden_by: str | None
+    write_mode: WriteMode
+
+    @property
+    def owner(self) -> str:
+        return self.overridden_by or self.declared_by
+
+
+@dataclass(frozen=True)
+class Classification:
+    """What a change to ``path`` is, under this workspace's recorded ownership."""
+
+    entry: ResolvedEntry | None
+    mode: WriteMode
+    owner: str | None
+    reason: str
+
+
+@dataclass(frozen=True)
+class Declaration:
+    """One layer's declaration of one entry, as the resolver sees it before merging."""
+
+    layer: str
+    name: str
+    path: str
+    overrides: bool = False
+
+
+class ResolvedManifest:
+    """Ownership as a lookup. Built by ``resolve``; read by ``classify``."""
+
+    def __init__(self, entries: Iterable[ResolvedEntry]) -> None:
+        self._entries = {e.name: e for e in entries}
+
+    @classmethod
+    def resolve(
+        cls, this_layer: str, declarations: Sequence[Declaration], *, appends: Iterable[str] = ()
+    ) -> ResolvedManifest:
+        """Merge layer declarations (ancestors first) with provenance kept.
+
+        A later declaration of a name already declared is a ``ResolutionCollision``
+        unless it says ``overrides``; an override records ``overridden_by`` and keeps
+        ``declared_by``. Names in ``appends`` are declared append-only by their owner.
+        """
+        merged: dict[str, ResolvedEntry] = {}
+        append_names = set(appends)
+        for d in declarations:
+            prior = merged.get(d.name)
+            if prior is None:
+                merged[d.name] = ResolvedEntry(
+                    name=d.name,
+                    path=d.path,
+                    declared_by=d.layer,
+                    overridden_by=None,
+                    write_mode=WriteMode.READ,
+                )
+                continue
+            if not d.overrides:
+                raise ResolutionCollision(
+                    f"{d.name!r} declared by {prior.declared_by!r} at {prior.path!r} and again by "
+                    f"{d.layer!r} at {d.path!r} without override"
+                )
+            merged[d.name] = ResolvedEntry(
+                name=d.name,
+                path=d.path,
+                declared_by=prior.declared_by,
+                overridden_by=d.layer,
+                write_mode=WriteMode.READ,
+            )
+        entries = []
+        for e in merged.values():
+            if e.name in append_names:
+                mode = WriteMode.APPEND
+            elif e.owner == this_layer:
+                mode = WriteMode.OWN
+            else:
+                mode = WriteMode.CONTRIBUTE
+            entries.append(
+                ResolvedEntry(
+                    name=e.name,
+                    path=e.path,
+                    declared_by=e.declared_by,
+                    overridden_by=e.overridden_by,
+                    write_mode=mode,
+                )
+            )
+        return cls(entries)
+
+    def entry(self, name: str) -> ResolvedEntry:
+        return self._entries[name]
+
+    def owner(self, name: str) -> str:
+        return self._entries[name].owner
+
+    def classify(self, path: str) -> Classification:
+        """The longest declared path prefix wins; a path under no entry is refused (READ)."""
+        best: ResolvedEntry | None = None
+        for e in self._entries.values():
+            root = e.path.rstrip("/") + "/"
+            if (path == e.path or path.startswith(root)) and (
+                best is None or len(e.path) > len(best.path)
+            ):
+                best = e
+        if best is None:
+            return Classification(
+                entry=None,
+                mode=WriteMode.READ,
+                owner=None,
+                reason=f"{path!r} is under no declared entry",
+            )
+        return Classification(
+            entry=best,
+            mode=best.write_mode,
+            owner=best.owner,
+            reason=f"{path!r} is under {best.name!r} declared_by={best.declared_by!r} "
+            f"overridden_by={best.overridden_by!r}",
+        )
+
+
+# --------------------------------------------------------------------------- sets
+
+
+@dataclass(frozen=True)
+class SetMember:
+    member_id: str
+    coordinate: Coordinate
+    destination: Destination
+    propagator: Propagator
+
+
+@dataclass(frozen=True)
+class MemberOutcome:
+    member_id: str
+    state: str  # a State value, or "not-attempted"
+    receipt: Receipt | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "member_id": self.member_id,
+            "state": self.state,
+            "receipt": self.receipt.as_dict() if self.receipt is not None else None,
+        }
+
+
+@dataclass(frozen=True)
+class SetReceipt:
+    set_id: str
+    phase: str  # "prepared" | "refused-at-prepare" | "landed" | "stopped"
+    order: tuple[str, ...]
+    outcomes: tuple[MemberOutcome, ...]
+    timestamp: str
+
+    @property
+    def landed(self) -> tuple[str, ...]:
+        return tuple(o.member_id for o in self.outcomes if o.state == str(State.ACKNOWLEDGED))
+
+    @property
+    def refused(self) -> tuple[str, ...]:
+        return tuple(
+            o.member_id
+            for o in self.outcomes
+            if o.state in (str(State.REFUSED), str(State.UNVERIFIABLE))
+        )
+
+    @property
+    def not_attempted(self) -> tuple[str, ...]:
+        return tuple(o.member_id for o in self.outcomes if o.state == "not-attempted")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "set_id": self.set_id,
+            "phase": self.phase,
+            "order": list(self.order),
+            "landed": list(self.landed),
+            "refused": list(self.refused),
+            "not_attempted": list(self.not_attempted),
+            "outcomes": [o.as_dict() for o in self.outcomes],
+            "timestamp": self.timestamp,
+        }
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds")
+
+
+class ContributionSet:
+    """Several contributions that must land together: prepare all, land in order, report."""
+
+    def __init__(self, set_id: str, members: Sequence[SetMember]) -> None:
+        if not members:
+            raise ValueError("a contribution set needs at least one member")
+        ids = [m.member_id for m in members]
+        if len(set(ids)) != len(ids):
+            raise ValueError(f"duplicate member ids in set {set_id!r}: {ids}")
+        self.set_id = set_id
+        self.members = tuple(members)
+
+    @property
+    def order(self) -> tuple[str, ...]:
+        return tuple(m.member_id for m in self.members)
+
+    def prepare(self) -> SetReceipt:
+        """Drive every member to ``planned`` without running a verb.
+
+        If any member refuses at plan, the set is refused BEFORE anything lands and the
+        receipt carries every member's evidence. A member whose source has nothing new
+        (``run`` returned ``None``) is reported as not-attempted: it is not part of this
+        set's landing.
+        """
+        outcomes: list[MemberOutcome] = []
+        for m in self.members:
+            receipt = m.propagator.run(m.coordinate, m.destination, stop_after=State.PLANNED)
+            if receipt is None:
+                outcomes.append(MemberOutcome(m.member_id, "not-attempted", None))
+            else:
+                outcomes.append(MemberOutcome(m.member_id, str(receipt.state), receipt))
+        any_refused = any(o.state == str(State.REFUSED) for o in outcomes)
+        return SetReceipt(
+            set_id=self.set_id,
+            phase="refused-at-prepare" if any_refused else "prepared",
+            order=self.order,
+            outcomes=tuple(outcomes),
+            timestamp=_now(),
+        )
+
+    def land(self, *, on_member_landed: Callable[[str], None] | None = None) -> SetReceipt:
+        """Resume each prepared member in order; STOP at the first that does not acknowledge.
+
+        Earlier members stay landed. The receipt names landed / refused / not-attempted
+        members so the author can resolve forward. Nothing is rolled back.
+        """
+        outcomes: list[MemberOutcome] = []
+        stopped = False
+        for m in self.members:
+            if stopped:
+                outcomes.append(MemberOutcome(m.member_id, "not-attempted", None))
+                continue
+            receipt = m.propagator.run(m.coordinate, m.destination)
+            if receipt is None:
+                outcomes.append(MemberOutcome(m.member_id, "not-attempted", None))
+                continue
+            outcomes.append(MemberOutcome(m.member_id, str(receipt.state), receipt))
+            if receipt.state is State.ACKNOWLEDGED:
+                if on_member_landed is not None:
+                    on_member_landed(m.member_id)
+            else:
+                stopped = True
+        return SetReceipt(
+            set_id=self.set_id,
+            phase="stopped" if stopped else "landed",
+            order=self.order,
+            outcomes=tuple(outcomes),
+            timestamp=_now(),
+        )
+
+
+# --------------------------------------------------------------------------- subspaces
+
+
+@dataclass(frozen=True)
+class OpenContribution:
+    coordinate_key: str
+    source_rev: str
+    last_state: str
+    operation_id: str | None
+
+
+class RetireRefused(RuntimeError):
+    """The subspace holds contributions that are neither acknowledged nor abandoned."""
+
+    def __init__(self, subspace: str, open_contributions: Sequence[OpenContribution]) -> None:
+        self.subspace = subspace
+        self.open_contributions = tuple(open_contributions)
+        listed = ", ".join(
+            f"{o.coordinate_key} @ {o.source_rev[:12]} ({o.last_state})" for o in open_contributions
+        )
+        super().__init__(f"{subspace}: {len(open_contributions)} open contribution(s): {listed}")
+
+
+@dataclass
+class Subspace:
+    """A workspace and the contributions authored in it, each carried by its own sink."""
+
+    name: str
+    contributions: list[tuple[Coordinate, Propagator]] = field(default_factory=list)
+    retired: bool = False
+
+    def open_contributions(self) -> list[OpenContribution]:
+        """Every (coordinate, source revision) attempt whose last state is not terminal.
+
+        Terminal means ACKNOWLEDGED, or REFUSED-and-then-ABANDONED by an explicit note.
+        A refused attempt with no abandon note is OPEN: the refusal described a moment and
+        the author has not said what becomes of the change.
+        """
+        found: list[OpenContribution] = []
+        for coordinate, propagator in self.contributions:
+            key = coordinate.key()
+            revs: dict[str, list[dict[str, object]]] = {}
+            for row in propagator.journal._rows():
+                if row.get("coordinate_key") != key:
+                    continue
+                revs.setdefault(str(row["source_rev"]), []).append(row)
+            for source_rev, rows in revs.items():
+                states = [str(r["state"]) for r in rows if "state" in r]
+                last_state = states[-1] if states else "(no transition)"
+                if last_state == str(State.ACKNOWLEDGED):
+                    continue
+                if any(r.get("note") == ABANDONED_NOTE for r in rows):
+                    continue
+                op_ids = [str(r["operation_id"]) for r in rows if r.get("operation_id")]
+                found.append(
+                    OpenContribution(
+                        coordinate_key=key,
+                        source_rev=source_rev,
+                        last_state=last_state,
+                        operation_id=op_ids[-1] if op_ids else None,
+                    )
+                )
+        return found
+
+    def abandon(self, coordinate: Coordinate, source_rev: str, *, reason: str) -> None:
+        """Explicitly give up a contribution: an ``abandoned`` note in its own journal."""
+        for c, propagator in self.contributions:
+            if c.key() != coordinate.key():
+                continue
+            attempts = propagator.journal.find(coordinate.key(), source_rev)
+            attempt = len(attempts) if attempts else 1
+            pending_id = f"{coordinate.key()}@{source_rev}"
+            if attempts and attempts[-1][-1].operation_id:
+                pending_id = str(attempts[-1][-1].operation_id)
+            propagator.journal.note(
+                pending_id=pending_id,
+                attempt=attempt,
+                coordinate_key=coordinate.key(),
+                source_rev=source_rev,
+                note=ABANDONED_NOTE,
+                data={"reason": reason},
+            )
+            return
+        raise KeyError(f"{self.name}: no contribution at {coordinate.key()}")
+
+    def retire(self) -> None:
+        """Refuse while any contribution is open; otherwise mark retired."""
+        open_ = self.open_contributions()
+        if open_:
+            raise RetireRefused(self.name, open_)
+        self.retired = True
+
+
+# --------------------------------------------------------------------------- append surfaces
+
+
+@dataclass(frozen=True)
+class AppendRecord:
+    seq: int
+    writer: str
+    payload: dict[str, object]
+    timestamp: str
+
+
+class AppendSurface:
+    """A declared append-only file with one guarded append point.
+
+    ``append`` takes an exclusive lock on the file, reads the last sequence number,
+    writes ``seq + 1`` with the record, flushes, fsyncs, and releases. Two writers
+    interleave in ARRIVAL order and both land; there is no expected base to refuse on
+    because appends commute. Nothing here ever rewrites an earlier record.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.touch(exist_ok=True)
+
+    def append(self, writer: str, payload: dict[str, object]) -> AppendRecord:
+        with open(self.path, "a+", encoding="utf-8") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                handle.seek(0)
+                last = 0
+                for line in handle:
+                    line = line.strip()
+                    if line:
+                        last = int(json.loads(line)["seq"])
+                record = AppendRecord(
+                    seq=last + 1, writer=writer, payload=payload, timestamp=_now()
+                )
+                handle.seek(0, os.SEEK_END)
+                handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+                return record
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def records(self) -> list[AppendRecord]:
+        out: list[AppendRecord] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                data = json.loads(line)
+                out.append(
+                    AppendRecord(
+                        seq=int(data["seq"]),
+                        writer=str(data["writer"]),
+                        payload=dict(data["payload"]),
+                        timestamp=str(data["timestamp"]),
+                    )
+                )
+        return out
+
+
+__all__ = [
+    "ABANDONED_NOTE",
+    "AppendRecord",
+    "AppendSurface",
+    "Classification",
+    "ContributionSet",
+    "Declaration",
+    "MemberOutcome",
+    "OpenContribution",
+    "ResolutionCollision",
+    "ResolvedEntry",
+    "ResolvedManifest",
+    "RetireRefused",
+    "SetMember",
+    "SetReceipt",
+    "Subspace",
+    "WriteMode",
+]

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -636,6 +636,8 @@ class Propagator:
         coordinate: Coordinate,
         destination: Destination,
         observation: Observation | None = None,
+        *,
+        stop_after: State | None = None,
     ) -> Receipt | None:
         """Drive one coordinate. ``None`` means no new source revision: not an operation.
 
@@ -644,8 +646,19 @@ class Propagator:
         its ``observation`` so the source is not asked twice; the cursor check runs on it
         all the same, because "nothing new" is exactly the answer that would hide a
         corrupted sink state, whoever observed.
+
+        ``stop_after=State.PLANNED`` drives the operation through its gates and stops
+        BEFORE the apply verb, journaled at ``planned``; a later ``run`` resumes it from
+        there. This is how a contribution SET prepares every member against its owner's
+        current base before landing any of them (Prototype 2).
         """
-        return self._run(coordinate, destination, report_current=False, observation=observation)
+        return self._run(
+            coordinate,
+            destination,
+            report_current=False,
+            observation=observation,
+            stop_after=stop_after,
+        )
 
     def _run(
         self,
@@ -654,6 +667,7 @@ class Propagator:
         *,
         report_current: bool,
         observation: Observation | None = None,
+        stop_after: State | None = None,
     ) -> Receipt | None:
         key = coordinate.key()
         if observation is None:
@@ -709,7 +723,7 @@ class Propagator:
         else:
             op = self._fresh(coordinate, destination, source_rev, observation.cursor, attempt=1)
 
-        self._drive(op)
+        self._drive(op, stop_after=stop_after)
         return self._receipt(coordinate, source_rev, op.attempt, replayed=False)
 
     def _terminal_receipt(self, coordinate: Coordinate, source_rev: str) -> Receipt:
@@ -809,7 +823,7 @@ class Propagator:
 
     # -- the state machine
 
-    def _drive(self, op: _Op) -> None:
+    def _drive(self, op: _Op, *, stop_after: State | None = None) -> None:
         last = op.transitions[-1].state if op.transitions else None
         if last is None:
             self._observe(op)
@@ -821,6 +835,8 @@ class Propagator:
             if not self._plan(op):
                 return  # refused at plan; journaled
             last = State.PLANNED
+        if stop_after is State.PLANNED and last is State.PLANNED:
+            return  # prepared: gates evaluated and journaled, no verb has run
         if last in (State.PLANNED, State.UNVERIFIABLE):
             if not self._apply(op):
                 return  # refused or unverifiable; journaled

--- a/gr2/prototypes/propagation_state_machine.py
+++ b/gr2/prototypes/propagation_state_machine.py
@@ -60,7 +60,18 @@ sink fetches into, so destinations are read but never written before apply).
 Fault injection for tests: ``kill_after`` raises :class:`SinkKilled` right after
 the named state is journaled (or right after the apply verb ran, before the read
 back, with ``KILL_AFTER_APPLY_VERB``); ``after_apply_verb`` runs a callable
-between the verb and the read back so a destination can be made unreadable.
+between the verb and the read back so a destination can be made unreadable;
+``before_apply_verb`` runs a callable after the apply step's own head check and
+before the verb, so a destination can be moved inside that window.
+
+Prototype 2 (the contribution protocol) adds ONE destination kind and no new
+state: :attr:`DestinationKind.CANONICAL` is a bare remote that OWNS the branch, and
+an operation with ``direction=up`` lands on it by a fast-forward push guarded by
+``--force-with-lease`` on the expected base. The receiving repository enforces the
+compare-and-swap; the plan's fast-forward gate guarantees the lease never forces;
+a rejected lease is a REFUSAL carrying the revision the owner holds, not an error.
+Replanning a refused contribution is the author's act — the machine never rebases,
+merges, or forces on anyone's behalf.
 """
 
 from __future__ import annotations
@@ -84,6 +95,10 @@ _GATE_IDS = (
     "destination.fast-forward",
 )
 _POSTCONDITION = "head-is-intended-after-and-tree-matches-digest"
+# A canonical destination is bare: the postcondition is about its BRANCH ref, and
+# "clean" is not part of it because there is no worktree to be clean.
+_POSTCONDITION_CANONICAL = "branch-is-intended-after-and-tree-matches-digest"
+_GATE_NOT_RUN = "not-run"
 
 # The prototype runs git without the user's global or system configuration so
 # that signing, hook paths, and identity settings on the host cannot reach the
@@ -134,6 +149,11 @@ class Operation(StrEnum):
 class DestinationKind(StrEnum):
     REPLICA = "replica"
     AUTHORING = "authoring"
+    # Prototype 2 (the contribution protocol): a bare remote that OWNS the branch and
+    # accepts a contribution by a fast-forward push guarded by ``--force-with-lease`` on the
+    # expected base — compare-and-swap enforced by the receiving repository, not by
+    # this process. It has no worktree, so cleanliness is not a property it has.
+    CANONICAL = "canonical"
 
 
 class State(StrEnum):
@@ -545,6 +565,7 @@ class Propagator:
         *,
         kill_after: State | str | None = None,
         after_apply_verb: Callable[[], None] | None = None,
+        before_apply_verb: Callable[[], None] | None = None,
         git_env: dict[str, str] | None = None,
     ) -> None:
         self.source_remote = source_remote
@@ -553,6 +574,10 @@ class Propagator:
         self.policy = policy
         self.kill_after = kill_after
         self.after_apply_verb = after_apply_verb
+        # Prototype 2 test seam: runs AFTER the apply step's own head check and BEFORE
+        # the verb, so a test can move a canonical destination inside the window the
+        # process-side check cannot see. The lease is what must catch that move.
+        self.before_apply_verb = before_apply_verb
         # None means "the default, isolated from the host"; an explicit {} means "inherit the
         # host environment" and must not collapse into the default because it is falsy
         self.git_env = _ISOLATED_GIT_ENV if git_env is None else git_env
@@ -584,13 +609,25 @@ class Propagator:
     # -- destination reads (never writes before apply)
 
     def read_head(self, destination: Destination) -> str:
+        # A canonical destination is read at its BRANCH ref, never HEAD: a bare
+        # repository's HEAD is a symref that may point anywhere, and the thing a
+        # contribution lands on is the branch the owner declared.
+        ref = (
+            f"refs/heads/{self.branch}" if destination.kind is DestinationKind.CANONICAL else "HEAD"
+        )
         try:
-            return _git(destination.path, "rev-parse", "HEAD", env=self.git_env)
+            return _git(destination.path, "rev-parse", "--verify", ref, env=self.git_env)
         except (subprocess.CalledProcessError, OSError) as exc:
             raise DestinationUnreadable(f"{destination.destination_id}: {exc}") from exc
 
     def _porcelain(self, destination: Destination) -> str:
         return _git(destination.path, "status", "--porcelain", env=self.git_env)
+
+    def _observed_ref_source(self, destination: Destination) -> str:
+        """The ref the mirror fetches for ahead/behind: the branch for a canonical, else HEAD."""
+        if destination.kind is DestinationKind.CANONICAL:
+            return f"refs/heads/{self.branch}"
+        return "HEAD"
 
     # -- driver
 
@@ -879,6 +916,19 @@ class Propagator:
             result_hash=_sha256_json({"gate": gate_id, "result": result, "detail": detail}),
         )
 
+    def _gate_not_run(self, gate_id: str, detail: str) -> GateResult:
+        """A gate judged inapplicable to this destination kind, recorded as such.
+
+        ``not-run`` is neither pass nor fail: it does not refuse, and it does not let a
+        reader mistake "the list was empty" for "every gate passed".
+        """
+        return GateResult(
+            gate_id=gate_id,
+            result=_GATE_NOT_RUN,
+            detail=detail,
+            result_hash=_sha256_json({"gate": gate_id, "result": _GATE_NOT_RUN, "detail": detail}),
+        )
+
     def _plan(self, op: _Op) -> bool:
         assert op.expected_base is not None and op.digest is not None
         gates: list[GateResult] = []
@@ -902,19 +952,32 @@ class Propagator:
             )
         )
 
-        porcelain = self._porcelain(op.destination)
-        gates.append(
-            self._gate(
-                "destination.clean",
-                porcelain == "",
-                "worktree and index clean"
-                if porcelain == ""
-                else f"dirty: {len(porcelain.splitlines())} path(s)",
+        if op.destination.kind is DestinationKind.CANONICAL:
+            # a bare repository has no worktree; the gate is recorded as NOT RUN rather
+            # than omitted, so a receipt with an empty gate list and one where this
+            # gate was judged inapplicable remain distinguishable (a gate list must say
+            # which gates ran, individually; an aggregate cannot)
+            gates.append(
+                self._gate_not_run(
+                    "destination.clean",
+                    "bare canonical destination: cleanliness is not a property it has",
+                )
             )
-        )
+        else:
+            porcelain = self._porcelain(op.destination)
+            gates.append(
+                self._gate(
+                    "destination.clean",
+                    porcelain == "",
+                    "worktree and index clean"
+                    if porcelain == ""
+                    else f"dirty: {len(porcelain.splitlines())} path(s)",
+                )
+            )
 
-        # the destination's HEAD is fetched INTO the mirror (a read of the destination),
-        # so ahead/behind is computed in the sink's own store
+        # the destination's branch (canonical) or HEAD (clone) is fetched INTO the
+        # mirror (a read of the destination), so ahead/behind is computed in the
+        # sink's own store
         observed_tag = hashlib.sha256(op.destination.destination_id.encode()).hexdigest()[:16]
         observed_ref = f"refs/observed/{observed_tag}"
         _git(
@@ -922,7 +985,7 @@ class Propagator:
             "fetch",
             "-q",
             str(op.destination.path),
-            f"+HEAD:{observed_ref}",
+            f"+{self._observed_ref_source(op.destination)}:{observed_ref}",
             env=self.git_env,
         )
         counts = _git(
@@ -1028,15 +1091,90 @@ class Propagator:
         self._note(
             op, "apply-verb-started", {"expected_base": head, "intended_after": op.intended_after}
         )
-        _git(
-            op.destination.path,
-            "fetch",
-            "-q",
-            str(self.mirror),
-            f"refs/remotes/source/{self.branch}",
-            env=self.git_env,
-        )
-        _git(op.destination.path, "merge", "-q", "--ff-only", op.intended_after, env=self.git_env)
+        if self.before_apply_verb is not None:
+            self.before_apply_verb()
+        if op.destination.kind is DestinationKind.CANONICAL:
+            # Prototype 2 (the contribution protocol): the contribution lands by a push FROM
+            # the mirror (which holds the fetched source objects) TO the owner's bare remote, as a
+            # fast-forward of ``expected_base`` guarded by ``--force-with-lease`` on
+            # that same base. The receiving repository enforces the compare-and-swap:
+            # if its branch is no longer at ``expected_base`` when the push arrives —
+            # including a move inside the window after this process's own head check —
+            # the push is rejected and nothing lands. That rejection is a REFUSAL with
+            # the observed base, not an exception: it is the protocol doing its job.
+            # Why ``--force-with-lease`` can never FORCE here: the plan's
+            # ``destination.fast-forward`` gate already established that ``intended_after``
+            # descends from ``expected_base`` (ahead == 0), so when the lease holds the
+            # update is a genuine fast-forward, and when the owner moved the lease rejects
+            # it before any update. Mutation-checked: forcing the gate to pass lets a stale
+            # contribution overwrite the owner (W2b goes red); dropping the lease for a bare
+            # ``--force`` lets a move inside the check→push window be overwritten (W2d goes
+            # red). The two halves are one mechanism and neither is sufficient alone.
+            lease = f"--force-with-lease=refs/heads/{self.branch}:{op.expected_base}"
+            push = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(self.mirror),
+                    "push",
+                    "-q",
+                    lease,
+                    str(op.destination.path),
+                    f"{op.intended_after}:refs/heads/{self.branch}",
+                ],
+                capture_output=True,
+                text=True,
+                env={**os.environ, **self.git_env},
+            )
+            if push.returncode != 0:
+                try:
+                    moved_to = self.read_head(op.destination)
+                except DestinationUnreadable as exc:
+                    self._record(
+                        op,
+                        State.UNVERIFIABLE,
+                        {
+                            "detail": (
+                                "the lease push returned non-zero and the destination could "
+                                f"not be read back: {exc}"
+                            ),
+                            "observed_base": None,
+                        },
+                    )
+                    return False
+                if moved_to != op.expected_base:
+                    self._record(
+                        op,
+                        State.REFUSED,
+                        {
+                            "refusal_reason": (
+                                f"destination.lease-refused: the owner's branch moved to "
+                                f"{moved_to} after the base check; expected {op.expected_base}"
+                            ),
+                            "observed_base": moved_to,
+                            "established_by": (
+                                "the receiving repository rejected the lease; read back names "
+                                "the revision it holds"
+                            ),
+                        },
+                    )
+                    return False
+                raise RuntimeError(
+                    "lease push failed although the owner's branch is still at the expected "
+                    f"base: {push.stderr.strip()}"
+                )
+        else:
+            _git(
+                op.destination.path,
+                "fetch",
+                "-q",
+                str(self.mirror),
+                f"refs/remotes/source/{self.branch}",
+                env=self.git_env,
+            )
+            _git(
+                op.destination.path, "merge", "-q", "--ff-only", op.intended_after, env=self.git_env
+            )
         if self.after_apply_verb is not None:
             self.after_apply_verb()
         if self.kill_after == KILL_AFTER_APPLY_VERB:
@@ -1088,19 +1226,25 @@ class Propagator:
         assert op.intended_after is not None and op.digest is not None
         head = self.read_head(op.destination)
         tree = tree_digest(op.destination.path, head, env=self.git_env)
-        porcelain = self._porcelain(op.destination)
-        holds = head == op.intended_after and tree == op.digest and porcelain == ""
-        detail = f"head={head} tree={tree} clean={porcelain == ''}"
+        if op.destination.kind is DestinationKind.CANONICAL:
+            postcondition = _POSTCONDITION_CANONICAL
+            holds = head == op.intended_after and tree == op.digest
+            detail = f"branch={head} tree={tree}"
+        else:
+            postcondition = _POSTCONDITION
+            porcelain = self._porcelain(op.destination)
+            holds = head == op.intended_after and tree == op.digest and porcelain == ""
+            detail = f"head={head} tree={tree} clean={porcelain == ''}"
         if not holds:
             self._note(
-                op, "postcondition-failed", {"postcondition": _POSTCONDITION, "detail": detail}
+                op, "postcondition-failed", {"postcondition": postcondition, "detail": detail}
             )
             return False
         self._record(
             op,
             State.VERIFIED,
             {
-                "postcondition_checked": _POSTCONDITION,
+                "postcondition_checked": postcondition,
                 "holds": True,
                 "detail": detail,
                 "established_by": "the named postcondition re-read from the destination",

--- a/gr2/tests/test_contribution_protocol.py
+++ b/gr2/tests/test_contribution_protocol.py
@@ -1,0 +1,466 @@
+"""Prototype 2, the protocol around the machine: ownership, sets, retirement, appends.
+
+Everything runs against throwaway repositories and files under ``tmp_path``. The
+topology is the W2 one (a scratch parent with a bare canonical remote and child
+clones) plus, where a SET needs them, further bare owners so that one set spans
+several destinations. What the witnesses prove:
+
+* W1  ownership is a RECORDED fact: every resolved entry carries ``declared_by``
+      and ``overridden_by``; ``owner`` is the override or the declaration; a path
+      classifies to its longest declared prefix; a path under no entry is refused;
+      two layers declaring the same entry without ``override`` is a NAMED
+      collision at resolution, never a silent precedence
+* W4  a contribution SET prepares EVERY member through its gates before any verb
+      runs, then lands in declared order; a refusal at prepare lands nothing; a
+      refusal MID-SET stops the set and the set receipt names the landed, the
+      refusing, and the not-attempted members; nothing is rolled back
+* W5  a subspace REFUSES to retire while any of its contributions is open; the
+      refusal lists operation ids; a refused contribution stays open until the
+      author abandons it explicitly, and the abandon is a note in the
+      contribution's own journal
+* W6  a declared append-only surface: two writers both land, in arrival order,
+      with no expected base to refuse on; earlier records are never rewritten;
+      a second handle on the same file sees the first handle's records
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from gr2.prototypes.contribution_protocol import (
+    ABANDONED_NOTE,
+    AppendSurface,
+    ContributionSet,
+    Declaration,
+    ResolutionCollision,
+    ResolvedManifest,
+    RetireRefused,
+    SetMember,
+    Subspace,
+    WriteMode,
+)
+from gr2.prototypes.propagation_state_machine import (
+    Coordinate,
+    Destination,
+    DestinationKind,
+    Direction,
+    Operation,
+    State,
+)
+from gr2.tests.test_propagation_contribution import (
+    _GIT_ENV,
+    Parent,
+    author,
+    canonical,
+    contribution,
+    contributor,
+    git,
+    owner_main,
+)
+
+# --------------------------------------------------------------------------- helpers
+
+
+def make_owner(root: Path, name: str) -> Parent:
+    """Another bare canonical with the same seed shape, so one set can span owners."""
+    owner = root / f"{name}.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "--initial-branch=main", str(owner)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    seed = root / f"seed-{name}"
+    subprocess.run(
+        ["git", "clone", "-q", str(owner), str(seed)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    git(seed, "switch", "-q", "-c", "main")
+    (seed / "canon.md").write_text(f"{name} canon v1\n")
+    (seed / "other.md").write_text(f"{name} other v1\n")
+    git(seed, "add", "canon.md", "other.md")
+    git(seed, "commit", "-q", "-m", f"{name} canon v1")
+    git(seed, "push", "-q", "-u", "origin", "main")
+    return Parent(owner=owner, base=git(seed, "rev-parse", "HEAD"), root=root)
+
+
+@pytest.fixture
+def parent(tmp_path: Path) -> Parent:
+    """The W2 parent shape, built by the same helper the extra owners use."""
+    return make_owner(tmp_path, "owner")
+
+
+def coordinate(child_id: str, destination_id: str) -> Coordinate:
+    return Coordinate(
+        source=child_id,
+        destination=destination_id,
+        layer="layer-parent",
+        direction=Direction.UP,
+        operation=Operation.CONTRIBUTE,
+        artifact_class="config",
+    )
+
+
+def member(owner: Parent, child: Path, member_id: str) -> SetMember:
+    """One set member: its own sink carrying ``child``'s branch to ``owner``'s canonical."""
+    destination = Destination(
+        destination_id=f"canonical-{member_id}", path=owner.owner, kind=DestinationKind.CANONICAL
+    )
+    return SetMember(
+        member_id=member_id,
+        coordinate=coordinate(f"child-{member_id}", destination.destination_id),
+        destination=destination,
+        propagator=contributor(owner, child, member_id),
+    )
+
+
+# --------------------------------------------------------------------------- W1
+
+
+def _declarations() -> list[Declaration]:
+    # ancestors first; the SHORTER path is declared before the longer one nested under it,
+    # so a first-match classifier and a longest-prefix classifier give different answers
+    return [
+        Declaration(layer="org", name="canon", path="config/canon.md"),
+        Declaration(layer="org", name="notes", path="team"),
+        Declaration(layer="team", name="ledger", path="team/ledger"),
+        Declaration(layer="team", name="canon", path="config/canon.md", overrides=True),
+    ]
+
+
+def test_w1_ownership_is_recorded_provenance_and_owner_is_override_or_declaration() -> None:
+    as_agent = ResolvedManifest.resolve("agent", _declarations())
+
+    canon = as_agent.entry("canon")
+    assert canon.declared_by == "org"
+    assert canon.overridden_by == "team"
+    assert canon.owner == "team"  # the override governs; the declaration is still recorded
+    assert canon.write_mode is WriteMode.CONTRIBUTE
+    notes = as_agent.entry("notes")
+    assert (notes.declared_by, notes.overridden_by, notes.owner) == ("org", None, "org")
+    assert as_agent.owner("ledger") == "team"
+
+    # the SAME declarations resolved AS the team: what the team owns is authored, not contributed
+    as_team = ResolvedManifest.resolve("team", _declarations())
+    assert as_team.entry("canon").write_mode is WriteMode.OWN
+    assert as_team.entry("ledger").write_mode is WriteMode.OWN
+    assert as_team.entry("notes").write_mode is WriteMode.CONTRIBUTE
+
+    # append-only is DECLARED by name, never inferred
+    with_append = ResolvedManifest.resolve("agent", _declarations(), appends=["ledger"])
+    assert with_append.entry("ledger").write_mode is WriteMode.APPEND
+    assert as_agent.entry("ledger").write_mode is WriteMode.CONTRIBUTE
+
+
+def test_w1_classify_picks_the_longest_declared_prefix_and_refuses_undeclared_paths() -> None:
+    manifest = ResolvedManifest.resolve("agent", _declarations())
+
+    canon = manifest.classify("config/canon.md")
+    assert canon.mode is WriteMode.CONTRIBUTE
+    assert canon.owner == "team"
+    assert canon.entry is not None and canon.entry.name == "canon"
+
+    nested = manifest.classify("team/ledger/2026.jsonl")  # under BOTH team/ and team/ledger
+    assert nested.entry is not None and nested.entry.name == "ledger"
+    assert nested.owner == "team"
+    sibling = manifest.classify("team/readme.md")
+    assert sibling.entry is not None and sibling.entry.name == "notes"
+    assert sibling.owner == "org"
+
+    # a path that merely shares a prefix STRING is not under the entry
+    assert manifest.classify("teamwork.md").entry is None
+    unknown = manifest.classify("elsewhere/file.md")
+    assert unknown.mode is WriteMode.READ
+    assert unknown.owner is None
+    assert "under no declared entry" in unknown.reason
+
+
+def test_w1_two_declarations_without_override_are_a_named_collision_not_precedence() -> None:
+    colliding = [
+        Declaration(layer="org", name="canon", path="config/canon.md"),
+        Declaration(layer="team", name="canon", path="team/canon.md"),
+    ]
+    with pytest.raises(ResolutionCollision) as refused:
+        ResolvedManifest.resolve("agent", colliding)
+    message = str(refused.value)
+    # the refusal NAMES both layers and both paths: a reader can act on it
+    for fragment in ("'org'", "'team'", "config/canon.md", "team/canon.md", "without override"):
+        assert fragment in message
+
+    # positive control: the same pair WITH an override resolves, provenance intact
+    resolved = ResolvedManifest.resolve(
+        "agent",
+        [
+            colliding[0],
+            Declaration(layer="team", name="canon", path="team/canon.md", overrides=True),
+        ],
+    )
+    entry = resolved.entry("canon")
+    assert (entry.declared_by, entry.overridden_by, entry.path) == ("org", "team", "team/canon.md")
+
+
+# --------------------------------------------------------------------------- W4
+
+
+def test_w4_a_set_prepares_every_member_before_any_verb_then_lands_in_declared_order(
+    parent: Parent, tmp_path: Path
+) -> None:
+    owner2 = make_owner(tmp_path, "owner2")
+    a1 = parent.child("a1")
+    a2 = owner2.child("a2")
+    new1 = author(a1, "canon v2 (set m1)\n")
+    new2 = author(a2, "owner2 canon v2 (set m2)\n")
+    contribution_set = ContributionSet(
+        "set-1", [member(parent, a1, "m1"), member(owner2, a2, "m2")]
+    )
+
+    prepared = contribution_set.prepare()
+
+    assert prepared.phase == "prepared"
+    assert [o.state for o in prepared.outcomes] == [str(State.PLANNED), str(State.PLANNED)]
+    # prepared, NOT landed: both owners still at their bases
+    assert owner_main(parent) == parent.base
+    assert owner_main(owner2) == owner2.base
+    for outcome in prepared.outcomes:
+        assert outcome.receipt is not None
+        assert [t.state for t in outcome.receipt.transitions] == [
+            State.OBSERVED,
+            State.FETCHED,
+            State.PLANNED,
+        ]
+
+    landed_order: list[str] = []
+    landed = contribution_set.land(on_member_landed=landed_order.append)
+
+    assert landed.phase == "landed"
+    assert landed.landed == ("m1", "m2")
+    assert landed_order == ["m1", "m2"]  # declared order, not arrival order
+    assert landed.refused == () and landed.not_attempted == ()
+    assert owner_main(parent) == new1
+    assert owner_main(owner2) == new2
+    # each member's receipt is the RESUMED attempt: one journaled attempt, planned then applied
+    for outcome in landed.outcomes:
+        assert outcome.receipt is not None and outcome.receipt.attempt == 1
+        assert outcome.receipt.state is State.ACKNOWLEDGED
+    as_dict = landed.as_dict()
+    assert as_dict["order"] == ["m1", "m2"] and as_dict["landed"] == ["m1", "m2"]
+
+
+def test_w4_a_refusal_at_prepare_lands_nothing_even_for_the_members_that_were_fine(
+    parent: Parent, tmp_path: Path
+) -> None:
+    owner2 = make_owner(tmp_path, "owner2")
+    a1 = parent.child("a1")
+    a2 = owner2.child("a2")
+    author(a1, "canon v2 (stale m1)\n")
+    new2 = author(a2, "owner2 canon v2 (fine m2)\n")
+    # an interloper lands on owner 1 first, so m1 is stale against the owner's CURRENT base
+    interloper = parent.child("interloper")
+    interloper_rev = author(interloper, "canon v2 (interloper)\n")
+    assert (
+        contributor(parent, interloper, "x")
+        .run(contribution("interloper"), canonical(parent))
+        .state
+        is State.ACKNOWLEDGED
+    )  # type: ignore[union-attr]
+
+    contribution_set = ContributionSet(
+        "set-2", [member(parent, a1, "m1"), member(owner2, a2, "m2")]
+    )
+    prepared = contribution_set.prepare()
+
+    assert prepared.phase == "refused-at-prepare"
+    assert prepared.refused == ("m1",)
+    m1, m2 = prepared.outcomes
+    assert m1.state == str(State.REFUSED) and m1.receipt is not None
+    assert "destination.fast-forward" in [
+        g.gate_id for g in m1.receipt.gate_results if g.result == "fail"
+    ]
+    assert m1.receipt.observed_base == interloper_rev
+    assert m2.state == str(State.PLANNED)  # m2 was fine, and it did NOT land
+    assert owner_main(owner2) == owner2.base
+    assert owner_main(parent) == interloper_rev
+    assert new2 != owner2.base
+
+
+def test_w4_a_mid_set_refusal_stops_the_set_and_reports_landed_refused_not_attempted(
+    parent: Parent, tmp_path: Path
+) -> None:
+    owner2 = make_owner(tmp_path, "owner2")
+    owner3 = make_owner(tmp_path, "owner3")
+    a1, a2, a3 = parent.child("a1"), owner2.child("a2"), owner3.child("a3")
+    new1 = author(a1, "canon v2 (m1)\n")
+    author(a2, "owner2 canon v2 (m2)\n")
+    new3 = author(a3, "owner3 canon v2 (m3)\n")
+    contribution_set = ContributionSet(
+        "set-3",
+        [member(parent, a1, "m1"), member(owner2, a2, "m2"), member(owner3, a3, "m3")],
+    )
+    assert contribution_set.prepare().phase == "prepared"
+
+    # between prepare and land, owner 2 moves: the compare-and-swap at apply will refuse m2
+    interloper = owner2.child("interloper2")
+    moved_to = author(interloper, "owner2 canon v2 (interloper)\n")
+    assert (
+        contributor(owner2, interloper, "x2")
+        .run(
+            coordinate("interloper2", "canonical-x2"),
+            Destination(
+                destination_id="canonical-x2", path=owner2.owner, kind=DestinationKind.CANONICAL
+            ),
+        )
+        .state
+        is State.ACKNOWLEDGED
+    )  # type: ignore[union-attr]
+
+    landed = contribution_set.land()
+
+    assert landed.phase == "stopped"
+    assert landed.landed == ("m1",)
+    assert landed.refused == ("m2",)
+    assert landed.not_attempted == ("m3",)
+    m1, m2, m3 = landed.outcomes
+    assert m2.receipt is not None and m2.receipt.state is State.REFUSED
+    assert "expected_base moved" in (m2.receipt.refusal_reason or "")
+    assert m2.receipt.observed_base == moved_to
+    assert m3.receipt is None
+    # nothing rolled back: m1 stays landed; m3 never reached its owner
+    assert owner_main(parent) == new1
+    assert owner_main(owner2) == moved_to
+    assert owner_main(owner3) == owner3.base
+    assert new3 != owner3.base
+
+
+def test_w4_a_set_refuses_to_exist_with_no_members_or_duplicate_member_ids(
+    parent: Parent,
+) -> None:
+    with pytest.raises(ValueError):
+        ContributionSet("empty", [])
+    a1 = parent.child("a1")
+    with pytest.raises(ValueError):
+        ContributionSet("dup", [member(parent, a1, "m1"), member(parent, a1, "m1")])
+
+
+# --------------------------------------------------------------------------- W5
+
+
+def test_w5_retire_refuses_while_a_contribution_is_open_and_names_its_operation_id(
+    parent: Parent,
+) -> None:
+    child_a = parent.child("child-a")
+    author(child_a, "canon v2 (a)\n")
+    sink = contributor(parent, child_a, "a")
+    coord = contribution("child-a")
+    prepared = sink.run(coord, canonical(parent), stop_after=State.PLANNED)
+    assert prepared is not None and prepared.state is State.PLANNED
+    subspace = Subspace("child-a", [(coord, sink)])
+
+    with pytest.raises(RetireRefused) as refused:
+        subspace.retire()
+    assert subspace.retired is False
+    [open_] = refused.value.open_contributions
+    assert open_.coordinate_key == coord.key()
+    assert open_.source_rev == prepared.source_rev
+    assert open_.last_state == str(State.PLANNED)
+    assert open_.operation_id == prepared.operation_id is not None
+    assert prepared.operation_id in str(refused.value) or open_.source_rev[:12] in str(
+        refused.value
+    )
+
+    # landing the contribution closes it; retire now succeeds
+    landed = sink.run(coord, canonical(parent))
+    assert landed is not None and landed.state is State.ACKNOWLEDGED
+    assert subspace.open_contributions() == []
+    subspace.retire()
+    assert subspace.retired is True
+
+
+def test_w5_a_refused_contribution_stays_open_until_abandoned_by_an_explicit_note(
+    parent: Parent,
+) -> None:
+    child_a = parent.child("child-a")
+    child_b = parent.child("child-b")
+    author(child_a, "canon v2 (a)\n")
+    stale = author(child_b, "canon v2 (b)\n")
+    assert (
+        contributor(parent, child_a, "a").run(contribution("child-a"), canonical(parent)).state
+        is State.ACKNOWLEDGED
+    )  # type: ignore[union-attr]
+    sink_b = contributor(parent, child_b, "b")
+    coord_b = contribution("child-b")
+    refused = sink_b.run(coord_b, canonical(parent))
+    assert refused is not None and refused.state is State.REFUSED
+    subspace = Subspace("child-b", [(coord_b, sink_b)])
+
+    # refused is NOT terminal: the author has not said what becomes of the change
+    with pytest.raises(RetireRefused) as blocked:
+        subspace.retire()
+    [open_] = blocked.value.open_contributions
+    assert (open_.source_rev, open_.last_state) == (stale, str(State.REFUSED))
+
+    subspace.abandon(coord_b, stale, reason="superseded by child-a's change")
+    assert sink_b.journal.notes(coord_b.key(), stale, ABANDONED_NOTE) == 1
+    assert subspace.open_contributions() == []
+    subspace.retire()
+    assert subspace.retired is True
+
+    # abandoning something the subspace does not hold is an error, not a silent no-op
+    with pytest.raises(KeyError):
+        subspace.abandon(contribution("child-z"), stale, reason="nope")
+
+
+# --------------------------------------------------------------------------- W6
+
+
+def test_w6_two_writers_both_land_in_arrival_order_and_earlier_records_are_never_rewritten(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "ledger" / "events.jsonl"
+    first_handle = AppendSurface(path)
+    second_handle = AppendSurface(path)  # a second writer on the SAME file, no shared state
+
+    r1 = first_handle.append("a", {"n": 1})
+    r2 = second_handle.append("b", {"n": 1})
+    r3 = first_handle.append("a", {"n": 2})
+    assert [r.seq for r in (r1, r2, r3)] == [1, 2, 3]
+    assert [(r.writer, r.payload["n"]) for r in first_handle.records()] == [
+        ("a", 1),
+        ("b", 1),
+        ("a", 2),
+    ]
+    # the second handle reads the first handle's records: the file is the state
+    assert second_handle.records() == first_handle.records()
+
+    # earlier records are a PREFIX of the file after any later append
+    before = path.read_bytes()
+    second_handle.append("b", {"n": 2})
+    after = path.read_bytes()
+    assert after.startswith(before) and len(after) > len(before)
+    assert [r.seq for r in first_handle.records()] == [1, 2, 3, 4]
+
+
+def test_w6_concurrent_writers_produce_one_gapless_sequence(tmp_path: Path) -> None:
+    path = tmp_path / "ledger" / "events.jsonl"
+    writers, each = 4, 25
+
+    def write_many(writer: str) -> None:
+        surface = AppendSurface(path)
+        for n in range(each):
+            surface.append(writer, {"n": n})
+
+    with ThreadPoolExecutor(max_workers=writers) as pool:
+        list(pool.map(write_many, [f"w{i}" for i in range(writers)]))
+
+    records = AppendSurface(path).records()
+    assert [r.seq for r in records] == list(range(1, writers * each + 1))
+    for i in range(writers):
+        mine = [r.payload["n"] for r in records if r.writer == f"w{i}"]
+        assert mine == list(range(each))  # each writer's own order is preserved

--- a/gr2/tests/test_contribution_protocol.py
+++ b/gr2/tests/test_contribution_protocol.py
@@ -42,6 +42,7 @@ from gr2.prototypes.contribution_protocol import (
     SetMember,
     Subspace,
     WriteMode,
+    state_latencies,
 )
 from gr2.prototypes.propagation_state_machine import (
     Coordinate,
@@ -464,3 +465,57 @@ def test_w6_concurrent_writers_produce_one_gapless_sequence(tmp_path: Path) -> N
     for i in range(writers):
         mine = [r.payload["n"] for r in records if r.writer == f"w{i}"]
         assert mine == list(range(each))  # each writer's own order is preserved
+
+
+# --------------------------------------------------------------------------- measurement
+
+
+def test_per_state_latency_is_read_from_the_receipts_own_timestamps_and_printed(
+    parent: Parent, tmp_path: Path
+) -> None:
+    """Not a witness: the measurement the prototype must print (per-state seconds, from
+    the receipt's timestamps, for one landing and for a two-member set). Run with ``-s``
+    or read the captured table; the assertions only pin that the timestamps are ordered
+    and that every state of the landing path has a row. For SET members the ``applied``
+    row spans prepare -> land by construction (the planned transition is written at
+    prepare time), so it reads as the time the prepared base sat, not the push alone."""
+    child_a = parent.child("child-a")
+    author(child_a, "canon v2 (a)\n")
+    single = contributor(parent, child_a, "a").run(contribution("child-a"), canonical(parent))
+    assert single is not None and single.state is State.ACKNOWLEDGED
+
+    owner2 = make_owner(tmp_path, "owner2")
+    b1, b2 = parent.child("b1"), owner2.child("b2")
+    author(b1, "canon v3 (set)\n")
+    author(b2, "owner2 canon v2 (set)\n")
+    contribution_set = ContributionSet(
+        "timed", [member(parent, b1, "m1"), member(owner2, b2, "m2")]
+    )
+    assert contribution_set.prepare().phase == "prepared"
+    landed = contribution_set.land()
+    assert landed.phase == "landed"
+
+    lines = ["per-state latency (seconds since previous transition), from receipt timestamps"]
+    for label, receipt in [("single", single)] + [
+        (o.member_id, o.receipt) for o in landed.outcomes if o.receipt is not None
+    ]:
+        rows = state_latencies(receipt)
+        assert [state for state, _ in rows] == [
+            str(State.OBSERVED),
+            str(State.FETCHED),
+            str(State.PLANNED),
+            str(State.APPLIED),
+            str(State.VERIFIED),
+            str(State.ACKNOWLEDGED),
+        ]
+        assert all(seconds >= 0.0 for _, seconds in rows)
+        total = sum(seconds for _, seconds in rows)
+        lines.append(
+            f"  {label:>6}: "
+            + "  ".join(f"{s}={sec:.3f}" for s, sec in rows)
+            + f"  total={total:.3f}"
+        )
+    report = tmp_path / "latency.txt"
+    report.write_text("\n".join(lines) + "\n")
+    print("\n" + report.read_text(), end="")  # visible with -s; the file is the artifact
+    assert report.read_text().count("total=") == 3

--- a/gr2/tests/test_propagation_contribution.py
+++ b/gr2/tests/test_propagation_contribution.py
@@ -1,0 +1,420 @@
+"""Prototype 2: the contribution protocol on the Prototype 0 machine.
+
+Everything here runs against throwaway repositories under ``tmp_path``. No real
+workspace, remote, or authoring clone is touched. The synthetic topology is a
+scratch PARENT and two SUBSPACES:
+
+* one bare ``owner.git`` — the parent layer's CANONICAL remote for ``main``, the
+  surface the children do not own and may only change by contributing
+* two child clones, ``child-a`` and ``child-b``, each an independent authoring
+  clone of that canonical (independent clones are the product)
+
+A contribution is a state-machine operation with ``direction=up``: the machine observes the
+child's branch, fetches it into the sink's mirror, plans against the owner's
+branch as read NOW, and lands it by a fast-forward push guarded by
+``--force-with-lease`` on the expected base — compare-and-swap enforced by the
+receiving repository, not by this process. What the witnesses prove:
+
+* W2a  a contribution walks observed -> fetched -> planned -> applied -> verified
+       -> acknowledged; the owner's branch reports the child's revision; the
+       receipt names exact revisions; the cleanliness gate is recorded NOT RUN
+       (a bare remote has no worktree), never silently omitted
+* W2b  the manufactured collision: after A lands, B's change (authored against
+       the OLD base) is REFUSED at plan — not a fast-forward of the observed base
+       — with the observed base in the receipt; the owner's refs and B's clone are
+       byte-for-byte untouched
+* W2c  the compare-and-swap race: B plans while the owner is at the old base, the
+       sink dies, A lands, B resumes — and B is REFUSED at apply because the
+       expected base moved; nothing of B's reaches the owner
+* W2d  the lease closes the window the process-side check cannot see: the owner
+       moves AFTER B's apply-step head check and BEFORE B's push; the receiving
+       repository rejects the lease; B is REFUSED with the revision the owner
+       holds; B's bytes never land
+* W2e  replan is the AUTHOR's act: B rebases onto the owner's branch and
+       re-contributes; the new revision is a fresh attempt and lands; the journal
+       carries the refused attempt and the acknowledged one, both by name
+* W2f  policy governs ``up`` exactly as it governs ``down``: a policy that does
+       not allow ``up`` refuses at ``policy.direction`` before any verb
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from gr2.prototypes.propagation_state_machine import (
+    Coordinate,
+    Destination,
+    DestinationKind,
+    Direction,
+    Operation,
+    Policy,
+    Propagator,
+    SinkKilled,
+    State,
+)
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "prototype",
+    "GIT_AUTHOR_EMAIL": "prototype@example.invalid",
+    "GIT_COMMITTER_NAME": "prototype",
+    "GIT_COMMITTER_EMAIL": "prototype@example.invalid",
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_NOSYSTEM": "1",
+}
+
+
+def git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    return proc.stdout.strip()
+
+
+def bare_refs(repo: Path) -> str:
+    return git(repo, "for-each-ref", "--format=%(refname) %(objectname)")
+
+
+def clone_snapshot(repo: Path) -> dict[str, str]:
+    return {
+        "refs": git(repo, "for-each-ref", "--format=%(refname) %(objectname)"),
+        "head": git(repo, "rev-parse", "HEAD"),
+        "porcelain": git(repo, "status", "--porcelain"),
+        "canon": (repo / "canon.md").read_text(),
+        "reflog": git(repo, "reflog", "show", "--format=%gs", "HEAD"),
+    }
+
+
+@dataclass
+class Parent:
+    """A scratch parent layer: its canonical remote plus two subspace clones."""
+
+    owner: Path
+    base: str
+    root: Path
+
+    def child(self, name: str) -> Path:
+        path = self.root / name
+        subprocess.run(
+            ["git", "clone", "-q", str(self.owner), str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, **_GIT_ENV},
+        )
+        return path
+
+    def sink(self, name: str) -> Path:
+        return self.root / f"sink-{name}"
+
+
+def author(child: Path, text: str, *, path: str = "canon.md") -> str:
+    (child / path).write_text(text)
+    git(child, "add", path)
+    git(child, "commit", "-q", "-m", f"{path}: {text.strip()[:40]}")
+    return git(child, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def parent(tmp_path: Path) -> Parent:
+    owner = tmp_path / "owner.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "--initial-branch=main", str(owner)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    seed = tmp_path / "seed"
+    subprocess.run(
+        ["git", "clone", "-q", str(owner), str(seed)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    git(seed, "switch", "-q", "-c", "main")
+    (seed / "canon.md").write_text("canon v1\n")
+    (seed / "other.md").write_text("other v1\n")
+    git(seed, "add", "canon.md", "other.md")
+    git(seed, "commit", "-q", "-m", "canon v1")
+    git(seed, "push", "-q", "-u", "origin", "main")
+    base = git(seed, "rev-parse", "HEAD")
+    return Parent(owner=owner, base=base, root=tmp_path)
+
+
+POLICY_UP = Policy(policy_hash="policy-prototype-2", allowed_directions=frozenset({Direction.UP}))
+POLICY_DOWN_ONLY = Policy(
+    policy_hash="policy-prototype-2-down-only", allowed_directions=frozenset({Direction.DOWN})
+)
+
+
+def contribution(child_id: str) -> Coordinate:
+    return Coordinate(
+        source=child_id,
+        destination="owner-canonical",
+        layer="layer-parent",
+        direction=Direction.UP,
+        operation=Operation.CONTRIBUTE,
+        artifact_class="config",
+    )
+
+
+def canonical(parent: Parent) -> Destination:
+    return Destination(
+        destination_id="owner-canonical", path=parent.owner, kind=DestinationKind.CANONICAL
+    )
+
+
+def contributor(
+    parent: Parent, child: Path, name: str, *, policy: Policy = POLICY_UP, **kw
+) -> Propagator:
+    """The sink that carries ONE child's contributions: its source is that child's clone."""
+    return Propagator(
+        source_remote=child, branch="main", state_dir=parent.sink(name), policy=policy, **kw
+    )
+
+
+def owner_main(parent: Parent) -> str:
+    return git(parent.owner, "rev-parse", "--verify", "refs/heads/main")
+
+
+# --------------------------------------------------------------------------- W2a
+
+
+def test_a_contribution_lands_on_the_owner_by_lease_push_and_names_exact_revisions(
+    parent: Parent,
+) -> None:
+    child_a = parent.child("child-a")
+    new = author(child_a, "canon v2 (a)\n")
+
+    receipt = contributor(parent, child_a, "a").run(contribution("child-a"), canonical(parent))
+
+    assert receipt is not None
+    assert receipt.state is State.ACKNOWLEDGED
+    assert [t.state for t in receipt.transitions] == [
+        State.OBSERVED,
+        State.FETCHED,
+        State.PLANNED,
+        State.APPLIED,
+        State.VERIFIED,
+        State.ACKNOWLEDGED,
+    ]
+    # the owner's BRANCH reports the child's revision: read back from the owner, not the verb
+    assert owner_main(parent) == new
+    assert receipt.source_rev == new
+    assert receipt.expected_base == parent.base
+    assert receipt.after == new
+    # the cleanliness gate is recorded NOT RUN for a bare destination, never omitted
+    by_id = {g.gate_id: g for g in receipt.gate_results}
+    assert by_id["destination.clean"].result == "not-run"
+    assert by_id["destination.base-unmoved"].result == "pass"
+    assert by_id["destination.fast-forward"].result == "pass"
+    assert by_id["policy.direction"].result == "pass"
+    verified = next(t for t in receipt.transitions if t.state is State.VERIFIED)
+    assert verified.observation["postcondition_checked"] == (
+        "branch-is-intended-after-and-tree-matches-digest"
+    )
+    applied = next(t for t in receipt.transitions if t.state is State.APPLIED)
+    assert applied.observation["verb_ran_now"] is True
+
+
+# --------------------------------------------------------------------------- W2b
+
+
+def test_the_manufactured_collision_refuses_the_stale_contribution_and_touches_nothing(
+    parent: Parent,
+) -> None:
+    child_a = parent.child("child-a")
+    child_b = parent.child("child-b")
+    a_new = author(child_a, "canon v2 (a)\n")
+    b_new = author(child_b, "canon v2 (b)\n")  # same logical path, authored against the OLD base
+
+    assert (
+        contributor(parent, child_a, "a").run(contribution("child-a"), canonical(parent)).state
+        is State.ACKNOWLEDGED
+    )
+    assert owner_main(parent) == a_new
+
+    owner_before = bare_refs(parent.owner)
+    b_before = clone_snapshot(child_b)
+
+    receipt = contributor(parent, child_b, "b").run(contribution("child-b"), canonical(parent))
+
+    assert receipt is not None
+    assert receipt.state is State.REFUSED
+    # refused at PLAN: the owner's branch is not an ancestor of B's revision
+    assert [t.state for t in receipt.transitions] == [
+        State.OBSERVED,
+        State.FETCHED,
+        State.PLANNED,
+        State.REFUSED,
+    ]
+    refused = receipt.transitions[-1]
+    assert "destination.fast-forward" in refused.observation["failed_gates"]
+    assert refused.observation["observed_base"] == a_new
+    assert receipt.source_rev == b_new
+    # nothing merged, nothing forced, nothing written: owner refs and B's clone unchanged
+    assert bare_refs(parent.owner) == owner_before
+    assert clone_snapshot(child_b) == b_before
+    assert owner_main(parent) == a_new
+
+
+# --------------------------------------------------------------------------- W2c
+
+
+def test_compare_and_swap_race_refuses_at_apply_when_the_base_moved_after_plan(
+    parent: Parent,
+) -> None:
+    child_a = parent.child("child-a")
+    child_b = parent.child("child-b")
+    a_new = author(child_a, "canon v2 (a)\n")
+    b_new = author(child_b, "other v2 (b)\n", path="other.md")  # DISJOINT paths, same base
+
+    # B plans while the owner is still at the base, then the sink dies
+    with pytest.raises(SinkKilled):
+        contributor(parent, child_b, "b", kill_after=State.PLANNED).run(
+            contribution("child-b"), canonical(parent)
+        )
+    # A lands in between
+    assert (
+        contributor(parent, child_a, "a").run(contribution("child-a"), canonical(parent)).state
+        is State.ACKNOWLEDGED
+    )
+    assert owner_main(parent) == a_new
+
+    # B resumes the SAME operation from planned: apply re-reads the base and refuses
+    receipt = contributor(parent, child_b, "b").run(contribution("child-b"), canonical(parent))
+
+    assert receipt is not None
+    assert receipt.state is State.REFUSED
+    refused = receipt.transitions[-1]
+    assert str(refused.observation["refusal_reason"]).startswith("expected_base moved")
+    assert refused.observation["observed_base"] == a_new
+    assert receipt.expected_base == parent.base
+    assert receipt.source_rev == b_new
+    # the owner still holds A's revision and nothing of B's is reachable from it
+    assert owner_main(parent) == a_new
+    contains = subprocess.run(
+        ["git", "-C", str(parent.owner), "merge-base", "--is-ancestor", b_new, "refs/heads/main"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    assert contains.returncode != 0  # B's revision is NOT an ancestor of the owner's branch
+
+
+# --------------------------------------------------------------------------- W2d
+
+
+def test_the_lease_refuses_a_move_inside_the_window_after_the_head_check(parent: Parent) -> None:
+    child_a = parent.child("child-a")
+    child_b = parent.child("child-b")
+    a_new = author(child_a, "canon v2 (a)\n")
+    b_new = author(child_b, "other v2 (b)\n", path="other.md")
+
+    def another_writer_lands() -> None:
+        # between B's apply-step head check and B's push, A pushes straight to the owner
+        git(child_a, "push", "-q", "origin", "main")
+        assert owner_main(parent) == a_new
+
+    receipt = contributor(parent, child_b, "b", before_apply_verb=another_writer_lands).run(
+        contribution("child-b"), canonical(parent)
+    )
+
+    assert receipt is not None
+    assert receipt.state is State.REFUSED
+    refused = receipt.transitions[-1]
+    assert str(refused.observation["refusal_reason"]).startswith("destination.lease-refused")
+    assert refused.observation["observed_base"] == a_new
+    # the plan was computed against the base, the apply verb was attempted, the lease held the line
+    assert receipt.expected_base == parent.base
+    assert [t.state for t in receipt.transitions] == [
+        State.OBSERVED,
+        State.FETCHED,
+        State.PLANNED,
+        State.REFUSED,
+    ]
+    assert owner_main(parent) == a_new
+    contains = subprocess.run(
+        ["git", "-C", str(parent.owner), "merge-base", "--is-ancestor", b_new, "refs/heads/main"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    assert contains.returncode != 0
+
+
+# --------------------------------------------------------------------------- W2e
+
+
+def test_replan_is_the_authors_act_and_the_rebased_contribution_lands_as_a_fresh_attempt(
+    parent: Parent,
+) -> None:
+    child_a = parent.child("child-a")
+    child_b = parent.child("child-b")
+    a_new = author(child_a, "canon v2 (a)\n")
+    b_stale = author(child_b, "other v2 (b)\n", path="other.md")
+    assert (
+        contributor(parent, child_a, "a").run(contribution("child-a"), canonical(parent)).state
+        is State.ACKNOWLEDGED
+    )
+
+    sink_b = contributor(parent, child_b, "b")
+    first = sink_b.run(contribution("child-b"), canonical(parent))
+    assert first is not None and first.state is State.REFUSED
+    assert first.source_rev == b_stale
+
+    # the AUTHOR replans: rebase B onto the owner's branch (the machine never did this)
+    git(child_b, "fetch", "-q", "origin")
+    git(child_b, "rebase", "-q", "origin/main")
+    b_rebased = git(child_b, "rev-parse", "HEAD")
+    assert b_rebased != b_stale
+    assert git(child_b, "merge-base", "--is-ancestor", a_new, b_rebased) == ""
+
+    second = sink_b.run(contribution("child-b"), canonical(parent))
+
+    assert second is not None
+    assert second.state is State.ACKNOWLEDGED
+    assert second.source_rev == b_rebased
+    assert second.expected_base == a_new
+    assert owner_main(parent) == b_rebased
+    # both attempts are in the journal by name: the refused one at the stale revision,
+    # the acknowledged one at the rebased revision — a refusal describes a moment
+    assert (
+        sink_b.journal.find(contribution("child-b").key(), b_stale)[-1][-1].state is State.REFUSED
+    )
+    assert (
+        sink_b.journal.find(contribution("child-b").key(), b_rebased)[-1][-1].state
+        is State.ACKNOWLEDGED
+    )
+    # the owner's tree now carries BOTH changes, because the author's rebase composed them
+    assert git(parent.owner, "show", "refs/heads/main:canon.md") == "canon v2 (a)"
+    assert git(parent.owner, "show", "refs/heads/main:other.md") == "other v2 (b)"
+
+
+# --------------------------------------------------------------------------- W2f
+
+
+def test_policy_that_does_not_allow_up_refuses_before_any_verb(parent: Parent) -> None:
+    child_a = parent.child("child-a")
+    author(child_a, "canon v2 (a)\n")
+    owner_before = bare_refs(parent.owner)
+
+    receipt = contributor(parent, child_a, "a", policy=POLICY_DOWN_ONLY).run(
+        contribution("child-a"), canonical(parent)
+    )
+
+    assert receipt is not None
+    assert receipt.state is State.REFUSED
+    refused = receipt.transitions[-1]
+    assert "policy.direction" in refused.observation["failed_gates"]
+    assert bare_refs(parent.owner) == owner_before
+    assert owner_main(parent) == parent.base


### PR DESCRIPTION
## What

Prototype 2 of the propagation work: the contribution protocol around the Prototype 0 state machine (#889), built ON Prototype 1 (#894, merged). Prototype 0 drives one change DOWN into a destination; this makes the same machine land a change UP, onto a canonical remote that the author does not own, by compare-and-swap enforced by the receiving repository — and adds the protocol that decides who owns what, lands several contributions together, refuses to retire a workspace that still holds open ones, and gives declared append-only surfaces the one behaviour everything else is denied. Everything is synthetic: throwaway repositories under `tmp_path`; no real workspace, remote, or authoring clone is touched.

`gr2/prototypes/propagation_state_machine.py` (Prototype 0) grows three things, each the smallest that the witnesses need:

- **`DestinationKind.CANONICAL`** — a bare remote that owns the branch. For this kind `read_head` reads `refs/heads/<branch>` (not `HEAD`), the cleanliness gate is recorded **NOT RUN** (`not-run`: a bare remote has no worktree; the gate is never silently omitted), and `_verify` skips the porcelain check. The postcondition is `branch-is-intended-after-and-tree-matches-digest`.
- **The `up` apply is a lease-guarded fast-forward push from the sink's mirror**: `git push --force-with-lease=refs/heads/<branch>:<expected_base> <owner> <intended_after>:refs/heads/<branch>`. The plan's `destination.fast-forward` gate and the lease are one mechanism seen from two sides: the gate guarantees the lease never forces (the intended revision descends from the expected base), the lease guarantees the base is what the owner still holds at the moment of the push. A rejected lease is a REFUSAL — `destination.lease-refused: the owner's branch moved to <rev> after the base check` — carrying the revision the owner holds as `observed_base`; a push that fails while the owner is still at the expected base raises, because that is not a refusal the protocol knows. No `--force` anywhere.
- **`run(..., stop_after=State.PLANNED)`** drives an operation through its gates and stops BEFORE the apply verb, journaled at `planned`; a later `run` resumes it from there. This is how a set prepares every member against its owner's current base before landing any of them. The stop point is the one place the drive loop checks; every other transition is unchanged.

`gr2/prototypes/contribution_protocol.py` (new) — neutral throughout: layer refs, destination ids, and surface names are opaque strings the caller resolves; the module holds no notion of who an agent or an org is, and who MAY contribute where is a policy it is handed, never derives:

- **`ResolvedManifest` / `ResolvedEntry` / `Declaration`** — ownership as a RECORDED fact. Every resolved entry carries `declared_by` (the layer whose declaration put it in the workspace), `overridden_by` (the layer whose override governs it, if any), and `write_mode` (`own` / `contribute` / `append` / `read`); `owner` is `overridden_by or declared_by`. `resolve(this_layer, declarations, appends=…)` merges layer declarations keeping provenance; two layers declaring the same entry without `overrides` raises `ResolutionCollision` naming both layers and both paths, never a silent precedence. `classify(path)` answers by the longest declared entry path (a path that merely shares a prefix string is not under the entry) and refuses a path under no entry. Today's resolver flattens this information away, so this is the specification of the field the resolver must grow, and the witnesses run against the stub.
- **`ContributionSet`** — several contributions that must land together. `prepare()` drives every member to `planned` (no verb); if any refuses there, nothing has landed and the set receipt says so. `land()` resumes each member in declared order and STOPS at the first that does not reach `acknowledged`, leaving earlier members landed (git history is forward-only; a rollback would be a new forward operation, never an un-push) and writing a `SetReceipt` that names the landed, the refusing, and the not-attempted members. All-or-REPORT, not all-or-nothing.
- **`Subspace`** — a workspace and its contributions. `retire()` raises `RetireRefused` listing every `(coordinate, source revision, last state, operation id)` that is neither acknowledged nor explicitly abandoned; `abandon()` writes an `abandoned` note into the contribution's own journal. A refusal is a moment, not a terminal state: a refused contribution stays open until its author says what becomes of it.
- **`AppendSurface`** — a declared append-only file: one guarded append point (exclusive lock held across write + flush + fsync), arrival-ordered sequence numbers, no expected base because appends commute — BY DECLARATION, never inferred from the shape of a change. File-level only; a git-tracked path is never an append surface to this protocol, because landing two appends there would mean merging on an author's behalf.
- **`state_latencies(receipt)`** — per-state seconds read from the receipt's own transition timestamps, a measurement and not a witness.

`gr2/tests/test_propagation_contribution.py` (new; a bare `owner.git` as the parent's canonical plus independent child clones) proves, each as its own witness:

- a contribution walks observed → fetched → planned → applied → verified → acknowledged; the owner's branch reports the child's revision, read back from the owner and not from the verb; the receipt names exact revisions; the cleanliness gate is recorded `not-run`; `verb_ran_now` is true
- the manufactured collision: after A lands, B's change authored against the OLD base is REFUSED at plan (`destination.fast-forward` fails) with `observed_base` = A's landing; the owner's refs and B's clone are byte-for-byte untouched
- the compare-and-swap race: B plans while the owner is at the old base, the sink dies (`kill_after=PLANNED`), A lands, B resumes — REFUSED at apply because the expected base moved; nothing of B's reaches the owner
- the lease closes the window the process-side check cannot see: with a test seam (`before_apply_verb`) the owner moves AFTER B's apply-step head check and BEFORE B's push; the receiving repository rejects the lease; B is REFUSED with the revision the owner holds; B's bytes never land
- replan is the AUTHOR's act: B rebases onto the owner's branch and re-contributes; the new revision is a fresh attempt and lands; the journal carries the refused attempt and the acknowledged one, both by name; the owner's tree carries both changes
- a policy that does not allow `up` refuses at `policy.direction` before any verb

`gr2/tests/test_contribution_protocol.py` (new) proves, each as its own witness:

- ownership is recorded provenance: `declared_by` / `overridden_by` / `owner`, the same declarations resolved AS the owning layer classify as `own`, append-only is declared by name; `classify` picks the longest declared prefix (declarations ordered so that a first-match classifier and a longest-prefix classifier disagree) and refuses undeclared paths; two declarations without override are a named collision, with the override form as the positive control
- a two-member set across two owners prepares every member (both owners still at their bases, transitions end at `planned`) then lands in declared order (callback order asserted), each member's receipt the RESUMED attempt 1; a refusal at prepare lands nothing — including the member that was fine; a three-member set with the second owner moved between prepare and land stops with landed = (m1), refused = (m2, `expected_base moved`, `observed_base` named), not-attempted = (m3), m1 still landed, m3's owner untouched; empty and duplicate-id sets are refused
- retire refuses while a prepared-but-unlanded contribution is open and names its operation id; landing it unblocks retire; a REFUSED contribution is open until an explicit `abandoned` note (counted in the journal), and abandoning a coordinate the subspace does not hold is a `KeyError`, not a no-op
- two handles on one append file interleave in arrival order with sequence numbers 1, 2, 3 and the second handle reads the first handle's records; earlier records are a byte prefix of the file after every later append; four concurrent writers × 25 appends produce one gapless sequence with each writer's own order preserved
- the per-state latency table is emitted (written to a file, printed under `-s`) for one landing and both members of a set, every state of the landing path present, all deltas non-negative; on this host one contribution lands in ~0.23 s end to end (fetch ~0.09, plan ~0.05, lease push ~0.07, verify ~0.02); for set members the `applied` row spans prepare → land by construction, so it reads as the time the prepared base sat, not the push alone

## Evidence (RAN)

- `python3 -m pytest gr2/tests/test_contribution_protocol.py gr2/tests/test_propagation_contribution.py gr2/tests/test_propagation_state_machine.py gr2/tests/test_propagation_daemon.py`: **101 passed, 1 xfailed** (12 + 6 protocol/contribution, 83 + 1 xfailed unchanged from Prototype 1's head; Python 3.13.2, pytest 9.0.2); Prototype 0 and Prototype 1 suites unchanged in count
- `ruff check` and `ruff format --check` clean on the four files touched
- mutation run, thirteen rows, each row asserting its anchor applied (count == 1 AND the mutated file's hash differs from the saved copy — one row in the first pass had silently NOT applied, which is why the hash assertion was added) and the suite run to a verdict, the module restored from a saved copy and hash-verified after every row. Machine (5): a bare `--force` in place of the lease killed exactly the lease witness; the apply-step head check dropped killed exactly the race witness; the fast-forward gate forced to pass for canonical killed the collision and replan witnesses; porcelain run on a bare destination killed four; the clean gate recorded `pass` instead of `not-run` killed the happy-path witness. Protocol (8): refused-treated-as-terminal killed the abandon witness; retire-ignores-open killed both retire witnesses; land-never-stops killed the mid-set witness; prepare-lands killed all three set witnesses; collision-by-precedence killed the collision witness; owner-ignores-override killed both ownership witnesses; append-caches-seq killed both append witnesses; classify-first-match killed the classify witness — after the fixture was reordered: in the first pass its declaration order happened to make first-match and longest-prefix agree, so the mutation survived and the fixture, not the code, was what got fixed
- the whole `gr2/tests` tree at this head: 985 passed, 1 xfailed, 43 subtests passed, 5 failed; the same 5 (two in `test_event_log_integrity.py`, one each in `test_gr2_packaging.py`, `test_sprint21_sync_platform.py`, `test_workspace_edit_lease_cap.py`) fail identically on `origin/dev` at the base commit — pre-existing and untouched here, re-verified at the frozen head

## Not in scope

- the resolver change itself (`declared_by` on the real merged manifest) — this PR specifies it with a stub and witnesses; the change to the resolver is the next step
- git-tracked append surfaces (a path inside the commit graph declared `append` would need a union-merge replan to land two appends, which this protocol refuses everywhere else); the prototype builds append surfaces at the store level only and says so
- `across` propagation, any transport, any policy content beyond the allowed-directions literal the tests hand the machine

Premium boundary: grip is OSS; this is local git mechanics over opaque identifiers and carries no identity, org, or policy content — who may contribute where is a policy the protocol is handed, never derives.
