### PR TITLE
fix: AppendSurface survives a torn write, and counts what it skips

### DIFF
--- a/gr2/prototypes/contribution_protocol.py
+++ b/gr2/prototypes/contribution_protocol.py
@@ -69,6 +69,7 @@ from pathlib import Path
 from gr2.prototypes.propagation_state_machine import (
     Coordinate,
     Destination,
+    MalformedLine,
     Propagator,
     Receipt,
     State,
@@ -482,12 +483,25 @@ class AppendSurface:
     writes ``seq + 1`` with the record, flushes, fsyncs, and releases. Two writers
     interleave in ARRIVAL order and both land; there is no expected base to refuse on
     because appends commute. Nothing here ever rewrites an earlier record.
+
+    A writer killed between ``write`` and its terminator leaves a remnant line. Both
+    scans SKIP such a line and COUNT it (``malformed_lines``, reflecting the most
+    recent full scan): an uncounted drop is silent, and this surface is the one place
+    a caller looks. ``append`` also repairs a missing terminator before writing, so a
+    remnant never GLUES the next record onto itself — without that repair the record
+    that follows a torn write is swallowed into an unparseable line and lost.
     """
 
     def __init__(self, path: Path) -> None:
         self.path = path
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.touch(exist_ok=True)
+        self._malformed: tuple[MalformedLine, ...] = ()
+
+    @property
+    def malformed_lines(self) -> tuple[MalformedLine, ...]:
+        """Lines the most recent full scan could not read. Empty is the healthy case."""
+        return self._malformed
 
     def append(self, writer: str, payload: dict[str, object]) -> AppendRecord:
         with open(self.path, "a+", encoding="utf-8") as handle:
@@ -495,14 +509,26 @@ class AppendSurface:
             try:
                 handle.seek(0)
                 last = 0
-                for line in handle:
-                    line = line.strip()
-                    if line:
-                        last = int(json.loads(line)["seq"])
+                malformed: list[MalformedLine] = []
+                raw_last = ""
+                for index, raw in enumerate(handle):
+                    raw_last = raw
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    try:
+                        last = max(last, int(json.loads(line)["seq"]))
+                    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                        malformed.append(
+                            MalformedLine(index=index, excerpt=line[:120], reason=str(exc))
+                        )
+                self._malformed = tuple(malformed)
                 record = AppendRecord(
                     seq=last + 1, writer=writer, payload=payload, timestamp=_now()
                 )
                 handle.seek(0, os.SEEK_END)
+                if raw_last and not raw_last.endswith("\n"):
+                    handle.write("\n")
                 handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
                 handle.flush()
                 os.fsync(handle.fileno())
@@ -512,8 +538,12 @@ class AppendSurface:
 
     def records(self) -> list[AppendRecord]:
         out: list[AppendRecord] = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            if line.strip():
+        malformed: list[MalformedLine] = []
+        for index, raw in enumerate(self.path.read_text(encoding="utf-8").splitlines()):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
                 data = json.loads(line)
                 out.append(
                     AppendRecord(
@@ -523,6 +553,9 @@ class AppendSurface:
                         timestamp=str(data["timestamp"]),
                     )
                 )
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                malformed.append(MalformedLine(index=index, excerpt=line[:120], reason=str(exc)))
+        self._malformed = tuple(malformed)
         return out
 
 

--- a/gr2/prototypes/contribution_protocol.py
+++ b/gr2/prototypes/contribution_protocol.py
@@ -476,6 +476,81 @@ class AppendRecord:
     timestamp: str
 
 
+def _decode_line(raw: bytes) -> tuple[str | None, str]:
+    """Bytes become text HERE, so the failure that can happen HERE is guarded here.
+
+    A JSONL file is a BYTE format. Read in text mode, the decode happens while the
+    iterator produces the line — outside every ``try`` in this module — so one
+    invalid byte anywhere raises before a guard can see it and the whole scan dies.
+    The exception type was never the problem: ``UnicodeDecodeError`` subclasses
+    ``ValueError``, which was already caught. The OPERATION that raises it simply sat
+    outside the guarded region. A line does not ARRIVE as text, it is MANUFACTURED as
+    text, and manufacturing it can fail on content; decoding per line confines a bad
+    byte to that line.
+    """
+
+    try:
+        return raw.decode("utf-8"), ""
+    except UnicodeDecodeError as exc:
+        return None, str(exc)
+
+
+def _excerpt(raw: bytes) -> str:
+    """A malformed line must be reportable even when it is not valid text."""
+
+    return raw[:120].decode("utf-8", "replace")
+
+
+def _read_json_object(line: str) -> tuple[dict[str, object] | None, str]:
+    """Parse ONE line into a JSON object, or say why it cannot be read.
+
+    ``json.loads`` is the ONLY operation in this file that can raise on file
+    content. It raises ``ValueError`` (``JSONDecodeError`` subclasses it, as does
+    the integer-literal length limit) or ``RecursionError`` (deeply nested input).
+    Everything after it VALIDATES rather than coerces, and that is the whole point:
+    a coercion over untrusted bytes forces the caller to enumerate the exceptions it
+    might raise, which is a denylist, and a denylist leaks. ``int()`` on a value
+    ``json`` can legitimately produce (``1e999`` parses to ``inf``) raises
+    ``OverflowError`` — a type no list written from the parse side would predict.
+    Validating instead removes the raise rather than cataloguing it.
+    """
+
+    try:
+        obj = json.loads(line)
+    except (ValueError, RecursionError) as exc:
+        return None, str(exc)
+    if not isinstance(obj, dict):
+        return None, f"line is a {type(obj).__name__}, not an object"
+    return obj, ""
+
+
+def _read_seq(obj: dict[str, object]) -> tuple[int | None, str]:
+    """A sequence number must be a real integer. ``bool`` is an ``int`` and is not one."""
+
+    seq = obj.get("seq")
+    if isinstance(seq, bool) or not isinstance(seq, int):
+        return None, f"seq is {type(seq).__name__}, not an integer"
+    return seq, ""
+
+
+def _read_record(obj: dict[str, object]) -> tuple[AppendRecord | None, str]:
+    """Every field checked by TYPE, so nothing here can raise on hostile content."""
+
+    seq, reason = _read_seq(obj)
+    if seq is None:
+        return None, reason
+    writer = obj.get("writer")
+    payload = obj.get("payload")
+    timestamp = obj.get("timestamp")
+    if not isinstance(writer, str):
+        return None, f"writer is {type(writer).__name__}, not a string"
+    if not isinstance(payload, dict):
+        return None, f"payload is {type(payload).__name__}, not an object"
+    if not isinstance(timestamp, str):
+        return None, f"timestamp is {type(timestamp).__name__}, not a string"
+    return AppendRecord(seq=seq, writer=writer, payload=payload, timestamp=timestamp), ""
+
+
 class AppendSurface:
     """A declared append-only file with one guarded append point.
 
@@ -490,6 +565,14 @@ class AppendSurface:
     a caller looks. ``append`` also repairs a missing terminator before writing, so a
     remnant never GLUES the next record onto itself — without that repair the record
     that follows a torn write is swallowed into an unparseable line and lost.
+
+    The file is read as BYTES and decoded one line at a time. A JSONL file is a byte
+    format, and in text mode the decode happens while the iterator produces the line,
+    outside every guard here — so a single invalid byte anywhere destroyed the whole
+    scan, including every record written correctly around it. A line passes through
+    four layers: read, decode, parse, and shape-check. The last three are each guarded
+    where they happen. Unbounded line length (a file with no terminator for a very
+    long span) is a resource limit on the first layer and is NOT defended here.
     """
 
     def __init__(self, path: Path) -> None:
@@ -504,32 +587,37 @@ class AppendSurface:
         return self._malformed
 
     def append(self, writer: str, payload: dict[str, object]) -> AppendRecord:
-        with open(self.path, "a+", encoding="utf-8") as handle:
+        with open(self.path, "a+b") as handle:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
             try:
                 handle.seek(0)
                 last = 0
                 malformed: list[MalformedLine] = []
-                raw_last = ""
+                raw_last = b""
                 for index, raw in enumerate(handle):
                     raw_last = raw
-                    line = raw.strip()
-                    if not line:
+                    stripped = raw.strip()
+                    if not stripped:
                         continue
-                    try:
-                        last = max(last, int(json.loads(line)["seq"]))
-                    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
-                        malformed.append(
-                            MalformedLine(index=index, excerpt=line[:120], reason=str(exc))
-                        )
+                    line, reason = _decode_line(stripped)
+                    if line is not None:
+                        obj, reason = _read_json_object(line)
+                        if obj is not None:
+                            seq, reason = _read_seq(obj)
+                            if seq is not None:
+                                last = max(last, seq)
+                                continue
+                    malformed.append(
+                        MalformedLine(index=index, excerpt=_excerpt(stripped), reason=reason)
+                    )
                 self._malformed = tuple(malformed)
                 record = AppendRecord(
                     seq=last + 1, writer=writer, payload=payload, timestamp=_now()
                 )
                 handle.seek(0, os.SEEK_END)
-                if raw_last and not raw_last.endswith("\n"):
-                    handle.write("\n")
-                handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+                if raw_last and not raw_last.endswith(b"\n"):
+                    handle.write(b"\n")
+                handle.write((json.dumps(asdict(record), sort_keys=True) + "\n").encode("utf-8"))
                 handle.flush()
                 os.fsync(handle.fileno())
                 return record
@@ -539,22 +627,19 @@ class AppendSurface:
     def records(self) -> list[AppendRecord]:
         out: list[AppendRecord] = []
         malformed: list[MalformedLine] = []
-        for index, raw in enumerate(self.path.read_text(encoding="utf-8").splitlines()):
-            line = raw.strip()
-            if not line:
+        for index, raw in enumerate(self.path.read_bytes().split(b"\n")):
+            stripped = raw.strip()
+            if not stripped:
                 continue
-            try:
-                data = json.loads(line)
-                out.append(
-                    AppendRecord(
-                        seq=int(data["seq"]),
-                        writer=str(data["writer"]),
-                        payload=dict(data["payload"]),
-                        timestamp=str(data["timestamp"]),
-                    )
-                )
-            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
-                malformed.append(MalformedLine(index=index, excerpt=line[:120], reason=str(exc)))
+            line, reason = _decode_line(stripped)
+            if line is not None:
+                obj, reason = _read_json_object(line)
+                if obj is not None:
+                    record, reason = _read_record(obj)
+                    if record is not None:
+                        out.append(record)
+                        continue
+            malformed.append(MalformedLine(index=index, excerpt=_excerpt(stripped), reason=reason))
         self._malformed = tuple(malformed)
         return out
 

--- a/gr2/tests/test_contribution_protocol.py
+++ b/gr2/tests/test_contribution_protocol.py
@@ -543,6 +543,132 @@ def test_w7_a_parseable_line_of_the_wrong_shape_is_counted_not_raised(tmp_path: 
     assert len(surface.malformed_lines) == 1
 
 
+# A line's CONTENT is untrusted. Each of these is valid JSON (or valid enough to
+# reach a coercion) and each one bricked the surface under a version of this fix
+# that listed exception types instead of validating shapes. The 1e999 case came from
+# review on this PR; the deep-nesting case is its sibling, found by asking what ELSE
+# escapes a denylist rather than patching the one instance the review cited.
+def _hostile(seq: str, writer: str = '"x"', payload: str = "{}", ts: str = '"t"') -> str:
+    return f'{{"seq": {seq}, "writer": {writer}, "payload": {payload}, "timestamp": {ts}}}'
+
+
+HOSTILE_LINES = {
+    "float infinity (1e999 -> inf; int() raises OverflowError)": _hostile("1e999"),
+    "not-a-number (NaN)": _hostile("NaN"),
+    "deeply nested (json.loads raises RecursionError)": _hostile("[" * 100000 + "]" * 100000),
+    "integer literal past the conversion limit": _hostile("9" * 6000),
+    "seq is an object": _hostile('{"a": 1}'),
+    "seq is a bool (bool IS an int in Python)": _hostile("true"),
+    "writer is an object": _hostile("1", writer='{"a": 1}'),
+    "payload is a string": _hostile("1", payload='"not-an-object"'),
+    "timestamp is a number": _hostile("1", ts="5"),
+    "line is an array, not an object": "[1, 2, 3]",
+    "line is a bare string": '"just a string"',
+}
+
+
+@pytest.mark.parametrize("label", sorted(HOSTILE_LINES))
+def test_w7_hostile_line_content_neither_bricks_nor_vanishes(label: str, tmp_path: Path) -> None:
+    """Both scans must survive ANY line content and count what they could not read.
+
+    A class witness, not an instance one. A guard that LISTS exception types is a
+    denylist over untrusted input, and a denylist leaks: it passes the case you
+    thought of and bricks on the next one. Every row here must survive both paths.
+    """
+    path = tmp_path / "ledger" / "events.jsonl"
+    surface = AppendSurface(path)
+    surface.append("a", {"n": 1})
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(HOSTILE_LINES[label] + "\n")
+
+    record = surface.append("b", {"n": 2})  # the WRITE path must not brick
+    assert record.seq == 2
+
+    assert [r.payload["n"] for r in surface.records()] == [1, 2]  # READ path survives
+    assert len(surface.malformed_lines) == 1  # the bad line is COUNTED, not dropped
+    assert surface.malformed_lines[0].reason  # with a reason a human can act on
+
+
+def test_w7_a_readable_seq_on_an_unreadable_record_is_still_never_reused(
+    tmp_path: Path,
+) -> None:
+    """Deliberate: a number that APPEARS in the file is not handed out again.
+
+    A line can be unreadable as a RECORD while its sequence number is perfectly
+    readable. Numbering honours it anyway, so no writer is ever issued a number a
+    reader can already see on disk — the safe direction when the two scans disagree
+    about whether a line exists.
+    """
+    path = tmp_path / "ledger" / "events.jsonl"
+    surface = AppendSurface(path)
+    surface.append("a", {"n": 1})
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(_hostile("9", payload='"not-an-object"') + "\n")
+
+    assert surface.append("b", {"n": 2}).seq == 10  # 9 is taken, even unreadably
+    assert [r.payload["n"] for r in surface.records()] == [1, 2]
+    assert len(surface.malformed_lines) == 1
+
+
+# A line's BYTES are untrusted too, and the decode happens BEFORE any JSON handling.
+# Reading in text mode raises while the iterator manufactures the line — outside every
+# guard — so one bad byte anywhere killed the whole scan. The 0xff case came from the
+# second review block on this PR; the rest are its class, found by asking what else the
+# bytes-to-text layer can refuse.
+def _hostile_bytes(writer: bytes) -> bytes:
+    return b'{"seq": 1, "writer": "' + writer + b'", "payload": {}, "timestamp": "t"}'
+
+
+HOSTILE_BYTES = {
+    "invalid byte 0xff": _hostile_bytes(b"\xff"),
+    "lone surrogate": _hostile_bytes(b"\xed\xa0\x80"),
+    "truncated multi-byte sequence": _hostile_bytes(b"\xe2\x82"),
+    "overlong encoding": _hostile_bytes(b"\xc0\xaf"),
+    "continuation byte with no lead": _hostile_bytes(b"\x80\x80"),
+    "line is pure binary": b"\x00\x01\xff\xfe\xfd",
+}
+
+
+@pytest.mark.parametrize("label", sorted(HOSTILE_BYTES))
+def test_w7_undecodable_bytes_neither_brick_nor_vanish(label: str, tmp_path: Path) -> None:
+    """The bytes-to-text boundary is content-dependent, so it is guarded like any other."""
+    path = tmp_path / "ledger" / "events.jsonl"
+    surface = AppendSurface(path)
+    surface.append("a", {"n": 1})
+    with path.open("ab") as handle:
+        handle.write(HOSTILE_BYTES[label] + b"\n")
+
+    record = surface.append("b", {"n": 2})  # the WRITE path must not brick
+    assert record.seq == 2
+
+    assert [r.payload["n"] for r in surface.records()] == [1, 2]  # READ path survives
+    assert len(surface.malformed_lines) == 1
+    assert surface.malformed_lines[0].reason
+    assert surface.malformed_lines[0].excerpt  # reportable even when it is not text
+
+
+def test_w7_an_undecodable_line_is_confined_to_itself(tmp_path: Path) -> None:
+    """The operational property: one bad byte costs ONE line, not the file.
+
+    Under a whole-file decode a single invalid byte anywhere destroys every record in
+    the surface, including the thousands written correctly before and after it.
+    """
+    path = tmp_path / "ledger" / "events.jsonl"
+    surface = AppendSurface(path)
+    for n in range(1, 6):
+        surface.append("a", {"n": n})
+    with path.open("ab") as handle:
+        handle.write(b'{"seq": 99, "writer": "\xff", "payload": {}, "timestamp": "t"}\n')
+    for n in range(6, 11):
+        surface.append("b", {"n": n})
+
+    records = surface.records()
+
+    assert [r.payload["n"] for r in records] == list(range(1, 11))  # every good line kept
+    assert len(surface.malformed_lines) == 1  # exactly the one bad line
+    assert "utf-8" in surface.malformed_lines[0].reason
+
+
 # --------------------------------------------------------------------------- measurement
 
 

--- a/gr2/tests/test_contribution_protocol.py
+++ b/gr2/tests/test_contribution_protocol.py
@@ -21,10 +21,15 @@ several destinations. What the witnesses prove:
 * W6  a declared append-only surface: two writers both land, in arrival order,
       with no expected base to refuse on; earlier records are never rewritten;
       a second handle on the same file sees the first handle's records
+* W7  a writer killed mid-write leaves a remnant: the append point survives it
+      (unguarded, it raises FOREVER and the surface is dead), the next record is
+      not GLUED onto the remnant and lost, and both scans skip the remnant AND
+      COUNT it, because an uncounted drop is a loss nobody can see
 """
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
@@ -465,6 +470,77 @@ def test_w6_concurrent_writers_produce_one_gapless_sequence(tmp_path: Path) -> N
     for i in range(writers):
         mine = [r.payload["n"] for r in records if r.writer == f"w{i}"]
         assert mine == list(range(each))  # each writer's own order is preserved
+
+
+# --------------------------------------------------------------------------- W7
+
+
+def _tear(path: Path, remnant: str) -> None:
+    """A writer killed between its write and its terminator: bytes, no newline."""
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(remnant)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def test_w7_a_torn_remnant_does_not_brick_the_append_point(tmp_path: Path) -> None:
+    """Unguarded, append() raises on the remnant on EVERY later call: the surface is dead."""
+    path = tmp_path / "ledger" / "events.jsonl"
+    surface = AppendSurface(path)
+    surface.append("a", {"n": 1})
+    surface.append("a", {"n": 2})
+    _tear(path, '{"seq": 3, "writer": "a", "pay')
+
+    record = surface.append("b", {"n": 3})
+
+    assert record.seq == 3  # the torn write never completed, so its number is free
+    assert [line.index for line in surface.malformed_lines] == [2]
+    # and the NEXT append works too: the remnant is not a once-survivable event
+    assert surface.append("b", {"n": 4}).seq == 4
+
+
+def test_w7_the_next_record_is_not_glued_onto_the_remnant(tmp_path: Path) -> None:
+    """Terminator repair. Without it the record following a torn write is swallowed."""
+    path = tmp_path / "ledger" / "events.jsonl"
+    surface = AppendSurface(path)
+    surface.append("a", {"n": 1})
+    _tear(path, '{"seq": 2, "writer": "a", "pay')
+
+    surface.append("b", {"n": 2})
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3, lines  # remnant and new record are SEPARATE lines
+    assert json.loads(lines[2])["payload"] == {"n": 2}  # the new record survived whole
+    assert [r.payload["n"] for r in surface.records()] == [1, 2]
+
+
+def test_w7_records_skips_the_remnant_and_counts_it(tmp_path: Path) -> None:
+    """Skipping alone is silent; the COUNT is what makes an invisible loss detectable."""
+    path = tmp_path / "ledger" / "events.jsonl"
+    surface = AppendSurface(path)
+    surface.append("a", {"n": 1})
+    _tear(path, '{"seq": 2, "writer": "a", "pay')
+    surface.append("b", {"n": 2})
+
+    assert [(r.seq, r.payload["n"]) for r in surface.records()] == [(1, 1), (2, 2)]
+    (bad,) = surface.malformed_lines
+    assert bad.index == 1 and bad.excerpt.startswith('{"seq": 2') and bad.reason
+    # the finding is a property of the FILE, not of one handle
+    fresh = AppendSurface(path)
+    assert len(fresh.records()) == 2 and len(fresh.malformed_lines) == 1
+
+
+def test_w7_a_parseable_line_of_the_wrong_shape_is_counted_not_raised(tmp_path: Path) -> None:
+    """JSON that parses but carries none of the record's fields is malformed HERE."""
+    path = tmp_path / "ledger" / "events.jsonl"
+    surface = AppendSurface(path)
+    surface.append("a", {"n": 1})
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"unrelated": true}\n')
+
+    assert surface.append("b", {"n": 2}).seq == 2  # the append point survives it
+    assert [r.payload["n"] for r in surface.records()] == [1, 2]
+    assert len(surface.malformed_lines) == 1
 
 
 # --------------------------------------------------------------------------- measurement


### PR DESCRIPTION
## What

`AppendSurface` (Prototype 2, `gr2/prototypes/contribution_protocol.py`) is the declared append-only surface: one guarded append point, exclusive lock across write + flush + fsync, arrival-ordered sequence numbers. A writer killed between its record and the terminator leaves a remnant line, and three things followed. All three were measured, not inferred:

1. **`append()` raised on the remnant and kept raising** — the surface was BRICKED permanently. Every later writer re-reads the whole file to compute the next sequence number, so every later writer died on the same line. The failure sits on the WRITE path, behind the lock, and is not survivable by retrying.
2. **The next record GLUED onto the remnant.** With no terminator to separate them, a record that had itself completed and fsynced became part of one unparseable line and was lost.
3. **`records()` raised**, so every reader died too.

Both scans now skip a line they cannot read **and count it** (`malformed_lines`, reflecting the most recent full scan). The count is the load-bearing half: skipping alone is silent, and the remnant otherwise sits in the file while a caller sees a healthy-looking surface with a contiguous sequence — a loss invisible by construction. `append()` also repairs a missing terminator before writing, so a completed record is never swallowed by an incomplete one.

## Two review blocks, and both times the guard was the wrong SHAPE, not missing a case

The range is two commits and is worth reading as one: the original fix, and one commit carrying both corrections. Each block moved the guard down a layer, and the second one is where it belongs.

**Block 1 — the guard was a denylist.** Valid JSON `seq` of `1e999` parses to `inf`; `int(inf)` raises `OverflowError`, which was not in the except tuple, so both scans still bricked permanently. Asking what *else* escaped the same guard found a sibling the review had not named: deeply nested JSON raises `RecursionError` from `json.loads` itself. Two escapes from one guard is not two bugs. An except tuple over untrusted content enumerates the failures imaginable from the parse side, while the **coercion after the parse** invents new ones — `int()` applied to a value `json` can legitimately produce raises a type no parse-side list predicts. So the coercion was removed: everything after the parse **validates types rather than converting them**, and `inf` is refused because a float is not a sequence number, with no exception existing to catch.

**Block 2 — the guard was in the wrong place.** A raw invalid UTF-8 byte raised `UnicodeDecodeError` in both scans before any JSON handling. The *type* was never the problem: `UnicodeDecodeError` subclasses `ValueError`, which was already caught. The **operation** that raises it sat outside the guarded region — in text mode the decode happens while the iterator manufactures the line, so the bytes are converted before any `try` can see them. The fix guarded the transformation and left the **acquisition** unguarded. A line does not arrive as text; it is manufactured as text, and manufacturing it is content-dependent.

Operationally that was worse than a brick: a whole-file decode means **one bad byte anywhere destroys every record in the surface**, including the thousands written correctly around it. The file is now read as bytes and decoded one line at a time, which is what a JSONL file actually is, so a bad byte costs exactly its own line.

**What the two blocks have in common** is the useful part: both times the fix was sound about the case in front of it and wrong about the boundary it was defending. A line passes through four layers — read, decode, parse, shape-check — and each of the last three is now guarded where it happens.

## Evidence (RAN)

- **23 witnesses on this surface, up from 0.** Eleven hostile-content rows (float infinity, NaN, deep nesting, an integer literal past the conversion limit, `seq` as an object, `seq` as a bool — a bool *is* an int in Python — a non-string writer, a non-object payload, a non-string timestamp, a bare array, a bare string); six undecodable-byte rows (invalid `0xff`, lone surrogate, truncated multi-byte sequence, overlong encoding, orphan continuation byte, pure binary); and structural witnesses for the remnant surviving twice, the following record being a separate whole line, a fresh handle reporting the same finding, the numbering semantic below, and **confinement** — ten good records surviving a bad byte written between them.
- **Ten mutation rows**, each asserting its own anchor applied (occurrence count == 1 and the file hash changed) and restoring from a hash-verified copy. Removing the decode guard kills seven by **real** `UnicodeDecodeError`, each naming its own fixture's byte; reverting the read to a whole-file text decode kills the same seven; `errors="replace"` instead of refusing turns a bad line into a fake record and kills six; reverting to the denylist form kills exactly the two escapes by real `OverflowError` and `RecursionError`; dropping `RecursionError` kills only the nesting row; restoring the coercion kills five; accepting a bool kills only the bool row; dropping the writer type check kills only the writer row; silencing either counter kills only that path's count assertions.
- **Two instrument defects found in my own harness and disclosed, because both touched decisive rows.** (a) The first version extracted failure types by grepping pytest output for exception names — and parametrized test IDs *contain* exception names, so it reported `OverflowError` and `RecursionError` for runs where neither was raised. It agreed with what I expected, which is when a harness is least questioned. The corrected extractor reads only `E`-prefixed traceback lines and is proven against a green control that must yield zero. (b) One mutation row was **discarded as contaminated** — 15 of its 22 kills were an `AttributeError` from a sloppy edit rather than from the defect — and re-run clean, where it kills 7 for the right reason.
- **One fixture of mine was wrong and the code was right**, found by the new witness and pinned rather than quietly edited away: a line can be unreadable as a *record* while its sequence number is perfectly readable, and numbering honours it anyway. No writer is ever issued a number a reader can already see on disk.
- Suites: `test_contribution_protocol.py`, `test_propagation_contribution.py`, `test_propagation_state_machine.py`, `test_propagation_daemon.py` — **127 passed, 1 xfailed**, against a measured baseline of **104 passed, 1 xfailed** on clean `dev` with these files stashed. Delta is exactly the 23 new witnesses. Import resolution pinned from inside pytest (the `gr2` package is synthesized by `conftest.py`, so an out-of-pytest import proves nothing).
- `ruff check` and `ruff format --check` clean on both files.

## Not in scope

- **Unbounded line length is deliberately NOT defended.** A file with no terminator for a very long span is a resource limit on the READ layer, below the three that are guarded here. It is stated in the class docstring as well as here rather than left to be discovered, because the two completeness claims this branch made earlier were both broken on first contact with a reviewer, and naming the enumeration is more honest than asserting the set is closed.
- The same defect class on the other three surfaces. This is fix 1 of 4 in a sweep; the remaining three land as their own PRs with their own witnesses, and the validate-don't-coerce, guard-the-decode shape established here is what they follow.
- Any change to protocol semantics: locking, arrival order, and the commute property are untouched, and their existing witnesses are unchanged.

Premium boundary: grip is OSS; this is local file mechanics over opaque identifiers and carries no identity, org, or policy content.

Ref #897
